### PR TITLE
docs(repo): audit M0 completion

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,4 +16,5 @@ Detailed architecture documents:
 - [Branch protection](architecture/branch-protection.md)
 - [Testing strategy](architecture/testing-strategy.md)
 - [Migration phases](architecture/migration-phases.md)
+- [M0 completion audit](architecture/m0-completion-audit.md)
 - [KiCad Studio and MCP integration](integration/kicad-studio-mcp.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,8 @@ Detailed architecture documents:
 - [Product boundaries](architecture/product-boundaries.md)
 - [Release model](architecture/release-model.md)
 - [Branch protection](architecture/branch-protection.md)
+- [Governance board model](architecture/governance-board.md)
+- [Definition of done](architecture/definition-of-done.md)
 - [Testing strategy](architecture/testing-strategy.md)
 - [Migration phases](architecture/migration-phases.md)
 - [M0 completion audit](architecture/m0-completion-audit.md)

--- a/docs/architecture/governance-board.md
+++ b/docs/architecture/governance-board.md
@@ -30,6 +30,8 @@ Issues:
 - #68 Add machine-readable compatibility matrix
 - #79 Define coding-agent execution policy and issue resolution order
 
+Completion evidence: [M0 completion audit](m0-completion-audit.md).
+
 ### M1 — Test Foundation
 
 Testing infrastructure and deterministic fixture coverage.

--- a/docs/architecture/m0-completion-audit.md
+++ b/docs/architecture/m0-completion-audit.md
@@ -1,0 +1,45 @@
+# M0 Completion Audit
+
+Audit date: 2026-05-21 (Europe/Istanbul)
+
+Scope: Linear OASLANA-90, GitHub milestone
+[#1](https://github.com/oaslananka/kicad-studio-kit/milestone/1), and the
+M0 Monorepo Foundation workstream.
+
+## Conclusion
+
+M0 is complete. The GitHub M0 milestone has zero open issues and all eight
+tracked foundation issues are closed. The Linear M0 project can be marked
+complete after this audit PR lands.
+
+Release-related follow-up PRs are not M0 implementation blockers:
+
+- [#94](https://github.com/oaslananka/kicad-studio-kit/pull/94) is the
+  product-scoped release PR for the VS Code extension.
+- [#95](https://github.com/oaslananka/kicad-studio-kit/pull/95) is the
+  grouped product-scoped release PR for KiCad MCP Pro libraries.
+- [#16](https://github.com/oaslananka/kicad-studio-kit/pull/16) is the
+  superseded monolithic release PR and remains read-only until maintainers
+  decide how to retire it.
+
+## Acceptance Evidence
+
+| Requirement                        | Evidence                                                                                                                                                                                                                                                                                                                                                                                                  | Status   |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Monorepo folder structure complete | `apps/vscode-extension`, `packages/mcp-server`, and `packages/mcp-npm` are the documented product roots in [Repository structure](repo-structure.md). GitHub issues [#49](https://github.com/oaslananka/kicad-studio-kit/issues/49) and [#56](https://github.com/oaslananka/kicad-studio-kit/issues/56) are closed.                                                                                       | Complete |
+| Ownership boundaries enforced      | Allowed and forbidden product dependencies are documented in [Product boundaries](product-boundaries.md), CODEOWNERS covers product workspaces, and the root `check` command runs `check:boundaries`. GitHub issue [#50](https://github.com/oaslananka/kicad-studio-kit/issues/50) is closed.                                                                                                             | Complete |
+| Product-scoped scripts exist       | Root scripts expose product-specific check, test, build, package, and release dry-run commands for the extension, MCP server, and npm wrapper. GitHub issue [#51](https://github.com/oaslananka/kicad-studio-kit/issues/51) is closed.                                                                                                                                                                    | Complete |
+| Compatibility metadata exists      | `compatibility.yaml`, [Support matrix](../support-matrix.md), and the root `check:compatibility` command define the KiCad, extension, MCP, and protocol compatibility baseline. GitHub issue [#68](https://github.com/oaslananka/kicad-studio-kit/issues/68) is closed.                                                                                                                                   | Complete |
+| Governance docs exist              | [Governance board model](governance-board.md), [Migration phases](migration-phases.md), [Definition of done](definition-of-done.md), and [Branch protection](branch-protection.md) define roadmap, execution, review, and protection rules. GitHub issues [#63](https://github.com/oaslananka/kicad-studio-kit/issues/63) and [#79](https://github.com/oaslananka/kicad-studio-kit/issues/79) are closed. | Complete |
+| Release split complete             | [Release model](release-model.md) documents product-scoped release ownership. PR [#91](https://github.com/oaslananka/kicad-studio-kit/pull/91) merged the split and closed GitHub issue [#52](https://github.com/oaslananka/kicad-studio-kit/issues/52).                                                                                                                                                  | Complete |
+
+## Milestone State
+
+GitHub milestone #1, `M0 -- Monorepo Foundation`, is complete with:
+
+- Open issues: 0
+- Closed issues: 8
+- Closed issue set: #49, #50, #51, #52, #56, #63, #68, #79
+
+The milestone is safe to close after this audit is merged and Linear OASLANA-90
+is updated with the final PR and validation results.

--- a/docs/architecture/migration-phases.md
+++ b/docs/architecture/migration-phases.md
@@ -39,6 +39,8 @@ Related issues: #51, #59.
 
 Related issues: #52, #87.
 
+M0 completion evidence: [M0 completion audit](m0-completion-audit.md).
+
 ## Phase M1+ - Shared test assets
 
 - [ ] Add dedicated KiCad fixture corpus.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ KiCad Studio Kit is the canonical monorepo for the KiCad Studio VS Code extensio
 - [Product boundaries](architecture/product-boundaries.md)
 - [Release model](architecture/release-model.md)
 - [Branch protection](architecture/branch-protection.md)
+- [M0 completion audit](architecture/m0-completion-audit.md)
 - [Testing strategy](testing-strategy.md)
 - [KiCad fixture corpus](kicad-fixture-corpus.md)
 - [KiCad Studio and MCP integration](integration/kicad-studio-mcp.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,8 @@ KiCad Studio Kit is the canonical monorepo for the KiCad Studio VS Code extensio
 - [Product boundaries](architecture/product-boundaries.md)
 - [Release model](architecture/release-model.md)
 - [Branch protection](architecture/branch-protection.md)
+- [Governance board model](architecture/governance-board.md)
+- [Definition of done](architecture/definition-of-done.md)
 - [M0 completion audit](architecture/m0-completion-audit.md)
 - [Testing strategy](testing-strategy.md)
 - [KiCad fixture corpus](kicad-fixture-corpus.md)


### PR DESCRIPTION
## Summary

- Add an auditable M0 completion record for Linear OASLANA-90 and GitHub milestone #1.
- Link the audit from the architecture index, docs index, governance board, and migration phases.
- Record that PR #91 closed the release split blocker and that release PRs #94/#95 are follow-up release artifacts, while #16 remains read-only.

## Linked issue

Linear: OASLANA-90
Related GitHub: milestone #1, issue #52, PR #91

## Type of change

- [ ] type:bug
- [ ] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `PATH="/home/goskyturkey/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" corepack pnpm exec prettier --check docs/architecture/m0-completion-audit.md docs/architecture.md docs/index.md docs/architecture/governance-board.md docs/architecture/migration-phases.md` — passed
- `PATH="/home/goskyturkey/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/tmp/codex-tools/actionlint:$PATH" corepack pnpm run check` — passed
- `git diff --check` — passed
- `uvx pre-commit run --all-files` — passed

Notes: `check_submission_readiness.py` still reports the existing PyPI reachability warning, and `audit_dependencies.py` still reports the acknowledged markdown/PyJWT advisories with no local upgrade path. These are existing repository audit notes and unrelated to this docs-only change.

## Protocol / MCP impact

- [x] Not applicable; reason: documentation-only M0 completion audit, no protocol or MCP implementation change.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [ ] Release notes considered for both products
- [ ] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
