### PR TITLE
test(mcp): add streamable http contract coverage

### DIFF
--- a/apps/vscode-extension/src/mcp/mcpClient.ts
+++ b/apps/vscode-extension/src/mcp/mcpClient.ts
@@ -172,6 +172,16 @@ export class McpClient {
       this.logger.debug(
         `MCP connection test failed: ${error instanceof Error ? error.message : String(error)}`
       );
+      if (this.state.server) {
+        return this.setState({
+          kind: 'Degraded',
+          available: install.found,
+          connected: false,
+          install,
+          server: this.state.server,
+          message: `MCP protocol contract failed: ${error instanceof Error ? error.message : String(error)}`
+        });
+      }
       // HTTP endpoint unreachable — fall back to VS Code stdio detection.
       if (hasVsCodeMcpJsonWithKicad()) {
         return this.setState({
@@ -622,6 +632,7 @@ export class McpClient {
     return {
       'Content-Type': 'application/json',
       Accept: 'application/json, text/event-stream',
+      'MCP-Protocol-Version': MCP_PROTOCOL_VERSION,
       ...(this.sessionId ? { 'MCP-Session-Id': this.sessionId } : {})
     };
   }

--- a/apps/vscode-extension/src/mcp/mcpClient.ts
+++ b/apps/vscode-extension/src/mcp/mcpClient.ts
@@ -172,7 +172,7 @@ export class McpClient {
       this.logger.debug(
         `MCP connection test failed: ${error instanceof Error ? error.message : String(error)}`
       );
-      if (this.state.server) {
+      if (this.state.connected && this.state.server) {
         return this.setState({
           kind: 'Degraded',
           available: install.found,

--- a/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
@@ -18,9 +18,7 @@ type McpToolsNode = {
   children?: McpToolsNode[] | undefined;
 };
 
-export class McpToolsProvider
-  implements vscode.TreeDataProvider<McpToolsNode>
-{
+export class McpToolsProvider implements vscode.TreeDataProvider<McpToolsNode> {
   private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<
     McpToolsNode | undefined
   >();
@@ -85,7 +83,12 @@ function buildMcpToolNodes(
   ];
 
   if (state.server) {
-    nodes.splice(3, 0, serverNode(state), capabilityNode(state.server.capabilities));
+    nodes.splice(
+      3,
+      0,
+      serverNode(state),
+      capabilityNode(state.server.capabilities)
+    );
   }
   if (state.message) {
     nodes.splice(1, 0, {
@@ -99,6 +102,20 @@ function buildMcpToolNodes(
 }
 
 function stateNode(state: McpConnectionState): McpToolsNode {
+  if (state.kind === 'Degraded') {
+    return {
+      label: 'MCP degraded',
+      description: state.server?.version ?? 'protocol contract failed',
+      tooltip:
+        state.message ??
+        'The MCP endpoint initialized but failed the Streamable HTTP contract check.',
+      icon: 'warning',
+      command: {
+        command: COMMANDS.retryMcp,
+        title: 'Retry MCP Connection'
+      }
+    };
+  }
   if (state.kind === 'Incompatible') {
     return {
       label: 'MCP incompatible',
@@ -139,7 +156,9 @@ function stateNode(state: McpConnectionState): McpToolsNode {
     description: state.available ? 'detected, not connected' : 'not detected',
     icon: state.available ? 'warning' : 'circle-slash',
     command: {
-      command: state.available ? COMMANDS.retryMcp : COMMANDS.setupMcpIntegration,
+      command: state.available
+        ? COMMANDS.retryMcp
+        : COMMANDS.setupMcpIntegration,
       title: state.available ? 'Retry MCP Connection' : 'Setup MCP Integration'
     }
   };
@@ -206,7 +225,9 @@ function capabilityGroup(label: string, values: string[]): McpToolsNode {
   return {
     label,
     description: values.length ? `${values.length}` : 'none',
-    tooltip: values.length ? values.join('\n') : `No ${label.toLowerCase()} advertised.`,
+    tooltip: values.length
+      ? values.join('\n')
+      : `No ${label.toLowerCase()} advertised.`,
     icon: values.length ? 'list-tree' : 'circle-slash',
     children: values.slice(0, 25).map((value) => ({
       label: value,

--- a/apps/vscode-extension/src/statusbar/kicadStatusBar.ts
+++ b/apps/vscode-extension/src/statusbar/kicadStatusBar.ts
@@ -46,14 +46,22 @@ export class KiCadStatusBar implements vscode.Disposable {
   private activeVariant: string | undefined;
 
   constructor(_context: vscode.ExtensionContext) {
-    this.kicadItem = this.make(P.kicad, COMMANDS.showStatusMenu, 'KiCad Studio');
+    this.kicadItem = this.make(
+      P.kicad,
+      COMMANDS.showStatusMenu,
+      'KiCad Studio'
+    );
     this.drcItem = this.make(P.drc, COMMANDS.runDRC, 'Run DRC');
     this.ercItem = this.make(P.erc, COMMANDS.runERC, 'Run ERC');
     this.sep1Item = this.makeSeparator(P.sep1);
     this.aiItem = this.make(P.ai, COMMANDS.openAiChat, 'Open AI Chat');
     this.mcpItem = this.make(P.mcp, COMMANDS.setupMcpIntegration, 'KiCad MCP');
     this.sep2Item = this.makeSeparator(P.sep2);
-    this.variantItem = this.make(P.variant, COMMANDS.setActiveVariant, 'Switch Variant');
+    this.variantItem = this.make(
+      P.variant,
+      COMMANDS.setActiveVariant,
+      'Switch Variant'
+    );
 
     this.sep1Item.show();
     // sep2 is hidden until a variant is active (renderVariant controls it)
@@ -224,7 +232,8 @@ export class KiCadStatusBar implements vscode.Disposable {
       this.aiItem.backgroundColor = undefined;
     } else if (this.aiHealthy === false) {
       this.aiItem.text = '$(warning) AI';
-      this.aiItem.tooltip = 'AI provider configured but last check failed. Click to open chat.';
+      this.aiItem.tooltip =
+        'AI provider configured but last check failed. Click to open chat.';
       this.aiItem.command = COMMANDS.openAiChat;
       this.aiItem.backgroundColor = new vscode.ThemeColor(
         'statusBarItem.warningBackground'
@@ -249,6 +258,17 @@ export class KiCadStatusBar implements vscode.Disposable {
       );
       return;
     }
+    if (this.mcpKind === 'Degraded') {
+      this.mcpItem.text = '$(warning) MCP';
+      this.mcpItem.tooltip =
+        this.mcpMessage ??
+        'MCP initialized but failed the Streamable HTTP contract check. Click to retry.';
+      this.mcpItem.command = COMMANDS.retryMcp;
+      this.mcpItem.backgroundColor = new vscode.ThemeColor(
+        'statusBarItem.warningBackground'
+      );
+      return;
+    }
     if (this.mcpKind === 'VsCodeStdio' || this.mcpConnected) {
       this.mcpItem.text = `$(plug) MCP${profile}`;
       this.mcpItem.tooltip =
@@ -262,7 +282,8 @@ export class KiCadStatusBar implements vscode.Disposable {
     if (this.mcpAvailable) {
       this.mcpItem.text = '$(plug) MCP';
       this.mcpItem.tooltip =
-        this.mcpMessage ?? 'kicad-mcp-pro detected but not connected. Click to retry.';
+        this.mcpMessage ??
+        'kicad-mcp-pro detected but not connected. Click to retry.';
       this.mcpItem.command = COMMANDS.retryMcp;
       this.mcpItem.backgroundColor = new vscode.ThemeColor(
         'statusBarItem.warningBackground'
@@ -270,7 +291,8 @@ export class KiCadStatusBar implements vscode.Disposable {
       return;
     }
     this.mcpItem.text = '$(plug) MCP';
-    this.mcpItem.tooltip = 'kicad-mcp-pro not detected. Click to install / set up.';
+    this.mcpItem.tooltip =
+      'kicad-mcp-pro not detected. Click to install / set up.';
     this.mcpItem.command = COMMANDS.installMcp;
     this.mcpItem.backgroundColor = undefined;
   }

--- a/apps/vscode-extension/src/types.ts
+++ b/apps/vscode-extension/src/types.ts
@@ -224,9 +224,9 @@ export interface ProjectTreeNode {
     | 'jobset'
     | 'fab-output'
     | 'model'
-      | 'file'
-      | 'folder'
-      | 'drc-rule';
+    | 'file'
+    | 'folder'
+    | 'drc-rule';
   uri?: vscode.Uri | undefined;
   children?: ProjectTreeNode[] | undefined;
 }
@@ -304,6 +304,7 @@ export type McpConnectionKind =
   | 'Disconnected'
   | 'Connecting'
   | 'Connected'
+  | 'Degraded'
   | 'Incompatible'
   | 'VsCodeStdio';
 

--- a/apps/vscode-extension/test/unit/mcpClient.test.ts
+++ b/apps/vscode-extension/test/unit/mcpClient.test.ts
@@ -608,6 +608,30 @@ describe('McpClient', () => {
     }
   );
 
+  it('does not mark cached server metadata as degraded when initialize fails before a live handshake', async () => {
+    const context = createExtensionContextMock();
+    await context.globalState.update('kicadstudio.mcp.lastServerCard', {
+      version: '1.0.0',
+      compat: 'compatible',
+      capabilities: { tools: [], resources: [], prompts: [] },
+      capturedAt: '2026-05-21T00:00:00.000Z'
+    });
+    global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const state = await createClient(context, {
+      maxRetries: 1
+    }).testConnection();
+
+    expect(state).toEqual(
+      expect.objectContaining({
+        kind: 'Disconnected',
+        available: true,
+        connected: false,
+        message: 'ECONNREFUSED'
+      })
+    );
+  });
+
   it('marks MCP degraded when tools/list returns a JSON-RPC error after initialize', async () => {
     const fetchMock = jest
       .fn()

--- a/apps/vscode-extension/test/unit/mcpClient.test.ts
+++ b/apps/vscode-extension/test/unit/mcpClient.test.ts
@@ -239,6 +239,34 @@ describe('McpClient', () => {
     );
   });
 
+  it('sends the negotiated MCP protocol version on HTTP requests', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonResponse(
+          { result: {} },
+          { headers: { 'MCP-Session-Id': 'protocol-session' } }
+        )
+      )
+      .mockResolvedValueOnce(createJsonResponse({ result: { tools: [] } }));
+    global.fetch = fetchMock as typeof fetch;
+
+    await expect(createClient().testConnection()).resolves.toEqual(
+      expect.objectContaining({ connected: true })
+    );
+
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toEqual(
+      expect.objectContaining({
+        'MCP-Protocol-Version': '2025-11-25'
+      })
+    );
+    expect(fetchMock.mock.calls[1]?.[1]?.headers).toEqual(
+      expect.objectContaining({
+        'MCP-Protocol-Version': '2025-11-25'
+      })
+    );
+  });
+
   it('refuses non-loopback MCP endpoints by default', async () => {
     __setConfiguration({
       'kicadstudio.mcp.endpoint': 'https://mcp.example.com',
@@ -533,6 +561,77 @@ describe('McpClient', () => {
 
     await expect(createClient().testConnection()).resolves.toEqual(
       expect.objectContaining({ available: true, connected: true })
+    );
+  });
+
+  it.each([400, 401, 403, 404, 421, 500])(
+    'marks MCP degraded when tools/list fails with HTTP %i after initialize',
+    async (status) => {
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValueOnce(
+          createJsonResponse(
+            { result: {} },
+            { headers: { 'MCP-Session-Id': 'degraded-session' } }
+          )
+        )
+        .mockResolvedValue(
+          createJsonResponse(
+            {
+              jsonrpc: '2.0',
+              id: null,
+              error: {
+                code: -32000,
+                message: 'MCP protocol contract failed'
+              }
+            },
+            { status }
+          )
+        );
+      global.fetch = fetchMock as typeof fetch;
+
+      const state = await createClient(createExtensionContextMock(), {
+        maxRetries: 1
+      }).testConnection();
+
+      expect(state).toEqual(
+        expect.objectContaining({
+          kind: 'Degraded',
+          available: true,
+          connected: false
+        })
+      );
+      expect(state.message).toContain('MCP protocol contract failed');
+      expect(state.message).toContain(
+        status === 404 ? 'does not expose Streamable HTTP' : `HTTP ${status}`
+      );
+    }
+  );
+
+  it('marks MCP degraded when tools/list returns a JSON-RPC error after initialize', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonResponse(
+          { result: {} },
+          { headers: { 'MCP-Session-Id': 'degraded-jsonrpc-session' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          error: {
+            message: 'Invalid JSON-RPC request'
+          }
+        })
+      );
+    global.fetch = fetchMock as typeof fetch;
+
+    await expect(createClient().testConnection()).resolves.toEqual(
+      expect.objectContaining({
+        kind: 'Degraded',
+        connected: false,
+        message: 'MCP protocol contract failed: Invalid JSON-RPC request'
+      })
     );
   });
 

--- a/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
@@ -53,8 +53,9 @@ describe('McpToolsProvider', () => {
       ])
     );
     expect(
-      provider.getTreeItem(children.find((item) => item.label === 'Capabilities') as never)
-        .description
+      provider.getTreeItem(
+        children.find((item) => item.label === 'Capabilities') as never
+      ).description
     ).toBe('2 tools, 1 resources, 1 prompts');
   });
 
@@ -74,7 +75,30 @@ describe('McpToolsProvider', () => {
     expect(provider.getTreeItem(state as never).command).toEqual(
       expect.objectContaining({ command: 'kicadstudio.mcp.retry' })
     );
-    expect(provider.getTreeItem(diagnostic as never).description).toBe('HTTP 503');
+    expect(provider.getTreeItem(diagnostic as never).description).toBe(
+      'HTTP 503'
+    );
+  });
+
+  it('renders degraded state as an actionable protocol warning row', () => {
+    const provider = new McpToolsProvider({
+      getState: () => ({
+        kind: 'Degraded',
+        available: true,
+        connected: false,
+        message: 'MCP protocol contract failed: HTTP 421'
+      })
+    } as never);
+
+    const state = childrenByLabel(provider, 'MCP degraded');
+    const diagnostic = childrenByLabel(provider, 'Last diagnostic');
+
+    expect(provider.getTreeItem(state as never).command).toEqual(
+      expect.objectContaining({ command: 'kicadstudio.mcp.retry' })
+    );
+    expect(provider.getTreeItem(diagnostic as never).description).toBe(
+      'MCP protocol contract failed: HTTP 421'
+    );
   });
 });
 

--- a/apps/vscode-extension/test/unit/statusBar.test.ts
+++ b/apps/vscode-extension/test/unit/statusBar.test.ts
@@ -141,6 +141,23 @@ describe('KiCadStatusBar', () => {
     bar.dispose();
   });
 
+  it('shows MCP degraded state when the protocol contract fails', () => {
+    const bar = new KiCadStatusBar({} as never);
+    bar.update({
+      mcpState: {
+        kind: 'Degraded',
+        available: true,
+        connected: false,
+        message: 'MCP protocol contract failed: HTTP 421'
+      }
+    });
+    const items = getItems();
+    expect(items[IDX.mcp]!.text).toContain('warning');
+    expect(items[IDX.mcp]!.tooltip).toContain('HTTP 421');
+    expect(items[IDX.mcp]!.backgroundColor).toBeDefined();
+    bar.dispose();
+  });
+
   it('shows MCP warn compat state as connected with version in tooltip', () => {
     const bar = new KiCadStatusBar({} as never);
     bar.update({

--- a/packages/mcp-server/src/kicad_mcp/server.py
+++ b/packages/mcp-server/src/kicad_mcp/server.py
@@ -656,10 +656,12 @@ class KiCadFastMCP(FastMCP):
 class _StreamableHttpContractMiddleware:
     """Normalize the public Streamable HTTP contract before FastMCP handles it."""
 
+    _SESSION_CACHE_LIMIT = 256
+
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
         self._session_ids: set[str] = set()
-        self._lock = threading.Lock()
+        self._session_order: deque[str] = deque()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         cfg = get_config()
@@ -675,7 +677,9 @@ class _StreamableHttpContractMiddleware:
         headers = _scope_headers(scope)
 
         # Let FastMCP's auth layer preserve its existing 401/403 error shape.
-        if cfg.auth_token and not _scope_bearer_token(headers):
+        if cfg.auth_token and not secrets.compare_digest(
+            _scope_bearer_token(headers), cfg.auth_token
+        ):
             await self.app(scope, replay_receive, send)
             return
 
@@ -760,12 +764,15 @@ class _StreamableHttpContractMiddleware:
         await self.app(scope, replay_receive, send_wrapper)
 
     def _has_session(self, session_id: str) -> bool:
-        with self._lock:
-            return session_id in self._session_ids
+        return session_id in self._session_ids
 
     def _remember_session(self, session_id: str) -> None:
-        with self._lock:
-            self._session_ids.add(session_id)
+        if session_id in self._session_ids:
+            return
+        if len(self._session_order) >= self._SESSION_CACHE_LIMIT:
+            self._session_ids.discard(self._session_order.popleft())
+        self._session_order.append(session_id)
+        self._session_ids.add(session_id)
 
 
 async def _buffer_request_body(receive: Receive) -> tuple[bytes, Receive]:
@@ -791,10 +798,15 @@ async def _buffer_request_body(receive: Receive) -> tuple[bytes, Receive]:
 
 
 def _scope_headers(scope: Scope) -> dict[str, str]:
-    return {
-        key.decode("latin-1").casefold(): value.decode("latin-1")
-        for key, value in scope.get("headers", [])
-    }
+    headers: dict[str, str] = {}
+    for key, value in scope.get("headers", []):
+        name = key.decode("latin-1").casefold()
+        decoded_value = value.decode("latin-1")
+        if name in headers:
+            headers[name] = f"{headers[name]}, {decoded_value}"
+        else:
+            headers[name] = decoded_value
+    return headers
 
 
 def _scope_bearer_token(headers: dict[str, str]) -> str:
@@ -858,7 +870,7 @@ async def _streamable_http_error_response(
     send: Send,
 ) -> None:
     response = JSONResponse(
-        {"jsonrpc": "2.0", "error": {"code": code, "message": message}, "id": None},
+        {"jsonrpc": "2.0", "error": {"code": code, "message": message}, "id": rpc_id},
         status_code=status_code,
     )
     await response(scope, receive, send)

--- a/packages/mcp-server/src/kicad_mcp/server.py
+++ b/packages/mcp-server/src/kicad_mcp/server.py
@@ -726,7 +726,7 @@ class _StreamableHttpContractMiddleware:
             return
 
         session_id = headers.get("mcp-session-id", "")
-        if cfg.stateful_http and rpc_method != "initialize":
+        if cfg.stateful_http and rpc_method and rpc_method != "initialize":
             if not session_id:
                 await _streamable_http_error_response(
                     code=-32000,

--- a/packages/mcp-server/src/kicad_mcp/server.py
+++ b/packages/mcp-server/src/kicad_mcp/server.py
@@ -35,10 +35,12 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse, Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from typer.models import OptionInfo
 
 from . import __version__
 from .capabilities import all_records as all_capability_records
+from .compatibility import MCP_PROTOCOL_VERSION
 from .config import LOOPBACK_HOSTS, KiCadMCPConfig, get_config, reset_config
 from .connection import KiCadConnectionError, get_board
 from .diagnostics import DiagnosticReport, build_doctor_report, build_health_report
@@ -552,6 +554,7 @@ class KiCadFastMCP(FastMCP):
     def streamable_http_app(self) -> Starlette:
         app = super().streamable_http_app()
         cfg = get_config()
+        app.add_middleware(_StreamableHttpContractMiddleware)
         if cfg.legacy_sse:
             sse_routes = self.sse_app().routes
             existing_paths = {getattr(route, "path", None) for route in app.routes}
@@ -648,6 +651,217 @@ class KiCadFastMCP(FastMCP):
                 elapsed_ms=elapsed_ms,
                 error_code=error_code,
             )
+
+
+class _StreamableHttpContractMiddleware:
+    """Normalize the public Streamable HTTP contract before FastMCP handles it."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+        self._session_ids: set[str] = set()
+        self._lock = threading.Lock()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        cfg = get_config()
+        if (
+            scope["type"] != "http"
+            or scope.get("method") != "POST"
+            or scope.get("path") != cfg.mount_path
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        body, replay_receive = await _buffer_request_body(receive)
+        headers = _scope_headers(scope)
+
+        # Let FastMCP's auth layer preserve its existing 401/403 error shape.
+        if cfg.auth_token and not _scope_bearer_token(headers):
+            await self.app(scope, replay_receive, send)
+            return
+
+        rpc_id, rpc_method = _json_rpc_metadata(body)
+        if not _accept_header_includes(headers.get("accept", ""), "application/json"):
+            await _streamable_http_error_response(
+                code=-32003,
+                message=(
+                    "Bad Request: Accept header must include application/json and "
+                    "text/event-stream."
+                ),
+                rpc_id=rpc_id,
+                status_code=400,
+                scope=scope,
+                receive=replay_receive,
+                send=send,
+            )
+            return
+        if not _accept_header_includes(headers.get("accept", ""), "text/event-stream"):
+            await _streamable_http_error_response(
+                code=-32003,
+                message=(
+                    "Bad Request: Accept header must include application/json and "
+                    "text/event-stream."
+                ),
+                rpc_id=rpc_id,
+                status_code=400,
+                scope=scope,
+                receive=replay_receive,
+                send=send,
+            )
+            return
+
+        protocol_version = headers.get("mcp-protocol-version")
+        if protocol_version and protocol_version != MCP_PROTOCOL_VERSION:
+            await _streamable_http_error_response(
+                code=-32002,
+                message=(
+                    f"Unsupported MCP-Protocol-Version: {protocol_version}. "
+                    f"Expected {MCP_PROTOCOL_VERSION}."
+                ),
+                rpc_id=rpc_id,
+                status_code=400,
+                scope=scope,
+                receive=replay_receive,
+                send=send,
+            )
+            return
+
+        session_id = headers.get("mcp-session-id", "")
+        if cfg.stateful_http and rpc_method != "initialize":
+            if not session_id:
+                await _streamable_http_error_response(
+                    code=-32000,
+                    message="Bad Request: Missing MCP-Session-Id header.",
+                    rpc_id=rpc_id,
+                    status_code=400,
+                    scope=scope,
+                    receive=replay_receive,
+                    send=send,
+                )
+                return
+            if not self._has_session(session_id):
+                await _streamable_http_error_response(
+                    code=-32001,
+                    message="Session not found for MCP-Session-Id.",
+                    rpc_id=rpc_id,
+                    status_code=404,
+                    scope=scope,
+                    receive=replay_receive,
+                    send=send,
+                )
+                return
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                response_session_id = _message_header(message, "mcp-session-id")
+                if response_session_id:
+                    self._remember_session(response_session_id)
+            await send(message)
+
+        await self.app(scope, replay_receive, send_wrapper)
+
+    def _has_session(self, session_id: str) -> bool:
+        with self._lock:
+            return session_id in self._session_ids
+
+    def _remember_session(self, session_id: str) -> None:
+        with self._lock:
+            self._session_ids.add(session_id)
+
+
+async def _buffer_request_body(receive: Receive) -> tuple[bytes, Receive]:
+    messages: list[Message] = []
+    chunks: list[bytes] = []
+    more_body = True
+    while more_body:
+        message = await receive()
+        messages.append(message)
+        if message["type"] != "http.request":
+            break
+        body = message.get("body", b"")
+        if isinstance(body, bytes):
+            chunks.append(body)
+        more_body = bool(message.get("more_body", False))
+
+    iterator = iter(messages)
+
+    async def replay_receive() -> Message:
+        return next(iterator, {"type": "http.request", "body": b"", "more_body": False})
+
+    return b"".join(chunks), replay_receive
+
+
+def _scope_headers(scope: Scope) -> dict[str, str]:
+    return {
+        key.decode("latin-1").casefold(): value.decode("latin-1")
+        for key, value in scope.get("headers", [])
+    }
+
+
+def _scope_bearer_token(headers: dict[str, str]) -> str:
+    authorization = headers.get("authorization", "")
+    prefix = "Bearer "
+    if not authorization.startswith(prefix):
+        return ""
+    return authorization[len(prefix) :].strip()
+
+
+def _accept_header_includes(value: str, media_type: str) -> bool:
+    media_main, media_subtype = media_type.casefold().split("/", 1)
+    for item in value.split(","):
+        item_type = item.split(";", 1)[0].strip().casefold()
+        if not item_type:
+            continue
+        if item_type == "*/*":
+            return True
+        if item_type == media_type:
+            return True
+        if item_type == f"{media_main}/*":
+            return True
+        if item_type == f"*/{media_subtype}":
+            return True
+    return False
+
+
+def _json_rpc_metadata(body: bytes) -> tuple[object | None, str | None]:
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except Exception:
+        return None, None
+    if not isinstance(payload, dict):
+        return None, None
+    rpc_id = payload.get("id")
+    rpc_method = payload.get("method")
+    return rpc_id, rpc_method if isinstance(rpc_method, str) else None
+
+
+def _message_header(message: Message, header_name: str) -> str:
+    expected = header_name.casefold().encode("latin-1")
+    headers = message.get("headers", [])
+    if not isinstance(headers, list):
+        return ""
+    for key, value in headers:
+        if not isinstance(key, bytes) or not isinstance(value, bytes):
+            continue
+        if key.lower() == expected:
+            return value.decode("latin-1")
+    return ""
+
+
+async def _streamable_http_error_response(
+    *,
+    code: int,
+    message: str,
+    rpc_id: object | None,
+    status_code: int,
+    scope: Scope,
+    receive: Receive,
+    send: Send,
+) -> None:
+    response = JSONResponse(
+        {"jsonrpc": "2.0", "error": {"code": code, "message": message}, "id": None},
+        status_code=status_code,
+    )
+    await response(scope, receive, send)
 
 
 class _OriginValidationMiddleware(BaseHTTPMiddleware):

--- a/packages/mcp-server/tests/unit/test_mcp_protocol_contract.py
+++ b/packages/mcp-server/tests/unit/test_mcp_protocol_contract.py
@@ -109,6 +109,29 @@ def test_stateful_session_errors_are_structured_and_spec_aligned(
     assert listed.status_code == 200
 
 
+def test_stateful_malformed_json_rpc_is_not_masked_by_session_check(
+    sample_project: Path,
+) -> None:
+    _ = sample_project
+    cfg = get_config()
+    cfg.transport = "streamable-http"
+    cfg.stateful_http = True
+    server = build_server("minimal")
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        response = client.post(
+            "/mcp",
+            headers=HTTP_HEADERS,
+            json={"jsonrpc": "2.0", "id": 9, "params": {}},
+        )
+
+    payload = response.json()
+    assert response.status_code == 400
+    assert payload["jsonrpc"] == "2.0"
+    assert payload["error"]["code"] != -32000
+    assert payload["error"]["message"] != "Bad Request: Missing MCP-Session-Id header."
+
+
 def test_streamable_http_rejects_unsupported_protocol_version_header(
     sample_project: Path,
 ) -> None:

--- a/packages/mcp-server/tests/unit/test_mcp_protocol_contract.py
+++ b/packages/mcp-server/tests/unit/test_mcp_protocol_contract.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from starlette.testclient import TestClient
+from starlette.types import Receive, Scope, Send
 
 from kicad_mcp.compatibility import MCP_PROTOCOL_VERSION
 from kicad_mcp.config import get_config
-from kicad_mcp.server import build_server
+from kicad_mcp.server import _StreamableHttpContractMiddleware, build_server
 
 HTTP_HEADERS = {
     "Accept": "application/json, text/event-stream",
@@ -38,12 +39,13 @@ def _assert_json_rpc_error(
     status_code: int,
     code: int,
     message: str,
+    request_id: object | None,
 ) -> None:
     assert response.status_code == status_code
     assert response.headers["content-type"].startswith("application/json")
     payload = response.json()
     assert payload["jsonrpc"] == "2.0"
-    assert payload["id"] is None
+    assert payload["id"] == request_id
     assert payload["error"]["code"] == code
     assert payload["error"]["message"] == message
 
@@ -99,12 +101,14 @@ def test_stateful_session_errors_are_structured_and_spec_aligned(
         status_code=400,
         code=-32000,
         message="Bad Request: Missing MCP-Session-Id header.",
+        request_id=2,
     )
     _assert_json_rpc_error(
         invalid_session,
         status_code=404,
         code=-32001,
         message="Session not found for MCP-Session-Id.",
+        request_id=3,
     )
     assert listed.status_code == 200
 
@@ -152,6 +156,7 @@ def test_streamable_http_rejects_unsupported_protocol_version_header(
         status_code=400,
         code=-32002,
         message=f"Unsupported MCP-Protocol-Version: 1900-01-01. Expected {MCP_PROTOCOL_VERSION}.",
+        request_id=1,
     )
 
 
@@ -177,4 +182,40 @@ def test_streamable_http_requires_json_and_sse_accept_header(sample_project: Pat
         status_code=400,
         code=-32003,
         message="Bad Request: Accept header must include application/json and text/event-stream.",
+        request_id=1,
     )
+
+
+def test_streamable_http_accepts_split_accept_headers(sample_project: Path) -> None:
+    _ = sample_project
+    cfg = get_config()
+    cfg.transport = "streamable-http"
+    server = build_server("minimal")
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        response = client.post(
+            "/mcp",
+            headers=[
+                ("Accept", "application/json"),
+                ("Accept", "text/event-stream"),
+                ("Content-Type", "application/json"),
+                ("MCP-Protocol-Version", MCP_PROTOCOL_VERSION),
+            ],
+            json=_initialize_request(),
+        )
+
+    assert response.status_code == 200
+
+
+def test_contract_middleware_bounds_remembered_streamable_http_sessions() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        _ = scope, receive, send
+
+    middleware = _StreamableHttpContractMiddleware(app)
+
+    for index in range(257):
+        middleware._remember_session(f"session-{index}")
+
+    assert middleware._has_session("session-0") is False
+    assert middleware._has_session("session-256") is True
+    assert len(middleware._session_ids) == 256

--- a/packages/mcp-server/tests/unit/test_mcp_protocol_contract.py
+++ b/packages/mcp-server/tests/unit/test_mcp_protocol_contract.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from starlette.testclient import TestClient
+
+from kicad_mcp.compatibility import MCP_PROTOCOL_VERSION
+from kicad_mcp.config import get_config
+from kicad_mcp.server import build_server
+
+HTTP_HEADERS = {
+    "Accept": "application/json, text/event-stream",
+    "Content-Type": "application/json",
+    "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+}
+
+
+def _initialize_request() -> dict[str, object]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "mcp-contract-test", "version": "1.0.0"},
+        },
+    }
+
+
+def _tools_list_request(request_id: int = 2) -> dict[str, object]:
+    return {"jsonrpc": "2.0", "id": request_id, "method": "tools/list", "params": {}}
+
+
+def _assert_json_rpc_error(
+    response,
+    *,
+    status_code: int,
+    code: int,
+    message: str,
+) -> None:
+    assert response.status_code == status_code
+    assert response.headers["content-type"].startswith("application/json")
+    payload = response.json()
+    assert payload["jsonrpc"] == "2.0"
+    assert payload["id"] is None
+    assert payload["error"]["code"] == code
+    assert payload["error"]["message"] == message
+
+
+def test_chatgpt_connector_stateless_tools_list_does_not_require_session_header(
+    sample_project: Path,
+) -> None:
+    _ = sample_project
+    cfg = get_config()
+    cfg.transport = "streamable-http"
+    cfg.stateful_http = False
+    server = build_server("minimal")
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        initialized = client.post("/mcp", headers=HTTP_HEADERS, json=_initialize_request())
+        listed = client.post("/mcp", headers=HTTP_HEADERS, json=_tools_list_request())
+
+    assert initialized.status_code == 200
+    assert "mcp-session-id" not in initialized.headers
+    assert listed.status_code == 200
+    tool_names = {tool["name"] for tool in listed.json()["result"]["tools"]}
+    assert "kicad_get_version" in tool_names
+
+
+def test_stateful_session_errors_are_structured_and_spec_aligned(
+    sample_project: Path,
+) -> None:
+    _ = sample_project
+    cfg = get_config()
+    cfg.transport = "streamable-http"
+    cfg.stateful_http = True
+    server = build_server("minimal")
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        initialized = client.post("/mcp", headers=HTTP_HEADERS, json=_initialize_request())
+        session_id = initialized.headers.get("mcp-session-id")
+        missing_session = client.post("/mcp", headers=HTTP_HEADERS, json=_tools_list_request())
+        invalid_session = client.post(
+            "/mcp",
+            headers={**HTTP_HEADERS, "Mcp-Session-Id": "missing-session"},
+            json=_tools_list_request(3),
+        )
+        listed = client.post(
+            "/mcp",
+            headers={**HTTP_HEADERS, "Mcp-Session-Id": str(session_id)},
+            json=_tools_list_request(4),
+        )
+
+    assert initialized.status_code == 200
+    assert session_id
+    _assert_json_rpc_error(
+        missing_session,
+        status_code=400,
+        code=-32000,
+        message="Bad Request: Missing MCP-Session-Id header.",
+    )
+    _assert_json_rpc_error(
+        invalid_session,
+        status_code=404,
+        code=-32001,
+        message="Session not found for MCP-Session-Id.",
+    )
+    assert listed.status_code == 200
+
+
+def test_streamable_http_rejects_unsupported_protocol_version_header(
+    sample_project: Path,
+) -> None:
+    _ = sample_project
+    cfg = get_config()
+    cfg.transport = "streamable-http"
+    server = build_server("minimal")
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        response = client.post(
+            "/mcp",
+            headers={**HTTP_HEADERS, "MCP-Protocol-Version": "1900-01-01"},
+            json=_initialize_request(),
+        )
+
+    _assert_json_rpc_error(
+        response,
+        status_code=400,
+        code=-32002,
+        message=f"Unsupported MCP-Protocol-Version: 1900-01-01. Expected {MCP_PROTOCOL_VERSION}.",
+    )
+
+
+def test_streamable_http_requires_json_and_sse_accept_header(sample_project: Path) -> None:
+    _ = sample_project
+    cfg = get_config()
+    cfg.transport = "streamable-http"
+    server = build_server("minimal")
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:3334") as client:
+        response = client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+            },
+            json=_initialize_request(),
+        )
+
+    _assert_json_rpc_error(
+        response,
+        status_code=400,
+        code=-32003,
+        message="Bad Request: Accept header must include application/json and text/event-stream.",
+    )

--- a/packages/mcp-server/tests/unit/test_release_hardening.py
+++ b/packages/mcp-server/tests/unit/test_release_hardening.py
@@ -352,13 +352,20 @@ def test_http_mcp_endpoint_requires_bearer_token(sample_project: Path) -> None:
     server = build_server("minimal")
     client = TestClient(server.streamable_http_app())
 
-    response = client.post(
+    missing_token = client.post(
         "/mcp",
         json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
     )
+    invalid_token = client.post(
+        "/mcp",
+        headers={"Accept": "application/json", "Authorization": "Bearer invalid-token"},
+        json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+    )
 
-    assert response.status_code == 401
-    assert response.json()["error"] == "invalid_token"
+    assert missing_token.status_code == 401
+    assert missing_token.json()["error"] == "invalid_token"
+    assert invalid_token.status_code == 401
+    assert invalid_token.json()["error"] == "invalid_token"
 
 
 def test_token_rotation_rejects_non_string_token(sample_project: Path) -> None:

--- a/packages/mcp-server/tests/unit/test_release_hardening.py
+++ b/packages/mcp-server/tests/unit/test_release_hardening.py
@@ -118,7 +118,9 @@ def test_stateful_streamable_http_requires_session_header_after_initialize(
     assert initialized.status_code == 200
     assert session_id
     assert missing_session.status_code == 400
-    assert "Missing session ID" in missing_session.text
+    assert missing_session.json()["error"]["message"] == (
+        "Bad Request: Missing MCP-Session-Id header."
+    )
     assert accepted_notification.status_code == 202
     assert listed.status_code == 200
     assert listed.json()["result"]["tools"]


### PR DESCRIPTION
## Summary
- Add MCP Streamable HTTP contract tests for ChatGPT-compatible stateless requests, stateful session reuse, missing/invalid session errors, protocol-version negotiation, and Accept header handling.
- Add a narrow ASGI contract middleware around the FastMCP Streamable HTTP app so transport errors are structured and spec-aligned before handler dispatch.
- Send `MCP-Protocol-Version` from the VS Code MCP client and surface post-initialize contract failures as a degraded, retryable MCP state in the status bar and MCP tools tree.

## Validation
- `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_mcp_protocol_contract.py packages/mcp-server/tests/unit/test_release_hardening.py::test_stateful_streamable_http_requires_session_header_after_initialize packages/mcp-server/tests/unit/test_release_hardening.py::test_http_mcp_endpoint_requires_bearer_token packages/mcp-server/tests/unit/test_wellknown_and_studio.py::test_streamable_http_legacy_sse_routes_are_opt_in -q` — passed
- `corepack pnpm --filter kicadstudio exec jest --runInBand test/unit/mcpClient.test.ts test/unit/statusBar.test.ts test/unit/mcpToolsProvider.test.ts --coverage=false` — passed
- `corepack pnpm --dir packages/mcp-server run lint` — passed
- `corepack pnpm --dir packages/mcp-server run typecheck` — passed
- `corepack pnpm --dir packages/mcp-server run test:unit` — passed
- `PYTHONPATH=scripts uv run --all-extras pytest tests -q` from `packages/mcp-server` — passed
- `uv run --project packages/mcp-server --all-extras kicad-mcp-pro --help` — passed
- `uv build --project packages/mcp-server` — passed
- `corepack pnpm --dir packages/mcp-server run security` — passed, with only repository-acknowledged pip-audit advisories and no unacknowledged vulnerabilities
- `corepack pnpm --filter kicadstudio run lint` — passed
- `corepack pnpm --filter kicadstudio run typecheck` — passed
- `corepack pnpm --filter kicadstudio run test:unit` — passed
- `corepack pnpm --filter kicadstudio run build` — passed
- `corepack pnpm install --frozen-lockfile` — passed
- `PATH="/home/goskyturkey/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/tmp/codex-tools/actionlint:$PATH" corepack pnpm run check` — passed
- `uvx pre-commit run --all-files` — passed
- `git diff --check` — passed

## Notes
- Direct `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests -q` from the repository root was not used as the repo harness because existing tests assume the MCP package cwd/script path; the package-cwd pytest invocation above and root `pnpm check` both pass.
- Official MCP Streamable HTTP transport guidance and OpenAI ChatGPT MCP connector documentation were checked before implementation; no dependency, workflow, runtime, or release artifact was changed.

Closes #44
Linear: OASLANA-43
