### PR TITLE
test(kicad-studio): harden project discovery coverage

### DIFF
--- a/apps/vscode-extension/src/providers/projectTreeProvider.ts
+++ b/apps/vscode-extension/src/providers/projectTreeProvider.ts
@@ -80,6 +80,12 @@ export class KiCadProjectTreeProvider implements vscode.TreeDataProvider<Project
     const outputDirName = vscode.workspace
       .getConfiguration()
       .get<string>('kicadstudio.defaultOutputDir', 'fab');
+    const resolvedRootPath = path.resolve(rootPath);
+    const resolvedOutputPath = path.resolve(rootPath, outputDirName);
+    const sourceFileOptions =
+      resolvedOutputPath === resolvedRootPath
+        ? undefined
+        : { ignoredDirectoryPaths: [resolvedOutputPath] };
     const [
       projectFiles,
       jobsetFiles,
@@ -88,13 +94,17 @@ export class KiCadProjectTreeProvider implements vscode.TreeDataProvider<Project
       models,
       fabFiles
     ] = await Promise.all([
-      collectFiles(rootPath, /\.(kicad_pro|kicad_sch|kicad_pcb|kicad_dru)$/i),
-      collectFiles(rootPath, /\.kicad_jobset$/i),
-      collectFiles(rootPath, /\.kicad_sym$/i),
-      collectFiles(rootPath, /\.kicad_mod$/i),
-      collectFiles(rootPath, /\.(step|stp|wrl)$/i),
       collectFiles(
-        path.join(rootPath, outputDirName),
+        rootPath,
+        /\.(kicad_pro|kicad_sch|kicad_pcb|kicad_dru)$/i,
+        sourceFileOptions
+      ),
+      collectFiles(rootPath, /\.kicad_jobset$/i, sourceFileOptions),
+      collectFiles(rootPath, /\.kicad_sym$/i, sourceFileOptions),
+      collectFiles(rootPath, /\.kicad_mod$/i, sourceFileOptions),
+      collectFiles(rootPath, /\.(step|stp|wrl)$/i, sourceFileOptions),
+      collectFiles(
+        resolvedOutputPath,
         /\.(gbr|drl|pdf|svg|zip|glb|csv|xlsx|json|html|net)$/i
       )
     ]);
