### PR TITLE
docs(test): define quality gate strategy

### DIFF
--- a/.github/workflows/nightly-quality-gates.yml
+++ b/.github/workflows/nightly-quality-gates.yml
@@ -1,0 +1,35 @@
+name: Nightly Quality Gates
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 2 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-quality-gates-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  monorepo-quality-gates:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          version-file: packages/mcp-server/uv.toml
+      - run: corepack enable
+      - run: corepack pnpm install --frozen-lockfile
+      - run: uv sync --all-extras --frozen --project packages/mcp-server
+      - run: corepack pnpm run check
+      - run: corepack pnpm run test:contract
+      - run: corepack pnpm run test:fixtures

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ corepack pnpm run test:contract
 - [Repository structure](docs/architecture/repo-structure.md)
 - [Product boundaries](docs/architecture/product-boundaries.md)
 - [Release model](docs/architecture/release-model.md)
-- [Testing strategy](docs/architecture/testing-strategy.md)
+- [Testing strategy](docs/testing-strategy.md)
 - [Integration model](docs/integration/kicad-studio-mcp.md)
 
 ## Examples

--- a/docs/architecture/testing-strategy.md
+++ b/docs/architecture/testing-strategy.md
@@ -1,53 +1,8 @@
 # Testing Strategy
 
-The repository supports product-scoped validation and full monorepo validation.
+The canonical repository-level testing strategy now lives at
+[../testing-strategy.md](../testing-strategy.md).
 
-## Root checks
-
-```bash
-corepack pnpm run check
-```
-
-The root check runs repository metadata checks, boundary checks, version checks, compatibility checks, governance self-tests, and every workspace `check` script.
-
-## Product-scoped checks
-
-```bash
-corepack pnpm run check:kicad-studio
-corepack pnpm run test:kicad-studio
-corepack pnpm run build:kicad-studio
-corepack pnpm run package:kicad-studio
-```
-
-```bash
-uv sync --all-extras --frozen --project packages/mcp-server
-corepack pnpm run check:kicad-mcp-pro
-corepack pnpm run test:kicad-mcp-pro
-corepack pnpm run build:kicad-mcp-pro
-corepack pnpm run package:kicad-mcp-pro
-```
-
-```bash
-corepack pnpm run check:mcp-npm
-```
-
-## Contract and fixture checks
-
-```bash
-corepack pnpm run test:contract
-corepack pnpm run test:fixtures
-```
-
-`test:contract` verifies compatibility metadata and MCP manifests. `test:fixtures` currently runs the MCP unit fixture suite; when a dedicated shared fixture package is introduced, this command should become the stable root entrypoint for that package.
-
-## CI lanes
-
-The GitHub Actions CI workflow has separate jobs for:
-
-- metadata and repo policy
-- VS Code extension
-- MCP server
-- npm launcher
-- forbidden-reference scanning
-
-Each product job uses its own package/build commands so one product can fail without hiding the other product's state.
+Architecture documents should link to that file when they need the active test
+layer matrix, quality gates, local commands, CI ownership, or OASLANA-35
+regression coverage map.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ KiCad Studio Kit is the canonical monorepo for the KiCad Studio VS Code extensio
 - [Product boundaries](architecture/product-boundaries.md)
 - [Release model](architecture/release-model.md)
 - [Branch protection](architecture/branch-protection.md)
