### PR TITLE
feat(mcp): add server info capabilities contract

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -237,7 +237,7 @@
         {
           "id": "kicadstudio.qualityGate",
           "name": "Quality Gates",
-          "when": "kicadstudio.mcpConnected && kicadstudio.hasProject",
+          "when": "kicadstudio.hasProject",
           "icon": "assets/views/quality-gates.svg"
         },
         {

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -237,7 +237,7 @@
         {
           "id": "kicadstudio.qualityGate",
           "name": "Quality Gates",
-          "when": "kicadstudio.hasProject",
+          "when": "kicadstudio.mcpConnected && kicadstudio.hasProject",
           "icon": "assets/views/quality-gates.svg"
         },
         {

--- a/apps/vscode-extension/src/mcp/mcpClient.ts
+++ b/apps/vscode-extension/src/mcp/mcpClient.ts
@@ -8,6 +8,7 @@ import type {
   McpConnectionState,
   McpInstallStatus,
   McpServerCard,
+  McpServerInfoContract,
   McpToolCall,
   QualityGateResult,
   StructuredMcpError,
@@ -166,7 +167,8 @@ export class McpClient {
         available: install.found,
         connected: true,
         install,
-        server: this.state.server
+        server: this.state.server,
+        message: this.state.message
       });
     } catch (error) {
       this.logger.debug(
@@ -543,17 +545,29 @@ export class McpClient {
     const initializeVersion = normalizeMcpVersion(
       initializeServerInfo?.version
     );
-    const metadataVersion = shouldReadWellKnownServerVersion(
+    const metadata = shouldReadWellKnownServerMetadata(
       initializeServerInfo,
       initializeVersion
     )
-      ? await this.readWellKnownServerVersion()
+      ? await this.readWellKnownServerMetadata()
       : undefined;
-    const version = metadataVersion ?? initializeVersion;
-    const compat = getMcpCompatStatus(version);
+    const version = metadata?.version ?? initializeVersion;
+    const serverInfo = metadata?.serverInfo;
+    const diagnostics = serverInfo ? serverInfoDiagnostics(serverInfo) : [];
+    const baseCompat = getMcpCompatStatus(version);
+    const compat =
+      baseCompat === 'incompatible'
+        ? baseCompat
+        : diagnostics.length
+          ? 'warn'
+          : baseCompat;
     const card: McpServerCard = {
       version,
-      capabilities: normalizeCapabilities(initializeResult?.capabilities),
+      capabilities: normalizeCapabilities(
+        initializeResult?.capabilities,
+        serverInfo,
+        diagnostics
+      ),
       compat,
       capturedAt: new Date().toISOString()
     };
@@ -597,13 +611,20 @@ export class McpClient {
       available: this.lastInstall.found,
       connected: true,
       install: this.lastInstall,
-      server: card
+      server: card,
+      message: diagnostics.length ? diagnostics.join(' ') : undefined
     });
   }
 
-  private async readWellKnownServerVersion(): Promise<string | undefined> {
-    const { readWellKnownMcpServerVersion } = await import('./serverMetadata');
-    return readWellKnownMcpServerVersion(this.getEndpoint(), this.logger);
+  private async readWellKnownServerMetadata(): Promise<
+    | {
+        version: string;
+        serverInfo?: McpServerInfoContract | undefined;
+      }
+    | undefined
+  > {
+    const { readWellKnownMcpServerMetadata } = await import('./serverMetadata');
+    return readWellKnownMcpServerMetadata(this.getEndpoint(), this.logger);
   }
 
   private setState(state: McpConnectionState): McpConnectionState {
@@ -754,6 +775,17 @@ function shouldReadWellKnownServerVersion(
   return KNOWN_MCP_SDK_VERSION_HINTS.has(version);
 }
 
+function shouldReadWellKnownServerMetadata(
+  serverInfo: InitializeResult['serverInfo'],
+  version: string
+): boolean {
+  const name = `${serverInfo?.name ?? ''} ${serverInfo?.title ?? ''}`;
+  return (
+    /kicad[- ]mcp[- ]pro/i.test(name) ||
+    shouldReadWellKnownServerVersion(serverInfo, version)
+  );
+}
+
 class McpStructuredError extends Error {
   readonly code: string;
   readonly hint: string | undefined;
@@ -851,13 +883,38 @@ function parseSseJsonRpc<T>(payload: string): JsonRpcResponse<T> {
   return JSON.parse(lastEvent) as JsonRpcResponse<T>;
 }
 
-function normalizeCapabilities(value: unknown): McpCapabilityCard {
+function normalizeCapabilities(
+  value: unknown,
+  serverInfo?: McpServerInfoContract | undefined,
+  diagnostics: string[] = []
+): McpCapabilityCard {
   const record = isRecord(value) ? value : {};
   return {
     tools: normalizeCapabilityNames(record['tools']),
     resources: normalizeCapabilityNames(record['resources']),
-    prompts: normalizeCapabilityNames(record['prompts'])
+    prompts: normalizeCapabilityNames(record['prompts']),
+    ...(serverInfo ? { serverInfo } : {}),
+    ...(diagnostics.length ? { diagnostics } : {})
   };
+}
+
+function serverInfoDiagnostics(serverInfo: McpServerInfoContract): string[] {
+  const diagnostics = [...serverInfo.diagnostics];
+  if (!serverInfo.kicad.cliFound) {
+    diagnostics.push(
+      'KiCad CLI is unavailable; file-backed DRC/ERC/export operations are disabled.'
+    );
+  }
+  if (!serverInfo.kicad.livePcbContext) {
+    diagnostics.push('Live KiCad PCB context is unavailable.');
+  }
+  if (!serverInfo.capabilities.fileBackedExports) {
+    diagnostics.push('File-backed export operations are unavailable.');
+  }
+  if (!serverInfo.transport.streamableHttp) {
+    diagnostics.push('Streamable HTTP transport is unavailable.');
+  }
+  return [...new Set(diagnostics)];
 }
 
 function normalizeCapabilityNames(value: unknown): string[] {
@@ -888,10 +945,39 @@ function cloneConnectionState(state: McpConnectionState): McpConnectionState {
           capabilities: {
             tools: [...state.server.capabilities.tools],
             resources: [...state.server.capabilities.resources],
-            prompts: [...state.server.capabilities.prompts]
+            prompts: [...state.server.capabilities.prompts],
+            ...(state.server.capabilities.serverInfo
+              ? {
+                  serverInfo: cloneServerInfoContract(
+                    state.server.capabilities.serverInfo
+                  )
+                }
+              : {}),
+            ...(state.server.capabilities.diagnostics
+              ? { diagnostics: [...state.server.capabilities.diagnostics] }
+              : {})
           }
         }
       : undefined
+  };
+}
+
+function cloneServerInfoContract(
+  serverInfo: McpServerInfoContract
+): McpServerInfoContract {
+  return {
+    ...serverInfo,
+    compatibilityRange: {
+      kicadStudio: { ...serverInfo.compatibilityRange.kicadStudio },
+      kicadMcpPro: { ...serverInfo.compatibilityRange.kicadMcpPro }
+    },
+    transport: { ...serverInfo.transport },
+    kicad: { ...serverInfo.kicad },
+    capabilities: {
+      ...serverInfo.capabilities,
+      cliExports: { ...serverInfo.capabilities.cliExports }
+    },
+    diagnostics: [...serverInfo.diagnostics]
   };
 }
 

--- a/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
@@ -18,9 +18,7 @@ type McpToolsNode = {
   children?: McpToolsNode[] | undefined;
 };
 
-export class McpToolsProvider
-  implements vscode.TreeDataProvider<McpToolsNode>
-{
+export class McpToolsProvider implements vscode.TreeDataProvider<McpToolsNode> {
   private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<
     McpToolsNode | undefined
   >();
@@ -85,7 +83,12 @@ function buildMcpToolNodes(
   ];
 
   if (state.server) {
-    nodes.splice(3, 0, serverNode(state), capabilityNode(state.server.capabilities));
+    nodes.splice(
+      3,
+      0,
+      serverNode(state),
+      capabilityNode(state.server.capabilities)
+    );
   }
   if (state.message) {
     nodes.splice(1, 0, {
@@ -139,7 +142,9 @@ function stateNode(state: McpConnectionState): McpToolsNode {
     description: state.available ? 'detected, not connected' : 'not detected',
     icon: state.available ? 'warning' : 'circle-slash',
     command: {
-      command: state.available ? COMMANDS.retryMcp : COMMANDS.setupMcpIntegration,
+      command: state.available
+        ? COMMANDS.retryMcp
+        : COMMANDS.setupMcpIntegration,
       title: state.available ? 'Retry MCP Connection' : 'Setup MCP Integration'
     }
   };
@@ -189,12 +194,30 @@ function serverNode(state: McpConnectionState): McpToolsNode {
 }
 
 function capabilityNode(capabilities: McpCapabilityCard): McpToolsNode {
+  const diagnostics = capabilities.diagnostics ?? [];
+  const description = `${capabilities.tools.length} tools, ${capabilities.resources.length} resources, ${capabilities.prompts.length} prompts${
+    diagnostics.length
+      ? `, ${diagnostics.length} diagnostic${diagnostics.length === 1 ? '' : 's'}`
+      : ''
+  }`;
+  const details = capabilities.serverInfo
+    ? [
+        capabilityDiagnosticsGroup(diagnostics),
+        kicadRuntimeNode(capabilities.serverInfo),
+        operationModesNode(capabilities.serverInfo)
+      ]
+    : diagnostics.length
+      ? [capabilityDiagnosticsGroup(diagnostics)]
+      : [];
   return {
     label: 'Capabilities',
-    description: `${capabilities.tools.length} tools, ${capabilities.resources.length} resources, ${capabilities.prompts.length} prompts`,
-    tooltip: 'Server-advertised MCP capability counts.',
+    description,
+    tooltip: diagnostics.length
+      ? diagnostics.join('\n')
+      : 'Server-advertised MCP capability counts.',
     icon: 'symbol-namespace',
     children: [
+      ...details,
       capabilityGroup('Tools', capabilities.tools),
       capabilityGroup('Resources', capabilities.resources),
       capabilityGroup('Prompts', capabilities.prompts)
@@ -202,11 +225,86 @@ function capabilityNode(capabilities: McpCapabilityCard): McpToolsNode {
   };
 }
 
+function capabilityDiagnosticsGroup(values: string[]): McpToolsNode {
+  return {
+    label: 'Capability diagnostics',
+    description: values.length ? `${values.length}` : 'none',
+    tooltip: values.length ? values.join('\n') : 'No capability diagnostics.',
+    icon: values.length ? 'warning' : 'pass',
+    children: values.map((value) => ({
+      label: value,
+      icon: 'warning'
+    }))
+  };
+}
+
+function kicadRuntimeNode(
+  serverInfo: NonNullable<McpCapabilityCard['serverInfo']>
+): McpToolsNode {
+  const cliStatus = serverInfo.kicad.cliFound
+    ? (serverInfo.kicad.cliVersion ?? 'version unknown')
+    : 'CLI unavailable';
+  return {
+    label: 'KiCad runtime',
+    description: serverInfo.kicad.livePcbContext ? 'live PCB' : 'degraded',
+    tooltip: [
+      `CLI: ${cliStatus}`,
+      `Path: ${serverInfo.kicad.cliPath}`,
+      `IPC: ${serverInfo.kicad.ipcAvailable ? 'available' : 'unavailable'}`,
+      `Live PCB: ${serverInfo.kicad.livePcbContext ? 'available' : 'unavailable'}`
+    ].join('\n'),
+    icon: serverInfo.kicad.livePcbContext ? 'circuit-board' : 'warning'
+  };
+}
+
+function operationModesNode(
+  serverInfo: NonNullable<McpCapabilityCard['serverInfo']>
+): McpToolsNode {
+  const modes = [
+    capabilityFlag('File-backed DRC', serverInfo.capabilities.fileBackedDrc),
+    capabilityFlag('File-backed ERC', serverInfo.capabilities.fileBackedErc),
+    capabilityFlag(
+      'File-backed exports',
+      serverInfo.capabilities.fileBackedExports
+    ),
+    capabilityFlag('Live PCB read', serverInfo.capabilities.livePcbRead),
+    capabilityFlag('Live PCB write', serverInfo.capabilities.livePcbWrite),
+    capabilityFlag(
+      'ChatGPT connector',
+      serverInfo.capabilities.chatgptConnectorCompatible
+    )
+  ];
+  return {
+    label: 'Operation modes',
+    description: `${modes.filter((mode) => mode.enabled).length}/${modes.length} available`,
+    tooltip: modes
+      .map(
+        (mode) => `${mode.label}: ${mode.enabled ? 'available' : 'unavailable'}`
+      )
+      .join('\n'),
+    icon: 'checklist',
+    children: modes.map((mode) => ({
+      label: mode.label,
+      description: mode.enabled ? 'available' : 'unavailable',
+      icon: mode.enabled ? 'pass' : 'circle-slash'
+    }))
+  };
+}
+
+function capabilityFlag(
+  label: string,
+  enabled: boolean
+): { label: string; enabled: boolean } {
+  return { label, enabled };
+}
+
 function capabilityGroup(label: string, values: string[]): McpToolsNode {
   return {
     label,
     description: values.length ? `${values.length}` : 'none',
-    tooltip: values.length ? values.join('\n') : `No ${label.toLowerCase()} advertised.`,
+    tooltip: values.length
+      ? values.join('\n')
+      : `No ${label.toLowerCase()} advertised.`,
     icon: values.length ? 'list-tree' : 'circle-slash',
     children: values.slice(0, 25).map((value) => ({
       label: value,

--- a/apps/vscode-extension/src/mcp/serverMetadata.ts
+++ b/apps/vscode-extension/src/mcp/serverMetadata.ts
@@ -107,7 +107,10 @@ function readWellKnownServerInfoContract(
       }
     },
     transport: {
-      type: transport['type'] === 'stdio' ? 'stdio' : 'streamable-http',
+      type:
+        transport['type'] === 'stdio' || transport['type'] === 'sse'
+          ? transport['type']
+          : 'streamable-http',
       streamableHttp: Boolean(transport['streamableHttp']),
       statelessHttp: Boolean(transport['statelessHttp']),
       legacySse: Boolean(transport['legacySse']),

--- a/apps/vscode-extension/src/mcp/serverMetadata.ts
+++ b/apps/vscode-extension/src/mcp/serverMetadata.ts
@@ -1,10 +1,23 @@
 import { getMcpCompatStatus, normalizeMcpVersion } from './compat';
 import type { Logger } from '../utils/logger';
+import type { McpServerInfoContract } from '../types';
+
+export interface WellKnownMcpServerMetadata {
+  version: string;
+  serverInfo?: McpServerInfoContract | undefined;
+}
 
 export async function readWellKnownMcpServerVersion(
   endpoint: string,
   logger: Pick<Logger, 'debug'>
 ): Promise<string | undefined> {
+  return (await readWellKnownMcpServerMetadata(endpoint, logger))?.version;
+}
+
+export async function readWellKnownMcpServerMetadata(
+  endpoint: string,
+  logger: Pick<Logger, 'debug'>
+): Promise<WellKnownMcpServerMetadata | undefined> {
   for (const path of ['/.well-known/mcp-server', '/well-known/mcp-server']) {
     try {
       const response = await fetch(`${endpoint}${path}`, {
@@ -14,12 +27,15 @@ export async function readWellKnownMcpServerVersion(
       if (!response.ok) {
         continue;
       }
-      const version = normalizeMcpVersion(
-        readWellKnownVersion((await response.json()) as unknown)
-      );
+      const payload = (await response.json()) as unknown;
+      const version = normalizeMcpVersion(readWellKnownVersion(payload));
       if (getMcpCompatStatus(version) !== 'incompatible') {
         logger.debug(`Using MCP server-card version ${version} from ${path}.`);
-        return version;
+        const serverInfo = readWellKnownServerInfoContract(payload);
+        return {
+          version,
+          ...(serverInfo ? { serverInfo } : {})
+        };
       }
     } catch {
       continue;
@@ -44,6 +60,98 @@ function readWellKnownVersion(value: unknown): string | undefined {
       : undefined;
 }
 
+function readWellKnownServerInfoContract(
+  value: unknown
+): McpServerInfoContract | undefined {
+  if (!isRecord(value) || !isRecord(value['serverInfoContract'])) {
+    return undefined;
+  }
+  const contract = value['serverInfoContract'];
+  if (contract['server'] !== 'kicad-mcp-pro') {
+    return undefined;
+  }
+  const transport = isRecord(contract['transport'])
+    ? contract['transport']
+    : {};
+  const kicad = isRecord(contract['kicad']) ? contract['kicad'] : {};
+  const capabilities = isRecord(contract['capabilities'])
+    ? contract['capabilities']
+    : {};
+  const cliExports = isRecord(capabilities['cliExports'])
+    ? capabilities['cliExports']
+    : {};
+  const compatibilityRange = isRecord(contract['compatibilityRange'])
+    ? contract['compatibilityRange']
+    : {};
+  const kicadStudio = isRecord(compatibilityRange['kicadStudio'])
+    ? compatibilityRange['kicadStudio']
+    : {};
+  const kicadMcpPro = isRecord(compatibilityRange['kicadMcpPro'])
+    ? compatibilityRange['kicadMcpPro']
+    : {};
+  return {
+    schemaVersion: stringValue(contract['schemaVersion']),
+    server: 'kicad-mcp-pro',
+    version: stringValue(contract['version']),
+    mcpProtocolVersion: stringValue(contract['mcpProtocolVersion']),
+    toolSchemaVersion: stringValue(contract['toolSchemaVersion']),
+    compatibilityRange: {
+      kicadStudio: {
+        required: stringValue(kicadStudio['required']),
+        recommended: stringValue(kicadStudio['recommended']),
+        testedAgainst: stringValue(kicadStudio['testedAgainst'])
+      },
+      kicadMcpPro: {
+        required: stringValue(kicadMcpPro['required']),
+        testedAgainst: stringValue(kicadMcpPro['testedAgainst'])
+      }
+    },
+    transport: {
+      type: transport['type'] === 'stdio' ? 'stdio' : 'streamable-http',
+      streamableHttp: Boolean(transport['streamableHttp']),
+      statelessHttp: Boolean(transport['statelessHttp']),
+      legacySse: Boolean(transport['legacySse']),
+      authRequired: Boolean(transport['authRequired']),
+      endpoint:
+        typeof transport['endpoint'] === 'string' ? transport['endpoint'] : null
+    },
+    kicad: {
+      cliFound: Boolean(kicad['cliFound']),
+      cliPath: stringValue(kicad['cliPath']),
+      cliVersion:
+        typeof kicad['cliVersion'] === 'string' ? kicad['cliVersion'] : null,
+      ipcAvailable: Boolean(kicad['ipcAvailable']),
+      livePcbContext: Boolean(kicad['livePcbContext'])
+    },
+    capabilities: {
+      fileBackedDrc: Boolean(capabilities['fileBackedDrc']),
+      fileBackedErc: Boolean(capabilities['fileBackedErc']),
+      fileBackedExports: Boolean(capabilities['fileBackedExports']),
+      livePcbRead: Boolean(capabilities['livePcbRead']),
+      livePcbWrite: Boolean(capabilities['livePcbWrite']),
+      chatgptConnectorCompatible: Boolean(
+        capabilities['chatgptConnectorCompatible']
+      ),
+      cliExports: {
+        ipc2581: Boolean(cliExports['ipc2581']),
+        odb: Boolean(cliExports['odb']),
+        svg: Boolean(cliExports['svg']),
+        dxf: Boolean(cliExports['dxf']),
+        step: Boolean(cliExports['step']),
+        render: Boolean(cliExports['render']),
+        spiceNetlist: Boolean(cliExports['spiceNetlist'])
+      }
+    },
+    diagnostics: Array.isArray(contract['diagnostics'])
+      ? contract['diagnostics'].map((item) => String(item))
+      : []
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value : '';
 }

--- a/apps/vscode-extension/src/types.ts
+++ b/apps/vscode-extension/src/types.ts
@@ -327,7 +327,7 @@ export interface McpServerInfoContract {
   toolSchemaVersion: string;
   compatibilityRange: McpServerInfoCompatibilityRange;
   transport: {
-    type: 'stdio' | 'streamable-http';
+    type: 'stdio' | 'streamable-http' | 'sse';
     streamableHttp: boolean;
     statelessHttp: boolean;
     legacySse: boolean;

--- a/apps/vscode-extension/src/types.ts
+++ b/apps/vscode-extension/src/types.ts
@@ -224,9 +224,9 @@ export interface ProjectTreeNode {
     | 'jobset'
     | 'fab-output'
     | 'model'
-      | 'file'
-      | 'folder'
-      | 'drc-rule';
+    | 'file'
+    | 'folder'
+    | 'drc-rule';
   uri?: vscode.Uri | undefined;
   children?: ProjectTreeNode[] | undefined;
 }
@@ -307,10 +307,66 @@ export type McpConnectionKind =
   | 'Incompatible'
   | 'VsCodeStdio';
 
+export interface McpServerInfoCompatibilityRange {
+  kicadStudio: {
+    required: string;
+    recommended: string;
+    testedAgainst: string;
+  };
+  kicadMcpPro: {
+    required: string;
+    testedAgainst: string;
+  };
+}
+
+export interface McpServerInfoContract {
+  schemaVersion: string;
+  server: 'kicad-mcp-pro';
+  version: string;
+  mcpProtocolVersion: string;
+  toolSchemaVersion: string;
+  compatibilityRange: McpServerInfoCompatibilityRange;
+  transport: {
+    type: 'stdio' | 'streamable-http';
+    streamableHttp: boolean;
+    statelessHttp: boolean;
+    legacySse: boolean;
+    authRequired: boolean;
+    endpoint: string | null;
+  };
+  kicad: {
+    cliFound: boolean;
+    cliPath: string;
+    cliVersion: string | null;
+    ipcAvailable: boolean;
+    livePcbContext: boolean;
+  };
+  capabilities: {
+    fileBackedDrc: boolean;
+    fileBackedErc: boolean;
+    fileBackedExports: boolean;
+    livePcbRead: boolean;
+    livePcbWrite: boolean;
+    chatgptConnectorCompatible: boolean;
+    cliExports: {
+      ipc2581: boolean;
+      odb: boolean;
+      svg: boolean;
+      dxf: boolean;
+      step: boolean;
+      render: boolean;
+      spiceNetlist: boolean;
+    };
+  };
+  diagnostics: string[];
+}
+
 export interface McpCapabilityCard {
   tools: string[];
   resources: string[];
   prompts: string[];
+  serverInfo?: McpServerInfoContract | undefined;
+  diagnostics?: string[] | undefined;
 }
 
 export interface McpServerCard {

--- a/apps/vscode-extension/test/integration/qualityGate.flow.test.ts
+++ b/apps/vscode-extension/test/integration/qualityGate.flow.test.ts
@@ -17,7 +17,7 @@ suite('Quality Gate Integration', () => {
       sidebarViews.some(
         (view) =>
           view.id === 'kicadstudio.qualityGate' &&
-          view.when === 'kicadstudio.mcpConnected && kicadstudio.hasProject'
+          view.when === 'kicadstudio.hasProject'
       )
     );
 

--- a/apps/vscode-extension/test/unit/mcpClient.versionGate.test.ts
+++ b/apps/vscode-extension/test/unit/mcpClient.versionGate.test.ts
@@ -13,10 +13,12 @@ function createJsonResponse(body: unknown) {
   };
 }
 
-function initializeResult(version: string | undefined) {
+function initializeResult(version: string | undefined, name?: string) {
   return {
     result: {
-      ...(version ? { serverInfo: { version } } : {}),
+      ...(version
+        ? { serverInfo: { ...(name ? { name } : {}), version } }
+        : {}),
       capabilities: {
         tools: [{ name: 'project_quality_gate_report' }],
         resources: [{ name: 'kicad://project/fix_queue' }],
@@ -31,6 +33,66 @@ function wellKnownResult(version: string) {
     serverInfo: {
       name: 'kicad-mcp-pro',
       version
+    }
+  };
+}
+
+function wellKnownServerInfoResult() {
+  return {
+    serverInfo: {
+      name: 'kicad-mcp-pro',
+      version: '1.0.0'
+    },
+    serverInfoContract: {
+      schemaVersion: '1.0.0',
+      server: 'kicad-mcp-pro',
+      version: '1.0.0',
+      mcpProtocolVersion: '2025-11-25',
+      toolSchemaVersion: '1.0.0',
+      compatibilityRange: {
+        kicadStudio: {
+          required: '>=1.0.0 <2.0.0',
+          recommended: '>=1.0.0 <2.0.0',
+          testedAgainst: '1.0.0'
+        },
+        kicadMcpPro: {
+          required: '>=1.0.0 <2.0.0',
+          testedAgainst: '1.0.0'
+        }
+      },
+      transport: {
+        type: 'streamable-http',
+        streamableHttp: true,
+        statelessHttp: true,
+        legacySse: false,
+        authRequired: false,
+        endpoint: 'http://127.0.0.1:27185/mcp'
+      },
+      kicad: {
+        cliFound: true,
+        cliPath: '/usr/bin/kicad-cli',
+        cliVersion: 'KiCad 10.0.3',
+        ipcAvailable: false,
+        livePcbContext: false
+      },
+      capabilities: {
+        fileBackedDrc: true,
+        fileBackedErc: true,
+        fileBackedExports: true,
+        livePcbRead: false,
+        livePcbWrite: false,
+        chatgptConnectorCompatible: false,
+        cliExports: {
+          ipc2581: false,
+          odb: false,
+          svg: false,
+          dxf: false,
+          step: false,
+          render: false,
+          spiceNetlist: false
+        }
+      },
+      diagnostics: ['Live KiCad PCB context is unavailable: No PCB is open.']
     }
   };
 }
@@ -125,6 +187,46 @@ describe('McpClient version gate', () => {
     expect(state.kind).toBe('Connected');
     expect(state.server?.version).toBe('1.0.0');
     expect(state.server?.compat).toBe('ok');
+  });
+
+  it('captures degraded server-info diagnostics from the HTTP server card', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(createJsonResponse(initializeResult('1.27.0')))
+      .mockResolvedValueOnce(createJsonResponse(wellKnownServerInfoResult()))
+      .mockResolvedValueOnce(
+        createJsonResponse({ result: { tools: [] } })
+      ) as typeof fetch;
+
+    const state = await createClient().testConnection();
+
+    expect(state.kind).toBe('Connected');
+    expect(state.connected).toBe(true);
+    expect(state.server?.compat).toBe('warn');
+    expect(state.message).toContain('Live KiCad PCB context is unavailable');
+    expect(state.server?.capabilities.serverInfo?.kicad.livePcbContext).toBe(
+      false
+    );
+    expect(
+      state.server?.capabilities.serverInfo?.capabilities.livePcbRead
+    ).toBe(false);
+  });
+
+  it('reads server-info diagnostics when initialize identifies kicad-mcp-pro', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonResponse(initializeResult('1.0.0', 'kicad-mcp-pro'))
+      )
+      .mockResolvedValueOnce(createJsonResponse(wellKnownServerInfoResult()))
+      .mockResolvedValueOnce(
+        createJsonResponse({ result: { tools: [] } })
+      ) as typeof fetch;
+
+    const state = await createClient().testConnection();
+
+    expect(state.server?.compat).toBe('warn');
+    expect(state.server?.capabilities.serverInfo?.schemaVersion).toBe('1.0.0');
   });
 
   it('blocks tool calls after an incompatible initialize response', async () => {

--- a/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
@@ -33,7 +33,63 @@ describe('McpToolsProvider', () => {
           capabilities: {
             tools: ['pcb_validate', 'sch_validate'],
             resources: ['project://active'],
-            prompts: ['manufacturing-review']
+            prompts: ['manufacturing-review'],
+            serverInfo: {
+              schemaVersion: '1.0.0',
+              server: 'kicad-mcp-pro',
+              version: '1.0.0',
+              mcpProtocolVersion: '2025-11-25',
+              toolSchemaVersion: '1.0.0',
+              compatibilityRange: {
+                kicadStudio: {
+                  required: '>=1.0.0 <2.0.0',
+                  recommended: '>=1.0.0 <2.0.0',
+                  testedAgainst: '1.0.0'
+                },
+                kicadMcpPro: {
+                  required: '>=1.0.0 <2.0.0',
+                  testedAgainst: '1.0.0'
+                }
+              },
+              transport: {
+                type: 'streamable-http',
+                streamableHttp: true,
+                statelessHttp: true,
+                legacySse: false,
+                authRequired: false,
+                endpoint: 'http://127.0.0.1:27185/mcp'
+              },
+              kicad: {
+                cliFound: true,
+                cliPath: '/usr/bin/kicad-cli',
+                cliVersion: 'KiCad 10.0.3',
+                ipcAvailable: false,
+                livePcbContext: false
+              },
+              capabilities: {
+                fileBackedDrc: true,
+                fileBackedErc: true,
+                fileBackedExports: true,
+                livePcbRead: false,
+                livePcbWrite: false,
+                chatgptConnectorCompatible: false,
+                cliExports: {
+                  ipc2581: false,
+                  odb: false,
+                  svg: false,
+                  dxf: false,
+                  step: false,
+                  render: false,
+                  spiceNetlist: false
+                }
+              },
+              diagnostics: [
+                'Live KiCad PCB context is unavailable: No PCB is open.'
+              ]
+            },
+            diagnostics: [
+              'Live KiCad PCB context is unavailable: No PCB is open.'
+            ]
           }
         }
       })
@@ -53,9 +109,23 @@ describe('McpToolsProvider', () => {
       ])
     );
     expect(
-      provider.getTreeItem(children.find((item) => item.label === 'Capabilities') as never)
-        .description
-    ).toBe('2 tools, 1 resources, 1 prompts');
+      provider.getTreeItem(
+        children.find((item) => item.label === 'Capabilities') as never
+      ).description
+    ).toBe('2 tools, 1 resources, 1 prompts, 1 diagnostic');
+    expect(
+      provider
+        .getChildren(
+          children.find((item) => item.label === 'Capabilities') as never
+        )
+        .map((item) => item.label)
+    ).toEqual(
+      expect.arrayContaining([
+        'Capability diagnostics',
+        'KiCad runtime',
+        'Operation modes'
+      ])
+    );
   });
 
   it('renders disconnected state as an actionable retry row', () => {
@@ -74,7 +144,9 @@ describe('McpToolsProvider', () => {
     expect(provider.getTreeItem(state as never).command).toEqual(
       expect.objectContaining({ command: 'kicadstudio.mcp.retry' })
     );
-    expect(provider.getTreeItem(diagnostic as never).description).toBe('HTTP 503');
+    expect(provider.getTreeItem(diagnostic as never).description).toBe(
+      'HTTP 503'
+    );
   });
 });
 

--- a/packages/mcp-server/docs/tools-reference.generated.md
+++ b/packages/mcp-server/docs/tools-reference.generated.md
@@ -1,6 +1,6 @@
 Machine-maintained catalog. Refresh with `pnpm run docs:tools`.
 
-Total public tools: 248.
+Total public tools: 249.
 
 | Tool | Profile(s) | Read-Only | Destructive | Open-World | Headless | Requires KiCad Running | Summary |
 |---|---|---:|---:|---:|---:|---:|---|
@@ -45,6 +45,7 @@ Total public tools: 248.
 | `get_unconnected_nets` | agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic | yes | no | no | yes | no | Return only unconnected net issues from DRC. This KiCad MCP Pro tool supports production EDA automation workflows for... |
 | `kicad_create_new_project` | all | no | no | no | yes | no | Create a new minimal KiCad project structure and activate it. |
 | `kicad_get_project_info` | all | yes | no | no | yes | no | Show the currently configured KiCad project paths. This KiCad MCP Pro tool supports production EDA automation workflo... |
+| `kicad_get_server_info` | all | yes | no | no | yes | no | Return versioned server information and capability diagnostics for clients. This KiCad MCP Pro tool supports producti... |
 | `kicad_get_tools_in_category` | all | yes | no | no | no | no | Get the tool names available in a specific category. This KiCad MCP Pro tool supports production EDA automation workf... |
 | `kicad_get_version` | all | yes | no | no | yes | no | Get KiCad version information and current connection status. This KiCad MCP Pro tool supports production EDA automati... |
 | `kicad_help` | all | no | no | no | yes | no | Show a concise startup guide and all tool categories. This KiCad MCP Pro tool supports production EDA automation work... |
@@ -296,6 +297,7 @@ Total public tools: 248.
 - `get_unconnected_nets`: profiles=agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic; readOnly=yes; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `kicad_create_new_project`: profiles=all; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `kicad_get_project_info`: profiles=all; readOnly=yes; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
+- `kicad_get_server_info`: profiles=all; readOnly=yes; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `kicad_get_tools_in_category`: profiles=all; readOnly=yes; destructive=no; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `kicad_get_version`: profiles=all; readOnly=yes; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `kicad_help`: profiles=all; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.

--- a/packages/mcp-server/docs/tools-reference.md
+++ b/packages/mcp-server/docs/tools-reference.md
@@ -131,7 +131,7 @@ Built-in prompt helpers for the critic/fixer loop:
 
 Machine-maintained catalog. Refresh with `pnpm run docs:tools`.
 
-Total public tools: 248.
+Total public tools: 249.
 
 | Tool | Profile(s) | Read-Only | Destructive | Open-World | Headless | Requires KiCad Running | Summary |
 |---|---|---:|---:|---:|---:|---:|---|
@@ -176,6 +176,7 @@ Total public tools: 248.
 | `get_unconnected_nets` | agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic | yes | no | no | yes | no | Return only unconnected net issues from DRC. This KiCad MCP Pro tool supports production EDA automation workflows for... |
 | `kicad_create_new_project` | all | no | no | no | yes | no | Create a new minimal KiCad project structure and activate it. |
 | `kicad_get_project_info` | all | yes | no | no | yes | no | Show the currently configured KiCad project paths. This KiCad MCP Pro tool supports production EDA automation workflo... |
+| `kicad_get_server_info` | all | yes | no | no | yes | no | Return versioned server information and capability diagnostics for clients. This KiCad MCP Pro tool supports producti... |
 | `kicad_get_tools_in_category` | all | yes | no | no | no | no | Get the tool names available in a specific category. This KiCad MCP Pro tool supports production EDA automation workf... |
 | `kicad_get_version` | all | yes | no | no | yes | no | Get KiCad version information and current connection status. This KiCad MCP Pro tool supports production EDA automati... |
 | `kicad_help` | all | no | no | no | yes | no | Show a concise startup guide and all tool categories. This KiCad MCP Pro tool supports production EDA automation work... |
@@ -427,6 +428,7 @@ Total public tools: 248.
 - `get_unconnected_nets`: profiles=agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic; readOnly=yes; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `kicad_create_new_project`: profiles=all; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `kicad_get_project_info`: profiles=all; readOnly=yes; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
+- `kicad_get_server_info`: profiles=all; readOnly=yes; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `kicad_get_tools_in_category`: profiles=all; readOnly=yes; destructive=no; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `kicad_get_version`: profiles=all; readOnly=yes; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `kicad_help`: profiles=all; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.

--- a/packages/mcp-server/src/kicad_mcp/resources/server_info.py
+++ b/packages/mcp-server/src/kicad_mcp/resources/server_info.py
@@ -1,0 +1,25 @@
+"""MCP resource and tool for server-info/capability discovery."""
+
+from __future__ import annotations
+
+import json
+
+from mcp.server.fastmcp import FastMCP
+
+from ..server_info import get_server_info_contract
+from ..tools.metadata import headless_compatible
+
+
+def register(mcp: FastMCP) -> None:
+    """Register the server-info discovery surface."""
+
+    @mcp.resource("kicad://server/info")
+    def server_info_resource() -> str:
+        """Return versioned server information and capability diagnostics."""
+        return json.dumps(get_server_info_contract(), sort_keys=True)
+
+    @mcp.tool(structured_output=True)
+    @headless_compatible
+    def kicad_get_server_info() -> dict[str, object]:
+        """Return versioned server information and capability diagnostics for clients."""
+        return get_server_info_contract()

--- a/packages/mcp-server/src/kicad_mcp/server.py
+++ b/packages/mcp-server/src/kicad_mcp/server.py
@@ -762,7 +762,7 @@ def _register_profile_components(
 ) -> None:
     """Register all profile-specific MCP surfaces on an already-created server."""
     from .prompts import workflows
-    from .resources import analysis, board_state, studio_context
+    from .resources import analysis, board_state, server_info, studio_context
     from .tools import (
         dfm,
         emc_compliance,
@@ -816,6 +816,7 @@ def _register_profile_components(
 
     analysis.register(server)
     board_state.register(server)
+    server_info.register(server)
     studio_context.register(server)
     workflows.register(server)
 

--- a/packages/mcp-server/src/kicad_mcp/server_info.py
+++ b/packages/mcp-server/src/kicad_mcp/server_info.py
@@ -2,26 +2,42 @@
 
 from __future__ import annotations
 
-from typing import cast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
 
 from . import __version__
 from .compatibility import MCP_PROTOCOL_VERSION, MCP_TOOL_SCHEMA_VERSION, compatibility_summary
-from .config import LOOPBACK_HOSTS, get_config
-from .connection import KiCadConnectionError, get_board
-from .discovery import find_kicad_version, get_cli_capabilities
+from .config import get_config
+from .connection import KiCadConnectionError, get_board, get_kicad
+from .discovery import CliCapabilities, get_cli_capabilities
 
 SERVER_INFO_SCHEMA_VERSION = "1.0.0"
+_BIND_ALL_HOSTS = {"0.0.0.0", "::"}  # noqa: S104 - bind-all sentinel, not a socket bind.
+_SEMVER_NUMBER_RE = re.compile(r"\d+")
+TransportType = Literal["stdio", "streamable-http", "sse"]
 
 
-def get_server_info_contract() -> dict[str, object]:
+@dataclass(frozen=True)
+class _CliDiscovery:
+    found: bool
+    version: str | None
+    capabilities: CliCapabilities | None
+
+
+_CLI_DISCOVERY_CACHE: dict[tuple[Path, int | None], _CliDiscovery] = {}
+
+
+def get_server_info_contract(*, probe_live_context: bool = True) -> dict[str, object]:
     """Return the stable server-info/capabilities payload for clients."""
     cfg = get_config()
-    cli_found = cfg.kicad_cli.exists()
-    cli_version = find_kicad_version(cfg.kicad_cli)
-    cli_capabilities = get_cli_capabilities(cfg.kicad_cli) if cli_found else None
-    ipc_available, live_pcb_context, live_diagnostic = _probe_live_context()
+    cli = _cached_cli_discovery(cfg.kicad_cli)
+    ipc_available, live_pcb_context, live_diagnostic = (
+        _probe_live_context() if probe_live_context else (False, False, None)
+    )
     diagnostics = _diagnostics(
-        cli_found=cli_found,
+        cli_found=cli.found,
         live_diagnostic=live_diagnostic,
     )
     return {
@@ -31,63 +47,85 @@ def get_server_info_contract() -> dict[str, object]:
         "mcpProtocolVersion": MCP_PROTOCOL_VERSION,
         "toolSchemaVersion": _as_semver(MCP_TOOL_SCHEMA_VERSION),
         "compatibilityRange": _compatibility_range(),
-        "transport": {
-            "type": _transport_type(),
-            "streamableHttp": cfg.transport != "stdio",
-            "statelessHttp": cfg.transport != "stdio" and not cfg.stateful_http,
-            "legacySse": cfg.legacy_sse,
-            "authRequired": cfg.transport != "stdio" and bool(cfg.auth_token),
-            "endpoint": _endpoint(),
-        },
+        "transport": get_transport_metadata(),
         "kicad": {
-            "cliFound": cli_found,
+            "cliFound": cli.found,
             "cliPath": str(cfg.kicad_cli),
-            "cliVersion": cli_version,
+            "cliVersion": cli.version,
             "ipcAvailable": ipc_available,
             "livePcbContext": live_pcb_context,
         },
         "capabilities": {
-            "fileBackedDrc": cli_found,
-            "fileBackedErc": cli_found,
-            "fileBackedExports": cli_found,
+            "fileBackedDrc": cli.found,
+            "fileBackedErc": cli.found,
+            "fileBackedExports": cli.found,
             "livePcbRead": live_pcb_context,
             "livePcbWrite": live_pcb_context,
             "chatgptConnectorCompatible": False,
             "cliExports": {
-                "ipc2581": bool(cli_capabilities and cli_capabilities.supports_ipc2581),
-                "odb": bool(cli_capabilities and cli_capabilities.supports_odb_export),
-                "svg": bool(cli_capabilities and cli_capabilities.supports_svg),
-                "dxf": bool(cli_capabilities and cli_capabilities.supports_dxf),
-                "step": bool(cli_capabilities and cli_capabilities.supports_step),
-                "render": bool(cli_capabilities and cli_capabilities.supports_render),
-                "spiceNetlist": bool(cli_capabilities and cli_capabilities.supports_spice_netlist),
+                "ipc2581": bool(cli.capabilities and cli.capabilities.supports_ipc2581),
+                "odb": bool(cli.capabilities and cli.capabilities.supports_odb_export),
+                "svg": bool(cli.capabilities and cli.capabilities.supports_svg),
+                "dxf": bool(cli.capabilities and cli.capabilities.supports_dxf),
+                "step": bool(cli.capabilities and cli.capabilities.supports_step),
+                "render": bool(cli.capabilities and cli.capabilities.supports_render),
+                "spiceNetlist": bool(cli.capabilities and cli.capabilities.supports_spice_netlist),
             },
         },
         "diagnostics": diagnostics,
     }
 
 
-def _transport_type() -> str:
-    return "stdio" if get_config().transport == "stdio" else "streamable-http"
+def get_transport_metadata() -> dict[str, object]:
+    """Return advertised transport metadata shared by server-info and well-known cards."""
+    cfg = get_config()
+    transport_type = _transport_type()
+    return {
+        "type": transport_type,
+        "streamableHttp": transport_type == "streamable-http",
+        "statelessHttp": transport_type == "streamable-http" and not cfg.stateful_http,
+        "legacySse": cfg.legacy_sse or transport_type == "sse",
+        "authRequired": transport_type != "stdio" and bool(cfg.auth_token),
+        "endpoint": _endpoint(transport_type),
+    }
 
 
-def _endpoint() -> str | None:
+def _transport_type() -> TransportType:
     cfg = get_config()
     if cfg.transport == "stdio":
+        return "stdio"
+    if cfg.transport == "sse" and cfg.legacy_sse:
+        return "sse"
+    return "streamable-http"
+
+
+def _endpoint(transport_type: TransportType | None = None) -> str | None:
+    cfg = get_config()
+    selected_transport = transport_type or _transport_type()
+    if selected_transport == "stdio":
         return None
-    host = cfg.host if cfg.host in LOOPBACK_HOSTS else "127.0.0.1"
+    host = _format_host_for_url(_advertised_host(cfg.host))
     return f"http://{host}:{cfg.port}{cfg.mount_path}"
 
 
 def _probe_live_context() -> tuple[bool, bool, str | None]:
     try:
+        get_kicad()
+    except KiCadConnectionError as exc:
+        message = str(exc).splitlines()[0] or "KiCad IPC is unavailable."
+        return False, False, f"KiCad IPC is unavailable: {message}"
+    except Exception as exc:  # pragma: no cover - defensive probe boundary
+        message = str(exc).splitlines()[0] or exc.__class__.__name__
+        return False, False, f"KiCad IPC probe failed: {message}"
+
+    try:
         get_board()
     except KiCadConnectionError as exc:
         message = str(exc).splitlines()[0] or "KiCad IPC is unavailable."
-        return False, False, f"Live KiCad PCB context is unavailable: {message}"
+        return True, False, f"Live KiCad PCB context is unavailable: {message}"
     except Exception as exc:  # pragma: no cover - defensive probe boundary
         message = str(exc).splitlines()[0] or exc.__class__.__name__
-        return False, False, f"Live KiCad PCB context probe failed: {message}"
+        return True, False, f"Live KiCad PCB context probe failed: {message}"
     return True, True, None
 
 
@@ -103,12 +141,44 @@ def _diagnostics(*, cli_found: bool, live_diagnostic: str | None) -> list[str]:
 
 
 def _as_semver(version: str) -> str:
-    parts = version.split(".")
-    if len(parts) == 1:
-        return f"{version}.0.0"
-    if len(parts) == 2:
-        return f"{version}.0"
-    return version
+    parts = _SEMVER_NUMBER_RE.findall(version)
+    if not parts:
+        return "0.0.0"
+    normalized = [*parts[:3], "0", "0"]
+    return ".".join(normalized[:3])
+
+
+def _cached_cli_discovery(cli_path: Path) -> _CliDiscovery:
+    resolved = cli_path.expanduser().resolve(strict=False)
+    try:
+        mtime_ns: int | None = resolved.stat().st_mtime_ns
+    except OSError:
+        return _CliDiscovery(found=False, version=None, capabilities=None)
+
+    key = (resolved, mtime_ns)
+    cached = _CLI_DISCOVERY_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    capabilities = get_cli_capabilities(resolved)
+    discovered = _CliDiscovery(found=True, version=capabilities.version, capabilities=capabilities)
+    _CLI_DISCOVERY_CACHE[key] = discovered
+    return discovered
+
+
+def _advertised_host(host: str) -> str:
+    normalized = host.strip()
+    if normalized in _BIND_ALL_HOSTS:
+        return "127.0.0.1"
+    return normalized
+
+
+def _format_host_for_url(host: str) -> str:
+    if host.startswith("[") and host.endswith("]"):
+        return host
+    if ":" in host:
+        return f"[{host}]"
+    return host
 
 
 def _compatibility_range() -> dict[str, dict[str, str]]:

--- a/packages/mcp-server/src/kicad_mcp/server_info.py
+++ b/packages/mcp-server/src/kicad_mcp/server_info.py
@@ -1,0 +1,131 @@
+"""Versioned server-info and capability discovery contract."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from . import __version__
+from .compatibility import MCP_PROTOCOL_VERSION, MCP_TOOL_SCHEMA_VERSION, compatibility_summary
+from .config import LOOPBACK_HOSTS, get_config
+from .connection import KiCadConnectionError, get_board
+from .discovery import find_kicad_version, get_cli_capabilities
+
+SERVER_INFO_SCHEMA_VERSION = "1.0.0"
+
+
+def get_server_info_contract() -> dict[str, object]:
+    """Return the stable server-info/capabilities payload for clients."""
+    cfg = get_config()
+    cli_found = cfg.kicad_cli.exists()
+    cli_version = find_kicad_version(cfg.kicad_cli)
+    cli_capabilities = get_cli_capabilities(cfg.kicad_cli) if cli_found else None
+    ipc_available, live_pcb_context, live_diagnostic = _probe_live_context()
+    diagnostics = _diagnostics(
+        cli_found=cli_found,
+        live_diagnostic=live_diagnostic,
+    )
+    return {
+        "schemaVersion": SERVER_INFO_SCHEMA_VERSION,
+        "server": "kicad-mcp-pro",
+        "version": __version__,
+        "mcpProtocolVersion": MCP_PROTOCOL_VERSION,
+        "toolSchemaVersion": _as_semver(MCP_TOOL_SCHEMA_VERSION),
+        "compatibilityRange": _compatibility_range(),
+        "transport": {
+            "type": _transport_type(),
+            "streamableHttp": cfg.transport != "stdio",
+            "statelessHttp": cfg.transport != "stdio" and not cfg.stateful_http,
+            "legacySse": cfg.legacy_sse,
+            "authRequired": cfg.transport != "stdio" and bool(cfg.auth_token),
+            "endpoint": _endpoint(),
+        },
+        "kicad": {
+            "cliFound": cli_found,
+            "cliPath": str(cfg.kicad_cli),
+            "cliVersion": cli_version,
+            "ipcAvailable": ipc_available,
+            "livePcbContext": live_pcb_context,
+        },
+        "capabilities": {
+            "fileBackedDrc": cli_found,
+            "fileBackedErc": cli_found,
+            "fileBackedExports": cli_found,
+            "livePcbRead": live_pcb_context,
+            "livePcbWrite": live_pcb_context,
+            "chatgptConnectorCompatible": False,
+            "cliExports": {
+                "ipc2581": bool(cli_capabilities and cli_capabilities.supports_ipc2581),
+                "odb": bool(cli_capabilities and cli_capabilities.supports_odb_export),
+                "svg": bool(cli_capabilities and cli_capabilities.supports_svg),
+                "dxf": bool(cli_capabilities and cli_capabilities.supports_dxf),
+                "step": bool(cli_capabilities and cli_capabilities.supports_step),
+                "render": bool(cli_capabilities and cli_capabilities.supports_render),
+                "spiceNetlist": bool(cli_capabilities and cli_capabilities.supports_spice_netlist),
+            },
+        },
+        "diagnostics": diagnostics,
+    }
+
+
+def _transport_type() -> str:
+    return "stdio" if get_config().transport == "stdio" else "streamable-http"
+
+
+def _endpoint() -> str | None:
+    cfg = get_config()
+    if cfg.transport == "stdio":
+        return None
+    host = cfg.host if cfg.host in LOOPBACK_HOSTS else "127.0.0.1"
+    return f"http://{host}:{cfg.port}{cfg.mount_path}"
+
+
+def _probe_live_context() -> tuple[bool, bool, str | None]:
+    try:
+        get_board()
+    except KiCadConnectionError as exc:
+        message = str(exc).splitlines()[0] or "KiCad IPC is unavailable."
+        return False, False, f"Live KiCad PCB context is unavailable: {message}"
+    except Exception as exc:  # pragma: no cover - defensive probe boundary
+        message = str(exc).splitlines()[0] or exc.__class__.__name__
+        return False, False, f"Live KiCad PCB context probe failed: {message}"
+    return True, True, None
+
+
+def _diagnostics(*, cli_found: bool, live_diagnostic: str | None) -> list[str]:
+    diagnostics: list[str] = []
+    if not cli_found:
+        diagnostics.append(
+            "KiCad CLI is unavailable; file-backed DRC/ERC/export operations are disabled."
+        )
+    if live_diagnostic is not None:
+        diagnostics.append(live_diagnostic)
+    return diagnostics
+
+
+def _as_semver(version: str) -> str:
+    parts = version.split(".")
+    if len(parts) == 1:
+        return f"{version}.0.0"
+    if len(parts) == 2:
+        return f"{version}.0"
+    return version
+
+
+def _compatibility_range() -> dict[str, dict[str, str]]:
+    matrix = compatibility_summary()
+    products = cast(dict[str, object], matrix["products"])
+    studio = cast(dict[str, object], products["kicad-studio"])
+    mcp_pro = cast(dict[str, object], products["kicad-mcp-pro"])
+    studio_range = cast(dict[str, str], studio["compatibleMcpPro"])
+    extension_range = cast(dict[str, str], mcp_pro["compatibleExtension"])
+    return {
+        "kicadStudio": {
+            "required": studio_range["required"],
+            "recommended": studio_range["recommended"],
+            "testedAgainst": studio_range["testedAgainst"],
+        },
+        "kicadMcpPro": {
+            "required": extension_range["required"],
+            "testedAgainst": extension_range["testedAgainst"],
+        },
+    }

--- a/packages/mcp-server/src/kicad_mcp/tools/router.py
+++ b/packages/mcp-server/src/kicad_mcp/tools/router.py
@@ -64,6 +64,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
             "kicad_scan_directory",
             "kicad_create_new_project",
             "kicad_get_version",
+            "kicad_get_server_info",
             "kicad_list_tool_categories",
             "kicad_get_tools_in_category",
             "kicad_help",

--- a/packages/mcp-server/src/kicad_mcp/wellknown.py
+++ b/packages/mcp-server/src/kicad_mcp/wellknown.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from . import __version__
 from .compatibility import MCP_PROTOCOL_VERSION, compatibility_summary
 from .config import get_config
+from .server_info import get_server_info_contract
 from .tools.router import (
     EXPERIMENTAL_TOOL_NAMES,
     PROFILE_CATEGORIES,
@@ -59,6 +60,7 @@ def get_wellknown_metadata() -> dict[str, object]:
         "categories": ["eda", "pcb", "kicad"],
         "description": "Project-aware PCB and schematic workflows for KiCad",
         "profiles": available_profiles(),
+        "serverInfoContract": get_server_info_contract(),
         "compatibility": compatibility_summary(),
         "kicad_version_required": (
             "10.0.x primary, 9.x supported, 8.x deprecated file-level fallback"

--- a/packages/mcp-server/src/kicad_mcp/wellknown.py
+++ b/packages/mcp-server/src/kicad_mcp/wellknown.py
@@ -6,8 +6,7 @@ from datetime import UTC, datetime
 
 from . import __version__
 from .compatibility import MCP_PROTOCOL_VERSION, compatibility_summary
-from .config import get_config
-from .server_info import get_server_info_contract
+from .server_info import get_server_info_contract, get_transport_metadata
 from .tools.router import (
     EXPERIMENTAL_TOOL_NAMES,
     PROFILE_CATEGORIES,
@@ -20,13 +19,8 @@ _SERVER_CARD_LAST_UPDATED = datetime.now(UTC).isoformat()
 
 def get_wellknown_metadata() -> dict[str, object]:
     """Return server discovery metadata for ``/.well-known/mcp-server``."""
-    cfg = get_config()
     protocol_version = MCP_PROTOCOL_VERSION
-    transport_type = "stdio" if cfg.transport == "stdio" else "streamable-http"
-    endpoint = None
-    if transport_type != "stdio":
-        host = cfg.host if cfg.host not in {"0.0.0.0", "::"} else "127.0.0.1"  # noqa: S104
-        endpoint = f"http://{host}:{cfg.port}{cfg.mount_path}"
+    transport = get_transport_metadata()
     return {
         "$schema": "https://static.modelcontextprotocol.io/schemas/mcp-server-card/v1.json",
         "version": __version__,
@@ -37,8 +31,8 @@ def get_wellknown_metadata() -> dict[str, object]:
             "version": __version__,
         },
         "transport": {
-            "type": transport_type,
-            "endpoint": endpoint,
+            "type": transport["type"],
+            "endpoint": transport["endpoint"],
         },
         "capabilities": {
             "tools": True,
@@ -60,7 +54,7 @@ def get_wellknown_metadata() -> dict[str, object]:
         "categories": ["eda", "pcb", "kicad"],
         "description": "Project-aware PCB and schematic workflows for KiCad",
         "profiles": available_profiles(),
-        "serverInfoContract": get_server_info_contract(),
+        "serverInfoContract": get_server_info_contract(probe_live_context=False),
         "compatibility": compatibility_summary(),
         "kicad_version_required": (
             "10.0.x primary, 9.x supported, 8.x deprecated file-level fallback"

--- a/packages/mcp-server/tests/unit/test_server_info_contract.py
+++ b/packages/mcp-server/tests/unit/test_server_info_contract.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from kicad_mcp.connection import KiCadConnectionError
+from kicad_mcp.discovery import CliCapabilities
+from kicad_mcp.server import create_server
+from kicad_mcp.server_info import get_server_info_contract
+from tests.conftest import call_tool_payload
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "protocol-schemas"
+    / "schemas"
+    / "kicad-mcp-server-info.schema.json"
+)
+
+
+def _validate_contract(payload: dict[str, object]) -> None:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(payload)
+
+
+def test_server_info_contract_matches_protocol_schema(monkeypatch, sample_project) -> None:
+    _ = sample_project
+    monkeypatch.setenv("KICAD_MCP_TRANSPORT", "http")
+    monkeypatch.setenv("KICAD_MCP_STATEFUL_HTTP", "true")
+    monkeypatch.setenv("KICAD_MCP_AUTH_TOKEN", "local-test-token-with-enough-entropy")
+    monkeypatch.setattr("kicad_mcp.server_info.find_kicad_version", lambda _cli: "KiCad 10.0.3")
+    monkeypatch.setattr(
+        "kicad_mcp.server_info.get_cli_capabilities",
+        lambda _cli: CliCapabilities(
+            version="KiCad 10.0.3",
+            supports_ipc2581=True,
+            supports_odb_export=True,
+            supports_svg=True,
+            supports_dxf=True,
+            supports_step=True,
+            supports_render=True,
+            supports_spice_netlist=True,
+        ),
+    )
+    monkeypatch.setattr("kicad_mcp.server_info.get_board", lambda: object())
+
+    payload = get_server_info_contract()
+
+    _validate_contract(payload)
+    assert payload["schemaVersion"] == "1.0.0"
+    assert payload["server"] == "kicad-mcp-pro"
+    assert payload["mcpProtocolVersion"] == "2025-11-25"
+    assert payload["toolSchemaVersion"] == "1.0.0"
+    assert payload["compatibilityRange"] == {
+        "kicadStudio": {
+            "required": ">=1.0.0 <2.0.0",
+            "recommended": ">=1.0.0 <2.0.0",
+            "testedAgainst": "1.0.0",
+        },
+        "kicadMcpPro": {
+            "required": ">=1.0.0 <2.0.0",
+            "testedAgainst": "1.0.0",
+        },
+    }
+    assert payload["transport"] == {
+        "type": "streamable-http",
+        "streamableHttp": True,
+        "statelessHttp": False,
+        "legacySse": False,
+        "authRequired": True,
+        "endpoint": "http://127.0.0.1:3334/mcp",
+    }
+    assert payload["kicad"] == {
+        "cliFound": True,
+        "cliPath": str(sample_project.parent / "kicad-cli"),
+        "cliVersion": "KiCad 10.0.3",
+        "ipcAvailable": True,
+        "livePcbContext": True,
+    }
+    assert payload["capabilities"] == {
+        "fileBackedDrc": True,
+        "fileBackedErc": True,
+        "fileBackedExports": True,
+        "livePcbRead": True,
+        "livePcbWrite": True,
+        "chatgptConnectorCompatible": False,
+        "cliExports": {
+            "ipc2581": True,
+            "odb": True,
+            "svg": True,
+            "dxf": True,
+            "step": True,
+            "render": True,
+            "spiceNetlist": True,
+        },
+    }
+    assert payload["diagnostics"] == []
+
+
+def test_server_info_contract_reports_degraded_live_context(monkeypatch, sample_project) -> None:
+    _ = sample_project
+    monkeypatch.setattr("kicad_mcp.server_info.find_kicad_version", lambda _cli: "KiCad 10.0.3")
+    monkeypatch.setattr(
+        "kicad_mcp.server_info.get_board",
+        lambda: (_ for _ in ()).throw(KiCadConnectionError("No PCB is open.")),
+    )
+
+    payload = get_server_info_contract()
+
+    _validate_contract(payload)
+    assert payload["kicad"]["ipcAvailable"] is False
+    assert payload["kicad"]["livePcbContext"] is False
+    assert payload["capabilities"]["livePcbRead"] is False
+    assert payload["capabilities"]["livePcbWrite"] is False
+    assert "Live KiCad PCB context is unavailable: No PCB is open." in payload["diagnostics"]
+
+
+@pytest.mark.anyio
+async def test_server_info_tool_and_resource_return_same_contract(
+    monkeypatch,
+    sample_project,
+) -> None:
+    _ = sample_project
+    monkeypatch.setattr("kicad_mcp.server_info.find_kicad_version", lambda _cli: "KiCad 10.0.3")
+    monkeypatch.setattr(
+        "kicad_mcp.server_info.get_board",
+        lambda: (_ for _ in ()).throw(KiCadConnectionError("No PCB is open.")),
+    )
+    server = create_server("minimal")
+
+    tool_payload = await call_tool_payload(server, "kicad_get_server_info", {})
+    resource_items = list(await server.read_resource("kicad://server/info"))
+    resource_payload = json.loads(resource_items[0].content)
+
+    assert tool_payload == resource_payload
+    _validate_contract(resource_payload)
+    assert resource_payload["server"] == "kicad-mcp-pro"

--- a/packages/mcp-server/tests/unit/test_server_info_contract.py
+++ b/packages/mcp-server/tests/unit/test_server_info_contract.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator
 
+from kicad_mcp import server_info
 from kicad_mcp.connection import KiCadConnectionError
 from kicad_mcp.discovery import CliCapabilities
 from kicad_mcp.server import create_server
@@ -31,7 +32,6 @@ def test_server_info_contract_matches_protocol_schema(monkeypatch, sample_projec
     monkeypatch.setenv("KICAD_MCP_TRANSPORT", "http")
     monkeypatch.setenv("KICAD_MCP_STATEFUL_HTTP", "true")
     monkeypatch.setenv("KICAD_MCP_AUTH_TOKEN", "local-test-token-with-enough-entropy")
-    monkeypatch.setattr("kicad_mcp.server_info.find_kicad_version", lambda _cli: "KiCad 10.0.3")
     monkeypatch.setattr(
         "kicad_mcp.server_info.get_cli_capabilities",
         lambda _cli: CliCapabilities(
@@ -45,6 +45,7 @@ def test_server_info_contract_matches_protocol_schema(monkeypatch, sample_projec
             supports_spice_netlist=True,
         ),
     )
+    monkeypatch.setattr("kicad_mcp.server_info.get_kicad", lambda: object())
     monkeypatch.setattr("kicad_mcp.server_info.get_board", lambda: object())
 
     payload = get_server_info_contract()
@@ -102,7 +103,7 @@ def test_server_info_contract_matches_protocol_schema(monkeypatch, sample_projec
 
 def test_server_info_contract_reports_degraded_live_context(monkeypatch, sample_project) -> None:
     _ = sample_project
-    monkeypatch.setattr("kicad_mcp.server_info.find_kicad_version", lambda _cli: "KiCad 10.0.3")
+    monkeypatch.setattr("kicad_mcp.server_info.get_kicad", lambda: object())
     monkeypatch.setattr(
         "kicad_mcp.server_info.get_board",
         lambda: (_ for _ in ()).throw(KiCadConnectionError("No PCB is open.")),
@@ -111,11 +112,130 @@ def test_server_info_contract_reports_degraded_live_context(monkeypatch, sample_
     payload = get_server_info_contract()
 
     _validate_contract(payload)
-    assert payload["kicad"]["ipcAvailable"] is False
+    assert payload["kicad"]["ipcAvailable"] is True
     assert payload["kicad"]["livePcbContext"] is False
     assert payload["capabilities"]["livePcbRead"] is False
     assert payload["capabilities"]["livePcbWrite"] is False
     assert "Live KiCad PCB context is unavailable: No PCB is open." in payload["diagnostics"]
+
+
+def test_server_info_contract_reports_unavailable_ipc(monkeypatch, sample_project) -> None:
+    _ = sample_project
+    monkeypatch.setattr(
+        "kicad_mcp.server_info.get_kicad",
+        lambda: (_ for _ in ()).throw(KiCadConnectionError("KiCad is not running.")),
+    )
+    monkeypatch.setattr("kicad_mcp.server_info.get_board", lambda: object())
+
+    payload = get_server_info_contract()
+
+    _validate_contract(payload)
+    assert payload["kicad"]["ipcAvailable"] is False
+    assert payload["kicad"]["livePcbContext"] is False
+    assert "KiCad IPC is unavailable: KiCad is not running." in payload["diagnostics"]
+
+
+def test_server_info_contract_skips_live_probe_for_metadata(monkeypatch, sample_project) -> None:
+    _ = sample_project
+    monkeypatch.setattr(
+        "kicad_mcp.server_info.get_kicad",
+        lambda: (_ for _ in ()).throw(AssertionError("IPC should not be probed")),
+    )
+    monkeypatch.setattr(
+        "kicad_mcp.server_info.get_board",
+        lambda: (_ for _ in ()).throw(AssertionError("Board should not be probed")),
+    )
+
+    payload = get_server_info_contract(probe_live_context=False)
+
+    _validate_contract(payload)
+    assert payload["kicad"]["ipcAvailable"] is False
+    assert payload["kicad"]["livePcbContext"] is False
+
+
+def test_server_info_contract_caches_cli_discovery(monkeypatch, sample_project) -> None:
+    _ = sample_project
+    calls = 0
+
+    def fake_capabilities(_cli: Path) -> CliCapabilities:
+        nonlocal calls
+        calls += 1
+        return CliCapabilities(version="KiCad 10.0.3", supports_svg=True)
+
+    monkeypatch.setattr("kicad_mcp.server_info.get_cli_capabilities", fake_capabilities)
+    monkeypatch.setattr("kicad_mcp.server_info.get_kicad", lambda: object())
+    monkeypatch.setattr("kicad_mcp.server_info.get_board", lambda: object())
+
+    first = get_server_info_contract()
+    second = get_server_info_contract()
+
+    assert first["kicad"]["cliVersion"] == "KiCad 10.0.3"
+    assert second["capabilities"]["cliExports"]["svg"] is True
+    assert calls == 1
+
+
+def test_server_info_contract_preserves_remote_advertised_host(
+    monkeypatch,
+    sample_project,
+) -> None:
+    _ = sample_project
+    monkeypatch.setenv("KICAD_MCP_TRANSPORT", "http")
+    monkeypatch.setenv("KICAD_MCP_HOST", "192.168.1.42")
+    monkeypatch.setenv("KICAD_MCP_AUTH_TOKEN", "remote-test-token-with-enough-entropy")
+    monkeypatch.setattr("kicad_mcp.server_info.get_kicad", lambda: object())
+    monkeypatch.setattr("kicad_mcp.server_info.get_board", lambda: object())
+
+    payload = get_server_info_contract()
+
+    _validate_contract(payload)
+    assert payload["transport"]["endpoint"] == "http://192.168.1.42:3334/mcp"
+
+
+def test_server_info_contract_brackets_ipv6_loopback(monkeypatch, sample_project) -> None:
+    _ = sample_project
+    monkeypatch.setenv("KICAD_MCP_TRANSPORT", "http")
+    monkeypatch.setenv("KICAD_MCP_HOST", "::1")
+    monkeypatch.setattr("kicad_mcp.server_info.get_kicad", lambda: object())
+    monkeypatch.setattr("kicad_mcp.server_info.get_board", lambda: object())
+
+    payload = get_server_info_contract()
+
+    _validate_contract(payload)
+    assert payload["transport"]["endpoint"] == "http://[::1]:3334/mcp"
+
+
+def test_server_info_contract_reports_legacy_sse_transport(
+    monkeypatch,
+    sample_project,
+) -> None:
+    _ = sample_project
+    monkeypatch.setenv("KICAD_MCP_TRANSPORT", "sse")
+    monkeypatch.setenv("KICAD_MCP_LEGACY_SSE", "true")
+    monkeypatch.setattr("kicad_mcp.server_info.get_kicad", lambda: object())
+    monkeypatch.setattr("kicad_mcp.server_info.get_board", lambda: object())
+
+    payload = get_server_info_contract()
+
+    _validate_contract(payload)
+    assert payload["transport"]["type"] == "sse"
+    assert payload["transport"]["streamableHttp"] is False
+    assert payload["transport"]["legacySse"] is True
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1", "1.0.0"),
+        ("1.2", "1.2.0"),
+        ("1.2.3", "1.2.3"),
+        ("1.2.3.4", "1.2.3"),
+        ("1.2.3-beta.1", "1.2.3"),
+        ("2025-11-25", "2025.11.25"),
+        ("dev", "0.0.0"),
+    ],
+)
+def test_as_semver_always_returns_three_numeric_components(raw: str, expected: str) -> None:
+    assert server_info._as_semver(raw) == expected
 
 
 @pytest.mark.anyio
@@ -124,7 +244,7 @@ async def test_server_info_tool_and_resource_return_same_contract(
     sample_project,
 ) -> None:
     _ = sample_project
-    monkeypatch.setattr("kicad_mcp.server_info.find_kicad_version", lambda _cli: "KiCad 10.0.3")
+    monkeypatch.setattr("kicad_mcp.server_info.get_kicad", lambda: object())
     monkeypatch.setattr(
         "kicad_mcp.server_info.get_board",
         lambda: (_ for _ in ()).throw(KiCadConnectionError("No PCB is open.")),

--- a/packages/mcp-server/tests/unit/test_wellknown_and_studio.py
+++ b/packages/mcp-server/tests/unit/test_wellknown_and_studio.py
@@ -36,6 +36,34 @@ def test_wellknown_routes_return_identical_payload(monkeypatch, sample_project) 
     assert dotted.json()["transport"]["endpoint"] == "http://127.0.0.1:3334/mcp"
 
 
+def test_wellknown_metadata_does_not_probe_live_kicad(monkeypatch, sample_project) -> None:
+    _ = sample_project
+    monkeypatch.setenv("KICAD_MCP_TRANSPORT", "http")
+    monkeypatch.setattr(
+        "kicad_mcp.server_info.get_kicad",
+        lambda: (_ for _ in ()).throw(AssertionError("IPC should not be probed")),
+    )
+    monkeypatch.setattr(
+        "kicad_mcp.server_info.get_board",
+        lambda: (_ for _ in ()).throw(AssertionError("Board should not be probed")),
+    )
+
+    metadata = get_wellknown_metadata()
+
+    assert metadata["serverInfoContract"]["kicad"]["ipcAvailable"] is False
+    assert metadata["serverInfoContract"]["kicad"]["livePcbContext"] is False
+
+
+def test_wellknown_metadata_brackets_ipv6_endpoint(monkeypatch, sample_project) -> None:
+    _ = sample_project
+    monkeypatch.setenv("KICAD_MCP_TRANSPORT", "http")
+    monkeypatch.setenv("KICAD_MCP_HOST", "::1")
+
+    metadata = get_wellknown_metadata()
+
+    assert metadata["transport"]["endpoint"] == "http://[::1]:3334/mcp"
+
+
 def test_streamable_http_legacy_sse_routes_are_opt_in(sample_project) -> None:
     _ = sample_project
     cfg = get_config()

--- a/packages/mcp-server/tests/unit/test_wellknown_schema.py
+++ b/packages/mcp-server/tests/unit/test_wellknown_schema.py
@@ -13,7 +13,7 @@ def test_wellknown_payload_contains_required_server_card_fields() -> None:
     assert payload["version"]
     assert payload["protocolVersion"]
     assert payload["serverInfo"]["title"] == "KiCad MCP Pro"
-    assert payload["transport"]["type"] in {"stdio", "streamable-http"}
+    assert payload["transport"]["type"] in {"stdio", "streamable-http", "sse"}
     assert payload["capabilities"]["tools"] is True
     assert payload["capabilities"]["resources"] is True
     assert payload["capabilities"]["prompts"] is True

--- a/packages/protocol-schemas/schemas/kicad-mcp-server-info.schema.json
+++ b/packages/protocol-schemas/schemas/kicad-mcp-server-info.schema.json
@@ -1,0 +1,225 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://oaslananka.github.io/kicad-studio-kit/schemas/kicad-mcp-server-info.schema.json",
+  "title": "KiCad MCP Pro server-info contract",
+  "description": "Stable capability discovery payload. Breaking contract changes must increment the schemaVersion major.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "server",
+    "version",
+    "mcpProtocolVersion",
+    "toolSchemaVersion",
+    "compatibilityRange",
+    "transport",
+    "kicad",
+    "capabilities",
+    "diagnostics"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "server": {
+      "const": "kicad-mcp-pro"
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "mcpProtocolVersion": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "toolSchemaVersion": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "compatibilityRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kicadStudio", "kicadMcpPro"],
+      "properties": {
+        "kicadStudio": {
+          "$ref": "#/$defs/productRangeWithRecommendation"
+        },
+        "kicadMcpPro": {
+          "$ref": "#/$defs/productRange"
+        }
+      }
+    },
+    "transport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "streamableHttp",
+        "statelessHttp",
+        "legacySse",
+        "authRequired",
+        "endpoint"
+      ],
+      "properties": {
+        "type": {
+          "enum": ["stdio", "streamable-http"]
+        },
+        "streamableHttp": {
+          "type": "boolean"
+        },
+        "statelessHttp": {
+          "type": "boolean"
+        },
+        "legacySse": {
+          "type": "boolean"
+        },
+        "authRequired": {
+          "type": "boolean"
+        },
+        "endpoint": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "kicad": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "cliFound",
+        "cliPath",
+        "cliVersion",
+        "ipcAvailable",
+        "livePcbContext"
+      ],
+      "properties": {
+        "cliFound": {
+          "type": "boolean"
+        },
+        "cliPath": {
+          "type": "string"
+        },
+        "cliVersion": {
+          "type": ["string", "null"]
+        },
+        "ipcAvailable": {
+          "type": "boolean"
+        },
+        "livePcbContext": {
+          "type": "boolean"
+        }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fileBackedDrc",
+        "fileBackedErc",
+        "fileBackedExports",
+        "livePcbRead",
+        "livePcbWrite",
+        "chatgptConnectorCompatible",
+        "cliExports"
+      ],
+      "properties": {
+        "fileBackedDrc": {
+          "type": "boolean"
+        },
+        "fileBackedErc": {
+          "type": "boolean"
+        },
+        "fileBackedExports": {
+          "type": "boolean"
+        },
+        "livePcbRead": {
+          "type": "boolean"
+        },
+        "livePcbWrite": {
+          "type": "boolean"
+        },
+        "chatgptConnectorCompatible": {
+          "type": "boolean"
+        },
+        "cliExports": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "ipc2581",
+            "odb",
+            "svg",
+            "dxf",
+            "step",
+            "render",
+            "spiceNetlist"
+          ],
+          "properties": {
+            "ipc2581": {
+              "type": "boolean"
+            },
+            "odb": {
+              "type": "boolean"
+            },
+            "svg": {
+              "type": "boolean"
+            },
+            "dxf": {
+              "type": "boolean"
+            },
+            "step": {
+              "type": "boolean"
+            },
+            "render": {
+              "type": "boolean"
+            },
+            "spiceNetlist": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "$defs": {
+    "productRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "testedAgainst"],
+      "properties": {
+        "required": {
+          "type": "string",
+          "minLength": 1
+        },
+        "testedAgainst": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "productRangeWithRecommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "recommended", "testedAgainst"],
+      "properties": {
+        "required": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recommended": {
+          "type": "string",
+          "minLength": 1
+        },
+        "testedAgainst": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/packages/protocol-schemas/schemas/kicad-mcp-server-info.schema.json
+++ b/packages/protocol-schemas/schemas/kicad-mcp-server-info.schema.json
@@ -63,7 +63,7 @@
       ],
       "properties": {
         "type": {
-          "enum": ["stdio", "streamable-http"]
+          "enum": ["stdio", "streamable-http", "sse"]
         },
         "streamableHttp": {
           "type": "boolean"


### PR DESCRIPTION
## Summary

Closes #58.
Linear: OASLANA-57.

- Add a versioned `kicad-mcp-pro` server-info/capabilities contract with schema version, MCP protocol/tool schema versions, compatibility ranges, transport/auth/SSE/stateless details, KiCad CLI/runtime state, file-backed/live capability booleans, CLI export capability flags, and diagnostics.
- Expose the contract through `kicad_get_server_info`, `kicad://server/info`, and the well-known MCP server metadata response.
- Add JSON Schema contract coverage under `packages/protocol-schemas` and update the VS Code MCP client/tools view to surface compatible/degraded/incompatible diagnostics before advanced UI is enabled.
- Review follow-up: cache CLI discovery for polled metadata, keep well-known discovery free of live KiCad IPC/board probes, report legacy SSE as non-streamable HTTP, preserve advertised remote hosts, bracket IPv6 endpoints, normalize schema versions to strict semver, separate IPC reachability from live PCB context, and keep the Quality Gates view reachable while MCP is disconnected.

## Validation

- `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_server_info_contract.py -q` (red before implementation, pass after)
- `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_server_info_contract.py packages/mcp-server/tests/unit/test_wellknown_schema.py packages/mcp-server/tests/unit/test_wellknown_and_studio.py -q` (pass, 24 tests)
- `corepack pnpm --filter kicadstudio exec jest test/unit/mcpClient.versionGate.test.ts test/unit/mcpToolsProvider.test.ts --runInBand --coverage=false` (red before implementation, pass after)
- `corepack pnpm install --frozen-lockfile` (pass)
- `uv sync --project packages/mcp-server --all-extras` (pass)
- `corepack pnpm --dir packages/mcp-server run format:check` (pass)
- `corepack pnpm --dir packages/mcp-server run lint` (pass)
- `corepack pnpm --dir packages/mcp-server run typecheck` (pass)
- `corepack pnpm --dir packages/mcp-server run test:unit` (pass)
- `uv run --project packages/mcp-server --all-extras kicad-mcp-pro --help` (pass)
- `corepack pnpm --dir packages/mcp-server run build` (pass)
- `corepack pnpm --dir packages/mcp-server run security:bandit` (pass)
- `corepack pnpm --dir packages/mcp-server run security:audit` (pass; existing acknowledged advisories only)
- `corepack pnpm --filter kicadstudio run format:check` (pass)
- `corepack pnpm --filter kicadstudio run lint` (pass)
- `corepack pnpm --filter kicadstudio run typecheck` (pass)
- `corepack pnpm --filter kicadstudio run test:unit` (pass, 464 tests)
- `corepack pnpm --filter kicadstudio run test:integration -- --runInBand` (pass, 10 tests)
- `corepack pnpm --filter kicadstudio run build` (pass)
- `corepack pnpm --dir packages/mcp-server run docs:tools` (pass)
- `corepack pnpm exec prettier --check packages/protocol-schemas/schemas/kicad-mcp-server-info.schema.json` (pass)
- `corepack pnpm run check:forbidden-refs` (pass after deleting generated VS Code `.vscode-test` cache from local integration test run)
- `.github` deprecation grep for deprecated workflow commands/Node runtime overrides (pass, no matches)
- `uvx pre-commit run --all-files` (pass)
- `git diff --check` (pass)
- `PATH="/tmp/codex-tools/actionlint:/home/goskyturkey/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" corepack pnpm run check` (pass)

## Notes

- No release, tag, publish, or release bot PR changes.
- The contract uses the repository compatibility matrix protocol version `2025-11-25`; the older issue example protocol date was treated as illustrative because the repo matrix is authoritative for this branch.
- Existing dependency audit acknowledgements remain: Markdown `PYSEC-2026-89` and PyJWT `PYSEC-2025-183`; no unacknowledged vulnerabilities were reported by the repo audit script.