@@ -419,15 +429,24 @@ function iconForFile(label: string): string {
 
 async function collectFiles(
   rootPath: string,
-  pattern: RegExp
+  pattern: RegExp,
+  options: {
+    ignoredDirectoryPaths?: readonly string[];
+  } = {}
 ): Promise<string[]> {
+  const resolvedRootPath = path.resolve(rootPath);
   try {
-    await fs.promises.access(rootPath);
+    await fs.promises.access(resolvedRootPath);
   } catch {
     return [];
   }
 
   const result: string[] = [];
+  const ignoredDirectoryPaths = new Set(
+    (options.ignoredDirectoryPaths ?? []).map((entry) =>
+      pathComparisonKey(path.resolve(resolvedRootPath, entry))
+    )
+  );
   const visit = async (currentPath: string): Promise<void> => {
     let entries: fs.Dirent[];
     try {
@@ -439,37 +458,84 @@ async function collectFiles(
       const absolute = path.join(currentPath, entry.name);
       if (entry.isDirectory()) {
         if (
-          [
-            // Version control / dependency management
-            '.git',
-            'node_modules',
-            // Build/coverage artefacts
-            'dist',
-            'out',
-            'build',
-            'coverage',
-            '.nyc_output',
-            // Extension development dirs (not KiCad design files)
-            'src',
-            'test',
-            'scripts',
-            'media',
-            'docs',
-            // Hidden/tooling dirs
-            '.vscode',
-            '.github',
-            '.husky'
-          ].includes(entry.name)
+          shouldIgnoreDirectory(entry.name, absolute, ignoredDirectoryPaths)
         ) {
           continue;
         }
         await visit(absolute);
-      } else if (pattern.test(entry.name)) {
+      } else if (!shouldIgnoreFile(entry.name) && pattern.test(entry.name)) {
         result.push(absolute);
       }
     }
   };
 
-  await visit(rootPath);
+  await visit(resolvedRootPath);
   return result.sort();
 }
+
+function shouldIgnoreDirectory(
+  name: string,
+  absolutePath: string,
+  ignoredDirectoryPaths: ReadonlySet<string>
+): boolean {
+  const normalizedName = name.toLowerCase();
+  if (
+    ignoredDirectoryPaths.has(pathComparisonKey(absolutePath)) ||
+    IGNORED_DIRECTORY_NAMES.has(normalizedName) ||
+    normalizedName.endsWith('-backups')
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function shouldIgnoreFile(name: string): boolean {
+  const normalizedName = name.toLowerCase();
+  return (
+    normalizedName.endsWith('.bak') ||
+    normalizedName.endsWith('.backup') ||
+    normalizedName.endsWith('.lck') ||
+    normalizedName.endsWith('.lock') ||
+    normalizedName.endsWith('.tmp') ||
+    normalizedName.endsWith('~')
+  );
+}
+
+function pathComparisonKey(filePath: string): string {
+  const normalizedPath = path.normalize(filePath);
+  return CASE_INSENSITIVE_PLATFORM_PATHS
+    ? normalizedPath.toLowerCase()
+    : normalizedPath;
+}
+
+const CASE_INSENSITIVE_PLATFORM_PATHS =
+  process.platform === 'win32' || process.platform === 'darwin';
+
+const IGNORED_DIRECTORY_NAMES = new Set([
+  // Version control / dependency management
+  '.git',
+  'node_modules',
+  // Build/coverage artefacts
+  'dist',
+  'out',
+  'build',
+  'coverage',
+  '.nyc_output',
+  'generated',
+  'temp',
+  'tmp',
+  'backups',
+  'backup',
+  // Extension development dirs (not KiCad design files)
+  'src',
+  'test',
+  'scripts',
+  'media',
+  'docs',
+  // Hidden/tooling and editor history dirs
+  '.vscode',
+  '.github',
+  '.husky',
+  '.history',
+  '.code-backups'
+]);

--- a/apps/vscode-extension/test/unit/projectTreeProvider.test.ts
+++ b/apps/vscode-extension/test/unit/projectTreeProvider.test.ts
@@ -4,34 +4,69 @@ import * as path from 'node:path';
 import { KiCadProjectTreeProvider } from '../../src/providers/projectTreeProvider';
 import type { ProjectTreeNode } from '../../src/types';
 import {
+  __setConfiguration,
   Diagnostic,
   DiagnosticSeverity,
   languages,
   Range,
-  Uri
+  Uri,
+  workspace
 } from './vscodeMock';
 
 jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
   virtual: true
 });
 
+function childrenFor(
+  root: ProjectTreeNode | undefined,
+  label: string
+): ProjectTreeNode[] {
+  return root?.children?.find((node) => node.label === label)?.children ?? [];
+}
+
+function labelsFor(root: ProjectTreeNode | undefined, label: string): string[] {
+  return childrenFor(root, label).map((node) => node.label);
+}
+
+function isCaseSensitiveDirectory(rootPath: string): boolean {
+  const marker = path.join(rootPath, 'case-check');
+  fs.writeFileSync(marker, '', 'utf8');
+  return !fs.existsSync(path.join(rootPath, 'CASE-CHECK'));
+}
+
 describe('KiCadProjectTreeProvider', () => {
+  const originalWorkspaceFolders = workspace.workspaceFolders;
+  let tempDir: string | undefined;
+
+  beforeEach(() => {
+    __setConfiguration({});
+    tempDir = undefined;
+    workspace.workspaceFolders = originalWorkspaceFolders;
+  });
+
+  afterEach(() => {
+    workspace.workspaceFolders = originalWorkspaceFolders;
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('groups core KiCad files by semantic project role', async () => {
-    const rootPath = fs.mkdtempSync(
+    tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'kicadstudio-project-tree-')
     );
-    fs.writeFileSync(path.join(rootPath, 'demo.kicad_pro'), '{}', 'utf8');
-    fs.writeFileSync(path.join(rootPath, 'demo.kicad_sch'), '', 'utf8');
-    fs.writeFileSync(path.join(rootPath, 'upper.KICAD_SCH'), '', 'utf8');
-    fs.writeFileSync(path.join(rootPath, 'demo.kicad_pcb'), '', 'utf8');
-    fs.writeFileSync(path.join(rootPath, 'demo.kicad_dru'), '', 'utf8');
+    fs.writeFileSync(path.join(tempDir, 'demo.kicad_pro'), '{}', 'utf8');
+    fs.writeFileSync(path.join(tempDir, 'demo.kicad_sch'), '', 'utf8');
+    fs.writeFileSync(path.join(tempDir, 'upper.KICAD_SCH'), '', 'utf8');
+    fs.writeFileSync(path.join(tempDir, 'demo.kicad_pcb'), '', 'utf8');
+    fs.writeFileSync(path.join(tempDir, 'demo.kicad_dru'), '', 'utf8');
 
     const provider = new KiCadProjectTreeProvider();
     const project = await (
       provider as unknown as {
         buildWorkspaceNode(path: string): Promise<ProjectTreeNode>;
       }
-    ).buildWorkspaceNode(rootPath);
+    ).buildWorkspaceNode(tempDir);
 
     expect(project.children?.map((node) => node.label)).toEqual([
       'Project Files',
@@ -39,10 +74,8 @@ describe('KiCadProjectTreeProvider', () => {
       'PCB',
       'Design Rules'
     ]);
-    expect(project.children?.[0]?.children?.map((node) => node.label)).toEqual([
-      'demo.kicad_pro'
-    ]);
-    expect(project.children?.[1]?.children).toEqual(
+    expect(labelsFor(project, 'Project Files')).toEqual(['demo.kicad_pro']);
+    expect(childrenFor(project, 'Schematic Sheets')).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           label: 'upper.KICAD_SCH',
@@ -50,8 +83,6 @@ describe('KiCadProjectTreeProvider', () => {
         })
       ])
     );
-
-    fs.rmSync(rootPath, { recursive: true, force: true });
   });
 
   it('uses distinct icons and open commands for KiCad file types', () => {
@@ -73,16 +104,124 @@ describe('KiCadProjectTreeProvider', () => {
       uri: Uri.file('/project/demo.kicad_dru') as never
     });
 
-    expect(schematic.iconPath).toEqual(expect.objectContaining({ id: 'symbol-class' }));
+    expect(schematic.iconPath).toEqual(
+      expect.objectContaining({ id: 'symbol-class' })
+    );
     expect(schematic.command).toEqual(
       expect.objectContaining({ command: 'kicadstudio.openSchematic' })
     );
-    expect(pcb.iconPath).toEqual(expect.objectContaining({ id: 'circuit-board' }));
+    expect(pcb.iconPath).toEqual(
+      expect.objectContaining({ id: 'circuit-board' })
+    );
     expect(pcb.command).toEqual(
       expect.objectContaining({ command: 'kicadstudio.openPCB' })
     );
     expect(rules.iconPath).toEqual(expect.objectContaining({ id: 'law' }));
-    expect(rules.command).toEqual(expect.objectContaining({ command: 'vscode.open' }));
+    expect(rules.command).toEqual(
+      expect.objectContaining({ command: 'vscode.open' })
+    );
+  });
+
+  it('discovers KiCad project files deterministically without backup or generated noise', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kicadstudio-tree-'));
+    workspace.workspaceFolders = [{ uri: Uri.file(tempDir) }] as never;
+    __setConfiguration({ 'kicadstudio.defaultOutputDir': 'fab' });
+
+    for (const file of [
+      'board.kicad_pcb',
+      'board.kicad_pro',
+      'board.kicad_sch',
+      'jobs/a-release.kicad_jobset',
+      'jobs/z-release.kicad_jobset',
+      'rules.kicad_dru',
+      '.code-backups/board.kicad_pcb',
+      '.history/board.kicad_sch',
+      'board-backups/board.kicad_sch',
+      'fab/board.kicad_pcb',
+      'fab/report.pdf',
+      'generated/board.kicad_pro',
+      'temp/scratch.kicad_sch'
+    ]) {
+      const absolute = path.join(tempDir, file);
+      fs.mkdirSync(path.dirname(absolute), { recursive: true });
+      fs.writeFileSync(absolute, '', 'utf8');
+    }
+
+    const provider = new KiCadProjectTreeProvider();
+    const [root] = await provider.getChildren();
+
+    expect(root?.label).toBe(path.basename(tempDir));
+    expect(root?.children?.map((node) => node.label)).toEqual([
+      'Project Files',
+      'Schematic Sheets',
+      'PCB',
+      'Design Rules',
+      'Jobsets',
+      'Fabrication Outputs'
+    ]);
+    expect(labelsFor(root, 'Project Files')).toEqual(['board.kicad_pro']);
+    expect(labelsFor(root, 'Schematic Sheets')).toEqual(['board.kicad_sch']);
+    expect(labelsFor(root, 'PCB')).toEqual(['board.kicad_pcb']);
+    expect(labelsFor(root, 'Design Rules')).toEqual(['rules.kicad_dru']);
+    expect(labelsFor(root, 'Jobsets')).toEqual([
+      'a-release.kicad_jobset',
+      'z-release.kicad_jobset'
+    ]);
+    expect(labelsFor(root, 'Fabrication Outputs')).toEqual(['report.pdf']);
+  });
+
+  it('honors absolute output directories for source ignores and fabrication outputs', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kicadstudio-tree-'));
+    const outputDir = path.join(tempDir, 'absolute-fab');
+    workspace.workspaceFolders = [{ uri: Uri.file(tempDir) }] as never;
+    __setConfiguration({ 'kicadstudio.defaultOutputDir': outputDir });
+
+    for (const file of [
+      'board.kicad_pcb',
+      'absolute-fab/board.kicad_pcb',
+      'absolute-fab/report.pdf'
+    ]) {
+      const absolute = path.join(tempDir, file);
+      fs.mkdirSync(path.dirname(absolute), { recursive: true });
+      fs.writeFileSync(absolute, '', 'utf8');
+    }
+
+    const provider = new KiCadProjectTreeProvider();
+    const [root] = await provider.getChildren();
+
+    expect(labelsFor(root, 'PCB')).toEqual(['board.kicad_pcb']);
+    expect(labelsFor(root, 'Fabrication Outputs')).toEqual(['report.pdf']);
+  });
+
+  it('keeps case-distinct source files and output directories separate on case-sensitive workspaces', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kicadstudio-tree-'));
+    if (!isCaseSensitiveDirectory(tempDir)) {
+      return;
+    }
+    workspace.workspaceFolders = [{ uri: Uri.file(tempDir) }] as never;
+    __setConfiguration({ 'kicadstudio.defaultOutputDir': 'fab' });
+
+    for (const file of [
+      'Board.kicad_pcb',
+      'board.kicad_pcb',
+      'Fab/board.kicad_sch',
+      'fab/board.kicad_pcb',
+      'fab/report.pdf'
+    ]) {
+      const absolute = path.join(tempDir, file);
+      fs.mkdirSync(path.dirname(absolute), { recursive: true });
+      fs.writeFileSync(absolute, '', 'utf8');
+    }
+
+    const provider = new KiCadProjectTreeProvider();
+    const [root] = await provider.getChildren();
+
+    expect(labelsFor(root, 'PCB')).toEqual([
+      'Board.kicad_pcb',
+      'board.kicad_pcb'
+    ]);
+    expect(labelsFor(root, 'Schematic Sheets')).toEqual(['board.kicad_sch']);
+    expect(labelsFor(root, 'Fabrication Outputs')).toEqual(['report.pdf']);
   });
 
   it('explains file roles and diagnostic state with tooltips and ThemeIcons', () => {

--- a/scripts/check-no-forbidden-refs.mjs
+++ b/scripts/check-no-forbidden-refs.mjs
@@ -10,6 +10,7 @@ const ignoredDirs = new Set([
   ".pytest_cache",
   ".mypy_cache",
   ".ruff_cache",
+  ".vscode-test",
   "__pycache__",
   "coverage",
   "htmlcov",


### PR DESCRIPTION
Linear: OASLANA-37
Refs #38

## Summary
- Harden KiCad project tree discovery so backup, history, generated, temp, and configured output directories do not appear as source project files.
- Preserve fabrication output discovery while using the resolved output path for absolute `kicadstudio.defaultOutputDir` values.
- Remove redundant recursive-walk dedupe and use platform-aware path comparison for ignored directories so case-sensitive workspaces keep distinct paths such as `fab` and `Fab` separate.
- Add temp-workspace unit regressions for grouped project discovery, absolute output directories, case-distinct paths, deterministic jobset ordering, and fabrication output listing.
- Refresh the quality gate integration assertion to match the current manifest and exclude generated VS Code integration runtimes from forbidden-reference scanning.

## Validation
- PASS: `corepack pnpm install --frozen-lockfile`
- PASS: `corepack pnpm run format:check`
- PASS: `corepack pnpm run lint`
- PASS: `corepack pnpm run typecheck`
- PASS: `corepack pnpm --filter kicadstudio exec jest --runInBand test/unit/projectTreeProvider.test.ts --coverage=false` (7 tests, 5.623s)
- PASS: `xvfb-run -a corepack pnpm run test` (extension unit 506 tests, extension integration 13 tests, MCP pytest full coverage 90.26%)
- PASS: `corepack pnpm run build`
- PASS: `corepack pnpm run check`
- PASS: `corepack pnpm audit --audit-level high`
- PASS: `uvx pre-commit run --all-files`
- PASS: `git diff --check`

## Notes
- Direct `corepack pnpm run test` failed in this headless shell because VS Code/Electron integration tests require a display (`Missing X server or $DISPLAY` / `SIGSEGV`). The same root test command passed under `xvfb-run -a`, matching the repo's CI pattern for VS Code host tests.
- `corepack pnpm run verify:dist` is blocked by the repository lacking a root `verify:dist` script (`ERR_PNPM_NO_SCRIPT`). I did not add unrelated dist/release tooling inside the OASLANA-37 project-discovery slice.
- `uv sync && uv run pytest` is not applicable to this code change because no MCP/Python files were touched; MCP pytest still ran through the root `test` and `check` gates.