-- [Testing strategy](architecture/testing-strategy.md)
+- [Testing strategy](testing-strategy.md)
 - [KiCad Studio and MCP integration](integration/kicad-studio-mcp.md)
 
 - Repository: https://github.com/oaslananka/kicad-studio-kit

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,184 @@
+# Testing Strategy
+
+OASLANA-35 / GitHub issue #36 defines the maximum automated test strategy for
+KiCad Studio Kit. The goal is to make normal development depend on repeatable
+local and CI gates instead of manual VS Code or KiCad inspection after every
+change.
+
+This document is the canonical repository-level testing guide. Product-specific
+notes can add detail, but they should not weaken these gates.
+
+## Gate Summary
+
+| Gate                 | Trigger                                                              | Purpose                                                                                         | Required command                              |
+| -------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Fast PR gate         | Every pull request                                                   | Catch formatting, lint, type, unit, package, metadata, boundary, and compatibility regressions. | `corepack pnpm run check`                     |
+| Product gate         | Product-scoped changes                                               | Prove the touched product still builds, tests, and packages independently.                      | Product commands below                        |
+| Contract gate        | Protocol, compatibility, or cross-product changes                    | Prove extension and MCP assumptions remain aligned.                                             | `corepack pnpm run test:contract`             |
+| Fixture gate         | Parser, diagnostics, command-builder, or KiCad file behavior changes | Prove deterministic KiCad corpus behavior stays stable.                                         | `corepack pnpm run test:fixtures`             |
+| Nightly quality gate | Scheduled and manual workflow                                        | Re-run the repository gate plus contract and fixture gates outside the fast PR path.            | `.github/workflows/nightly-quality-gates.yml` |
+| Manual smoke         | Release candidate only                                               | Final human inspection where automation is not practical.                                       | PR notes must name the exact manual check     |
+
+## Test Layers
+
+| Layer                                 | Scope                                                                                                                                | Owner path                                                               | Runner or API                                                  | Gate                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------ |
+| Static checks                         | Format, lint, typecheck, metadata, product boundaries, version consistency, compatibility matrix, governance self-test.              | Root, `apps/vscode-extension`, `packages/mcp-server`, `packages/mcp-npm` | pnpm, TypeScript, Ruff, mypy, repository scripts               | Fast PR gate                                           |
+| Extension unit tests                  | Project discovery, command builders, diagnostics, state machines, MCP client behavior, webview HTML helpers, parsers.                | `apps/vscode-extension/test/unit/`                                       | Jest                                                           | Fast PR gate                                           |
+| Extension integration tests           | Activation, commands, context keys, diagnostics, project tree, status bar, custom editors, real-server flows.                        | `apps/vscode-extension/test/integration/`                                | `@vscode/test-electron` and VS Code Extension Development Host | Product gate, nightly gate when enabled                |
+| Extension webview and E2E tests       | Viewer state machine, fit and zoom behavior, layer panel, toolbar, loading, error, empty states.                                     | `apps/vscode-extension/test/e2e/`                                        | Playwright                                                     | Product gate or nightly gate based on environment      |
+| Visual regression                     | Schematic and PCB viewer surfaces, sidebars, themes, viewport sizes.                                                                 | `apps/vscode-extension/test/e2e/` snapshot suites                        | Playwright `toHaveScreenshot`                                  | Nightly gate until baselines are stable enough for PRs |
+| Accessibility and keyboard navigation | Activity bar views, custom editors, tree views, status actions, command flows.                                                       | Extension integration and Playwright suites                              | VS Code test host, Playwright accessibility snapshots          | Product gate or nightly gate                           |
+| MCP unit tests                        | Pure Python helpers, tool metadata, routers, server startup, semantic gates, release guards.                                         | `packages/mcp-server/tests/unit/`                                        | pytest                                                         | Fast PR gate                                           |
+| MCP integration tests                 | File-backed KiCad behavior, export/manufacturing tools, project quality gates, simulation and routing tools.                         | `packages/mcp-server/tests/integration/`                                 | pytest plus optional `kicad-cli`                               | Nightly gate unless the fixture is pure and fast       |
+| MCP E2E tests                         | Server startup, stdio, journal/rollback, release-gate workflows.                                                                     | `packages/mcp-server/tests/e2e/`                                         | pytest                                                         | Nightly gate                                           |
+| KiCad CLI contract tests              | KiCad 10 primary behavior plus supported 9.x and deprecated 8.x compatibility where supported.                                       | Shared fixtures and MCP integration tests                                | `kicad-cli`                                                    | Nightly/canary gate                                    |
+| MCP transport contract tests          | Streamable HTTP initialize flow, session handling, stateless behavior, `MCP-Protocol-Version`, tool discovery, errors, and timeouts. | MCP tests and future shared contract package                             | pytest/http client                                             | Contract gate                                          |
+| Real-pair tests                       | Built VS Code extension connected to built MCP server against fixture workspaces.                                                    | Future shared harness                                                    | VS Code test host plus local MCP server                        | Nightly gate                                           |
+| Real KiCad GUI IPC smoke              | KiCad application IPC behavior that cannot be proven headlessly.                                                                     | Dedicated smoke harness                                                  | KiCad GUI plus fixture workspace                               | Nightly only                                           |
+| Release candidate manual smoke        | Marketplace/package artifact sanity only.                                                                                            | PR/release notes                                                         | Human confirmation                                             | Release candidate only                                 |
+
+## Fast PR Gates
+
+Fast gates must be deterministic and must not depend on a manually opened KiCad
+or VS Code desktop session.
+
+Run the complete repository gate before opening or updating a PR that touches
+root tooling, CI, shared compatibility, release policy, or docs:
+
+```bash
+corepack enable
+corepack pnpm install --frozen-lockfile
+uv sync --all-extras --frozen --project packages/mcp-server
+corepack pnpm run check
+```
+
+Extension-only changes use:
+
+```bash
+corepack pnpm run check:kicad-studio
+corepack pnpm run test:kicad-studio
+corepack pnpm run build:kicad-studio
+corepack pnpm run package:kicad-studio
+```
+
+MCP server changes use:
+
+```bash
+uv sync --all-extras --frozen --project packages/mcp-server
+corepack pnpm run check:kicad-mcp-pro
+corepack pnpm run test:kicad-mcp-pro
+corepack pnpm run build:kicad-mcp-pro
+corepack pnpm run package:kicad-mcp-pro
+```
+
+npm wrapper changes use:
+
+```bash
+corepack pnpm run check:mcp-npm
+```
+
+Protocol, compatibility, or cross-product changes use:
+
+```bash
+corepack pnpm run test:contract
+corepack pnpm run test:fixtures
+```
+
+## Nightly Quality Gates
+
+The nightly gate catches slow and environment-sensitive regressions without
+making every PR wait for the heaviest checks. It must stay non-release: no tags,
+no publishing, no marketplace uploads, and no artifact promotion.
+
+The scheduled workflow is `.github/workflows/nightly-quality-gates.yml`. It
+runs on `workflow_dispatch` and a daily cron schedule. The workflow currently
+executes:
+
+```bash
+corepack pnpm run check
+corepack pnpm run test:contract
+corepack pnpm run test:fixtures
+```
+
+As the M1-M4 roadmap lands, extend this workflow in focused PRs:
+
+| Future gate                | Tracking issue | Required behavior                                                                                                              |
+| -------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Shared fixture corpus      | OASLANA-36     | Replace placeholder fixture coverage with a shared deterministic KiCad corpus and golden expected outputs.                     |
+| Unit test expansion        | OASLANA-37     | Cover project discovery, command builders, diagnostics, state machines, and MCP client behavior.                               |
+| MCP protocol contracts     | OASLANA-43     | Cover Streamable HTTP, session headers, stateless mode, tool discovery, errors, timeouts, and ChatGPT connector compatibility. |
+| MCP adapter layer tests    | OASLANA-56     | Verify extension UI and commands use the adapter boundary instead of direct MCP calls.                                         |
+| Server-info contract tests | OASLANA-57     | Verify advertised server-info, capability metadata, and compatibility ranges.                                                  |
+| Real-pair E2E              | OASLANA-75     | Build both products, start the server, launch the extension host, connect them, and validate capability handshakes.            |
+| VS Code canary             | OASLANA-81     | Run current stable, insiders, and minimum supported VS Code versions.                                                          |
+| KiCad canary               | OASLANA-82     | Run primary, supported, deprecated, and prerelease KiCad CLI lanes where practical.                                            |
+
+## Regression Coverage Map
+
+Every bug fix should add an automated regression when practical. If automation
+is not practical, the PR must explain why and include the manual smoke command
+or artifact.
+
+| Issue      | Risk covered                                                                    | Required test layer                                                        |
+| ---------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| OASLANA-35 | Missing repository-level testing strategy and quality gates.                    | `docs/testing-strategy.md` plus `corepack pnpm run check:testing-strategy` |
+| OASLANA-36 | KiCad file parser or quality-gate regressions that lack deterministic fixtures. | Shared KiCad fixture corpus and golden expected outputs                    |
+| OASLANA-37 | Extension helpers regressing without unit coverage.                             | Jest unit suites under `apps/vscode-extension/test/unit/`                  |
+| OASLANA-43 | MCP transport/session compatibility regressions.                                | MCP contract tests for Streamable HTTP and `MCP-Protocol-Version` behavior |
+| OASLANA-56 | Extension code bypassing the MCP adapter boundary.                              | Adapter unit tests plus integration tests for UI and command calls         |
+| OASLANA-57 | MCP server-info or capability metadata drift.                                   | Server-info and compatibility contract tests                               |
+| OASLANA-75 | Extension and MCP server passing independently but failing as a pair.           | Real-pair E2E tests                                                        |
+| OASLANA-16 | Schematic viewer rendering as a tiny low-resolution thumbnail.                  | Playwright viewer fit tests plus visual regression snapshots               |
+| OASLANA-20 | Project tree duplicate rows or unclear file state indicators.                   | Extension integration tests for project tree model and labels              |
+| OASLANA-68 | Stale state across project, diagnostics, viewer, MCP, and export surfaces.      | State-store unit tests plus integration checks for derived UI state        |
+| OASLANA-63 | Ownership or branch protection drift.                                           | CODEOWNERS/policy validation and PR checklist checks                       |
+| OASLANA-64 | Supply-chain regressions in both products and artifacts.                        | Security workflow, package validation, audit, and provenance checks        |
+| OASLANA-81 | VS Code runtime/API compatibility regressions.                                  | Scheduled VS Code stable/insiders/minimum canary lane                      |
+| OASLANA-82 | KiCad CLI/file-format compatibility regressions.                                | Scheduled KiCad version canary lane                                        |
+
+## Local Commands
+
+Use the narrowest command first while developing, then run the broader gate
+before pushing.
+
+| Change type                    | Narrow command                                                                                              | Broad command                                  |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Root docs or governance        | `corepack pnpm run check:testing-strategy`                                                                  | `corepack pnpm run check`                      |
+| Extension unit behavior        | `corepack pnpm --filter kicadstudio run test:unit -- <test file>`                                           | `corepack pnpm run check:kicad-studio`         |
+| Extension integration behavior | `corepack pnpm --filter kicadstudio run test:integration`                                                   | `corepack pnpm run check:kicad-studio`         |
+| Extension webview/E2E behavior | `corepack pnpm --filter kicadstudio run test:e2e`                                                           | Nightly quality gate once snapshots are stable |
+| MCP unit behavior              | `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/<test_file>.py -q` | `corepack pnpm run check:kicad-mcp-pro`        |
+| MCP full behavior              | `corepack pnpm --dir packages/mcp-server run test`                                                          | `corepack pnpm run check:kicad-mcp-pro`        |
+| Protocol or compatibility      | `corepack pnpm run test:contract`                                                                           | `corepack pnpm run check`                      |
+| Fixtures                       | `corepack pnpm run test:fixtures`                                                                           | `corepack pnpm run check`                      |
+
+## CI Ownership
+
+CI ownership follows product boundaries:
+
+- `.github/workflows/ci.yml` owns fast PR lanes for metadata, extension, MCP
+  server, npm wrapper, and forbidden reference checks.
+- `.github/workflows/security.yml`, `.github/workflows/gitleaks.yml`, and
+  `.github/workflows/codeql.yml` own security and static analysis lanes.
+- `.github/workflows/nightly-quality-gates.yml` owns the non-release scheduled
+  quality gate.
+- Product-specific validation remains inside each product package so the root
+  workflow can compose it without direct source imports between products.
+
+## Source Verification
+
+This strategy was checked against current primary sources:
+
+- VS Code extension testing docs for Extension Development Host and
+  `@vscode/test-electron`.
+- VS Code webview UX guidance for constrained webview usage and native UI
+  preference.
+- Playwright visual comparison docs for `toHaveScreenshot`, snapshot naming,
+  and snapshot update flow.
+- KiCad 10 command-line documentation for `kicad-cli` driven ERC, DRC, export,
+  and version checks.
+- Model Context Protocol 2025-06-18 transport docs for Streamable HTTP,
+  session handling, and `MCP-Protocol-Version`.
+- GitHub Actions workflow syntax docs for scheduled and manually dispatched
+  non-release quality gates.

