### PR TITLE
feat(studio): add mcp tool adapter layer

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -237,7 +237,7 @@
         {
           "id": "kicadstudio.qualityGate",
           "name": "Quality Gates",
-          "when": "kicadstudio.hasProject",
+          "when": "kicadstudio.mcpConnected && kicadstudio.hasProject",
           "icon": "assets/views/quality-gates.svg"
         },
         {

--- a/apps/vscode-extension/src/ai/chatHtml.ts
+++ b/apps/vscode-extension/src/ai/chatHtml.ts
@@ -209,6 +209,12 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       display: grid;
       gap: 5px;
     }
+    .tool-error {
+      margin: 0 9px 9px;
+      color: var(--danger);
+      font-size: 12px;
+      white-space: pre-wrap;
+    }
     footer {
       display: grid;
       gap: 8px;
@@ -473,6 +479,12 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
         list.appendChild(row);
       }
       details.appendChild(list);
+      if (message.toolApplyError) {
+        const error = document.createElement('div');
+        error.className = 'tool-error';
+        error.textContent = text(message.toolApplyError);
+        details.appendChild(error);
+      }
       if (!message.applied) {
         const actions = document.createElement('div');
         actions.className = 'tool-actions';

--- a/apps/vscode-extension/src/ai/chatPanel.ts
+++ b/apps/vscode-extension/src/ai/chatPanel.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { AI_CHAT_MAX_HISTORY, COMMANDS, SETTINGS } from '../constants';
 import { AIStreamAbortedError } from '../errors';
-import { McpClient } from '../mcp/mcpClient';
+import type { ChatMcpAdapter } from '../mcp/mcpToolAdapter';
 import { extractMcpToolCalls } from '../mcp/toolCallParser';
 import type { McpToolCall } from '../types';
 import { Logger } from '../utils/logger';
@@ -60,7 +60,7 @@ export class KiCadChatPanel implements vscode.Disposable {
     context: vscode.ExtensionContext,
     providers: AIProviderRegistry,
     logger: Logger,
-    mcpClient?: McpClient
+    mcpAdapter?: ChatMcpAdapter
   ): KiCadChatPanel {
     if (KiCadChatPanel.instance) {
       KiCadChatPanel.instance.panel.reveal(vscode.ViewColumn.Beside);
@@ -84,7 +84,7 @@ export class KiCadChatPanel implements vscode.Disposable {
       panel,
       providers,
       logger,
-      mcpClient
+      mcpAdapter
     );
     KiCadChatPanel.instance = instance;
     context.subscriptions.push(instance);
@@ -96,7 +96,7 @@ export class KiCadChatPanel implements vscode.Disposable {
     panel: vscode.WebviewPanel,
     private readonly providers: AIProviderRegistry,
     private readonly logger: Logger,
-    private readonly mcpClient?: McpClient
+    private readonly mcpAdapter?: ChatMcpAdapter
   ) {
     this.panel = panel;
     const selection = providers.getSelection();
@@ -271,8 +271,8 @@ export class KiCadChatPanel implements vscode.Disposable {
     ]
       .filter(Boolean)
       .join('\n\n');
-    const mcpState = this.mcpClient
-      ? await this.mcpClient.testConnection()
+    const mcpState = this.mcpAdapter
+      ? await this.mcpAdapter.testConnection()
       : undefined;
     const systemPrompt = buildSystemPrompt(aiLanguage, {
       ...activeContext.projectContext,
@@ -412,17 +412,18 @@ export class KiCadChatPanel implements vscode.Disposable {
     if (!target?.toolCalls?.length) {
       return;
     }
-    if (!this.mcpClient) {
+    if (!this.mcpAdapter) {
       void vscode.window.showWarningMessage(
         'MCP client is not available in this session.'
       );
       return;
     }
+    const mcpAdapter = this.mcpAdapter;
 
     const previews = await Promise.all(
       target.toolCalls.map(async (toolCall) => {
         try {
-          return `${toolCall.name}: ${await this.mcpClient?.previewToolCall(toolCall)}`;
+          return `${toolCall.name}: ${await mcpAdapter.previewToolCall(toolCall)}`;
         } catch {
           return `${toolCall.name}: preview unavailable`;
         }
@@ -439,7 +440,7 @@ export class KiCadChatPanel implements vscode.Disposable {
     }
 
     for (const toolCall of target.toolCalls) {
-      await this.mcpClient.callTool(toolCall.name, toolCall.arguments);
+      await mcpAdapter.executeToolCall(toolCall);
     }
 
     target.applied = true;

--- a/apps/vscode-extension/src/ai/chatPanel.ts
+++ b/apps/vscode-extension/src/ai/chatPanel.ts
@@ -26,6 +26,7 @@ interface ChatMessage {
   timestamp: number;
   toolCalls?: McpToolCall[];
   applied?: boolean;
+  toolApplyError?: string;
 }
 
 const CHAT_HISTORY_KEY = 'kicadstudio.aiChat.history';
@@ -440,10 +441,29 @@ export class KiCadChatPanel implements vscode.Disposable {
     }
 
     for (const toolCall of target.toolCalls) {
-      await mcpAdapter.executeToolCall(toolCall);
+      try {
+        await mcpAdapter.executeToolCall(toolCall);
+      } catch (error) {
+        const message = messageFromUnknown(error);
+        const errorText = `MCP tool call failed for ${toolCall.name}: ${message}`;
+        target.toolApplyError = errorText;
+        this.logger.error(
+          `AI chat MCP tool call failed: ${toolCall.name} (${toolArgumentContext(toolCall)})`,
+          error
+        );
+        await this.persistHistory();
+        await this.panel.webview.postMessage({
+          type: 'assistantReplace',
+          message: target
+        });
+        await this.postStatus(errorText);
+        void vscode.window.showErrorMessage(errorText);
+        return;
+      }
     }
 
     target.applied = true;
+    delete target.toolApplyError;
     await this.persistHistory();
     await this.panel.webview.postMessage({
       type: 'assistantReplace',
@@ -471,4 +491,13 @@ export class KiCadChatPanel implements vscode.Disposable {
     this.disposables.forEach((disposable) => disposable.dispose());
     KiCadChatPanel.instance = undefined;
   }
+}
+
+function messageFromUnknown(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function toolArgumentContext(toolCall: McpToolCall): string {
+  const keys = Object.keys(toolCall.arguments ?? {});
+  return keys.length ? `argument keys: ${keys.join(', ')}` : 'no arguments';
 }

--- a/apps/vscode-extension/src/commands/aiCommands.ts
+++ b/apps/vscode-extension/src/commands/aiCommands.ts
@@ -71,7 +71,7 @@ export function registerAiCommands(
         extensionContext,
         services.aiProviders,
         services.logger,
-        services.mcpClient
+        services.mcpAdapter
       );
       await panel.submitPrompt(
         'Analyze the latest DRC results and prioritize fixes.',
@@ -88,7 +88,7 @@ export function registerAiCommands(
         extensionContext,
         services.aiProviders,
         services.logger,
-        services.mcpClient
+        services.mcpAdapter
       );
     }),
 

--- a/apps/vscode-extension/src/commands/manufacturingReleaseWizard.ts
+++ b/apps/vscode-extension/src/commands/manufacturingReleaseWizard.ts
@@ -18,34 +18,34 @@ export async function runManufacturingReleaseWizard(
     return;
   }
 
-  const gates = await services.mcpAdapter.runProjectQualityGate();
-  const blocking = gates.filter((gate) =>
-    ['FAIL', 'BLOCKED'].includes(gate.status)
-  );
-  if (blocking.length) {
-    telemetry.trackEvent('wizard.blocked');
-    void vscode.window.showWarningMessage(formatBlockedMessage(blocking));
-    return;
-  }
-
-  const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  const defaultOutput = root
-    ? path.join(
-        root,
-        'output',
-        `release-${variant || 'default'}-${new Date()
-          .toISOString()
-          .replace(/[:.]/g, '-')}`
-      )
-    : '';
-  await vscode.window.showInputBox({
-    title: 'Manufacturing release output folder',
-    value: defaultOutput,
-    prompt:
-      'kicad-mcp-pro 1.0.0 uses its configured output directory; this path is recorded for user confirmation.'
-  });
-
   try {
+    const gates = await services.mcpAdapter.runProjectQualityGate();
+    const blocking = gates.filter((gate) =>
+      ['FAIL', 'BLOCKED'].includes(gate.status)
+    );
+    if (blocking.length) {
+      telemetry.trackEvent('wizard.blocked');
+      void vscode.window.showWarningMessage(formatBlockedMessage(blocking));
+      return;
+    }
+
+    const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const defaultOutput = root
+      ? path.join(
+          root,
+          'output',
+          `release-${variant || 'default'}-${new Date()
+            .toISOString()
+            .replace(/[:.]/g, '-')}`
+        )
+      : '';
+    await vscode.window.showInputBox({
+      title: 'Manufacturing release output folder',
+      value: defaultOutput,
+      prompt:
+        'kicad-mcp-pro 1.0.0 uses its configured output directory; this path is recorded for user confirmation.'
+    });
+
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,

--- a/apps/vscode-extension/src/commands/manufacturingReleaseWizard.ts
+++ b/apps/vscode-extension/src/commands/manufacturingReleaseWizard.ts
@@ -10,7 +10,7 @@ import { telemetry } from '../utils/telemetry';
 import type { CommandServices } from './types';
 
 export async function runManufacturingReleaseWizard(
-  services: Pick<CommandServices, 'variantProvider' | 'mcpClient' | 'context'>
+  services: Pick<CommandServices, 'variantProvider' | 'mcpAdapter' | 'context'>
 ): Promise<void> {
   telemetry.trackEvent('wizard.start');
   const variant = await chooseVariant(services);
@@ -18,7 +18,7 @@ export async function runManufacturingReleaseWizard(
     return;
   }
 
-  const gates = await services.mcpClient.runProjectQualityGate();
+  const gates = await services.mcpAdapter.runProjectQualityGate();
   const blocking = gates.filter((gate) =>
     ['FAIL', 'BLOCKED'].includes(gate.status)
   );
@@ -53,7 +53,7 @@ export async function runManufacturingReleaseWizard(
         cancellable: false
       },
       async () => {
-        await services.mcpClient.exportManufacturingPackage(
+        await services.mcpAdapter.exportManufacturingPackage(
           variant || undefined
         );
       }

--- a/apps/vscode-extension/src/commands/mcpCommands.ts
+++ b/apps/vscode-extension/src/commands/mcpCommands.ts
@@ -36,9 +36,7 @@ export function registerMcpCommands(
           }
           if (choice === 'Open Repository') {
             await vscode.env.openExternal(
-              vscode.Uri.parse(
-                'https://github.com/oaslananka/kicad-studio-kit'
-              )
+              vscode.Uri.parse('https://github.com/oaslananka/kicad-studio-kit')
             );
           }
           return;
@@ -243,7 +241,7 @@ export function registerMcpCommands(
     registerTrustedCommand(
       COMMANDS.openDesignIntent,
       () => {
-        DesignIntentPanel.createOrShow(extensionContext, services.mcpClient);
+        DesignIntentPanel.createOrShow(extensionContext, services.mcpAdapter);
       },
       'Design Intent'
     ),
@@ -284,7 +282,7 @@ export function registerMcpCommands(
       async () => {
         await DrcRuleEditorPanel.createOrShow(
           extensionContext,
-          services.mcpClient
+          services.mcpAdapter
         );
       },
       'DRC Rule MCP Editing'

--- a/apps/vscode-extension/src/commands/types.ts
+++ b/apps/vscode-extension/src/commands/types.ts
@@ -11,6 +11,7 @@ import type { AIProviderRegistry } from '../ai/aiProvider';
 import type { ErrorAnalyzer } from '../ai/errorAnalyzer';
 import type { CircuitExplainer } from '../ai/circuitExplainer';
 import type { McpClient } from '../mcp/mcpClient';
+import type { StudioMcpAdapter } from '../mcp/mcpToolAdapter';
 import type { KiCadLibraryIndexer } from '../library/libraryIndexer';
 import type { LibrarySearchProvider } from '../library/librarySearchProvider';
 import type { VariantProvider } from '../variants/variantProvider';
@@ -40,6 +41,7 @@ export interface CommandServices {
   errorAnalyzer: ErrorAnalyzer;
   circuitExplainer: CircuitExplainer;
   mcpClient: McpClient;
+  mcpAdapter: StudioMcpAdapter;
   mcpLogger: McpLogger;
   qualityGateProvider: QualityGateProvider;
   libraryIndexer: KiCadLibraryIndexer;

--- a/apps/vscode-extension/src/drc/drcRuleEditorPanel.ts
+++ b/apps/vscode-extension/src/drc/drcRuleEditorPanel.ts
@@ -1,16 +1,16 @@
 import * as vscode from 'vscode';
 import { createNonce } from '../utils/nonce';
 import { asRecord, asString, hasType } from '../utils/webviewMessages';
-import type { McpClient } from '../mcp/mcpClient';
+import type { DrcRulesMcpAdapter } from '../mcp/mcpToolAdapter';
 
 export class DrcRuleEditorPanel {
   private static currentPanel: DrcRuleEditorPanel | undefined;
 
   static async createOrShow(
     context: vscode.ExtensionContext,
-    mcpClient: McpClient
+    mcpAdapter: DrcRulesMcpAdapter
   ): Promise<void> {
-    const state = await mcpClient.testConnection();
+    const state = await mcpAdapter.testConnection();
     if (!state.connected) {
       const choice = await vscode.window.showWarningMessage(
         'DRC rule editing requires a connected kicad-mcp-pro server.',
@@ -36,14 +36,14 @@ export class DrcRuleEditorPanel {
     DrcRuleEditorPanel.currentPanel = new DrcRuleEditorPanel(
       panel,
       context,
-      mcpClient
+      mcpAdapter
     );
   }
 
   private constructor(
     private readonly panel: vscode.WebviewPanel,
     context: vscode.ExtensionContext,
-    private readonly mcpClient: McpClient
+    private readonly mcpAdapter: DrcRulesMcpAdapter
   ) {
     this.panel.webview.html = this.renderHtml(context);
     this.panel.onDidDispose(() => {
@@ -65,7 +65,7 @@ export class DrcRuleEditorPanel {
     }
 
     if (message.type === 'upsert') {
-      await this.mcpClient.callTool('drc_rule_upsert', {
+      await this.mcpAdapter.upsertDrcRule({
         name,
         condition: asString(payload['condition']) ?? '',
         constraint: asString(payload['constraint']) ?? ''
@@ -73,7 +73,7 @@ export class DrcRuleEditorPanel {
       return;
     }
 
-    await this.mcpClient.callTool('drc_rule_delete', { name });
+    await this.mcpAdapter.deleteDrcRule(name);
   }
 
   private renderHtml(_context: vscode.ExtensionContext): string {

--- a/apps/vscode-extension/src/drc/drcRuleEditorPanel.ts
+++ b/apps/vscode-extension/src/drc/drcRuleEditorPanel.ts
@@ -10,14 +10,27 @@ export class DrcRuleEditorPanel {
     context: vscode.ExtensionContext,
     mcpAdapter: DrcRulesMcpAdapter
   ): Promise<void> {
-    const state = await mcpAdapter.testConnection();
+    let state: Awaited<ReturnType<DrcRulesMcpAdapter['testConnection']>>;
+    try {
+      state = await mcpAdapter.testConnection();
+    } catch (error) {
+      await showDrcRuleEditorError(
+        'Unable to check MCP connection for DRC rule editing',
+        error
+      );
+      return;
+    }
     if (!state.connected) {
       const choice = await vscode.window.showWarningMessage(
         'DRC rule editing requires a connected kicad-mcp-pro server.',
         'Setup MCP'
       );
       if (choice === 'Setup MCP') {
-        await vscode.commands.executeCommand('kicadstudio.setupMcpIntegration');
+        try {
+          await vscode.commands.executeCommand('kicadstudio.setupMcpIntegration');
+        } catch (error) {
+          await showDrcRuleEditorError('Unable to open MCP setup', error);
+        }
       }
       return;
     }
@@ -65,15 +78,23 @@ export class DrcRuleEditorPanel {
     }
 
     if (message.type === 'upsert') {
-      await this.mcpAdapter.upsertDrcRule({
-        name,
-        condition: asString(payload['condition']) ?? '',
-        constraint: asString(payload['constraint']) ?? ''
-      });
+      try {
+        await this.mcpAdapter.upsertDrcRule({
+          name,
+          condition: asString(payload['condition']) ?? '',
+          constraint: asString(payload['constraint']) ?? ''
+        });
+      } catch (error) {
+        await showDrcRuleEditorError(`Unable to save DRC rule ${name}`, error);
+      }
       return;
     }
 
-    await this.mcpAdapter.deleteDrcRule(name);
+    try {
+      await this.mcpAdapter.deleteDrcRule(name);
+    } catch (error) {
+      await showDrcRuleEditorError(`Unable to delete DRC rule ${name}`, error);
+    }
   }
 
   private renderHtml(_context: vscode.ExtensionContext): string {
@@ -123,4 +144,15 @@ export class DrcRuleEditorPanel {
 </body>
 </html>`;
   }
+}
+
+async function showDrcRuleEditorError(
+  prefix: string,
+  error: unknown
+): Promise<void> {
+  await vscode.window.showErrorMessage(`${prefix}: ${messageFromUnknown(error)}`);
+}
+
+function messageFromUnknown(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -49,6 +49,7 @@ import { registerMcpServerDefinitionProvider } from './lm/mcpServerDefinitionPro
 import { ContextBridge } from './mcp/contextBridge';
 import { McpClient } from './mcp/mcpClient';
 import { McpDetector } from './mcp/mcpDetector';
+import { McpToolAdapter } from './mcp/mcpToolAdapter';
 import { McpToolsProvider } from './mcp/mcpToolsProvider';
 import { FixQueueProvider } from './mcp/fixQueueProvider';
 import { KiCadDiagnosticsAggregator } from './language/diagnosticsAggregator';
@@ -151,11 +152,12 @@ export async function activate(
     logger: mcpLogger
   });
   extensionMcpClient = mcpClient;
-  const contextBridge = new ContextBridge(mcpClient);
-  const mcpToolsProvider = new McpToolsProvider(mcpClient);
-  const variantProvider = new VariantProvider(mcpClient);
-  const fixQueueProvider = new FixQueueProvider(mcpClient);
-  const qualityGateProvider = new QualityGateProvider(context, mcpClient);
+  const mcpToolAdapter = new McpToolAdapter(mcpClient);
+  const contextBridge = new ContextBridge(mcpToolAdapter);
+  const mcpToolsProvider = new McpToolsProvider(mcpToolAdapter);
+  const variantProvider = new VariantProvider(mcpToolAdapter);
+  const fixQueueProvider = new FixQueueProvider(mcpToolAdapter);
+  const qualityGateProvider = new QualityGateProvider(context, mcpToolAdapter);
   const drcRulesProvider = new DrcRulesProvider(parser);
   const errorAnalyzer = new ErrorAnalyzer(aiProviders, logger);
   const circuitExplainer = new CircuitExplainer(aiProviders, logger);
@@ -359,6 +361,7 @@ export async function activate(
     libraryIndexer,
     librarySearch,
     mcpClient,
+    mcpAdapter: mcpToolAdapter,
     mcpLogger,
     variantProvider,
     drcRulesProvider,

--- a/apps/vscode-extension/src/mcp/contextBridge.ts
+++ b/apps/vscode-extension/src/mcp/contextBridge.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import type { StudioContext } from '../types';
-import { McpClient } from './mcpClient';
+import type { ContextMcpAdapter } from './mcpToolAdapter';
 
 export type ContextPushReason = 'save' | 'focus' | 'cursor' | 'drc' | 'default';
 
@@ -22,7 +22,7 @@ export class ContextBridge {
     | undefined;
   private flushTimer: NodeJS.Timeout | undefined;
 
-  constructor(private readonly client: McpClient) {}
+  constructor(private readonly adapter: ContextMcpAdapter) {}
 
   dispose(): void {
     if (this.flushTimer) {
@@ -71,7 +71,7 @@ export class ContextBridge {
     }
 
     this.lastContextHash = next.hash;
-    void this.client.pushContext(next.context);
+    void this.adapter.pushStudioContext(next.context);
   }
 }
 

--- a/apps/vscode-extension/src/mcp/designIntentPanel.ts
+++ b/apps/vscode-extension/src/mcp/designIntentPanel.ts
@@ -39,22 +39,40 @@ export class DesignIntentPanel {
       }
 
       if (message.type === 'load') {
-        const intent = await mcpAdapter.getDesignIntent();
-        await panel.webview.postMessage({
-          type: 'loaded',
-          data: intent ?? {}
-        });
+        try {
+          const intent = await mcpAdapter.getDesignIntent();
+          await panel.webview.postMessage({
+            type: 'loaded',
+            data: intent ?? {}
+          });
+        } catch (error) {
+          await this.postError(panel, 'Unable to load design intent', error);
+        }
         return;
       }
 
       if (message.type === 'save') {
         const record = asRecord(message);
-        await mcpAdapter.setDesignIntent(asRecord(record?.['data']) ?? {});
-        void vscode.window.showInformationMessage(
-          'Design intent saved. AI can now use your project intent as context.'
-        );
+        try {
+          await mcpAdapter.setDesignIntent(asRecord(record?.['data']) ?? {});
+          void vscode.window.showInformationMessage(
+            'Design intent saved. AI can now use your project intent as context.'
+          );
+        } catch (error) {
+          await this.postError(panel, 'Unable to save design intent', error);
+        }
       }
     });
+  }
+
+  private static async postError(
+    panel: vscode.WebviewPanel,
+    prefix: string,
+    error: unknown
+  ): Promise<void> {
+    const message = messageFromUnknown(error);
+    await panel.webview.postMessage({ type: 'error', error: message });
+    await vscode.window.showErrorMessage(`${prefix}: ${message}`);
   }
 
   private static getFormHtml(): string {
@@ -116,10 +134,15 @@ export class DesignIntentPanel {
     button:hover {
       background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
     }
+    #status {
+      min-height: 18px;
+      color: var(--vscode-errorForeground);
+    }
   </style>
 </head>
 <body>
   <h1>KiCad Design Intent</h1>
+  <p id="status" role="status" aria-live="polite"></p>
   <form id="intent-form" aria-label="Design intent form">
     <label for="powerTreeRefs">Power tree references
       <textarea id="powerTreeRefs" name="powerTreeRefs" placeholder="U1, U2, L1, FB1"
@@ -179,6 +202,9 @@ export class DesignIntentPanel {
     window.addEventListener('message', (event) => {
       const message = event.data;
       if (message.type !== 'loaded' || !message.data) {
+        if (message.type === 'error') {
+          document.getElementById('status').textContent = message.error || 'MCP request failed.';
+        }
         return;
       }
       for (const [key, value] of Object.entries(message.data)) {
@@ -194,4 +220,8 @@ export class DesignIntentPanel {
 </body>
 </html>`;
   }
+}
+
+function messageFromUnknown(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/vscode-extension/src/mcp/designIntentPanel.ts
+++ b/apps/vscode-extension/src/mcp/designIntentPanel.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { asRecord, hasType } from '../utils/webviewMessages';
-import { McpClient } from './mcpClient';
+import type { DesignIntentMcpAdapter } from './mcpToolAdapter';
 import { createNonce } from '../utils/nonce';
 
 export class DesignIntentPanel {
@@ -8,7 +8,7 @@ export class DesignIntentPanel {
 
   static createOrShow(
     context: vscode.ExtensionContext,
-    mcpClient: McpClient
+    mcpAdapter: DesignIntentMcpAdapter
   ): void {
     if (DesignIntentPanel.currentPanel) {
       DesignIntentPanel.currentPanel.reveal(vscode.ViewColumn.Beside);
@@ -39,10 +39,7 @@ export class DesignIntentPanel {
       }
 
       if (message.type === 'load') {
-        const intent = await mcpClient.callTool(
-          'project_get_design_intent',
-          {}
-        );
+        const intent = await mcpAdapter.getDesignIntent();
         await panel.webview.postMessage({
           type: 'loaded',
           data: intent ?? {}
@@ -52,10 +49,7 @@ export class DesignIntentPanel {
 
       if (message.type === 'save') {
         const record = asRecord(message);
-        await mcpClient.callTool(
-          'project_set_design_intent',
-          asRecord(record?.['data']) ?? {}
-        );
+        await mcpAdapter.setDesignIntent(asRecord(record?.['data']) ?? {});
         void vscode.window.showInformationMessage(
           'Design intent saved. AI can now use your project intent as context.'
         );

--- a/apps/vscode-extension/src/mcp/fixQueueProvider.ts
+++ b/apps/vscode-extension/src/mcp/fixQueueProvider.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { COMMANDS } from '../constants';
 import type { FixItem } from '../types';
-import { McpClient } from './mcpClient';
+import { isRecoverableMcpUnavailableError } from './mcpErrorMapper';
+import type { FixQueueMcpAdapter } from './mcpToolAdapter';
 
 class FixQueueTreeItem extends vscode.TreeItem {
   constructor(public readonly item: FixItem) {
@@ -31,7 +32,7 @@ export class FixQueueProvider implements vscode.TreeDataProvider<FixItem> {
   readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
   private items: FixItem[] = [];
 
-  constructor(private readonly mcpClient: McpClient) {}
+  constructor(private readonly adapter: FixQueueMcpAdapter) {}
 
   getTreeItem(element: FixItem): vscode.TreeItem {
     return new FixQueueTreeItem(element);
@@ -60,17 +61,12 @@ export class FixQueueProvider implements vscode.TreeDataProvider<FixItem> {
 
   async refresh(): Promise<void> {
     try {
-      this.items = await this.mcpClient.fetchFixQueue();
+      this.items = await this.adapter.fetchFixQueue();
     } catch (err) {
       // Swallow errors when MCP is connected via VS Code stdio (HTTP not
       // available) or when the server is temporarily unreachable, so the
       // tree view degrades gracefully instead of surfacing a raw error toast.
-      const msg = err instanceof Error ? err.message : String(err);
-      if (
-        !msg.includes('stdio') &&
-        !msg.includes('fetch') &&
-        !msg.includes('ECONNREFUSED')
-      ) {
+      if (!isRecoverableMcpUnavailableError(err)) {
         throw err;
       }
       this.items = [];
@@ -84,7 +80,7 @@ export class FixQueueProvider implements vscode.TreeDataProvider<FixItem> {
       await this.applyFix(item);
       return;
     }
-    await this.mcpClient.callTool('apply_fix', { id });
+    await this.adapter.applyFixById(id);
     await this.refresh();
   }
 
@@ -125,7 +121,7 @@ export class FixQueueProvider implements vscode.TreeDataProvider<FixItem> {
   ): Promise<void> {
     const preview =
       item.preview ??
-      (await this.mcpClient.previewToolCall({
+      (await this.adapter.previewToolCall({
         name: item.tool,
         arguments: item.args
       }));
@@ -150,10 +146,7 @@ export class FixQueueProvider implements vscode.TreeDataProvider<FixItem> {
       return;
     }
 
-    await this.mcpClient.callTool(
-      item.tool || 'apply_fix',
-      item.tool ? item.args : { id: item.id }
-    );
+    await this.adapter.applyFixTool(item);
     item.status = 'done';
     this.onDidChangeTreeDataEmitter.fire(undefined);
     void vscode.window.showInformationMessage(`Applied: ${item.description}`);

--- a/apps/vscode-extension/src/mcp/mcpErrorMapper.ts
+++ b/apps/vscode-extension/src/mcp/mcpErrorMapper.ts
@@ -1,0 +1,105 @@
+export type McpMappedErrorKind =
+  | 'bad-request'
+  | 'http'
+  | 'incompatible'
+  | 'missing-tool'
+  | 'network'
+  | 'server'
+  | 'session'
+  | 'stdio'
+  | 'timeout'
+  | 'unknown';
+
+export interface McpMappedError {
+  kind: McpMappedErrorKind;
+  message: string;
+  retryable: boolean;
+  status?: number | undefined;
+  code?: string | undefined;
+  hint?: string | undefined;
+}
+
+export function mapMcpError(error: unknown): McpMappedError {
+  const message = error instanceof Error ? error.message : String(error);
+  const status = httpStatusFromMessage(message);
+  const code = stringProperty(error, 'code');
+  const hint = stringProperty(error, 'hint');
+
+  if (
+    code &&
+    /(?:tool|method).*(?:missing|not[_-]?found)|not[_-]?found/i.test(code)
+  ) {
+    return {
+      kind: 'missing-tool',
+      message,
+      retryable: false,
+      code,
+      hint
+    };
+  }
+
+  if (/stdio/i.test(message)) {
+    return { kind: 'stdio', message, retryable: false, code, hint };
+  }
+  if (/incompatible/i.test(message)) {
+    return { kind: 'incompatible', message, retryable: false, code, hint };
+  }
+  if (/timed out|timeout|AbortError/i.test(message)) {
+    return { kind: 'timeout', message, retryable: true, code, hint };
+  }
+  if (status === 400) {
+    return {
+      kind: 'bad-request',
+      message,
+      retryable: false,
+      status,
+      code,
+      hint
+    };
+  }
+  if (status === 421) {
+    return { kind: 'session', message, retryable: true, status, code, hint };
+  }
+  if (typeof status === 'number' && status >= 500) {
+    return { kind: 'server', message, retryable: true, status, code, hint };
+  }
+  if (typeof status === 'number') {
+    return { kind: 'http', message, retryable: false, status, code, hint };
+  }
+  if (
+    error instanceof TypeError ||
+    /(?:ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|network|fetch)/i.test(
+      message
+    )
+  ) {
+    return { kind: 'network', message, retryable: true, code, hint };
+  }
+
+  return { kind: 'unknown', message, retryable: false, code, hint };
+}
+
+export function isRecoverableMcpUnavailableError(error: unknown): boolean {
+  const mapped = mapMcpError(error);
+  return (
+    mapped.kind === 'stdio' ||
+    mapped.kind === 'network' ||
+    mapped.kind === 'timeout'
+  );
+}
+
+function httpStatusFromMessage(message: string): number | undefined {
+  const match = /\bHTTP\s+(\d{3})\b/i.exec(message);
+  if (!match) {
+    return undefined;
+  }
+  const status = Number(match[1]);
+  return Number.isFinite(status) ? status : undefined;
+}
+
+function stringProperty(value: unknown, property: string): string | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  return typeof record[property] === 'string' ? record[property] : undefined;
+}

--- a/apps/vscode-extension/src/mcp/mcpErrorMapper.ts
+++ b/apps/vscode-extension/src/mcp/mcpErrorMapper.ts
@@ -39,7 +39,7 @@ export function mapMcpError(error: unknown): McpMappedError {
   }
 
   if (/stdio/i.test(message)) {
-    return { kind: 'stdio', message, retryable: false, code, hint };
+    return { kind: 'stdio', message, retryable: true, code, hint };
   }
   if (/incompatible/i.test(message)) {
     return { kind: 'incompatible', message, retryable: false, code, hint };

--- a/apps/vscode-extension/src/mcp/mcpToolAdapter.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolAdapter.ts
@@ -1,0 +1,236 @@
+import type {
+  FixItem,
+  McpConnectionState,
+  McpInstallStatus,
+  McpServerCard,
+  McpToolCall,
+  QualityGateResult,
+  StudioContext
+} from '../types';
+import type { McpClient } from './mcpClient';
+import { mapMcpError, type McpMappedError } from './mcpErrorMapper';
+
+export interface McpConnectionAdapter {
+  detectInstall(): Promise<McpInstallStatus>;
+  getState(): McpConnectionState;
+  getLastServerCard(): McpServerCard | undefined;
+  testConnection(): Promise<McpConnectionState>;
+  retryNow(): Promise<McpConnectionState>;
+}
+
+export interface ContextMcpAdapter {
+  pushStudioContext(context: StudioContext): Promise<void>;
+}
+
+export interface ToolExecutionMcpAdapter {
+  previewToolCall(toolCall: McpToolCall): Promise<string>;
+  executeToolCall(
+    toolCall: McpToolCall
+  ): Promise<Record<string, unknown> | undefined>;
+}
+
+export interface ChatMcpAdapter extends ToolExecutionMcpAdapter {
+  testConnection(): Promise<McpConnectionState>;
+}
+
+export interface QualityGateMcpAdapter {
+  runProjectQualityGate(): Promise<QualityGateResult[]>;
+  runPlacementQualityGate(): Promise<QualityGateResult>;
+  runTransferQualityGate(): Promise<QualityGateResult>;
+  runManufacturingQualityGate(): Promise<QualityGateResult>;
+}
+
+export interface ManufacturingMcpAdapter {
+  runProjectQualityGate(): Promise<QualityGateResult[]>;
+  exportManufacturingPackage(
+    variant: string | undefined
+  ): Promise<Record<string, unknown> | undefined>;
+}
+
+export interface FixQueueMcpAdapter extends ToolExecutionMcpAdapter {
+  fetchFixQueue(): Promise<FixItem[]>;
+  applyFixTool(item: FixItem): Promise<void>;
+  applyFixById(id: string): Promise<void>;
+}
+
+export interface VariantMcpAdapter {
+  testConnection(): Promise<McpConnectionState>;
+  setActiveVariant(name: string): Promise<void>;
+}
+
+export interface DrcRuleUpdate {
+  name: string;
+  condition: string;
+  constraint: string;
+}
+
+export interface DrcRulesMcpAdapter {
+  testConnection(): Promise<McpConnectionState>;
+  upsertDrcRule(rule: DrcRuleUpdate): Promise<void>;
+  deleteDrcRule(name: string): Promise<void>;
+}
+
+export interface DesignIntentMcpAdapter {
+  getDesignIntent(): Promise<Record<string, unknown> | undefined>;
+  setDesignIntent(intent: Record<string, unknown>): Promise<void>;
+}
+
+export interface BomNetlistMcpAdapter {
+  exportBom(
+    args?: Record<string, unknown>
+  ): Promise<Record<string, unknown> | undefined>;
+  exportNetlist(
+    args?: Record<string, unknown>
+  ): Promise<Record<string, unknown> | undefined>;
+  exportSpiceNetlist(
+    args?: Record<string, unknown>
+  ): Promise<Record<string, unknown> | undefined>;
+}
+
+export interface StudioMcpAdapter
+  extends
+    McpConnectionAdapter,
+    ContextMcpAdapter,
+    QualityGateMcpAdapter,
+    ManufacturingMcpAdapter,
+    FixQueueMcpAdapter,
+    ChatMcpAdapter,
+    VariantMcpAdapter,
+    DrcRulesMcpAdapter,
+    DesignIntentMcpAdapter,
+    BomNetlistMcpAdapter {}
+
+export type McpAdapterClient = Pick<
+  McpClient,
+  | 'callTool'
+  | 'detectInstall'
+  | 'exportManufacturingPackage'
+  | 'fetchFixQueue'
+  | 'getLastServerCard'
+  | 'getState'
+  | 'previewToolCall'
+  | 'pushContext'
+  | 'retryNow'
+  | 'runManufacturingQualityGate'
+  | 'runPlacementQualityGate'
+  | 'runProjectQualityGate'
+  | 'runTransferQualityGate'
+  | 'testConnection'
+>;
+
+export class McpToolAdapter implements StudioMcpAdapter {
+  constructor(private readonly client: McpAdapterClient) {}
+
+  detectInstall(): Promise<McpInstallStatus> {
+    return this.client.detectInstall();
+  }
+
+  getState(): McpConnectionState {
+    return this.client.getState();
+  }
+
+  getLastServerCard(): McpServerCard | undefined {
+    return this.client.getLastServerCard();
+  }
+
+  testConnection(): Promise<McpConnectionState> {
+    return this.client.testConnection();
+  }
+
+  retryNow(): Promise<McpConnectionState> {
+    return this.client.retryNow();
+  }
+
+  pushStudioContext(context: StudioContext): Promise<void> {
+    return this.client.pushContext(context);
+  }
+
+  fetchFixQueue(): Promise<FixItem[]> {
+    return this.client.fetchFixQueue();
+  }
+
+  previewToolCall(toolCall: McpToolCall): Promise<string> {
+    return this.client.previewToolCall(toolCall);
+  }
+
+  executeToolCall(
+    toolCall: McpToolCall
+  ): Promise<Record<string, unknown> | undefined> {
+    return this.client.callTool(toolCall.name, toolCall.arguments);
+  }
+
+  async applyFixTool(item: FixItem): Promise<void> {
+    await this.client.callTool(
+      item.tool || 'apply_fix',
+      item.tool ? item.args : { id: item.id }
+    );
+  }
+
+  async applyFixById(id: string): Promise<void> {
+    await this.client.callTool('apply_fix', { id });
+  }
+
+  runProjectQualityGate(): Promise<QualityGateResult[]> {
+    return this.client.runProjectQualityGate();
+  }
+
+  runPlacementQualityGate(): Promise<QualityGateResult> {
+    return this.client.runPlacementQualityGate();
+  }
+
+  runTransferQualityGate(): Promise<QualityGateResult> {
+    return this.client.runTransferQualityGate();
+  }
+
+  runManufacturingQualityGate(): Promise<QualityGateResult> {
+    return this.client.runManufacturingQualityGate();
+  }
+
+  exportManufacturingPackage(
+    variant: string | undefined
+  ): Promise<Record<string, unknown> | undefined> {
+    return this.client.exportManufacturingPackage(variant);
+  }
+
+  async setActiveVariant(name: string): Promise<void> {
+    await this.client.callTool('variant_set_active', { name });
+  }
+
+  async upsertDrcRule(rule: DrcRuleUpdate): Promise<void> {
+    await this.client.callTool('drc_rule_upsert', { ...rule });
+  }
+
+  async deleteDrcRule(name: string): Promise<void> {
+    await this.client.callTool('drc_rule_delete', { name });
+  }
+
+  getDesignIntent(): Promise<Record<string, unknown> | undefined> {
+    return this.client.callTool('project_get_design_intent', {});
+  }
+
+  async setDesignIntent(intent: Record<string, unknown>): Promise<void> {
+    await this.client.callTool('project_set_design_intent', intent);
+  }
+
+  exportBom(
+    args: Record<string, unknown> = {}
+  ): Promise<Record<string, unknown> | undefined> {
+    return this.client.callTool('export_bom', args);
+  }
+
+  exportNetlist(
+    args: Record<string, unknown> = {}
+  ): Promise<Record<string, unknown> | undefined> {
+    return this.client.callTool('export_netlist', args);
+  }
+
+  exportSpiceNetlist(
+    args: Record<string, unknown> = {}
+  ): Promise<Record<string, unknown> | undefined> {
+    return this.client.callTool('export_spice_netlist', args);
+  }
+
+  mapError(error: unknown): McpMappedError {
+    return mapMcpError(error);
+  }
+}

--- a/apps/vscode-extension/src/mcp/mcpToolAdapter.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolAdapter.ts
@@ -70,6 +70,15 @@ export interface DrcRulesMcpAdapter {
   deleteDrcRule(name: string): Promise<void>;
 }
 
+export interface DrcErcMcpAdapter {
+  runDrc(
+    args?: Record<string, unknown>
+  ): Promise<Record<string, unknown> | undefined>;
+  runErc(
+    args?: Record<string, unknown>
+  ): Promise<Record<string, unknown> | undefined>;
+}
+
 export interface DesignIntentMcpAdapter {
   getDesignIntent(): Promise<Record<string, unknown> | undefined>;
   setDesignIntent(intent: Record<string, unknown>): Promise<void>;
@@ -97,6 +106,7 @@ export interface StudioMcpAdapter
     ChatMcpAdapter,
     VariantMcpAdapter,
     DrcRulesMcpAdapter,
+    DrcErcMcpAdapter,
     DesignIntentMcpAdapter,
     BomNetlistMcpAdapter {}
 
@@ -202,6 +212,18 @@ export class McpToolAdapter implements StudioMcpAdapter {
 
   async deleteDrcRule(name: string): Promise<void> {
     await this.client.callTool('drc_rule_delete', { name });
+  }
+
+  runDrc(
+    args: Record<string, unknown> = {}
+  ): Promise<Record<string, unknown> | undefined> {
+    return this.client.callTool('run_drc', args);
+  }
+
+  runErc(
+    args: Record<string, unknown> = {}
+  ): Promise<Record<string, unknown> | undefined> {
+    return this.client.callTool('run_erc', args);
   }
 
   getDesignIntent(): Promise<Record<string, unknown> | undefined> {

--- a/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
@@ -5,7 +5,7 @@ import type {
   McpConnectionState,
   McpInstallStatus
 } from '../types';
-import type { McpClient } from './mcpClient';
+import type { McpConnectionAdapter } from './mcpToolAdapter';
 import { readConfiguredMcpProfile } from '../commands/mcpProfilePicker';
 
 type McpToolsNode = {
@@ -18,15 +18,15 @@ type McpToolsNode = {
   children?: McpToolsNode[] | undefined;
 };
 
-export class McpToolsProvider
-  implements vscode.TreeDataProvider<McpToolsNode>
-{
+export class McpToolsProvider implements vscode.TreeDataProvider<McpToolsNode> {
   private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<
     McpToolsNode | undefined
   >();
   readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
 
-  constructor(private readonly mcpClient: Pick<McpClient, 'getState'>) {}
+  constructor(
+    private readonly mcpAdapter: Pick<McpConnectionAdapter, 'getState'>
+  ) {}
 
   refresh(): void {
     this.onDidChangeTreeDataEmitter.fire(undefined);
@@ -58,7 +58,7 @@ export class McpToolsProvider
       return element.children;
     }
     return buildMcpToolNodes(
-      this.mcpClient.getState(),
+      this.mcpAdapter.getState(),
       readConfiguredMcpProfile()
     );
   }
@@ -85,7 +85,12 @@ function buildMcpToolNodes(
   ];
 
   if (state.server) {
-    nodes.splice(3, 0, serverNode(state), capabilityNode(state.server.capabilities));
+    nodes.splice(
+      3,
+      0,
+      serverNode(state),
+      capabilityNode(state.server.capabilities)
+    );
   }
   if (state.message) {
     nodes.splice(1, 0, {
@@ -139,7 +144,9 @@ function stateNode(state: McpConnectionState): McpToolsNode {
     description: state.available ? 'detected, not connected' : 'not detected',
     icon: state.available ? 'warning' : 'circle-slash',
     command: {
-      command: state.available ? COMMANDS.retryMcp : COMMANDS.setupMcpIntegration,
+      command: state.available
+        ? COMMANDS.retryMcp
+        : COMMANDS.setupMcpIntegration,
       title: state.available ? 'Retry MCP Connection' : 'Setup MCP Integration'
     }
   };
@@ -206,7 +213,9 @@ function capabilityGroup(label: string, values: string[]): McpToolsNode {
   return {
     label,
     description: values.length ? `${values.length}` : 'none',
-    tooltip: values.length ? values.join('\n') : `No ${label.toLowerCase()} advertised.`,
+    tooltip: values.length
+      ? values.join('\n')
+      : `No ${label.toLowerCase()} advertised.`,
     icon: values.length ? 'list-tree' : 'circle-slash',
     children: values.slice(0, 25).map((value) => ({
       label: value,

--- a/apps/vscode-extension/src/providers/qualityGateProvider.ts
+++ b/apps/vscode-extension/src/providers/qualityGateProvider.ts
@@ -6,7 +6,7 @@ import type {
   QualityGateStatus,
   QualityGateViolation
 } from '../types';
-import type { McpClient } from '../mcp/mcpClient';
+import type { QualityGateMcpAdapter } from '../mcp/mcpToolAdapter';
 
 type QualityGateElement =
   | {
@@ -37,7 +37,7 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
 
   constructor(
     private readonly context: vscode.ExtensionContext,
-    private readonly mcpClient: McpClient
+    private readonly mcpAdapter: QualityGateMcpAdapter
   ) {
     this.gates = this.readCachedGates() ?? DEFAULT_GATES;
   }
@@ -111,10 +111,10 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
   async runAll(): Promise<void> {
     try {
       const [project, placement, transfer, manufacturing] = await Promise.all([
-        this.mcpClient.runProjectQualityGate(),
-        this.mcpClient.runPlacementQualityGate(),
-        this.mcpClient.runTransferQualityGate(),
-        this.mcpClient.runManufacturingQualityGate()
+        this.mcpAdapter.runProjectQualityGate(),
+        this.mcpAdapter.runPlacementQualityGate(),
+        this.mcpAdapter.runTransferQualityGate(),
+        this.mcpAdapter.runManufacturingQualityGate()
       ]);
       this.gates = markRunTime(
         mergeGates([...project, placement, transfer, manufacturing])
@@ -136,16 +136,14 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
 
   async runGate(gate: QualityGateResult): Promise<void> {
     const next = gate.id.includes('placement')
-      ? await this.mcpClient.runPlacementQualityGate()
+      ? await this.mcpAdapter.runPlacementQualityGate()
       : gate.id.includes('transfer')
-        ? await this.mcpClient.runTransferQualityGate()
+        ? await this.mcpAdapter.runTransferQualityGate()
         : gate.id.includes('manufacturing')
-          ? await this.mcpClient.runManufacturingQualityGate()
-          : ((await this.mcpClient.runProjectQualityGate())[0] ?? gate);
+          ? await this.mcpAdapter.runManufacturingQualityGate()
+          : ((await this.mcpAdapter.runProjectQualityGate())[0] ?? gate);
     this.gates = markRunTime(
-      mergeGates(
-        this.gates.map((item) => (item.id === gate.id ? next : item))
-      )
+      mergeGates(this.gates.map((item) => (item.id === gate.id ? next : item)))
     );
     await this.persist();
     this.onDidChangeTreeDataEmitter.fire(undefined);
@@ -158,8 +156,8 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
     this.drcTimer = setTimeout(() => {
       this.drcTimer = undefined;
       void Promise.all([
-        this.mcpClient.runPlacementQualityGate(),
-        this.mcpClient.runTransferQualityGate()
+        this.mcpAdapter.runPlacementQualityGate(),
+        this.mcpAdapter.runTransferQualityGate()
       ])
         .then(async ([placement, transfer]) => {
           this.gates = markRunTime(

--- a/apps/vscode-extension/src/variants/variantProvider.ts
+++ b/apps/vscode-extension/src/variants/variantProvider.ts
@@ -7,7 +7,7 @@ import type {
   VariantOverride
 } from '../types';
 import { findFirstWorkspaceFile } from '../utils/pathUtils';
-import type { McpClient } from '../mcp/mcpClient';
+import type { VariantMcpAdapter } from '../mcp/mcpToolAdapter';
 import { createNonce } from '../utils/nonce';
 
 interface VariantDocument {
@@ -48,7 +48,7 @@ export class VariantProvider implements vscode.TreeDataProvider<
   private variants: KiCadVariant[] = [];
   private projectFile: string | undefined;
 
-  constructor(private readonly mcpClient?: McpClient | undefined) {}
+  constructor(private readonly mcpAdapter?: VariantMcpAdapter | undefined) {}
 
   refresh(): void {
     void this.loadVariants().then(() =>
@@ -223,13 +223,13 @@ export class VariantProvider implements vscode.TreeDataProvider<
   }
 
   private async syncActiveVariantToMcp(name: string): Promise<void> {
-    if (!this.mcpClient) {
+    if (!this.mcpAdapter) {
       return;
     }
     try {
-      const state = await this.mcpClient.testConnection();
+      const state = await this.mcpAdapter.testConnection();
       if (state.connected) {
-        await this.mcpClient.callTool('variant_set_active', { name });
+        await this.mcpAdapter.setActiveVariant(name);
       }
     } catch {
       // Variant switching should remain local when MCP is unavailable.

--- a/apps/vscode-extension/test/unit/chatPanel.test.ts
+++ b/apps/vscode-extension/test/unit/chatPanel.test.ts
@@ -447,4 +447,89 @@ describe('KiCadChatPanel', () => {
         ?.applied
     ).toBe(true);
   });
+
+  it('surfaces MCP apply failures without unhandled rejections', async () => {
+    const context = createExtensionContextMock();
+    const panelMock = createPanelMock();
+    (vscode.window.createWebviewPanel as jest.Mock).mockReturnValue(
+      panelMock.panel
+    );
+    const logger = createLogger();
+    const mcpClient = {
+      testConnection: jest.fn(async () => ({
+        available: true,
+        connected: true
+      })),
+      previewToolCall: jest.fn(async () => 'Update fabrication profile'),
+      executeToolCall: jest.fn(async () => {
+        throw new Error('MCP apply failed');
+      })
+    };
+    const registry = {
+      getSelection: () => ({
+        provider: 'openai',
+        model: 'gpt-5.4',
+        openAIApiMode: 'responses'
+      }),
+      getProviderForSelection: jest.fn(async () => ({
+        name: 'OpenAI',
+        isConfigured: () => true,
+        analyze: jest.fn(
+          async () => `Recommended change
+
+\`\`\`mcp
+{"name":"project_set_design_intent","arguments":{"fabricationProfile":"jlcpcb"}}
+\`\`\``
+        ),
+        testConnection: jest.fn(async () => ({ ok: true, latencyMs: 10 }))
+      }))
+    };
+    (vscode.window.showInformationMessage as jest.Mock).mockReset();
+    (vscode.window.showInformationMessage as jest.Mock).mockResolvedValue(
+      'Apply'
+    );
+
+    const chat = KiCadChatPanel.createOrShow(
+      context as never,
+      registry as never,
+      logger as never,
+      mcpClient as never
+    );
+
+    await chat.submitPrompt('suggest a change', 'ctx');
+    const history = (chat as any).history as Array<{
+      role: string;
+      timestamp: number;
+      toolCalls?: Array<{ name: string }>;
+      applied?: boolean;
+    }>;
+    const assistantMessage = history.find(
+      (entry) => entry.role === 'assistant' && entry.toolCalls?.length
+    );
+
+    await expect(
+      panelMock.send({
+        type: 'applyToolCalls',
+        timestamp: assistantMessage?.timestamp
+      })
+    ).resolves.toBeUndefined();
+    await flushPromises();
+
+    expect(mcpClient.executeToolCall).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('project_set_design_intent'),
+      expect.any(Error)
+    );
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('MCP apply failed')
+    );
+    expect(panelMock.panel.webview.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'assistantReplace',
+        message: expect.objectContaining({
+          toolApplyError: expect.stringContaining('MCP tool call failed')
+        })
+      })
+    );
+  });
 });

--- a/apps/vscode-extension/test/unit/chatPanel.test.ts
+++ b/apps/vscode-extension/test/unit/chatPanel.test.ts
@@ -32,6 +32,10 @@ function createPanelMock() {
   };
 }
 
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe('KiCadChatPanel', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
@@ -376,7 +380,7 @@ describe('KiCadChatPanel', () => {
         connected: true
       })),
       previewToolCall: jest.fn(async () => 'Update fabrication profile'),
-      callTool: jest.fn(async () => ({}))
+      executeToolCall: jest.fn(async () => ({}))
     };
     const registry = {
       getSelection: () => ({
@@ -427,12 +431,17 @@ describe('KiCadChatPanel', () => {
       type: 'applyToolCalls',
       timestamp: assistantMessage?.timestamp
     });
+    await flushPromises();
     expect(mcpClient.previewToolCall).toHaveBeenCalled();
+    expect(mcpClient.executeToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'project_set_design_intent' })
+    );
 
     await panelMock.send({
       type: 'ignoreToolCalls',
       timestamp: assistantMessage?.timestamp
     });
+    await flushPromises();
     expect(
       history.find((entry) => entry.timestamp === assistantMessage?.timestamp)
         ?.applied

--- a/apps/vscode-extension/test/unit/contextBridge.test.ts
+++ b/apps/vscode-extension/test/unit/contextBridge.test.ts
@@ -17,8 +17,10 @@ describe('ContextBridge', () => {
   });
 
   it('does not push semantically identical context twice', async () => {
-    const client = { pushContext: jest.fn().mockResolvedValue(undefined) };
-    const bridge = new ContextBridge(client as never);
+    const adapter = {
+      pushStudioContext: jest.fn().mockResolvedValue(undefined)
+    };
+    const bridge = new ContextBridge(adapter as never);
 
     await bridge.pushContext(context);
     jest.advanceTimersByTime(500);
@@ -31,41 +33,47 @@ describe('ContextBridge', () => {
     jest.advanceTimersByTime(500);
     await Promise.resolve();
 
-    expect(client.pushContext).toHaveBeenCalledTimes(1);
+    expect(adapter.pushStudioContext).toHaveBeenCalledTimes(1);
   });
 
   it('flushes a pending context on dispose', async () => {
-    const client = { pushContext: jest.fn().mockResolvedValue(undefined) };
-    const bridge = new ContextBridge(client as never);
+    const adapter = {
+      pushStudioContext: jest.fn().mockResolvedValue(undefined)
+    };
+    const bridge = new ContextBridge(adapter as never);
 
     await bridge.pushContext(context);
     bridge.dispose();
     await Promise.resolve();
 
-    expect(client.pushContext).toHaveBeenCalledWith(context);
+    expect(adapter.pushStudioContext).toHaveBeenCalledWith(context);
   });
 
   it('uses source-aware delays for context push reasons', async () => {
-    const client = { pushContext: jest.fn().mockResolvedValue(undefined) };
-    const bridge = new ContextBridge(client as never);
+    const adapter = {
+      pushStudioContext: jest.fn().mockResolvedValue(undefined)
+    };
+    const bridge = new ContextBridge(adapter as never);
 
     await bridge.pushContext(context, 'focus');
     jest.advanceTimersByTime(199);
-    expect(client.pushContext).not.toHaveBeenCalled();
+    expect(adapter.pushStudioContext).not.toHaveBeenCalled();
     jest.advanceTimersByTime(1);
     await Promise.resolve();
 
-    expect(client.pushContext).toHaveBeenCalledTimes(1);
+    expect(adapter.pushStudioContext).toHaveBeenCalledTimes(1);
 
     await bridge.pushContext({ ...context, selectedReference: 'U1' }, 'drc');
     await Promise.resolve();
 
-    expect(client.pushContext).toHaveBeenCalledTimes(2);
+    expect(adapter.pushStudioContext).toHaveBeenCalledTimes(2);
   });
 
   it('treats active variant, KiCad version, and design blocks as context-changing fields', async () => {
-    const client = { pushContext: jest.fn().mockResolvedValue(undefined) };
-    const bridge = new ContextBridge(client as never);
+    const adapter = {
+      pushStudioContext: jest.fn().mockResolvedValue(undefined)
+    };
+    const bridge = new ContextBridge(adapter as never);
 
     await bridge.pushContext({
       ...context,
@@ -84,6 +92,6 @@ describe('ContextBridge', () => {
     jest.advanceTimersByTime(500);
     await Promise.resolve();
 
-    expect(client.pushContext).toHaveBeenCalledTimes(2);
+    expect(adapter.pushStudioContext).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/vscode-extension/test/unit/designIntentPanel.test.ts
+++ b/apps/vscode-extension/test/unit/designIntentPanel.test.ts
@@ -40,7 +40,12 @@ describe('DesignIntentPanel', () => {
     disposePanel?.();
   });
 
-  function createPanel(mcpClient = { callTool: jest.fn() }) {
+  function createPanel(
+    mcpClient = {
+      getDesignIntent: jest.fn(),
+      setDesignIntent: jest.fn()
+    }
+  ) {
     DesignIntentPanel.createOrShow(
       createExtensionContextMock() as never,
       mcpClient as never
@@ -78,15 +83,13 @@ describe('DesignIntentPanel', () => {
       notes: 'Keep sensors clustered'
     };
     const { mcpClient, messageHandler } = createPanel({
-      callTool: jest.fn().mockResolvedValue(intent)
+      getDesignIntent: jest.fn().mockResolvedValue(intent),
+      setDesignIntent: jest.fn()
     });
 
     await messageHandler({ type: 'load' });
 
-    expect(mcpClient.callTool).toHaveBeenCalledWith(
-      'project_get_design_intent',
-      {}
-    );
+    expect(mcpClient.getDesignIntent).toHaveBeenCalledWith();
     expect(panel.webview.postMessage).toHaveBeenCalledWith({
       type: 'loaded',
       data: intent
@@ -95,7 +98,8 @@ describe('DesignIntentPanel', () => {
 
   it('posts an empty intent object when MCP returns no saved design intent', async () => {
     const { messageHandler } = createPanel({
-      callTool: jest.fn().mockResolvedValue(undefined)
+      getDesignIntent: jest.fn().mockResolvedValue(undefined),
+      setDesignIntent: jest.fn()
     });
 
     await messageHandler({ type: 'load' });
@@ -108,7 +112,8 @@ describe('DesignIntentPanel', () => {
 
   it('saves only object-shaped design intent payloads through MCP', async () => {
     const { mcpClient, messageHandler } = createPanel({
-      callTool: jest.fn().mockResolvedValue(undefined)
+      getDesignIntent: jest.fn(),
+      setDesignIntent: jest.fn().mockResolvedValue(undefined)
     });
     const data = {
       powerTreeRefs: 'U1,U2',
@@ -117,31 +122,27 @@ describe('DesignIntentPanel', () => {
 
     await messageHandler({ type: 'save', data });
 
-    expect(mcpClient.callTool).toHaveBeenCalledWith(
-      'project_set_design_intent',
-      data
-    );
+    expect(mcpClient.setDesignIntent).toHaveBeenCalledWith(data);
     expect(window.showInformationMessage).toHaveBeenCalledWith(
       'Design intent saved. AI can now use your project intent as context.'
     );
 
     await messageHandler({ type: 'save', data: 'not an object' });
 
-    expect(mcpClient.callTool).toHaveBeenLastCalledWith(
-      'project_set_design_intent',
-      {}
-    );
+    expect(mcpClient.setDesignIntent).toHaveBeenLastCalledWith({});
   });
 
   it('ignores unknown or malformed webview messages', async () => {
     const { mcpClient, messageHandler } = createPanel({
-      callTool: jest.fn()
+      getDesignIntent: jest.fn(),
+      setDesignIntent: jest.fn()
     });
 
     await messageHandler({ type: 'delete', data: {} });
     await messageHandler('load');
 
-    expect(mcpClient.callTool).not.toHaveBeenCalled();
+    expect(mcpClient.getDesignIntent).not.toHaveBeenCalled();
+    expect(mcpClient.setDesignIntent).not.toHaveBeenCalled();
     expect(panel.webview.postMessage).not.toHaveBeenCalled();
   });
 
@@ -150,7 +151,7 @@ describe('DesignIntentPanel', () => {
 
     DesignIntentPanel.createOrShow(
       createExtensionContextMock() as never,
-      { callTool: jest.fn() } as never
+      { getDesignIntent: jest.fn(), setDesignIntent: jest.fn() } as never
     );
 
     expect(window.createWebviewPanel).toHaveBeenCalledTimes(1);
@@ -180,7 +181,7 @@ describe('DesignIntentPanel', () => {
 
     DesignIntentPanel.createOrShow(
       createExtensionContextMock() as never,
-      { callTool: jest.fn() } as never
+      { getDesignIntent: jest.fn(), setDesignIntent: jest.fn() } as never
     );
 
     expect(window.createWebviewPanel).toHaveBeenCalledTimes(2);

--- a/apps/vscode-extension/test/unit/designIntentPanel.test.ts
+++ b/apps/vscode-extension/test/unit/designIntentPanel.test.ts
@@ -110,6 +110,39 @@ describe('DesignIntentPanel', () => {
     });
   });
 
+  it('reports MCP load and save failures to the webview and user', async () => {
+    const { mcpClient, messageHandler } = createPanel({
+      getDesignIntent: jest.fn().mockRejectedValue(new Error('load failed')),
+      setDesignIntent: jest.fn().mockRejectedValue(new Error('save failed'))
+    });
+
+    await expect(messageHandler({ type: 'load' })).resolves.toBeUndefined();
+
+    expect(mcpClient.getDesignIntent).toHaveBeenCalledWith();
+    expect(panel.webview.postMessage).toHaveBeenCalledWith({
+      type: 'error',
+      error: 'load failed'
+    });
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'Unable to load design intent: load failed'
+    );
+
+    await expect(
+      messageHandler({ type: 'save', data: { notes: 'Keep sensors clustered' } })
+    ).resolves.toBeUndefined();
+
+    expect(mcpClient.setDesignIntent).toHaveBeenCalledWith({
+      notes: 'Keep sensors clustered'
+    });
+    expect(panel.webview.postMessage).toHaveBeenCalledWith({
+      type: 'error',
+      error: 'save failed'
+    });
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'Unable to save design intent: save failed'
+    );
+  });
+
   it('saves only object-shaped design intent payloads through MCP', async () => {
     const { mcpClient, messageHandler } = createPanel({
       getDesignIntent: jest.fn(),

--- a/apps/vscode-extension/test/unit/drcRuleEditorPanel.test.ts
+++ b/apps/vscode-extension/test/unit/drcRuleEditorPanel.test.ts
@@ -27,6 +27,7 @@ function createPanelMock() {
 describe('DrcRuleEditorPanel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (DrcRuleEditorPanel as any).currentPanel = undefined;
   });
 
   it('opens setup guidance when MCP is not connected', async () => {
@@ -44,6 +45,47 @@ describe('DrcRuleEditorPanel', () => {
     expect(window.showWarningMessage).toHaveBeenCalledWith(
       'DRC rule editing requires a connected kicad-mcp-pro server.',
       'Setup MCP'
+    );
+  });
+
+  it('reports MCP connection test and setup command failures', async () => {
+    const failingClient = {
+      testConnection: jest.fn().mockRejectedValue(new Error('probe failed'))
+    };
+
+    await expect(
+      DrcRuleEditorPanel.createOrShow(
+        {
+          extensionUri: vscode.Uri.file('/extension')
+        } as vscode.ExtensionContext,
+        failingClient as never
+      )
+    ).resolves.toBeUndefined();
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'Unable to check MCP connection for DRC rule editing: probe failed'
+    );
+
+    const disconnectedClient = {
+      testConnection: jest.fn().mockResolvedValue({ connected: false })
+    };
+    (window.showWarningMessage as jest.Mock).mockResolvedValue('Setup MCP');
+    (vscode.commands.executeCommand as jest.Mock).mockRejectedValue(
+      new Error('setup failed')
+    );
+
+    await DrcRuleEditorPanel.createOrShow(
+      {
+        extensionUri: vscode.Uri.file('/extension')
+      } as vscode.ExtensionContext,
+      disconnectedClient as never
+    );
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'kicadstudio.setupMcpIntegration'
+    );
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'Unable to open MCP setup: setup failed'
     );
   });
 
@@ -84,5 +126,48 @@ describe('DrcRuleEditorPanel', () => {
     });
     expect(mcpClient.deleteDrcRule).toHaveBeenCalledWith('power_clearance');
     expect(panelMock.panel.webview.html).toContain('KiCad DRC Rule Editor');
+  });
+
+  it('reports DRC rule edit failures from webview messages', async () => {
+    const panelMock = createPanelMock();
+    (window.createWebviewPanel as jest.Mock).mockReturnValue(panelMock.panel);
+    const mcpClient = {
+      testConnection: jest.fn().mockResolvedValue({ connected: true }),
+      upsertDrcRule: jest.fn().mockRejectedValue(new Error('upsert failed')),
+      deleteDrcRule: jest.fn().mockRejectedValue(new Error('delete failed'))
+    };
+
+    await DrcRuleEditorPanel.createOrShow(
+      {
+        extensionUri: vscode.Uri.file('/extension')
+      } as vscode.ExtensionContext,
+      mcpClient as never
+    );
+
+    await expect(
+      panelMock.post({
+        type: 'upsert',
+        payload: {
+          name: 'power_clearance',
+          condition: "A.NetClass == 'POWER'",
+          constraint: 'clearance min 0.35mm'
+        }
+      })
+    ).resolves.toBeUndefined();
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'Unable to save DRC rule power_clearance: upsert failed'
+    );
+
+    await expect(
+      panelMock.post({
+        type: 'delete',
+        payload: {
+          name: 'power_clearance'
+        }
+      })
+    ).resolves.toBeUndefined();
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'Unable to delete DRC rule power_clearance: delete failed'
+    );
   });
 });

--- a/apps/vscode-extension/test/unit/drcRuleEditorPanel.test.ts
+++ b/apps/vscode-extension/test/unit/drcRuleEditorPanel.test.ts
@@ -52,7 +52,8 @@ describe('DrcRuleEditorPanel', () => {
     (window.createWebviewPanel as jest.Mock).mockReturnValue(panelMock.panel);
     const mcpClient = {
       testConnection: jest.fn().mockResolvedValue({ connected: true }),
-      callTool: jest.fn().mockResolvedValue({})
+      upsertDrcRule: jest.fn().mockResolvedValue(undefined),
+      deleteDrcRule: jest.fn().mockResolvedValue(undefined)
     };
 
     await DrcRuleEditorPanel.createOrShow(
@@ -76,14 +77,12 @@ describe('DrcRuleEditorPanel', () => {
       }
     });
 
-    expect(mcpClient.callTool).toHaveBeenCalledWith('drc_rule_upsert', {
+    expect(mcpClient.upsertDrcRule).toHaveBeenCalledWith({
       name: 'power_clearance',
       condition: "A.NetClass == 'POWER'",
       constraint: 'clearance min 0.35mm'
     });
-    expect(mcpClient.callTool).toHaveBeenCalledWith('drc_rule_delete', {
-      name: 'power_clearance'
-    });
+    expect(mcpClient.deleteDrcRule).toHaveBeenCalledWith('power_clearance');
     expect(panelMock.panel.webview.html).toContain('KiCad DRC Rule Editor');
   });
 });

--- a/apps/vscode-extension/test/unit/fixQueueProvider.actions.test.ts
+++ b/apps/vscode-extension/test/unit/fixQueueProvider.actions.test.ts
@@ -54,7 +54,8 @@ describe('FixQueueProvider code-action support', () => {
         }
       ]),
       previewToolCall: jest.fn(),
-      callTool: jest.fn().mockResolvedValue({})
+      applyFixTool: jest.fn().mockResolvedValue(undefined),
+      applyFixById: jest.fn().mockResolvedValue(undefined)
     };
     const provider = new FixQueueProvider(client as never);
     (window.showInformationMessage as jest.Mock).mockResolvedValue('Apply');
@@ -65,7 +66,9 @@ describe('FixQueueProvider code-action support', () => {
     expect(workspace.openTextDocument).toHaveBeenCalledWith(
       expect.objectContaining({ content: 'diff' })
     );
-    expect(client.callTool).toHaveBeenCalledWith('apply_fix', { id: 'fix-1' });
+    expect(client.applyFixTool).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'fix-1' })
+    );
   });
 
   it('builds tree items for severities and stops bulk apply on failure', async () => {
@@ -89,7 +92,7 @@ describe('FixQueueProvider code-action support', () => {
         }
       ]),
       previewToolCall: jest.fn().mockResolvedValue('preview'),
-      callTool: jest
+      applyFixTool: jest
         .fn()
         .mockRejectedValueOnce(new Error('stop'))
         .mockResolvedValue({})
@@ -108,7 +111,7 @@ describe('FixQueueProvider code-action support', () => {
     (window.showWarningMessage as jest.Mock).mockResolvedValue('Apply All');
     await provider.applyAll();
 
-    expect(client.callTool).toHaveBeenCalledTimes(1);
+    expect(client.applyFixTool).toHaveBeenCalledTimes(1);
     expect(first?.status).toBe('failed');
   });
 

--- a/apps/vscode-extension/test/unit/manufacturingReleaseWizard.test.ts
+++ b/apps/vscode-extension/test/unit/manufacturingReleaseWizard.test.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import { runManufacturingReleaseWizard } from '../../src/commands/manufacturingReleaseWizard';
+import { window } from './vscodeMock';
+
+describe('runManufacturingReleaseWizard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createServices(overrides?: {
+    runProjectQualityGate?: jest.Mock;
+    exportManufacturingPackage?: jest.Mock;
+  }) {
+    return {
+      context: {
+        extensionUri: vscode.Uri.file('/extension')
+      },
+      variantProvider: {
+        listVariants: jest.fn().mockResolvedValue([
+          {
+            name: 'Default',
+            isDefault: true,
+            componentOverrides: []
+          }
+        ])
+      },
+      mcpAdapter: {
+        runProjectQualityGate:
+          overrides?.runProjectQualityGate ?? jest.fn().mockResolvedValue([]),
+        exportManufacturingPackage:
+          overrides?.exportManufacturingPackage ??
+          jest.fn().mockResolvedValue(undefined)
+      }
+    };
+  }
+
+  it('handles project quality gate failures through wizard error handling', async () => {
+    const services = createServices({
+      runProjectQualityGate: jest
+        .fn()
+        .mockRejectedValue(new Error('quality gate failed'))
+    });
+
+    await expect(
+      runManufacturingReleaseWizard(services as never)
+    ).resolves.toBeUndefined();
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'quality gate failed',
+      'Open Output Channel',
+      'Re-run Wizard'
+    );
+    expect(
+      services.mcpAdapter.exportManufacturingPackage
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/apps/vscode-extension/test/unit/mcpToolAdapter.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolAdapter.test.ts
@@ -117,6 +117,8 @@ describe('McpToolAdapter', () => {
       constraint: 'clearance min 0.35mm'
     });
     await adapter.deleteDrcRule('power_clearance');
+    await adapter.runDrc({ save_report: true });
+    await adapter.runErc({ save_report: true });
     await adapter.getDesignIntent();
     await adapter.setDesignIntent({ notes: 'Keep sensors clustered' });
     await adapter.exportBom({ variant: 'Assembly-A' });
@@ -138,6 +140,12 @@ describe('McpToolAdapter', () => {
     });
     expect(client.callTool).toHaveBeenCalledWith('drc_rule_delete', {
       name: 'power_clearance'
+    });
+    expect(client.callTool).toHaveBeenCalledWith('run_drc', {
+      save_report: true
+    });
+    expect(client.callTool).toHaveBeenCalledWith('run_erc', {
+      save_report: true
     });
     expect(client.callTool).toHaveBeenCalledWith(
       'project_get_design_intent',

--- a/apps/vscode-extension/test/unit/mcpToolAdapter.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolAdapter.test.ts
@@ -1,0 +1,224 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { mapMcpError } from '../../src/mcp/mcpErrorMapper';
+import { McpToolAdapter } from '../../src/mcp/mcpToolAdapter';
+import type { FixItem, StudioContext } from '../../src/types';
+
+describe('McpToolAdapter', () => {
+  it('executes fix queue tools through a single adapter method', async () => {
+    const client = {
+      callTool: jest.fn().mockResolvedValue({})
+    };
+    const adapter = new McpToolAdapter(client as never);
+    const item: FixItem = {
+      id: 'fix-1',
+      description: 'move track',
+      severity: 'warning',
+      tool: 'pcb_apply_fix',
+      args: { id: 'fix-1' },
+      status: 'pending'
+    };
+
+    await adapter.applyFixTool(item);
+    await adapter.applyFixById('fallback-fix');
+
+    expect(client.callTool).toHaveBeenNthCalledWith(1, 'pcb_apply_fix', {
+      id: 'fix-1'
+    });
+    expect(client.callTool).toHaveBeenNthCalledWith(2, 'apply_fix', {
+      id: 'fallback-fix'
+    });
+  });
+
+  it('wraps connection state and context push workflows', async () => {
+    const state = { kind: 'Connected', available: true, connected: true };
+    const server = {
+      version: '1.0.0',
+      compat: 'ok',
+      capturedAt: '2026-05-21T00:00:00.000Z',
+      capabilities: { tools: [], resources: [], prompts: [] }
+    };
+    const client = {
+      detectInstall: jest.fn().mockResolvedValue({ found: true }),
+      getState: jest.fn().mockReturnValue(state),
+      getLastServerCard: jest.fn().mockReturnValue(server),
+      testConnection: jest.fn().mockResolvedValue(state),
+      retryNow: jest.fn().mockResolvedValue(state),
+      pushContext: jest.fn().mockResolvedValue(undefined)
+    };
+    const adapter = new McpToolAdapter(client as never);
+    const context = {
+      activeFile: undefined,
+      fileType: 'pcb',
+      drcErrors: []
+    } satisfies StudioContext;
+
+    await adapter.detectInstall();
+    adapter.getState();
+    adapter.getLastServerCard();
+    await adapter.testConnection();
+    await adapter.retryNow();
+    await adapter.pushStudioContext(context);
+
+    expect(client.detectInstall).toHaveBeenCalled();
+    expect(client.getState).toHaveBeenCalled();
+    expect(client.getLastServerCard).toHaveBeenCalled();
+    expect(client.testConnection).toHaveBeenCalled();
+    expect(client.retryNow).toHaveBeenCalled();
+    expect(client.pushContext).toHaveBeenCalledWith(context);
+  });
+
+  it('delegates typed quality gate workflows without exposing raw tool names', async () => {
+    const client = {
+      runProjectQualityGate: jest.fn().mockResolvedValue([]),
+      runPlacementQualityGate: jest.fn().mockResolvedValue({
+        id: 'placement'
+      }),
+      runTransferQualityGate: jest.fn().mockResolvedValue({
+        id: 'transfer'
+      }),
+      runManufacturingQualityGate: jest.fn().mockResolvedValue({
+        id: 'manufacturing'
+      })
+    };
+    const adapter = new McpToolAdapter(client as never);
+
+    await adapter.runProjectQualityGate();
+    await adapter.runPlacementQualityGate();
+    await adapter.runTransferQualityGate();
+    await adapter.runManufacturingQualityGate();
+
+    expect(client.runProjectQualityGate).toHaveBeenCalled();
+    expect(client.runPlacementQualityGate).toHaveBeenCalled();
+    expect(client.runTransferQualityGate).toHaveBeenCalled();
+    expect(client.runManufacturingQualityGate).toHaveBeenCalled();
+  });
+
+  it('exposes typed tool workflows for UI and commands', async () => {
+    const client = {
+      callTool: jest.fn().mockResolvedValue({ ok: true }),
+      exportManufacturingPackage: jest.fn().mockResolvedValue({ ok: true }),
+      previewToolCall: jest.fn().mockResolvedValue('preview')
+    };
+    const adapter = new McpToolAdapter(client as never);
+
+    await adapter.previewToolCall({
+      name: 'project_set_design_intent',
+      arguments: { fabricationProfile: 'jlcpcb' }
+    });
+    await adapter.executeToolCall({
+      name: 'project_set_design_intent',
+      arguments: { fabricationProfile: 'jlcpcb' }
+    });
+    await adapter.setActiveVariant('Assembly-A');
+    await adapter.upsertDrcRule({
+      name: 'power_clearance',
+      condition: "A.NetClass == 'POWER'",
+      constraint: 'clearance min 0.35mm'
+    });
+    await adapter.deleteDrcRule('power_clearance');
+    await adapter.getDesignIntent();
+    await adapter.setDesignIntent({ notes: 'Keep sensors clustered' });
+    await adapter.exportBom({ variant: 'Assembly-A' });
+    await adapter.exportNetlist({ format: 'kicad' });
+    await adapter.exportSpiceNetlist({ output: 'sim.cir' });
+    await adapter.exportManufacturingPackage('Assembly-A');
+
+    expect(client.previewToolCall).toHaveBeenCalledWith({
+      name: 'project_set_design_intent',
+      arguments: { fabricationProfile: 'jlcpcb' }
+    });
+    expect(client.callTool).toHaveBeenCalledWith('variant_set_active', {
+      name: 'Assembly-A'
+    });
+    expect(client.callTool).toHaveBeenCalledWith('drc_rule_upsert', {
+      name: 'power_clearance',
+      condition: "A.NetClass == 'POWER'",
+      constraint: 'clearance min 0.35mm'
+    });
+    expect(client.callTool).toHaveBeenCalledWith('drc_rule_delete', {
+      name: 'power_clearance'
+    });
+    expect(client.callTool).toHaveBeenCalledWith(
+      'project_get_design_intent',
+      {}
+    );
+    expect(client.callTool).toHaveBeenCalledWith('project_set_design_intent', {
+      notes: 'Keep sensors clustered'
+    });
+    expect(client.callTool).toHaveBeenCalledWith('export_bom', {
+      variant: 'Assembly-A'
+    });
+    expect(client.callTool).toHaveBeenCalledWith('export_netlist', {
+      format: 'kicad'
+    });
+    expect(client.callTool).toHaveBeenCalledWith('export_spice_netlist', {
+      output: 'sim.cir'
+    });
+    expect(client.exportManufacturingPackage).toHaveBeenCalledWith(
+      'Assembly-A'
+    );
+  });
+
+  it('maps common transport and protocol errors into stable categories', () => {
+    expect(
+      mapMcpError(new Error('MCP request timed out after 5000ms.'))
+    ).toEqual(expect.objectContaining({ kind: 'timeout', retryable: true }));
+    expect(mapMcpError(new Error('HTTP 400'))).toEqual(
+      expect.objectContaining({ kind: 'bad-request', status: 400 })
+    );
+    expect(mapMcpError(new Error('HTTP 421'))).toEqual(
+      expect.objectContaining({ kind: 'session', status: 421, retryable: true })
+    );
+    expect(mapMcpError(new Error('HTTP 500'))).toEqual(
+      expect.objectContaining({ kind: 'server', status: 500, retryable: true })
+    );
+    expect(
+      mapMcpError(
+        Object.assign(new Error('Tool missing'), {
+          code: 'tool_not_found',
+          hint: 'Upgrade kicad-mcp-pro'
+        })
+      )
+    ).toEqual(
+      expect.objectContaining({
+        kind: 'missing-tool',
+        code: 'tool_not_found',
+        hint: 'Upgrade kicad-mcp-pro'
+      })
+    );
+    expect(mapMcpError(new Error('MCP server is incompatible.'))).toEqual(
+      expect.objectContaining({ kind: 'incompatible', retryable: false })
+    );
+  });
+
+  it('keeps raw tool execution inside the client and adapter boundary', () => {
+    const allowed = new Set([
+      path.normalize('mcp/mcpClient.ts'),
+      path.normalize('mcp/mcpToolAdapter.ts')
+    ]);
+    const srcRoot = path.resolve(__dirname, '../../src');
+    const offenders = collectTypescriptFiles(srcRoot)
+      .flatMap((file) => {
+        const relative = path.normalize(path.relative(srcRoot, file));
+        if (allowed.has(relative)) {
+          return [];
+        }
+        const text = fs.readFileSync(file, 'utf8');
+        return text.includes('.callTool(') ? [relative] : [];
+      })
+      .sort();
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+function collectTypescriptFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return collectTypescriptFiles(fullPath);
+    }
+    return entry.isFile() && entry.name.endsWith('.ts') ? [fullPath] : [];
+  });
+}

--- a/apps/vscode-extension/test/unit/mcpToolAdapter.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolAdapter.test.ts
@@ -172,6 +172,9 @@ describe('McpToolAdapter', () => {
     expect(
       mapMcpError(new Error('MCP request timed out after 5000ms.'))
     ).toEqual(expect.objectContaining({ kind: 'timeout', retryable: true }));
+    expect(mapMcpError(new Error('stdio transport closed'))).toEqual(
+      expect.objectContaining({ kind: 'stdio', retryable: true })
+    );
     expect(mapMcpError(new Error('HTTP 400'))).toEqual(
       expect.objectContaining({ kind: 'bad-request', status: 400 })
     );

--- a/apps/vscode-extension/test/unit/variantProvider.test.ts
+++ b/apps/vscode-extension/test/unit/variantProvider.test.ts
@@ -158,6 +158,7 @@ describe('VariantProvider', () => {
         componentOverrides: []
       })
     ).resolves.toBeUndefined();
+    expect(throwingClient.setActiveVariant).not.toHaveBeenCalled();
   });
 
   it('builds tree items for variants and override rows', async () => {

--- a/apps/vscode-extension/test/unit/variantProvider.test.ts
+++ b/apps/vscode-extension/test/unit/variantProvider.test.ts
@@ -113,11 +113,11 @@ describe('VariantProvider', () => {
   });
 
   it('syncs the active variant to MCP when a client is provided', async () => {
-    const mcpClient = {
+    const mcpAdapter = {
       testConnection: jest.fn().mockResolvedValue({ connected: true }),
-      callTool: jest.fn().mockResolvedValue({})
+      setActiveVariant: jest.fn().mockResolvedValue(undefined)
     };
-    const provider = new VariantProvider(mcpClient as never);
+    const provider = new VariantProvider(mcpAdapter as never);
 
     await provider.setActive({
       name: 'No-RF',
@@ -125,15 +125,13 @@ describe('VariantProvider', () => {
       componentOverrides: []
     });
 
-    expect(mcpClient.callTool).toHaveBeenCalledWith('variant_set_active', {
-      name: 'No-RF'
-    });
+    expect(mcpAdapter.setActiveVariant).toHaveBeenCalledWith('No-RF');
   });
 
   it('keeps variant switching local when MCP is disconnected or throws', async () => {
     const disconnectedClient = {
       testConnection: jest.fn().mockResolvedValue({ connected: false }),
-      callTool: jest.fn()
+      setActiveVariant: jest.fn()
     };
     const disconnectedProvider = new VariantProvider(
       disconnectedClient as never
@@ -145,11 +143,11 @@ describe('VariantProvider', () => {
       componentOverrides: []
     });
 
-    expect(disconnectedClient.callTool).not.toHaveBeenCalled();
+    expect(disconnectedClient.setActiveVariant).not.toHaveBeenCalled();
 
     const throwingClient = {
       testConnection: jest.fn().mockRejectedValue(new Error('offline')),
-      callTool: jest.fn()
+      setActiveVariant: jest.fn()
     };
     const throwingProvider = new VariantProvider(throwingClient as never);
 


### PR DESCRIPTION
## Summary

Introduces a typed MCP adapter boundary inside the VS Code extension and routes extension MCP tool workflows through it instead of calling raw MCP tools from UI/view/command layers.

- Added `McpToolAdapter` and `McpErrorMapper` for typed tool delegation and stable MCP error categories.
- Routed context push, MCP dashboard state, fix queue, quality gates, variant sync, DRC rule editing, DRC/ERC tool adapters, BOM/netlist exports, design intent, AI chat tool calls, and manufacturing release export through adapter methods.
- Added unit coverage for adapter delegation, transport/protocol error mapping, and a source-boundary regression that keeps raw `.callTool(` usage inside `mcpClient`/`mcpToolAdapter`.
- Addressed CodeRabbit review feedback by making stdio error retryability consistent, catching MCP tool-apply failures in chat, routing manufacturing quality-gate errors through structured command handling, and adding explicit DRC/design-intent MCP failure handling with regression tests.

## Linked issue

Linear: OASLANA-56
Closes #57

## Type of change

- [ ] type:bug
- [x] type:feature
- [ ] type:docs
- [x] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

Initial adapter implementation:
- `corepack pnpm install --frozen-lockfile` - pass
- `corepack pnpm --filter kicadstudio exec jest --runInBand test/unit/mcpToolAdapter.test.ts test/unit/fixQueueProvider.actions.test.ts test/unit/qualityGateProvider.test.ts test/unit/variantProvider.test.ts test/unit/drcRuleEditorPanel.test.ts test/unit/designIntentPanel.test.ts test/unit/chatPanel.test.ts --coverage=false` - pass, 7 suites / 53 tests
- `corepack pnpm --filter kicadstudio exec jest --runInBand test/unit/contextBridge.test.ts test/unit/mcpToolAdapter.test.ts --coverage=false` - pass, 2 suites / 10 tests
- `corepack pnpm --filter kicadstudio exec jest --runInBand test/unit/mcpToolAdapter.test.ts --coverage=false` - pass after DRC/ERC adapter methods, 1 suite / 6 tests
- `corepack pnpm --filter kicadstudio run lint` - pass
- `corepack pnpm --filter kicadstudio run typecheck` - pass
- `corepack pnpm --filter kicadstudio run test:unit` - pass, 67 suites / 468 tests
- `corepack pnpm --filter kicadstudio run build` - pass
- `corepack pnpm run check` - pass after full adapter implementation
- `corepack pnpm run check` - pass again after DRC/ERC adapter methods
- `uvx pre-commit run --all-files` - pass
- `git diff --check` - pass

Review-fix validation for `dbb67ef`:
- `corepack pnpm --filter kicadstudio exec jest test/unit/mcpToolAdapter.test.ts test/unit/variantProvider.test.ts test/unit/chatPanel.test.ts test/unit/designIntentPanel.test.ts test/unit/drcRuleEditorPanel.test.ts test/unit/manufacturingReleaseWizard.test.ts --runInBand --coverage=false` - pass, 6 suites / 47 tests
- `corepack pnpm install --frozen-lockfile` - pass
- `corepack pnpm --filter kicadstudio run lint` - pass
- `corepack pnpm --filter kicadstudio run typecheck` - pass
- `corepack pnpm --filter kicadstudio run test:unit` - pass, 68 suites / 473 tests
- `corepack pnpm --filter kicadstudio run build` - pass
- `corepack pnpm --filter kicadstudio run test:integration -- --runInBand` - pass, 10 tests
- `corepack pnpm --filter kicadstudio run check` - pass
- `corepack pnpm --filter kicadstudio run audit:ci` - pass, no known vulnerabilities
- `uvx pre-commit run --all-files` - pass
- `git diff --check` - pass

Remote checks after `dbb67ef`:
- CI run 26202740233 - success
- Docs run 26202740206 - success
- CodeQL run 26202740234 - success
- Security run 26202740205 - success
- Gitleaks run 26202740237 - success
- CommitCheck - success
- pre-commit.ci - success

Security/audit note: `pnpm check` originally reported only repository-acknowledged markdown/PyJWT advisories with no local upgrade path. The review-fix `audit:ci` pass reported no known vulnerabilities in the touched extension scope.

## Protocol / MCP impact

- [ ] Not applicable; reason:
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [x] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [ ] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

No MCP server protocol/schema changes are introduced. This is an extension-side adapter boundary around existing tool names and typed client methods.

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [ ] CHANGELOG entry (if user-visible)
- [ ] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts

Docs/changelog are not updated because this is an internal extension architecture boundary with no user-facing behavior or command syntax change.