--- a/examples/led-basic/KICAD_TEST.kicad_pcb
+++ b/examples/led-basic/KICAD_TEST.kicad_pcb
@@ -87,482 +87,482 @@
 	)
 	(gr_rect (start 45 45) (end 75 58) (stroke (width 0.1) (type solid)) (fill no) (layer "Edge.Cuts") (uuid "22222222-2222-4222-8222-222222222001"))
 	(gr_text "KiCad Studio Test" (at 60 46.5 0) (layer "F.SilkS") (uuid "22222222-2222-4222-8222-222222222002") (effects (font (size 1.1 1.1) (thickness 0.15))))
-	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"	
-		(version 20260206)	
-		(generator "kicad-footprint-generator")	
+	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
 		(layer "F.Cu")
 		(at 50 50 0)
-		(uuid "22222222-2222-4222-8222-222222222010")	
-		(descr "Through hole straight pin header, 1x02, 2.54mm pitch, single row")	
-		(tags "Through hole pin header THT 1x02 2.54mm single row")	
-		(property "Reference" "J1"	
-			(at 0 -2.38 0)	
-			(layer "F.SilkS")	
-			(effects	
-				(font	
-					(size 1 1)	
-					(thickness 0.15)	
-				)	
-			)	
-		)	
-		(property "Value" "POWER_IN"	
-			(at 0 4.92 0)	
-			(layer "F.Fab")	
-			(effects	
-				(font	
-					(size 1 1)	
-					(thickness 0.15)	
-				)	
-			)	
-		)	
-		(property "KiLib_Generator" "connector/pin_header_socket"	
-			(at 0 0 0)	
-			(layer "F.SilkS")	
-			(hide yes)	
-			(effects	
-				(font	
-					(size 1 1)	
-					(thickness 0.15)	
-				)	
-			)	
-		)	
-		(attr through_hole)	
-		(duplicate_pad_numbers_are_jumpers no)	
-		(fp_line	
-			(start -1.38 -1.38)	
-			(end 0 -1.38)	
-			(stroke	
-				(width 0.12)	
-				(type solid)	
-			)	
-			(layer "F.SilkS")	
-		)	
-		(fp_line	
-			(start -1.38 0)	
-			(end -1.38 -1.38)	
-			(stroke	
-				(width 0.12)	
-				(type solid)	
-			)	
-			(layer "F.SilkS")	
-		)	
-		(fp_line	
-			(start -1.38 1.27)	
-			(end -1.38 3.92)	
-			(stroke	
-				(width 0.12)	
-				(type solid)	
-			)	
-			(layer "F.SilkS")	
-		)	
-		(fp_line	
-			(start -1.38 1.27)	
-			(end 1.38 1.27)	
-			(stroke	
-				(width 0.12)	
-				(type solid)	
-			)	
-			(layer "F.SilkS")	
-		)	
-		(fp_line	
-			(start -1.38 3.92)	
-			(end 1.38 3.92)	
-			(stroke	
-				(width 0.12)	
-				(type solid)	
-			)	
-			(layer "F.SilkS")	
-		)	
-		(fp_line	
-			(start 1.38 1.27)	
-			(end 1.38 3.92)	
-			(stroke	
-				(width 0.12)	
-				(type solid)	
-			)	
-			(layer "F.SilkS")	
-		)	
-		(fp_rect	
-			(start -1.77 -1.77)	
-			(end 1.77 4.32)	
-			(stroke	
-				(width 0.05)	
-				(type solid)	
-			)	
-			(fill no)	
-			(layer "F.CrtYd")	
-		)	
-		(fp_line	
-			(start -1.27 -0.635)	
-			(end -0.635 -1.27)	
-			(stroke	
-				(width 0.1)	
-				(type solid)	
-			)	
-			(layer "F.Fab")	
-		)	
-		(fp_line	
-			(start -1.27 3.81)	
-			(end -1.27 -0.635)	
-			(stroke	
-				(width 0.1)	
-				(type solid)	
-			)	
-			(layer "F.Fab")	
-		)	
-		(fp_line	
-			(start -0.635 -1.27)	
-			(end 1.27 -1.27)	
-			(stroke	
-				(width 0.1)	
-				(type solid)	
-			)	
-			(layer "F.Fab")	
-		)	
-		(fp_line	
-			(start 1.27 -1.27)	
-			(end 1.27 3.81)	
-			(stroke	
-				(width 0.1)	
-				(type solid)	
-			)	
-			(layer "F.Fab")	
-		)	
-		(fp_line	
-			(start 1.27 3.81)	
-			(end -1.27 3.81)	
-			(stroke	
-				(width 0.1)	
-				(type solid)	
-			)	
-			(layer "F.Fab")	
-		)	
-		(fp_text user "${REFERENCE}"	
-			(at 0 1.27 90)	
-			(layer "F.Fab")	
-			(effects	
-				(font	
-					(size 1 1)	
-					(thickness 0.15)	
-				)	
-			)	
-		)	
-		(pad "1" thru_hole rect	
-			(at 0 0)	
-			(size 1.7 1.7)	
-			(drill 1)	
-			(layers "*.Cu" "*.Mask")	
-			(remove_unused_layers no)	
-		
+		(uuid "22222222-2222-4222-8222-222222222010")
+		(descr "Through hole straight pin header, 1x02, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x02 2.54mm single row")
+		(property "Reference" "J1"
+			(at 0 -2.38 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "POWER_IN"
+			(at 0 4.92 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "connector/pin_header_socket"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.38 -1.38)
+			(end 0 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 0)
+			(end -1.38 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end -1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end 1.38 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 3.92)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1.38 1.27)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.77 -1.77)
+			(end 1.77 4.32)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1.27 3.81)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 3.81)
+			(end -1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 1.27 90)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole rect
+			(at 0 0)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
 			(net "/VIN")
 			(pinfunction "Pin_1")
-			(pintype "passive"))	
-		(pad "2" thru_hole circle	
-			(at 0 2.54)	
-			(size 1.7 1.7)	
-			(drill 1)	
-			(layers "*.Cu" "*.Mask")	
-			(remove_unused_layers no)	
-		
+			(pintype "passive"))
+		(pad "2" thru_hole circle
+			(at 0 2.54)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
 			(net "GND")
 			(pinfunction "Pin_2")
-			(pintype "passive"))	
-		(embedded_fonts no)	
-		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"	
-			(offset	
-				(xyz 0 0 0)	
-			)	
-			(scale	
-				(xyz 1 1 1)	
-			)	
-			(rotate	
-				(xyz 0 0 0)	
-			)	
-		)	
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 	)
-	(footprint "Resistor_SMD:R_0805_2012Metric"	
-		(version 20260206)	
-		(generator "kicad-footprint-generator")	
+	(footprint "Resistor_SMD:R_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
 		(layer "F.Cu")
 		(at 60 50 0)
-		(uuid "22222222-2222-4222-8222-222222222020")	
-		(descr "Resistor SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: IPC-SM-782 page 72, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf)")	
-		(tags "resistor")	
-		(property "Reference" "R1"	
-			(at 0 -1.65 0)	
-			(layer "F.SilkS")	
-			(effects	
-				(font	
-					(size 1 1)	
-					(thickness 0.15)	
-				)	
-			)	
-		)	
-		(property "Value" "1k"	
-			(at 0 1.65 0)	
-			(layer "F.Fab")	
-			(effects	
-				(font	
-					(size 1 1)	
-					(thickness 0.15)	
-				)	
-			)	
-		)	
-		(property "KiLib_Generator" "SMD_2terminal_chip_molded"	
-			(at 0 0 0)	
-			(layer "F.SilkS")	
-			(hide yes)	
-			(effects	
-				(font	
-					(size 1 1)	
-					(thickness 0.15)	
-				)	
-			)	
-		)	
-		(attr smd)	
-		(duplicate_pad_numbers_are_jumpers no)	
-		(fp_line	
-			(start -0.227064 -0.735)	
-			(end 0.227064 -0.735)	
-			(stroke	
-				(width 0.12)	
-				(type solid)	
-			)	
-			(layer "F.SilkS")	
-		)	
-		(fp_line	
-			(start -0.227064 0.735)	
-			(end 0.227064 0.735)	
-			(stroke	
-				(width 0.12)	
-				(type solid)	
-			)	
-			(layer "F.SilkS")	
-		)	
-		(fp_rect	
-			(start -1.68 -0.95)	
-			(end 1.68 0.95)	
-			(stroke	
-				(width 0.05)	
-				(type solid)	
-			)	
-			(fill no)	
-			(layer "F.CrtYd")	
-		)	
-		(fp_rect	
-			(start -1 -0.625)	
-			(end 1 0.625)	
-			(stroke	
-				(width 0.1)	
-				(type solid)	
-			)	
-			(fill no)	
-			(layer "F.Fab")	
-		)	
-		(fp_text user "${REFERENCE}"	
-			(at 0 0 0)	
-			(layer "F.Fab")	
-			(effects	
-				(font	
-					(size 0.5 0.5)	
-					(thickness 0.08)	
-				)	
-			)	
-		)	
-		(pad "1" smd roundrect	
-			(at -0.9125 0)	
-			(size 1.025 1.4)	
-			(layers "F.Cu" "F.Mask" "F.Paste")	
-			(roundrect_rratio 0.243902)	
-		
+		(uuid "22222222-2222-4222-8222-222222222020")
+		(descr "Resistor SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: IPC-SM-782 page 72, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf)")
+		(tags "resistor")
+		(property "Reference" "R1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.227064 -0.735)
+			(end 0.227064 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -0.227064 0.735)
+			(end 0.227064 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_rect
+			(start -1 -0.625)
+			(end 1 0.625)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
 			(net "/VIN")
 			(pinfunction "1")
-			(pintype "passive"))	
-		(pad "2" smd roundrect	
-			(at 0.9125 0)	
-			(size 1.025 1.4)	
-			(layers "F.Cu" "F.Mask" "F.Paste")	
-			(roundrect_rratio 0.243902)	
-		
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
 			(net "/LED_A")
 			(pinfunction "2")
-			(pintype "passive"))	
-		(embedded_fonts no)	
-		(model "${KICAD10_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0805_2012Metric.step"	
-			(offset	
-				(xyz 0 0 0)	
-			)	
-			(scale	
-				(xyz 1 1 1)	
-			)	
-			(rotate	
-				(xyz 0 0 0)	
-			)	
-		)	
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 	)
-	(footprint "LED_SMD:LED_0805_2012Metric"	
-		(version 20260206)	
-		(generator "kicad-footprint-generator")	
+	(footprint "LED_SMD:LED_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
 		(layer "F.Cu")
 		(at 68 50 0)
-		(uuid "22222222-2222-4222-8222-222222222030")	
-		(descr "LED SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: https://docs.google.com/spreadsheets/d/1BsfQQcO9C6DZCsRaXUlFlo91Tg2WpOkGARC1WS5S8t0/edit?usp=sharing)")	
-		(tags "LED")	
-		(property "Reference" "D1"	
-			(at 0 -1.65 0)	
-			(layer "F.SilkS")	
-			(effects	
-				(font	
-					(size 1 1)	
-					(thickness 0.15)	
-				)	
-			)	
-		)	
-		(property "Value" "GREEN"	
-			(at 0 1.65 0)	
-			(layer "F.Fab")	
-			(effects	
-				(font	
-					(size 1 1)	
-					(thickness 0.15)	
-				)	
-			)	
-		)	
-		(property "KiLib_Generator" "SMD_2terminal_chip_molded"	
-			(at 0 0 0)	
-			(layer "F.SilkS")	
-			(hide yes)	
-			(effects	
-				(font	
-					(size 1 1)	
-					(thickness 0.15)	
-				)	
-			)	
-		)	
-		(attr smd)	
-		(duplicate_pad_numbers_are_jumpers no)	
-		(fp_line	
-			(start -1.685 -0.96)	
-			(end -1.685 0.96)	
-			(stroke	
-				(width 0.12)	
-				(type solid)	
-			)	
-			(layer "F.SilkS")	
-		)	
-		(fp_line	
-			(start -1.685 0.96)	
-			(end 1 0.96)	
-			(stroke	
-				(width 0.12)	
-				(type solid)	
-			)	
-			(layer "F.SilkS")	
-		)	
-		(fp_line	
-			(start 1 -0.96)	
-			(end -1.685 -0.96)	
-			(stroke	
-				(width 0.12)	
-				(type solid)	
-			)	
-			(layer "F.SilkS")	
-		)	
-		(fp_rect	
-			(start -1.68 -0.95)	
-			(end 1.68 0.95)	
-			(stroke	
-				(width 0.05)	
-				(type solid)	
-			)	
-			(fill no)	
-			(layer "F.CrtYd")	
-		)	
-		(fp_line	
-			(start -1 -0.3)	
-			(end -1 0.6)	
-			(stroke	
-				(width 0.1)	
-				(type solid)	
-			)	
-			(layer "F.Fab")	
-		)	
-		(fp_line	
-			(start -1 0.6)	
-			(end 1 0.6)	
-			(stroke	
-				(width 0.1)	
-				(type solid)	
-			)	
-			(layer "F.Fab")	
-		)	
-		(fp_line	
-			(start -0.7 -0.6)	
-			(end -1 -0.3)	
-			(stroke	
-				(width 0.1)	
-				(type solid)	
-			)	
-			(layer "F.Fab")	
-		)	
-		(fp_line	
-			(start 1 -0.6)	
-			(end -0.7 -0.6)	
-			(stroke	
-				(width 0.1)	
-				(type solid)	
-			)	
-			(layer "F.Fab")	
-		)	
-		(fp_line	
-			(start 1 0.6)	
-			(end 1 -0.6)	
-			(stroke	
-				(width 0.1)	
-				(type solid)	
-			)	
-			(layer "F.Fab")	
-		)	
-		(fp_text user "${REFERENCE}"	
-			(at 0 0 0)	
-			(layer "F.Fab")	
-			(effects	
-				(font	
-					(size 0.5 0.5)	
-					(thickness 0.08)	
-				)	
-			)	
-		)	
-		(pad "1" smd roundrect	
-			(at -0.9375 0)	
-			(size 0.975 1.4)	
-			(layers "F.Cu" "F.Mask" "F.Paste")	
-			(roundrect_rratio 0.25)	
-		
+		(uuid "22222222-2222-4222-8222-222222222030")
+		(descr "LED SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: https://docs.google.com/spreadsheets/d/1BsfQQcO9C6DZCsRaXUlFlo91Tg2WpOkGARC1WS5S8t0/edit?usp=sharing)")
+		(tags "LED")
+		(property "Reference" "D1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GREEN"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.685 -0.96)
+			(end -1.685 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.685 0.96)
+			(end 1 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1 -0.96)
+			(end -1.685 -0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1 -0.3)
+			(end -1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1 0.6)
+			(end 1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.7 -0.6)
+			(end -1 -0.3)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 -0.6)
+			(end -0.7 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 0.6)
+			(end 1 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
 			(net "GND")
 			(pinfunction "K")
-			(pintype "passive"))	
-		(pad "2" smd roundrect	
-			(at 0.9375 0)	
-			(size 0.975 1.4)	
-			(layers "F.Cu" "F.Mask" "F.Paste")	
-			(roundrect_rratio 0.25)	
-		
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
 			(net "/LED_A")
 			(pinfunction "A")
-			(pintype "passive"))	
-		(embedded_fonts no)	
-		(model "${KICAD10_3DMODEL_DIR}/LED_SMD.3dshapes/LED_0805_2012Metric.step"	
-			(offset	
-				(xyz 0 0 0)	
-			)	
-			(scale	
-				(xyz 1 1 1)	
-			)	
-			(rotate	
-				(xyz 0 0 0)	
-			)	
-		)	
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/LED_SMD.3dshapes/LED_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
 	)
 	(segment (start 50 50) (end 59.0875 50) (width 0.35) (layer "F.Cu") (net "/VIN") (uuid "22222222-2222-4222-8222-222222222040"))
 	(segment (start 60.9125 50) (end 60.9125 47.5) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222041"))

--- a/examples/led-basic/KICAD_TEST.kicad_sch
+++ b/examples/led-basic/KICAD_TEST.kicad_sch
@@ -243,999 +243,999 @@
 		(embedded_fonts no)
 	)
 		(symbol "Connector_Generic:Conn_01x02"
-		
+
 				(pin_names
-		
+
 					(offset 1.016)
-		
+
 					(hide yes)
-		
+
 				)
-		
+
 				(exclude_from_sim no)
-		
+
 				(in_bom yes)
-		
+
 				(on_board yes)
-		
+
 				(in_pos_files yes)
-		
+
 				(duplicate_pin_numbers_are_jumpers no)
-		
+
 				(property "Reference" "J"
-		
+
 					(at 0 2.54 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Value" "Conn_01x02"
-		
+
 					(at 0 -5.08 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Footprint" ""
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Datasheet" ""
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "ki_keywords" "connector"
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "ki_fp_filters" "Connector*:*_1x??_*"
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(symbol "Conn_01x02_1_1"
-		
+
 					(rectangle
-		
+
 						(start -1.27 1.27)
-		
+
 						(end 1.27 -3.81)
-		
+
 						(stroke
-		
+
 							(width 0.254)
-		
+
 							(type default)
-		
+
 						)
-		
+
 						(fill
-		
+
 							(type background)
-		
+
 						)
-		
+
 					)
-		
+
 					(rectangle
-		
+
 						(start -1.27 0.127)
-		
+
 						(end 0 -0.127)
-		
+
 						(stroke
-		
+
 							(width 0.1524)
-		
+
 							(type default)
-		
+
 						)
-		
+
 						(fill
-		
+
 							(type none)
-		
+
 						)
-		
+
 					)
-		
+
 					(rectangle
-		
+
 						(start -1.27 -2.413)
-		
+
 						(end 0 -2.667)
-		
+
 						(stroke
-		
+
 							(width 0.1524)
-		
+
 							(type default)
-		
+
 						)
-		
+
 						(fill
-		
+
 							(type none)
-		
+
 						)
-		
+
 					)
-		
+
 					(pin passive line
-		
+
 						(at -5.08 0 0)
-		
+
 						(length 3.81)
-		
+
 						(name "Pin_1"
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 						(number "1"
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 					)
-		
+
 					(pin passive line
-		
+
 						(at -5.08 -2.54 0)
-		
+
 						(length 3.81)
-		
+
 						(name "Pin_2"
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 						(number "2"
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(embedded_fonts no)
-		
+
 			)
 		(symbol "Device:LED"
-		
+
 				(pin_numbers
-		
+
 					(hide yes)
-		
+
 				)
-		
+
 				(pin_names
-		
+
 					(offset 1.016)
-		
+
 					(hide yes)
-		
+
 				)
-		
+
 				(exclude_from_sim no)
-		
+
 				(in_bom yes)
-		
+
 				(on_board yes)
-		
+
 				(in_pos_files yes)
-		
+
 				(duplicate_pin_numbers_are_jumpers no)
-		
+
 				(property "Reference" "D"
-		
+
 					(at 0 2.54 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Value" "LED"
-		
+
 					(at 0 -2.54 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Footprint" ""
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Datasheet" ""
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Description" "Light emitting diode"
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Sim.Pins" "1=K 2=A"
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "ki_keywords" "LED diode"
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(symbol "LED_0_1"
-		
+
 					(polyline
-		
+
 						(pts
-		
+
 							(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
-		
+
 						)
-		
+
 						(stroke
-		
+
 							(width 0)
-		
+
 							(type default)
-		
+
 						)
-		
+
 						(fill
-		
+
 							(type none)
-		
+
 						)
-		
+
 					)
-		
+
 					(polyline
-		
+
 						(pts
-		
+
 							(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
-		
+
 						)
-		
+
 						(stroke
-		
+
 							(width 0)
-		
+
 							(type default)
-		
+
 						)
-		
+
 						(fill
-		
+
 							(type none)
-		
+
 						)
-		
+
 					)
-		
+
 					(polyline
-		
+
 						(pts
-		
+
 							(xy -1.27 0) (xy 1.27 0)
-		
+
 						)
-		
+
 						(stroke
-		
+
 							(width 0)
-		
+
 							(type default)
-		
+
 						)
-		
+
 						(fill
-		
+
 							(type none)
-		
+
 						)
-		
+
 					)
-		
+
 					(polyline
-		
+
 						(pts
-		
+
 							(xy -1.27 -1.27) (xy -1.27 1.27)
-		
+
 						)
-		
+
 						(stroke
-		
+
 							(width 0.254)
-		
+
 							(type default)
-		
+
 						)
-		
+
 						(fill
-		
+
 							(type none)
-		
+
 						)
-		
+
 					)
-		
+
 					(polyline
-		
+
 						(pts
-		
+
 							(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
-		
+
 						)
-		
+
 						(stroke
-		
+
 							(width 0.254)
-		
+
 							(type default)
-		
+
 						)
-		
+
 						(fill
-		
+
 							(type none)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(symbol "LED_1_1"
-		
+
 					(pin passive line
-		
+
 						(at -3.81 0 0)
-		
+
 						(length 2.54)
-		
+
 						(name "K"
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 						(number "1"
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 					)
-		
+
 					(pin passive line
-		
+
 						(at 3.81 0 180)
-		
+
 						(length 2.54)
-		
+
 						(name "A"
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 						(number "2"
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(embedded_fonts no)
-		
+
 			)
 		(symbol "Device:R"
-		
+
 				(pin_numbers
-		
+
 					(hide yes)
-		
+
 				)
-		
+
 				(pin_names
-		
+
 					(offset 0)
-		
+
 				)
-		
+
 				(exclude_from_sim no)
-		
+
 				(in_bom yes)
-		
+
 				(on_board yes)
-		
+
 				(in_pos_files yes)
-		
+
 				(duplicate_pin_numbers_are_jumpers no)
-		
+
 				(property "Reference" "R"
-		
+
 					(at 2.032 0 90)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Value" "R"
-		
+
 					(at 0 0 90)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Footprint" ""
-		
+
 					(at -1.778 0 90)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Datasheet" ""
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "Description" "Resistor"
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "ki_keywords" "R res resistor"
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(property "ki_fp_filters" "R_*"
-		
+
 					(at 0 0 0)
-		
+
 					(show_name no)
-		
+
 					(do_not_autoplace no)
-		
+
 					(hide yes)
-		
+
 					(effects
-		
+
 						(font
-		
+
 							(size 1.27 1.27)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(symbol "R_0_1"
-		
+
 					(rectangle
-		
+
 						(start -1.016 -2.54)
-		
+
 						(end 1.016 2.54)
-		
+
 						(stroke
-		
+
 							(width 0.254)
-		
+
 							(type default)
-		
+
 						)
-		
+
 						(fill
-		
+
 							(type none)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(symbol "R_1_1"
-		
+
 					(pin passive line
-		
+
 						(at 0 3.81 270)
-		
+
 						(length 1.27)
-		
+
 						(name ""
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 						(number "1"
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 					)
-		
+
 					(pin passive line
-		
+
 						(at 0 -3.81 90)
-		
+
 						(length 1.27)
-		
+
 						(name ""
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 						(number "2"
-		
+
 							(effects
-		
+
 								(font
-		
+
 									(size 1.27 1.27)
-		
+
 								)
-		
+
 							)
-		
+
 						)
-		
+
 					)
-		
+
 				)
-		
+
 				(embedded_fonts no)
-		
+
 			)
 	)
 	(wire (pts (xy 45.72 76.2) (xy 60.96 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111201"))

--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
     "check:version": "node scripts/check-version-consistency.mjs",
     "check:compatibility": "uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/check_compatibility_matrix.py",
     "check:governance": "node scripts/sync-governance-project-items.mjs --self-test",
+    "check:testing-strategy": "node scripts/check-testing-strategy.mjs",
     "check:publish": "node scripts/check-publish-preflight.mjs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:governance && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:governance && pnpm run check:testing-strategy && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.0",

--- a/scripts/check-testing-strategy.mjs
+++ b/scripts/check-testing-strategy.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const strategyPath = path.join(root, "docs", "testing-strategy.md");
+const packagePath = path.join(root, "package.json");
+const nightlyWorkflowPath = path.join(
+  root,
+  ".github",
+  "workflows",
+  "nightly-quality-gates.yml",
+);
+
+const requiredSections = [
+  "# Testing Strategy",
+  "## Gate Summary",
+  "## Test Layers",
+  "## Fast PR Gates",
+  "## Nightly Quality Gates",
+  "## Regression Coverage Map",
+  "## Local Commands",
+  "## CI Ownership",
+  "## Source Verification",
+];
+
+const requiredPhrases = [
+  "OASLANA-35",
+  "GitHub issue #36",
+  "corepack pnpm run check",
+  "corepack pnpm run check:kicad-studio",
+  "corepack pnpm run test:kicad-studio",
+  "corepack pnpm run build:kicad-studio",
+  "corepack pnpm run package:kicad-studio",
+  "uv sync --all-extras --frozen --project packages/mcp-server",
+  "corepack pnpm run check:kicad-mcp-pro",
+  "corepack pnpm run test:kicad-mcp-pro",
+  "corepack pnpm run build:kicad-mcp-pro",
+  "corepack pnpm run package:kicad-mcp-pro",
+  "corepack pnpm run check:mcp-npm",
+  "corepack pnpm run test:contract",
+  "corepack pnpm run test:fixtures",
+  "@vscode/test-electron",
+  "Playwright",
+  "toHaveScreenshot",
+  "kicad-cli",
+  "Streamable HTTP",
+  "MCP-Protocol-Version",
+  "visual regression",
+  "accessibility",
+  "manual smoke",
+];
+
+const roadmapIssueIds = [
+  "OASLANA-35",
+  "OASLANA-36",
+  "OASLANA-37",
+  "OASLANA-43",
+  "OASLANA-56",
+  "OASLANA-57",
+  "OASLANA-75",
+  "OASLANA-16",
+  "OASLANA-20",
+  "OASLANA-68",
+  "OASLANA-63",
+  "OASLANA-64",
+  "OASLANA-81",
+  "OASLANA-82",
+];
+
+function readText(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    throw new Error(
+      `Missing required file ${path.relative(root, filePath)}: ${error.message}`,
+    );
+  }
+}
+
+function assertIncludes(haystack, needle, source) {
+  if (!haystack.includes(needle)) {
+    throw new Error(`${source} must include ${JSON.stringify(needle)}`);
+  }
+}
+
+const strategy = readText(strategyPath);
+const packageJson = JSON.parse(readText(packagePath));
+const nightlyWorkflow = readText(nightlyWorkflowPath);
+
+for (const section of requiredSections) {
+  assertIncludes(strategy, section, "docs/testing-strategy.md");
+}
+
+for (const phrase of requiredPhrases) {
+  assertIncludes(strategy, phrase, "docs/testing-strategy.md");
+}
+
+for (const issueId of roadmapIssueIds) {
+  assertIncludes(
+    strategy,
+    issueId,
+    "docs/testing-strategy.md regression coverage map",
+  );
+}
+
+const scripts = packageJson.scripts ?? {};
+if (
+  scripts["check:testing-strategy"] !==
+  "node scripts/check-testing-strategy.mjs"
+) {
+  throw new Error("package.json must define check:testing-strategy");
+}
+
+if (!scripts.check?.includes("pnpm run check:testing-strategy")) {
+  throw new Error("package.json check must run check:testing-strategy");
+}
+
+assertIncludes(
+  nightlyWorkflow,
+  "name: Nightly Quality Gates",
+  "nightly-quality-gates workflow",
+);
+assertIncludes(nightlyWorkflow, "cron:", "nightly-quality-gates workflow");
+assertIncludes(
+  nightlyWorkflow,
+  "corepack pnpm run check",
+  "nightly-quality-gates workflow",
+);
+assertIncludes(
+  nightlyWorkflow,
+  "corepack pnpm run test:contract",
+  "nightly-quality-gates workflow",
+);
+assertIncludes(
+  nightlyWorkflow,
+  "corepack pnpm run test:fixtures",
+  "nightly-quality-gates workflow",
+);


### PR DESCRIPTION
## Summary
- Defines the canonical OASLANA-35 / GitHub #36 testing strategy in `docs/testing-strategy.md`.
- Adds `scripts/check-testing-strategy.mjs` and wires it into root `pnpm check` so the strategy, regression map, commands, and nightly workflow stay present.
- Adds a non-release `Nightly Quality Gates` workflow for scheduled/manual repository validation.
- Updates docs navigation to the canonical testing strategy.
- Normalizes existing `examples/led-basic` KiCad files via the repository pre-commit trailing-whitespace hook.

Linear: OASLANA-35
Closes #36

## Validation
- `node scripts/check-testing-strategy.mjs` failed before `docs/testing-strategy.md` existed, proving the new guard covered the missing strategy document.
- `PATH="/home/goskyturkey/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" corepack pnpm run check:testing-strategy`
- `PATH="/home/goskyturkey/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" corepack pnpm exec prettier --check README.md docs/index.md docs/architecture/testing-strategy.md docs/testing-strategy.md package.json scripts/check-testing-strategy.mjs .github/workflows/nightly-quality-gates.yml`
- `/tmp/codex-tools/actionlint/actionlint .github/workflows/nightly-quality-gates.yml`
- `uvx yamllint .github/workflows/nightly-quality-gates.yml`
- `rg -n '::set-output|::save-state|ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION|node12|node16|node20' .github/workflows .github/actions action.yml action.yaml 2>/dev/null || true`
- `PATH="/home/goskyturkey/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/tmp/codex-tools/actionlint:$PATH" corepack pnpm run check` (run twice after pre-commit normalized fixtures)
- `uvx pre-commit run --all-files`
- `git diff --check`

## Notes
- No release, tag, package publish, or release bot PR change was made.
- Local `act -l` could not run because `act` is not installed in this environment.
- The two KiCad example file diffs are pre-commit whitespace/EOF normalization only.

## Freshness / deprecation checks
- Checked official VS Code extension testing docs, VS Code webview UX docs, Playwright visual snapshot docs, KiCad 10 CLI docs, MCP 2025-06-18 transport docs, and GitHub Actions workflow syntax docs.
- Resolved Playwright docs via Context7 for current `toHaveScreenshot` / snapshot workflow guidance.
- Reused existing pinned checkout/setup-node/setup-uv action commits and verified the workflow contains no deprecated Node action runtime strings or deprecated workflow command strings.
