### PR TITLE
feat(studio): centralize extension state stores

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -237,7 +237,7 @@
         {
           "id": "kicadstudio.qualityGate",
           "name": "Quality Gates",
-          "when": "kicadstudio.mcpConnected && kicadstudio.hasProject",
+          "when": "kicadstudio.hasProject",
           "icon": "assets/views/quality-gates.svg"
         },
         {

--- a/apps/vscode-extension/src/cli/exportCommands.ts
+++ b/apps/vscode-extension/src/cli/exportCommands.ts
@@ -21,6 +21,7 @@ import { zipDirectory } from '../utils/zipUtils';
 import { KiCadCliDetector } from './kicadCliDetector';
 import { ExportPresetStore } from './exportPresets';
 import { KiCadCliRunner } from './kicadCliRunner';
+import type { ExportStateStore, ExportSurfaceKind } from '../state/stateStores';
 
 export type ExportCommandKind =
   | 'export-gerbers'
@@ -386,7 +387,8 @@ export class KiCadExportService {
     private readonly bomParser: BomParser,
     private readonly bomExporter: BomExporter,
     private readonly presets: ExportPresetStore,
-    private readonly logger: Logger
+    private readonly logger: Logger,
+    private readonly exportState?: ExportStateStore | undefined
   ) {}
 
   async exportGerbers(resource?: vscode.Uri): Promise<void> {
@@ -941,12 +943,23 @@ export class KiCadExportService {
       format === 'csv'
         ? inferOutputPath(file, outputDir, '-bom', '.csv')
         : inferOutputPath(file, outputDir, '-bom', '.xlsx');
-
-    if (format === 'csv') {
-      await this.bomExporter.exportCsv(entries, outputFile);
-    } else {
-      await this.bomExporter.exportXlsx(entries, outputFile);
+    const uri = vscode.Uri.file(file);
+    this.exportState?.begin('bom', uri, `Exporting BOM ${format.toUpperCase()}.`);
+    try {
+      if (format === 'csv') {
+        await this.bomExporter.exportCsv(entries, outputFile);
+      } else {
+        await this.bomExporter.exportXlsx(entries, outputFile);
+      }
+    } catch (error) {
+      this.exportState?.fail('bom', uri, error);
+      throw error;
     }
+    this.exportState?.complete(
+      'bom',
+      uri,
+      `BOM ${format.toUpperCase()} exported.`
+    );
     await this.showOutputFolder(outputDir);
   }
 
@@ -965,6 +978,9 @@ export class KiCadExportService {
     if (!outputDir) {
       return;
     }
+    const uri = vscode.Uri.file(file);
+    const surfaceKind = exportSurfaceFor(kind);
+    this.exportState?.begin(surfaceKind, uri, title);
     const buildOptions = await this.getBuildOptions(
       file,
       kind === 'export-gerbers' || kind === 'export-gerbers-with-drill'
@@ -975,8 +991,10 @@ export class KiCadExportService {
       title
     );
     if (!exported) {
+      this.exportState?.fail(surfaceKind, uri, `${title} failed.`);
       return;
     }
+    this.exportState?.complete(surfaceKind, uri, `${title} completed.`);
     await this.showOutputFolder(outputDir);
   }
 
@@ -1332,6 +1350,13 @@ export class KiCadExportService {
       ...(gerberLayers.length ? { gerberLayers } : {})
     };
   }
+}
+
+function exportSurfaceFor(kind: ExportCommandKind): ExportSurfaceKind {
+  if (kind === 'export-netlist') {
+    return 'netlist';
+  }
+  return kind === 'export-sch-bom' ? 'bom' : 'export';
 }
 
 function collectFilesWithExtension(root: string, extension: string): string[] {

--- a/apps/vscode-extension/src/commands/checkCommands.ts
+++ b/apps/vscode-extension/src/commands/checkCommands.ts
@@ -20,11 +20,7 @@ export function registerCheckCommands(
         }
         try {
           const result = await services.checkService.runDRC(file);
-          services.diagnosticsCollection.set(
-            vscode.Uri.file(file),
-            result.diagnostics
-          );
-          services.statusBar.update({ drc: result.summary });
+          applyValidationResult(services, file, result);
           services.setLatestDrcRun({
             file,
             diagnostics: result.diagnostics,
@@ -69,11 +65,7 @@ export function registerCheckCommands(
         }
         try {
           const result = await services.checkService.runERC(file);
-          services.diagnosticsCollection.set(
-            vscode.Uri.file(file),
-            result.diagnostics
-          );
-          services.statusBar.update({ erc: result.summary });
+          applyValidationResult(services, file, result);
           if (result.diagnostics.length > 0) {
             await vscode.commands.executeCommand(
               'workbench.actions.view.problems'
@@ -90,4 +82,36 @@ export function registerCheckCommands(
       'Run ERC'
     )
   ];
+}
+
+function applyValidationResult(
+  services: CommandServices,
+  file: string,
+  result: {
+    diagnostics: readonly vscode.Diagnostic[];
+    summary: {
+      file: string;
+      errors: number;
+      warnings: number;
+      infos: number;
+      source: 'drc' | 'erc' | 'syntax';
+      capturedAt?: string | undefined;
+    };
+  }
+): void {
+  const uri = vscode.Uri.file(file);
+  if (services.diagnosticState) {
+    services.diagnosticState.applyValidationResult(
+      uri,
+      result.diagnostics,
+      result.summary
+    );
+    return;
+  }
+  services.diagnosticsCollection.set(uri, result.diagnostics);
+  services.statusBar.update(
+    result.summary.source === 'drc'
+      ? { drc: result.summary }
+      : { erc: result.summary }
+  );
 }

--- a/apps/vscode-extension/src/commands/types.ts
+++ b/apps/vscode-extension/src/commands/types.ts
@@ -21,6 +21,7 @@ import type { QualityGateProvider } from '../providers/qualityGateProvider';
 import type { KiCadProjectTreeProvider } from '../providers/projectTreeProvider';
 import type { Logger } from '../utils/logger';
 import type { DiagnosticSummary } from '../types';
+import type { DiagnosticStateStore } from '../state/stateStores';
 
 /**
  * Shared service dependencies that are passed to all command registration
@@ -35,6 +36,7 @@ export interface CommandServices {
   diffEditorProvider: DiffEditorProvider;
   fixQueueProvider: FixQueueProvider;
   diagnosticsCollection: vscode.DiagnosticCollection;
+  diagnosticState?: DiagnosticStateStore | undefined;
   statusBar: KiCadStatusBar;
   componentSearch: ComponentSearchService;
   aiProviders: AIProviderRegistry;

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -68,7 +68,15 @@ import { PcbEditorProvider } from './providers/pcbEditorProvider';
 import { KiCadProjectTreeProvider } from './providers/projectTreeProvider';
 import { QualityGateProvider } from './providers/qualityGateProvider';
 import { SchematicEditorProvider } from './providers/schematicEditorProvider';
+import { ValidationViewProvider } from './providers/validationViewProvider';
 import { KiCadStatusBar } from './statusbar/kicadStatusBar';
+import {
+  DiagnosticStateStore,
+  ExportStateStore,
+  McpStateStore,
+  ProjectStateStore,
+  ViewerStateStore
+} from './state/stateStores';
 import { KiCadTaskProvider } from './tasks/kicadTaskProvider';
 import { VariantProvider } from './variants/variantProvider';
 import { readConfiguredMcpProfile } from './commands/mcpProfilePicker';
@@ -108,6 +116,10 @@ export async function activate(
   const cliRunner = new KiCadCliRunner(cliDetector, logger);
   const importService = new KiCadImportService(cliRunner, cliDetector, logger);
   const statusBar = new KiCadStatusBar(context);
+  const projectState = new ProjectStateStore();
+  const viewerState = new ViewerStateStore();
+  const mcpState = new McpStateStore();
+  const exportState = new ExportStateStore();
   const bomParser = new BomParser(parser);
   const bomExporter = new BomExporter();
   const presetStore = new ExportPresetStore(context);
@@ -117,30 +129,37 @@ export async function activate(
     bomParser,
     bomExporter,
     presetStore,
-    logger
+    logger,
+    exportState
   );
   const diagnosticsCollection = new KiCadDiagnosticsAggregator(
     vscode.languages.createDiagnosticCollection(DIAGNOSTIC_COLLECTION_NAME)
   );
+  const diagnosticState = new DiagnosticStateStore(diagnosticsCollection);
   const diagnosticsProvider = new KiCadDiagnosticsProvider(
     parser,
     diagnosticsCollection
   );
   const checkService = new KiCadCheckService(cliRunner, parser, logger);
   const treeProvider = new KiCadProjectTreeProvider();
-  const bomViewProvider = new BomViewProvider(context, parser);
+  const validationViewProvider = new ValidationViewProvider(diagnosticState);
+  const bomViewProvider = new BomViewProvider(context, parser, exportState);
   const netlistViewProvider = new NetlistViewProvider(
     context,
     parser,
     cliRunner,
-    logger
+    logger,
+    exportState
   );
   const schematicEditorProvider = new SchematicEditorProvider(
     context,
-    async (resource) => exportService.renderViewerSvg(resource)
+    async (resource) => exportService.renderViewerSvg(resource),
+    viewerState
   );
-  const pcbEditorProvider = new PcbEditorProvider(context, async (resource) =>
-    exportService.renderViewerSvg(resource)
+  const pcbEditorProvider = new PcbEditorProvider(
+    context,
+    async (resource) => exportService.renderViewerSvg(resource),
+    viewerState
   );
   const gitDiffDetector = new GitDiffDetector(parser);
   const diffEditorProvider = new DiffEditorProvider(context, gitDiffDetector);
@@ -154,10 +173,14 @@ export async function activate(
   extensionMcpClient = mcpClient;
   const mcpToolAdapter = new McpToolAdapter(mcpClient);
   const contextBridge = new ContextBridge(mcpToolAdapter);
-  const mcpToolsProvider = new McpToolsProvider(mcpToolAdapter);
+  const mcpToolsProvider = new McpToolsProvider(mcpState);
   const variantProvider = new VariantProvider(mcpToolAdapter);
-  const fixQueueProvider = new FixQueueProvider(mcpToolAdapter);
-  const qualityGateProvider = new QualityGateProvider(context, mcpToolAdapter);
+  const fixQueueProvider = new FixQueueProvider(mcpToolAdapter, mcpState);
+  const qualityGateProvider = new QualityGateProvider(
+    context,
+    mcpToolAdapter,
+    mcpState
+  );
   const drcRulesProvider = new DrcRulesProvider(parser);
   const errorAnalyzer = new ErrorAnalyzer(aiProviders, logger);
   const circuitExplainer = new CircuitExplainer(aiProviders, logger);
@@ -179,6 +202,11 @@ export async function activate(
   context.subscriptions.push(
     logger,
     statusBar,
+    projectState,
+    diagnosticState,
+    viewerState,
+    mcpState,
+    exportState,
     contextBridge,
     diagnosticsCollection,
     libraryIndexer,
@@ -186,6 +214,19 @@ export async function activate(
     pcbEditorProvider,
     bomViewProvider,
     netlistViewProvider,
+    validationViewProvider,
+    diagnosticState.onDidChange((state) => {
+      statusBar.update({ drc: state.drc, erc: state.erc });
+    }),
+    mcpState.onDidChange((state) => {
+      statusBar.update({
+        mcpState: state,
+        mcpProfile: readConfiguredMcpProfile()
+      });
+      mcpToolsProvider.refresh();
+      qualityGateProvider.refresh();
+      void fixQueueProvider.refresh().catch(() => undefined);
+    }),
     vscode.window.registerCustomEditorProvider(
       SCHEMATIC_EDITOR_VIEW_TYPE,
       schematicEditorProvider,
@@ -240,10 +281,10 @@ export async function activate(
       getTreeItem: (element: vscode.TreeItem) => element,
       getChildren: () => []
     }),
-    vscode.window.registerTreeDataProvider(VALIDATION_VIEW_ID, {
-      getTreeItem: (element: vscode.TreeItem) => element,
-      getChildren: () => []
-    }),
+    vscode.window.registerTreeDataProvider(
+      VALIDATION_VIEW_ID,
+      validationViewProvider
+    ),
     vscode.window.registerTreeDataProvider(LIBRARY_VIEW_ID, {
       getTreeItem: (element: vscode.TreeItem) => element,
       getChildren: () => []
@@ -352,6 +393,7 @@ export async function activate(
     fixQueueProvider,
     qualityGateProvider,
     diagnosticsCollection,
+    diagnosticState,
     statusBar,
     componentSearch,
     aiProviders,
@@ -390,6 +432,7 @@ export async function activate(
       libraryIndexer,
       variantProvider,
       diagnosticsCollection,
+      diagnosticState,
       getStudioContext: buildStudioContext,
       setLatestDrcRun: (value) => {
         latestDrcRun = value;
@@ -469,10 +512,16 @@ export async function activate(
     const kicadVersionMajor = Number(cli?.version.split('.')[0] ?? '0');
     const hasVariants = await workspaceHasVariants();
     const mcpProfile = readConfiguredMcpProfile();
+    const projectSnapshot = projectState.update({
+      activeResource: activeUri,
+      hasProject,
+      hasVariants,
+      workspaceTrusted: trusted
+    });
     await vscode.commands.executeCommand(
       'setContext',
       CONTEXT_KEYS.hasProject,
-      hasProject
+      projectSnapshot.hasProject
     );
     await vscode.commands.executeCommand(
       'setContext',
@@ -502,7 +551,7 @@ export async function activate(
     await vscode.commands.executeCommand(
       'setContext',
       CONTEXT_KEYS.hasVariants,
-      hasVariants
+      projectSnapshot.hasVariants
     );
     await vscode.commands.executeCommand(
       'setContext',
@@ -540,12 +589,10 @@ export async function activate(
       const result = shouldRunDrc
         ? await checkService.runDRC(document.fileName)
         : await checkService.runERC(document.fileName);
-      diagnosticsCollection.set(
+      diagnosticState.applyValidationResult(
         vscode.Uri.file(document.fileName),
-        result.diagnostics
-      );
-      statusBar.update(
-        shouldRunDrc ? { drc: result.summary } : { erc: result.summary }
+        result.diagnostics,
+        result.summary
       );
       if (shouldRunDrc) {
         latestDrcRun = {
@@ -591,16 +638,12 @@ export async function activate(
   async function refreshMcpState(): Promise<void> {
     if (!isWorkspaceTrusted()) {
       await setRestrictedMcpContexts();
-      statusBar.update({
-        mcpState: {
-          kind: 'Disconnected',
-          available: false,
-          connected: false,
-          message: 'MCP integration is disabled in Restricted Mode.'
-        },
-        mcpProfile: readConfiguredMcpProfile()
+      mcpState.update({
+        kind: 'Disconnected',
+        available: false,
+        connected: false,
+        message: 'MCP integration is disabled in Restricted Mode.'
       });
-      mcpToolsProvider.refresh();
       return;
     }
 
@@ -635,11 +678,7 @@ export async function activate(
       CONTEXT_KEYS.mcpVsCodeStdio,
       state.kind === 'VsCodeStdio'
     );
-    statusBar.update({
-      mcpState: state,
-      mcpProfile: readConfiguredMcpProfile()
-    });
-    mcpToolsProvider.refresh();
+    mcpState.update(state);
 
     if (
       state.available &&

--- a/apps/vscode-extension/src/lm/languageModelTools.ts
+++ b/apps/vscode-extension/src/lm/languageModelTools.ts
@@ -16,6 +16,7 @@ import { isWorkspaceTrusted } from '../utils/workspaceTrust';
 import { KiCadCheckService } from '../cli/checkCommands';
 import { KiCadCliDetector } from '../cli/kicadCliDetector';
 import { KiCadCliRunner } from '../cli/kicadCliRunner';
+import type { DiagnosticStateStore } from '../state/stateStores';
 import {
   createLanguageModelTextPart,
   createLanguageModelToolResult,
@@ -71,6 +72,7 @@ export interface LanguageModelToolServices {
   libraryIndexer: KiCadLibraryIndexer;
   variantProvider: VariantProvider;
   diagnosticsCollection: vscode.DiagnosticCollection;
+  diagnosticState?: DiagnosticStateStore | undefined;
   getStudioContext(): Promise<StudioContext>;
   setLatestDrcRun(value: {
     file: string;
@@ -176,10 +178,7 @@ function createRunDrcTool(
       }
 
       const result = await services.checkService.runDRC(file);
-      services.diagnosticsCollection.set(
-        vscode.Uri.file(file),
-        result.diagnostics
-      );
+      applyValidationResult(services, file, result);
       services.setLatestDrcRun({
         file,
         diagnostics: result.diagnostics,
@@ -216,10 +215,7 @@ function createRunErcTool(
       }
 
       const result = await services.checkService.runERC(file);
-      services.diagnosticsCollection.set(
-        vscode.Uri.file(file),
-        result.diagnostics
-      );
+      applyValidationResult(services, file, result);
 
       return buildToolResult(
         `ERC completed for ${path.basename(file)}: ${formatSummary(result.summary)}.`,
@@ -231,6 +227,26 @@ function createRunErcTool(
       );
     }
   };
+}
+
+function applyValidationResult(
+  services: LanguageModelToolServices,
+  file: string,
+  result: {
+    diagnostics: readonly vscode.Diagnostic[];
+    summary: DiagnosticSummary;
+  }
+): void {
+  const uri = vscode.Uri.file(file);
+  if (services.diagnosticState) {
+    services.diagnosticState.applyValidationResult(
+      uri,
+      result.diagnostics,
+      result.summary
+    );
+    return;
+  }
+  services.diagnosticsCollection.set(uri, result.diagnostics);
 }
 
 function createExportGerbersTool(

--- a/apps/vscode-extension/src/mcp/fixQueueProvider.ts
+++ b/apps/vscode-extension/src/mcp/fixQueueProvider.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
 import { COMMANDS } from '../constants';
-import type { FixItem } from '../types';
+import type { FixItem, McpConnectionState } from '../types';
 import { isRecoverableMcpUnavailableError } from './mcpErrorMapper';
 import type { FixQueueMcpAdapter } from './mcpToolAdapter';
+import type { McpStateStore } from '../state/stateStores';
 
 class FixQueueTreeItem extends vscode.TreeItem {
   constructor(public readonly item: FixItem) {
@@ -32,13 +33,20 @@ export class FixQueueProvider implements vscode.TreeDataProvider<FixItem> {
   readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
   private items: FixItem[] = [];
 
-  constructor(private readonly adapter: FixQueueMcpAdapter) {}
+  constructor(
+    private readonly adapter: FixQueueMcpAdapter,
+    private readonly mcpState?: Pick<McpStateStore, 'getState'> | undefined
+  ) {}
 
   getTreeItem(element: FixItem): vscode.TreeItem {
     return new FixQueueTreeItem(element);
   }
 
   getChildren(): FixItem[] {
+    const state = this.mcpState?.getState();
+    if (state && !supportsHttpFixQueue(state)) {
+      return [];
+    }
     return this.items;
   }
 
@@ -60,6 +68,12 @@ export class FixQueueProvider implements vscode.TreeDataProvider<FixItem> {
   }
 
   async refresh(): Promise<void> {
+    const state = this.mcpState?.getState();
+    if (state && !supportsHttpFixQueue(state)) {
+      this.items = [];
+      this.onDidChangeTreeDataEmitter.fire(undefined);
+      return;
+    }
     try {
       this.items = await this.adapter.fetchFixQueue();
     } catch (err) {
@@ -155,4 +169,8 @@ export class FixQueueProvider implements vscode.TreeDataProvider<FixItem> {
 
 function normalizePath(value: string): string {
   return value.replace(/\\/g, '/').toLowerCase();
+}
+
+function supportsHttpFixQueue(state: McpConnectionState): boolean {
+  return state.kind === 'Connected' && state.connected;
 }

--- a/apps/vscode-extension/src/providers/baseKiCanvasEditorProvider.ts
+++ b/apps/vscode-extension/src/providers/baseKiCanvasEditorProvider.ts
@@ -9,6 +9,7 @@ import {
   WEBVIEW_MESSAGE_DEBOUNCE_MS
 } from '../constants';
 import type { ViewerMetadata, ViewerState } from '../types';
+import { ViewerStateStore } from '../state/stateStores';
 import { bufferToBase64 } from '../utils/fileUtils';
 import {
   asNumber,
@@ -72,7 +73,6 @@ export abstract class BaseKiCanvasEditorProvider
   private readonly disposables: vscode.Disposable[] = [];
   private readonly refreshDebounce = new Map<string, NodeJS.Timeout>();
   private readonly fileCache = new Map<string, CachedFilePayload>();
-  private readonly stateByUri = new Map<string, ViewerState>();
   private theme = vscode.workspace
     .getConfiguration()
     .get<string>(SETTINGS.viewerTheme, 'kicad');
@@ -83,7 +83,8 @@ export abstract class BaseKiCanvasEditorProvider
 
   constructor(
     protected readonly context: vscode.ExtensionContext,
-    private readonly svgFallbackProvider?: ViewerSvgFallbackProvider
+    private readonly svgFallbackProvider?: ViewerSvgFallbackProvider,
+    private readonly viewerState = new ViewerStateStore()
   ) {
     this.disposables.push(
       vscode.workspace.onDidSaveTextDocument((document) => {
@@ -127,14 +128,14 @@ export abstract class BaseKiCanvasEditorProvider
             this.fileType,
             theme
           ),
-          restoreState: info.state ?? this.stateByUri.get(info.uri.toString())
+          restoreState: info.state ?? this.viewerState.getState(info.uri)
         }
       });
     }
   }
 
   getViewerState(uri: vscode.Uri): ViewerState | undefined {
-    return this.stateByUri.get(uri.toString());
+    return this.viewerState.getState(uri);
   }
 
   protected buildViewerMetadata(
@@ -213,7 +214,7 @@ export abstract class BaseKiCanvasEditorProvider
             const nextState = readViewerState(message.payload);
             if (info && nextState) {
               info.state = nextState;
-              this.stateByUri.set(document.uri.toString(), info.state);
+              this.viewerState.updateState(document.uri, info.state);
             }
           }
           if (message.type === 'selectionChanged') {
@@ -224,7 +225,7 @@ export abstract class BaseKiCanvasEditorProvider
                 ...(info.state ?? { zoom: 1, grid: false, theme: this.theme }),
                 ...payload
               };
-              this.stateByUri.set(document.uri.toString(), info.state);
+              this.viewerState.updateState(document.uri, info.state);
             }
           }
           if (message.type === 'exportPng') {
@@ -249,7 +250,7 @@ export abstract class BaseKiCanvasEditorProvider
                 ...(info.state ?? { zoom: 1, grid: false, theme: this.theme }),
                 selectedReference: reference ?? info.state?.selectedReference
               };
-              this.stateByUri.set(document.uri.toString(), info.state);
+              this.viewerState.updateState(document.uri, info.state);
             }
           }
           if (message.type === 'requestSvgFallback') {
@@ -290,6 +291,7 @@ export abstract class BaseKiCanvasEditorProvider
       );
       await this.postFile(webviewPanel, document.uri);
     } catch (error) {
+      this.viewerState.recordError(document.uri, error);
       webviewPanel.webview.html = createViewerErrorHtml(
         path.basename(document.uri.fsPath),
         error,
@@ -299,22 +301,28 @@ export abstract class BaseKiCanvasEditorProvider
   }
 
   protected async refreshDocument(uri: vscode.Uri): Promise<void> {
-    const payload = await this.buildViewerPayload(uri);
-    for (const panel of this.panels.get(uri.toString()) ?? []) {
-      if (!panel.visible) {
-        const info = this.panelInfo.get(panel);
-        if (info) {
-          info.pendingRefresh = true;
+    this.viewerState.beginReload(uri);
+    try {
+      const payload = await this.buildViewerPayload(uri);
+      for (const panel of this.panels.get(uri.toString()) ?? []) {
+        if (!panel.visible) {
+          const info = this.panelInfo.get(panel);
+          if (info) {
+            info.pendingRefresh = true;
+          }
+          continue;
         }
-        continue;
+        await panel.webview.postMessage({
+          type: 'refresh',
+          payload: {
+            ...payload,
+            restoreState: this.panelInfo.get(panel)?.state
+          }
+        });
       }
-      await panel.webview.postMessage({
-        type: 'refresh',
-        payload: {
-          ...payload,
-          restoreState: this.panelInfo.get(panel)?.state
-        }
-      });
+    } catch (error) {
+      this.viewerState.recordError(uri, error);
+      throw error;
     }
   }
 
@@ -362,7 +370,7 @@ export abstract class BaseKiCanvasEditorProvider
     const mtimeMs = stat.mtime;
     const cached = this.fileCache.get(cacheKey);
     if (cached && cached.mtimeMs === mtimeMs) {
-      const restoreState = this.stateByUri.get(cacheKey);
+      const restoreState = this.viewerState.getState(uri);
       return {
         fileName,
         base64: cached.base64,
@@ -422,7 +430,7 @@ export abstract class BaseKiCanvasEditorProvider
       ),
       ...(nextPayload.metadata ? { metadata: nextPayload.metadata } : {}),
       ...(() => {
-        const restoreState = this.stateByUri.get(cacheKey);
+        const restoreState = this.viewerState.getState(uri);
         return restoreState ? { restoreState } : {};
       })()
     };
@@ -440,7 +448,7 @@ export abstract class BaseKiCanvasEditorProvider
     this.panelInfo.set(panel, {
       uri,
       pendingRefresh: false,
-      state: this.stateByUri.get(uri.toString())
+      state: this.viewerState.getState(uri)
     });
   }
 

--- a/apps/vscode-extension/src/providers/baseKiCanvasEditorProvider.ts
+++ b/apps/vscode-extension/src/providers/baseKiCanvasEditorProvider.ts
@@ -301,17 +301,26 @@ export abstract class BaseKiCanvasEditorProvider
   }
 
   protected async refreshDocument(uri: vscode.Uri): Promise<void> {
+    const visiblePanels: vscode.WebviewPanel[] = [];
+    for (const panel of this.panels.get(uri.toString()) ?? []) {
+      if (panel.visible) {
+        visiblePanels.push(panel);
+        continue;
+      }
+      const info = this.panelInfo.get(panel);
+      if (info) {
+        info.pendingRefresh = true;
+      }
+    }
+
+    if (!visiblePanels.length) {
+      return;
+    }
+
     this.viewerState.beginReload(uri);
     try {
       const payload = await this.buildViewerPayload(uri);
-      for (const panel of this.panels.get(uri.toString()) ?? []) {
-        if (!panel.visible) {
-          const info = this.panelInfo.get(panel);
-          if (info) {
-            info.pendingRefresh = true;
-          }
-          continue;
-        }
+      for (const panel of visiblePanels) {
         await panel.webview.postMessage({
           type: 'refresh',
           payload: {

--- a/apps/vscode-extension/src/providers/bomViewProvider.ts
+++ b/apps/vscode-extension/src/providers/bomViewProvider.ts
@@ -9,6 +9,7 @@ import { SExpressionParser } from '../language/sExpressionParser';
 import { readTextFileSync } from '../utils/fileUtils';
 import { asRecord, asString, hasType } from '../utils/webviewMessages';
 import { createNonce } from '../utils/nonce';
+import type { ExportStateStore } from '../state/stateStores';
 
 export class BomViewProvider
   implements vscode.WebviewViewProvider, vscode.Disposable
@@ -24,7 +25,8 @@ export class BomViewProvider
 
   constructor(
     private readonly context: vscode.ExtensionContext,
-    parser: SExpressionParser
+    parser: SExpressionParser,
+    private readonly exportState?: ExportStateStore | undefined
   ) {
     this.bomParser = new BomParser(parser);
     this.disposables.push(
@@ -97,16 +99,25 @@ export class BomViewProvider
   async refresh(): Promise<void> {
     const file = await this.findSchematicFile();
     if (!file) {
+      this.exportState?.complete('bom', undefined, 'No schematic opened.');
       this.manager.setStatus('Open a .kicad_sch schematic file to load the Bill of Materials.');
       return;
     }
+    const uri = vscode.Uri.file(file);
+    this.exportState?.begin('bom', uri, 'Loading Bill of Materials.');
     this.manager.setLoading();
     this.currentFile = file;
     try {
       const entries = this.bomParser.parse(readTextFileSync(file));
       this.manager.setEntries(entries);
+      this.exportState?.complete(
+        'bom',
+        uri,
+        `Bill of Materials loaded from ${path.basename(file)}.`
+      );
     } catch (error) {
       this.currentFile = undefined;
+      this.exportState?.fail('bom', uri, error);
       this.manager.setStatus(
         error instanceof Error
           ? `Could not load BOM from ${path.basename(file)}: ${error.message}`

--- a/apps/vscode-extension/src/providers/netlistViewProvider.ts
+++ b/apps/vscode-extension/src/providers/netlistViewProvider.ts
@@ -8,6 +8,7 @@ import { KiCadCliRunner } from '../cli/kicadCliRunner';
 import { Logger } from '../utils/logger';
 import { createNonce } from '../utils/nonce';
 import { findSiblingProjectFile } from '../utils/pathUtils';
+import type { ExportStateStore } from '../state/stateStores';
 
 export class NetlistViewProvider
   implements vscode.WebviewViewProvider, vscode.Disposable
@@ -21,7 +22,8 @@ export class NetlistViewProvider
     private readonly context: vscode.ExtensionContext,
     private readonly parser: SExpressionParser,
     private readonly runner?: KiCadCliRunner,
-    private readonly logger?: Logger
+    private readonly logger?: Logger,
+    private readonly exportState?: ExportStateStore | undefined
   ) {
     this.disposables.push(
       vscode.window.onDidChangeActiveTextEditor(() => this.scheduleRefresh(250)),
@@ -70,6 +72,7 @@ export class NetlistViewProvider
     const file = await this.findSchematicFile();
     if (!file) {
       this._lastFile = '';
+      this.exportState?.complete('netlist', undefined, 'No schematic opened.');
       await this.postNetlist([], 'No schematic opened.');
       return;
     }
@@ -77,7 +80,13 @@ export class NetlistViewProvider
       return;
     }
     this._lastFile = file;
+    const uri = vscode.Uri.file(file);
     if (!this.runner) {
+      this.exportState?.fail(
+        'netlist',
+        uri,
+        'kicad-cli is not configured, so real net/node extraction is unavailable.'
+      );
       await this.postNetlist(
         [],
         'kicad-cli is not configured, so real net/node extraction is unavailable.'
@@ -85,11 +94,18 @@ export class NetlistViewProvider
       return;
     }
     try {
+      this.exportState?.begin('netlist', uri, 'Exporting KiCad netlist.');
       await this.postNetlist(
         await this.buildNetlistFromCli(file),
         `Netlist from ${path.basename(file)}`
       );
+      this.exportState?.complete(
+        'netlist',
+        uri,
+        `Netlist loaded from ${path.basename(file)}.`
+      );
     } catch (error) {
+      this.exportState?.fail('netlist', uri, error);
       this.logger?.warn(
         `Netlist extraction failed: ${error instanceof Error ? error.message : String(error)}`
       );

--- a/apps/vscode-extension/src/providers/qualityGateProvider.ts
+++ b/apps/vscode-extension/src/providers/qualityGateProvider.ts
@@ -2,11 +2,13 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { COMMANDS } from '../constants';
 import type {
+  McpConnectionState,
   QualityGateResult,
   QualityGateStatus,
   QualityGateViolation
 } from '../types';
 import type { QualityGateMcpAdapter } from '../mcp/mcpToolAdapter';
+import type { McpStateStore } from '../state/stateStores';
 
 type QualityGateElement =
   | {
@@ -37,7 +39,8 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
 
   constructor(
     private readonly context: vscode.ExtensionContext,
-    private readonly mcpAdapter: QualityGateMcpAdapter
+    private readonly mcpAdapter: QualityGateMcpAdapter,
+    private readonly mcpState?: Pick<McpStateStore, 'getState'> | undefined
   ) {
     this.gates = this.readCachedGates() ?? DEFAULT_GATES;
   }
@@ -91,7 +94,12 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
 
   getChildren(element?: QualityGateElement): QualityGateElement[] {
     if (!element) {
-      return orderGates(this.gates).map((gate) => ({ kind: 'gate', gate }));
+      const state = this.mcpState?.getState();
+      const gates =
+        state && !supportsHttpQualityGates(state)
+          ? blockedGates(this.gates, state)
+          : this.gates;
+      return orderGates(gates).map((gate) => ({ kind: 'gate', gate }));
     }
     if (element.kind === 'gate') {
       return element.gate.violations.map((violation) => ({
@@ -220,6 +228,28 @@ function pendingGate(id: string, label: string): QualityGateResult {
     details: [],
     violations: []
   };
+}
+
+function blockedGates(
+  gates: QualityGateResult[],
+  state: McpConnectionState
+): QualityGateResult[] {
+  const summary =
+    state.kind === 'VsCodeStdio'
+      ? 'HTTP MCP connection required for Quality Gates.'
+      : state.kind === 'Incompatible'
+        ? 'Compatible kicad-mcp-pro server required.'
+        : 'Connect kicad-mcp-pro before running Quality Gates.';
+  return gates.map((gate) => ({
+    ...gate,
+    status: 'BLOCKED',
+    summary: state.message ? `${summary} ${state.message}` : summary,
+    violations: []
+  }));
+}
+
+function supportsHttpQualityGates(state: McpConnectionState): boolean {
+  return state.kind === 'Connected' && state.connected;
 }
 
 function descriptionForGate(gate: QualityGateResult): string {

--- a/apps/vscode-extension/src/providers/qualityGateProvider.ts
+++ b/apps/vscode-extension/src/providers/qualityGateProvider.ts
@@ -117,6 +117,10 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
   }
 
   async runAll(): Promise<void> {
+    if (this.blockUnavailableRunAction()) {
+      return;
+    }
+
     try {
       const [project, placement, transfer, manufacturing] = await Promise.all([
         this.mcpAdapter.runProjectQualityGate(),
@@ -143,6 +147,10 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
   }
 
   async runGate(gate: QualityGateResult): Promise<void> {
+    if (this.blockUnavailableRunAction()) {
+      return;
+    }
+
     const next = gate.id.includes('placement')
       ? await this.mcpAdapter.runPlacementQualityGate()
       : gate.id.includes('transfer')
@@ -217,6 +225,16 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
       vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? 'workspace';
     return `kicadstudio.qualityGate.${path.basename(root)}`;
   }
+
+  private blockUnavailableRunAction(): boolean {
+    const state = this.mcpState?.getState();
+    if (!state || supportsHttpQualityGates(state)) {
+      return false;
+    }
+
+    void vscode.window.showInformationMessage(qualityGateBlockMessage(state));
+    return true;
+  }
 }
 
 function pendingGate(id: string, label: string): QualityGateResult {
@@ -234,18 +252,21 @@ function blockedGates(
   gates: QualityGateResult[],
   state: McpConnectionState
 ): QualityGateResult[] {
-  const summary =
-    state.kind === 'VsCodeStdio'
-      ? 'HTTP MCP connection required for Quality Gates.'
-      : state.kind === 'Incompatible'
-        ? 'Compatible kicad-mcp-pro server required.'
-        : 'Connect kicad-mcp-pro before running Quality Gates.';
+  const summary = qualityGateBlockMessage(state);
   return gates.map((gate) => ({
     ...gate,
     status: 'BLOCKED',
     summary: state.message ? `${summary} ${state.message}` : summary,
     violations: []
   }));
+}
+
+function qualityGateBlockMessage(state: McpConnectionState): string {
+  return state.kind === 'VsCodeStdio'
+    ? 'HTTP MCP connection required for Quality Gates.'
+    : state.kind === 'Incompatible'
+      ? 'Compatible kicad-mcp-pro server required.'
+      : 'Connect kicad-mcp-pro before running Quality Gates.';
 }
 
 function supportsHttpQualityGates(state: McpConnectionState): boolean {

--- a/apps/vscode-extension/src/providers/validationViewProvider.ts
+++ b/apps/vscode-extension/src/providers/validationViewProvider.ts
@@ -1,0 +1,98 @@
+import * as vscode from 'vscode';
+import { COMMANDS } from '../constants';
+import type { DiagnosticSummary } from '../types';
+import type { DiagnosticStateStore } from '../state/stateStores';
+
+export interface ValidationRow {
+  label: 'DRC' | 'ERC';
+  summary: DiagnosticSummary | undefined;
+}
+
+export class ValidationViewProvider
+  implements vscode.TreeDataProvider<ValidationRow>, vscode.Disposable
+{
+  private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<
+    ValidationRow | undefined
+  >();
+  readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
+  private readonly subscription: vscode.Disposable;
+
+  constructor(private readonly diagnostics: DiagnosticStateStore) {
+    this.subscription = diagnostics.onDidChange(() =>
+      this.onDidChangeTreeDataEmitter.fire(undefined)
+    );
+  }
+
+  getTreeItem(element: ValidationRow): vscode.TreeItem {
+    const item = new vscode.TreeItem(
+      element.label,
+      vscode.TreeItemCollapsibleState.None
+    );
+    item.description = describe(element.summary);
+    item.tooltip = tooltip(element);
+    item.iconPath = new vscode.ThemeIcon(iconFor(element.summary));
+    item.command = {
+      command: element.label === 'DRC' ? COMMANDS.runDRC : COMMANDS.runERC,
+      title: `Run ${element.label}`
+    };
+    return item;
+  }
+
+  getChildren(): ValidationRow[] {
+    const snapshot = this.diagnostics.getSnapshot();
+    return [
+      { label: 'DRC', summary: snapshot.drc },
+      { label: 'ERC', summary: snapshot.erc }
+    ];
+  }
+
+  dispose(): void {
+    this.subscription.dispose();
+    this.onDidChangeTreeDataEmitter.dispose();
+  }
+}
+
+function describe(summary: DiagnosticSummary | undefined): string {
+  if (!summary) {
+    return 'PENDING - no cached result';
+  }
+  return `${statusFor(summary)} - ${summary.errors} errors, ${summary.warnings} warnings`;
+}
+
+function tooltip(row: ValidationRow): string {
+  if (!row.summary) {
+    return `${row.label} has not been run yet.`;
+  }
+  return [
+    `${row.label}: ${statusFor(row.summary)}`,
+    row.summary.file,
+    `${row.summary.errors} errors`,
+    `${row.summary.warnings} warnings`,
+    `${row.summary.infos} info`
+  ].join('\n');
+}
+
+function iconFor(summary: DiagnosticSummary | undefined): string {
+  switch (statusFor(summary)) {
+    case 'FAIL':
+      return 'error';
+    case 'WARN':
+      return 'warning';
+    case 'PASS':
+      return 'pass';
+    case 'PENDING':
+      return 'play-circle';
+  }
+}
+
+function statusFor(
+  summary: DiagnosticSummary | undefined
+): 'PENDING' | 'PASS' | 'WARN' | 'FAIL' {
+  if (!summary) {
+    return 'PENDING';
+  }
+  if (summary.errors > 0) {
+    return 'FAIL';
+  }
+  return summary.warnings > 0 ? 'WARN' : 'PASS';
+}

--- a/apps/vscode-extension/src/state/stateStores.ts
+++ b/apps/vscode-extension/src/state/stateStores.ts
@@ -1,0 +1,452 @@
+import * as vscode from 'vscode';
+import type {
+  DiagnosticSummary,
+  McpCapabilityCard,
+  McpConnectionState,
+  McpInstallStatus,
+  McpServerCard,
+  ViewerState
+} from '../types';
+import { redactSensitiveText } from '../utils/secrets';
+
+export interface ProjectStateSnapshot {
+  activeResource: string | undefined;
+  hasProject: boolean;
+  hasVariants: boolean;
+  workspaceTrusted: boolean;
+}
+
+interface ProjectState extends Omit<ProjectStateSnapshot, 'activeResource'> {
+  activeResource: vscode.Uri | undefined;
+}
+
+export class ProjectStateStore implements vscode.Disposable {
+  private readonly onDidChangeEmitter =
+    new vscode.EventEmitter<ProjectStateSnapshot>();
+  readonly onDidChange = this.onDidChangeEmitter.event;
+  private state: ProjectState = {
+    activeResource: undefined,
+    hasProject: false,
+    hasVariants: false,
+    workspaceTrusted: false
+  };
+
+  update(update: Partial<ProjectState>): ProjectStateSnapshot {
+    this.state = { ...this.state, ...update };
+    const snapshot = this.getSnapshot();
+    this.onDidChangeEmitter.fire(snapshot);
+    return snapshot;
+  }
+
+  getSnapshot(): ProjectStateSnapshot {
+    return {
+      activeResource: this.state.activeResource?.toString(),
+      hasProject: this.state.hasProject,
+      hasVariants: this.state.hasVariants,
+      workspaceTrusted: this.state.workspaceTrusted
+    };
+  }
+
+  getDiagnosticBundleSnapshot(): ProjectStateSnapshot {
+    return this.getSnapshot();
+  }
+
+  dispose(): void {
+    this.onDidChangeEmitter.dispose();
+  }
+}
+
+export interface DiagnosticStateSnapshot {
+  drc: DiagnosticSummary | undefined;
+  erc: DiagnosticSummary | undefined;
+}
+
+interface LatestDrcRun {
+  file: string;
+  diagnostics: vscode.Diagnostic[];
+  summary: DiagnosticSummary;
+}
+
+export class DiagnosticStateStore implements vscode.Disposable {
+  private readonly onDidChangeEmitter =
+    new vscode.EventEmitter<DiagnosticStateSnapshot>();
+  readonly onDidChange = this.onDidChangeEmitter.event;
+  private drc: DiagnosticSummary | undefined;
+  private erc: DiagnosticSummary | undefined;
+  private latestDrcRun: LatestDrcRun | undefined;
+
+  constructor(private readonly diagnostics: vscode.DiagnosticCollection) {}
+
+  applyValidationResult(
+    uri: vscode.Uri,
+    diagnostics: readonly vscode.Diagnostic[],
+    summary: DiagnosticSummary
+  ): DiagnosticStateSnapshot {
+    this.diagnostics.set(uri, diagnostics);
+    const nextSummary = cloneSummary(summary);
+    if (summary.source === 'drc') {
+      this.drc = nextSummary;
+      this.latestDrcRun = {
+        file: summary.file,
+        diagnostics: [...diagnostics],
+        summary: nextSummary
+      };
+    }
+    if (summary.source === 'erc') {
+      this.erc = nextSummary;
+    }
+    const snapshot = this.getSnapshot();
+    this.onDidChangeEmitter.fire(snapshot);
+    return snapshot;
+  }
+
+  getLatestDrcRun(): LatestDrcRun | undefined {
+    return this.latestDrcRun
+      ? {
+          file: this.latestDrcRun.file,
+          diagnostics: [...this.latestDrcRun.diagnostics],
+          summary: cloneSummary(this.latestDrcRun.summary)
+        }
+      : undefined;
+  }
+
+  getSnapshot(): DiagnosticStateSnapshot {
+    return {
+      drc: this.drc ? cloneSummary(this.drc) : undefined,
+      erc: this.erc ? cloneSummary(this.erc) : undefined
+    };
+  }
+
+  getDiagnosticBundleSnapshot(): DiagnosticStateSnapshot {
+    return this.getSnapshot();
+  }
+
+  dispose(): void {
+    this.onDidChangeEmitter.dispose();
+  }
+}
+
+type ViewerSurfaceStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+interface ViewerSurfaceState {
+  uri: vscode.Uri;
+  state: ViewerState | undefined;
+  error: string | undefined;
+  status: ViewerSurfaceStatus;
+}
+
+export interface ViewerStateSnapshot {
+  viewers: Array<{
+    uri: string;
+    state: ViewerState | undefined;
+    error: string | undefined;
+    status: ViewerSurfaceStatus;
+  }>;
+}
+
+export class ViewerStateStore implements vscode.Disposable {
+  private readonly onDidChangeEmitter =
+    new vscode.EventEmitter<ViewerStateSnapshot>();
+  readonly onDidChange = this.onDidChangeEmitter.event;
+  private readonly viewers = new Map<string, ViewerSurfaceState>();
+
+  beginReload(uri: vscode.Uri): ViewerStateSnapshot {
+    return this.updateSurface(uri, {
+      error: undefined,
+      status: 'loading'
+    });
+  }
+
+  recordError(uri: vscode.Uri, error: unknown): ViewerStateSnapshot {
+    return this.updateSurface(uri, {
+      error: error instanceof Error ? error.message : String(error),
+      status: 'error'
+    });
+  }
+
+  updateState(uri: vscode.Uri, state: ViewerState): ViewerStateSnapshot {
+    return this.updateSurface(uri, {
+      error: undefined,
+      state: cloneViewerState(state),
+      status: 'ready'
+    });
+  }
+
+  getState(uri: vscode.Uri): ViewerState | undefined {
+    const state = this.viewers.get(uri.toString())?.state;
+    return state ? cloneViewerState(state) : undefined;
+  }
+
+  getSnapshot(): ViewerStateSnapshot {
+    return {
+      viewers: [...this.viewers.values()].map((viewer) => ({
+        uri: viewer.uri.toString(),
+        state: viewer.state ? cloneViewerState(viewer.state) : undefined,
+        error: viewer.error,
+        status: viewer.status
+      }))
+    };
+  }
+
+  getDiagnosticBundleSnapshot(): ViewerStateSnapshot {
+    const snapshot = this.getSnapshot();
+    return {
+      viewers: snapshot.viewers.map((viewer) => ({
+        ...viewer,
+        error: viewer.error ? redactSensitiveText(viewer.error) : undefined
+      }))
+    };
+  }
+
+  dispose(): void {
+    this.onDidChangeEmitter.dispose();
+  }
+
+  private updateSurface(
+    uri: vscode.Uri,
+    update: Partial<Omit<ViewerSurfaceState, 'uri'>>
+  ): ViewerStateSnapshot {
+    const previous = this.viewers.get(uri.toString());
+    this.viewers.set(uri.toString(), {
+      uri,
+      state: previous?.state,
+      error: previous?.error,
+      status: previous?.status ?? 'idle',
+      ...update
+    });
+    const snapshot = this.getSnapshot();
+    this.onDidChangeEmitter.fire(snapshot);
+    return snapshot;
+  }
+}
+
+export class McpStateStore implements vscode.Disposable {
+  private readonly onDidChangeEmitter =
+    new vscode.EventEmitter<McpConnectionState>();
+  readonly onDidChange = this.onDidChangeEmitter.event;
+  private state: McpConnectionState = {
+    kind: 'Disconnected',
+    available: false,
+    connected: false
+  };
+
+  update(state: McpConnectionState): McpConnectionState {
+    this.state = cloneMcpConnectionState(state);
+    const snapshot = this.getState();
+    this.onDidChangeEmitter.fire(snapshot);
+    return snapshot;
+  }
+
+  getState(): McpConnectionState {
+    return cloneMcpConnectionState(this.state);
+  }
+
+  getDiagnosticBundleSnapshot(): McpConnectionState {
+    const snapshot = this.getState();
+    return {
+      ...snapshot,
+      message: snapshot.message
+        ? redactSensitiveText(snapshot.message)
+        : undefined,
+      server: snapshot.server
+        ? {
+            ...snapshot.server,
+            capabilities: {
+              ...snapshot.server.capabilities,
+              diagnostics: snapshot.server.capabilities.diagnostics?.map((value) =>
+                redactSensitiveText(value)
+              )
+            }
+          }
+        : undefined
+    };
+  }
+
+  dispose(): void {
+    this.onDidChangeEmitter.dispose();
+  }
+}
+
+export type ExportSurfaceKind = 'export' | 'bom' | 'netlist';
+type ExportSurfaceStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+interface ExportSurfaceState {
+  kind: ExportSurfaceKind;
+  resource: vscode.Uri | undefined;
+  message: string | undefined;
+  error: string | undefined;
+  status: ExportSurfaceStatus;
+}
+
+export interface ExportStateSnapshot {
+  surfaces: Array<{
+    kind: ExportSurfaceKind;
+    resource: string | undefined;
+    message: string | undefined;
+    error: string | undefined;
+    status: ExportSurfaceStatus;
+  }>;
+}
+
+export class ExportStateStore implements vscode.Disposable {
+  private readonly onDidChangeEmitter =
+    new vscode.EventEmitter<ExportStateSnapshot>();
+  readonly onDidChange = this.onDidChangeEmitter.event;
+  private readonly surfaces = new Map<ExportSurfaceKind, ExportSurfaceState>();
+
+  begin(
+    kind: ExportSurfaceKind,
+    resource?: vscode.Uri,
+    message?: string
+  ): ExportStateSnapshot {
+    return this.updateSurface(kind, {
+      resource,
+      message,
+      error: undefined,
+      status: 'loading'
+    });
+  }
+
+  complete(
+    kind: ExportSurfaceKind,
+    resource?: vscode.Uri,
+    message?: string
+  ): ExportStateSnapshot {
+    return this.updateSurface(kind, {
+      resource,
+      message,
+      error: undefined,
+      status: 'ready'
+    });
+  }
+
+  fail(
+    kind: ExportSurfaceKind,
+    resource: vscode.Uri | undefined,
+    error: unknown
+  ): ExportStateSnapshot {
+    return this.updateSurface(kind, {
+      resource,
+      error: error instanceof Error ? error.message : String(error),
+      status: 'error'
+    });
+  }
+
+  getSnapshot(): ExportStateSnapshot {
+    return {
+      surfaces: [...this.surfaces.values()].map((surface) => ({
+        kind: surface.kind,
+        resource: surface.resource?.toString(),
+        message: surface.message,
+        error: surface.error,
+        status: surface.status
+      }))
+    };
+  }
+
+  getDiagnosticBundleSnapshot(): ExportStateSnapshot {
+    const snapshot = this.getSnapshot();
+    return {
+      surfaces: snapshot.surfaces.map((surface) => ({
+        ...surface,
+        message: surface.message
+          ? redactSensitiveText(surface.message)
+          : undefined,
+        error: surface.error ? redactSensitiveText(surface.error) : undefined
+      }))
+    };
+  }
+
+  dispose(): void {
+    this.onDidChangeEmitter.dispose();
+  }
+
+  private updateSurface(
+    kind: ExportSurfaceKind,
+    update: Partial<Omit<ExportSurfaceState, 'kind'>>
+  ): ExportStateSnapshot {
+    const previous = this.surfaces.get(kind);
+    this.surfaces.set(kind, {
+      kind,
+      resource: previous?.resource,
+      message: previous?.message,
+      error: previous?.error,
+      status: previous?.status ?? 'idle',
+      ...update
+    });
+    const snapshot = this.getSnapshot();
+    this.onDidChangeEmitter.fire(snapshot);
+    return snapshot;
+  }
+}
+
+function cloneSummary(summary: DiagnosticSummary): DiagnosticSummary {
+  return { ...summary };
+}
+
+function cloneViewerState(state: ViewerState): ViewerState {
+  return {
+    ...state,
+    selectedArea: state.selectedArea ? { ...state.selectedArea } : undefined,
+    activeLayers: state.activeLayers ? [...state.activeLayers] : undefined
+  };
+}
+
+function cloneMcpConnectionState(state: McpConnectionState): McpConnectionState {
+  return {
+    ...state,
+    install: cloneInstall(state.install),
+    server: cloneServerCard(state.server)
+  };
+}
+
+function cloneInstall(
+  install: McpInstallStatus | undefined
+): McpInstallStatus | undefined {
+  return install ? { ...install } : undefined;
+}
+
+function cloneServerCard(
+  server: McpServerCard | undefined
+): McpServerCard | undefined {
+  return server
+    ? {
+        ...server,
+        capabilities: cloneCapabilities(server.capabilities)
+      }
+    : undefined;
+}
+
+function cloneCapabilities(capabilities: McpCapabilityCard): McpCapabilityCard {
+  return {
+    ...capabilities,
+    tools: [...capabilities.tools],
+    resources: [...capabilities.resources],
+    prompts: [...capabilities.prompts],
+    diagnostics: capabilities.diagnostics
+      ? [...capabilities.diagnostics]
+      : undefined,
+    serverInfo: capabilities.serverInfo
+      ? {
+          ...capabilities.serverInfo,
+          compatibilityRange: {
+            kicadStudio: {
+              ...capabilities.serverInfo.compatibilityRange.kicadStudio
+            },
+            kicadMcpPro: {
+              ...capabilities.serverInfo.compatibilityRange.kicadMcpPro
+            }
+          },
+          transport: { ...capabilities.serverInfo.transport },
+          kicad: { ...capabilities.serverInfo.kicad },
+          capabilities: {
+            ...capabilities.serverInfo.capabilities,
+            cliExports: {
+              ...capabilities.serverInfo.capabilities.cliExports
+            }
+          },
+          diagnostics: [...capabilities.serverInfo.diagnostics]
+        }
+      : undefined
+  };
+}

--- a/apps/vscode-extension/src/state/stateStores.ts
+++ b/apps/vscode-extension/src/state/stateStores.ts
@@ -255,7 +255,16 @@ export class McpStateStore implements vscode.Disposable {
               ...snapshot.server.capabilities,
               diagnostics: snapshot.server.capabilities.diagnostics?.map((value) =>
                 redactSensitiveText(value)
-              )
+              ),
+              serverInfo: snapshot.server.capabilities.serverInfo
+                ? {
+                    ...snapshot.server.capabilities.serverInfo,
+                    diagnostics:
+                      snapshot.server.capabilities.serverInfo.diagnostics?.map(
+                        (value) => redactSensitiveText(value)
+                      ) ?? []
+                  }
+                : undefined
             }
           }
         : undefined
@@ -418,34 +427,35 @@ function cloneServerCard(
 }
 
 function cloneCapabilities(capabilities: McpCapabilityCard): McpCapabilityCard {
+  const serverInfo = capabilities.serverInfo;
   return {
     ...capabilities,
-    tools: [...capabilities.tools],
-    resources: [...capabilities.resources],
-    prompts: [...capabilities.prompts],
+    tools: [...(capabilities.tools ?? [])],
+    resources: [...(capabilities.resources ?? [])],
+    prompts: [...(capabilities.prompts ?? [])],
     diagnostics: capabilities.diagnostics
       ? [...capabilities.diagnostics]
       : undefined,
-    serverInfo: capabilities.serverInfo
+    serverInfo: serverInfo
       ? {
-          ...capabilities.serverInfo,
+          ...serverInfo,
           compatibilityRange: {
             kicadStudio: {
-              ...capabilities.serverInfo.compatibilityRange.kicadStudio
+              ...serverInfo.compatibilityRange?.kicadStudio
             },
             kicadMcpPro: {
-              ...capabilities.serverInfo.compatibilityRange.kicadMcpPro
+              ...serverInfo.compatibilityRange?.kicadMcpPro
             }
           },
-          transport: { ...capabilities.serverInfo.transport },
-          kicad: { ...capabilities.serverInfo.kicad },
+          transport: { ...serverInfo.transport },
+          kicad: { ...serverInfo.kicad },
           capabilities: {
-            ...capabilities.serverInfo.capabilities,
+            ...serverInfo.capabilities,
             cliExports: {
-              ...capabilities.serverInfo.capabilities.cliExports
+              ...serverInfo.capabilities?.cliExports
             }
           },
-          diagnostics: [...capabilities.serverInfo.diagnostics]
+          diagnostics: [...(serverInfo.diagnostics ?? [])]
         }
       : undefined
   };

--- a/apps/vscode-extension/test/unit/fixQueueProvider.actions.test.ts
+++ b/apps/vscode-extension/test/unit/fixQueueProvider.actions.test.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { FixQueueProvider } from '../../src/mcp/fixQueueProvider';
+import { McpStateStore } from '../../src/state/stateStores';
 import { window, workspace } from './vscodeMock';
 
 describe('FixQueueProvider code-action support', () => {
@@ -142,5 +143,33 @@ describe('FixQueueProvider code-action support', () => {
     };
     const provider = new FixQueueProvider(client as never);
     await expect(provider.refresh()).rejects.toThrow('unexpected server crash');
+  });
+
+  it('does not keep stale fixes when MCP cannot serve the queue', async () => {
+    const mcpState = new McpStateStore();
+    mcpState.update({
+      kind: 'Incompatible',
+      available: true,
+      connected: false,
+      message: 'Upgrade required.'
+    });
+    const client = {
+      fetchFixQueue: jest.fn().mockResolvedValue([
+        {
+          id: 'fix-stale',
+          description: 'Stale fix',
+          severity: 'warning',
+          tool: 'apply_fix',
+          args: {},
+          status: 'pending'
+        }
+      ])
+    };
+    const provider = new FixQueueProvider(client as never, mcpState);
+
+    await provider.refresh();
+
+    expect(client.fetchFixQueue).not.toHaveBeenCalled();
+    expect(provider.getChildren()).toEqual([]);
   });
 });

--- a/apps/vscode-extension/test/unit/qualityGateProvider.test.ts
+++ b/apps/vscode-extension/test/unit/qualityGateProvider.test.ts
@@ -1,4 +1,5 @@
 import { QualityGateProvider } from '../../src/providers/qualityGateProvider';
+import { McpStateStore } from '../../src/state/stateStores';
 import { createExtensionContextMock, env, workspace } from './vscodeMock';
 
 describe('QualityGateProvider', () => {
@@ -17,6 +18,31 @@ describe('QualityGateProvider', () => {
     expect(children).toHaveLength(5);
     expect(provider.getTreeItem(children[0] as never).description).toContain(
       'PENDING'
+    );
+  });
+
+  it('blocks cached gates while MCP is outside the HTTP connected state', () => {
+    const mcpState = new McpStateStore();
+    mcpState.update({
+      kind: 'VsCodeStdio',
+      available: true,
+      connected: true,
+      message: 'HTTP quality gates are unavailable in VS Code stdio.'
+    });
+    const provider = new QualityGateProvider(
+      createExtensionContextMock() as never,
+      {} as never,
+      mcpState
+    );
+
+    const children = provider.getChildren();
+
+    expect(children).toHaveLength(5);
+    expect(
+      children.every((item) => item.kind === 'gate' && item.gate.status === 'BLOCKED')
+    ).toBe(true);
+    expect(provider.getTreeItem(children[0] as never).description).toContain(
+      'BLOCKED'
     );
   });
 

--- a/apps/vscode-extension/test/unit/qualityGateProvider.test.ts
+++ b/apps/vscode-extension/test/unit/qualityGateProvider.test.ts
@@ -1,6 +1,11 @@
 import { QualityGateProvider } from '../../src/providers/qualityGateProvider';
 import { McpStateStore } from '../../src/state/stateStores';
-import { createExtensionContextMock, env, workspace } from './vscodeMock';
+import {
+  createExtensionContextMock,
+  env,
+  window,
+  workspace
+} from './vscodeMock';
 
 describe('QualityGateProvider', () => {
   beforeEach(() => {
@@ -43,6 +48,42 @@ describe('QualityGateProvider', () => {
     ).toBe(true);
     expect(provider.getTreeItem(children[0] as never).description).toContain(
       'BLOCKED'
+    );
+  });
+
+  it('blocks run actions while HTTP quality gates are unavailable', async () => {
+    const mcpState = new McpStateStore();
+    mcpState.update({
+      kind: 'Disconnected',
+      available: true,
+      connected: false,
+      message: 'MCP connection closed.'
+    });
+    const client = {
+      runProjectQualityGate: jest.fn(),
+      runPlacementQualityGate: jest.fn(),
+      runTransferQualityGate: jest.fn(),
+      runManufacturingQualityGate: jest.fn()
+    };
+    const provider = new QualityGateProvider(
+      createExtensionContextMock() as never,
+      client as never,
+      mcpState
+    );
+
+    await provider.runAll();
+    await provider.runGate({
+      id: 'schematic',
+      label: 'Schematic',
+      status: 'PENDING',
+      summary: '',
+      details: [],
+      violations: []
+    });
+
+    expect(client.runProjectQualityGate).not.toHaveBeenCalled();
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Connect kicad-mcp-pro')
     );
   });
 

--- a/apps/vscode-extension/test/unit/stateStores.test.ts
+++ b/apps/vscode-extension/test/unit/stateStores.test.ts
@@ -1,0 +1,159 @@
+import * as vscode from 'vscode';
+import {
+  DiagnosticStateStore,
+  ExportStateStore,
+  McpStateStore,
+  ProjectStateStore,
+  ViewerStateStore
+} from '../../src/state/stateStores';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+function createDiagnosticsCollection(): vscode.DiagnosticCollection {
+  return {
+    name: 'kicad',
+    set: jest.fn(),
+    delete: jest.fn(),
+    clear: jest.fn(),
+    forEach: jest.fn(),
+    get: jest.fn(),
+    has: jest.fn(),
+    dispose: jest.fn(),
+    [Symbol.iterator]: jest.fn(() => [][Symbol.iterator]())
+  } as unknown as vscode.DiagnosticCollection;
+}
+
+function createDiagnostic(message: string): vscode.Diagnostic {
+  const diagnostic = new vscode.Diagnostic(
+    new vscode.Range(0, 0, 0, 1),
+    message,
+    vscode.DiagnosticSeverity.Error
+  );
+  diagnostic.source = 'kicad-cli:drc';
+  return diagnostic;
+}
+
+describe('extension state stores', () => {
+  it('applies validation results once for Problems, status, and debug snapshots', () => {
+    const collection = createDiagnosticsCollection();
+    const store = new DiagnosticStateStore(collection);
+    const boardUri = vscode.Uri.file('/workspace/demo.kicad_pcb');
+    const stale = createDiagnostic('Clearance violation');
+
+    store.applyValidationResult(boardUri, [stale], {
+      file: boardUri.fsPath,
+      errors: 1,
+      warnings: 0,
+      infos: 0,
+      source: 'drc'
+    });
+    store.applyValidationResult(boardUri, [], {
+      file: boardUri.fsPath,
+      errors: 0,
+      warnings: 0,
+      infos: 0,
+      source: 'drc'
+    });
+
+    expect(collection.set).toHaveBeenNthCalledWith(1, boardUri, [stale]);
+    expect(collection.set).toHaveBeenLastCalledWith(boardUri, []);
+    expect(store.getSnapshot()).toMatchObject({
+      drc: {
+        file: boardUri.fsPath,
+        errors: 0
+      },
+      erc: undefined
+    });
+    expect(store.getLatestDrcRun()).toEqual({
+      file: boardUri.fsPath,
+      diagnostics: [],
+      summary: expect.objectContaining({ errors: 0, source: 'drc' })
+    });
+    expect(store.getDiagnosticBundleSnapshot()).toEqual({
+      drc: expect.objectContaining({ errors: 0, source: 'drc' }),
+      erc: undefined
+    });
+  });
+
+  it('tracks project context without leaking mutable Uri instances', () => {
+    const store = new ProjectStateStore();
+    const activeResource = vscode.Uri.file('/workspace/demo.kicad_sch');
+
+    store.update({
+      activeResource,
+      hasProject: true,
+      hasVariants: false,
+      workspaceTrusted: true
+    });
+
+    expect(store.getSnapshot()).toEqual({
+      activeResource: activeResource.toString(),
+      hasProject: true,
+      hasVariants: false,
+      workspaceTrusted: true
+    });
+  });
+
+  it('clears stale viewer errors when a reload starts', () => {
+    const store = new ViewerStateStore();
+    const boardUri = vscode.Uri.file('/workspace/demo.kicad_pcb');
+
+    store.recordError(boardUri, 'Bearer sk-sensitive-viewer-token failed');
+    store.updateState(boardUri, {
+      zoom: 2,
+      grid: true,
+      theme: 'dark',
+      selectedReference: 'U1'
+    });
+    store.beginReload(boardUri);
+
+    expect(store.getState(boardUri)).toEqual(
+      expect.objectContaining({
+        zoom: 2,
+        selectedReference: 'U1'
+      })
+    );
+    expect(store.getDiagnosticBundleSnapshot()).toEqual({
+      viewers: [
+        expect.objectContaining({
+          uri: boardUri.toString(),
+          error: undefined,
+          status: 'loading'
+        })
+      ]
+    });
+  });
+
+  it('redacts MCP and export diagnostics in bundle snapshots', () => {
+    const mcp = new McpStateStore();
+    const exports = new ExportStateStore();
+
+    mcp.update({
+      kind: 'Disconnected',
+      available: true,
+      connected: false,
+      message: 'Authorization: Bearer sk-mcp-secret'
+    });
+    exports.fail(
+      'bom',
+      vscode.Uri.file('/workspace/demo.kicad_sch'),
+      'token=raw-export-secret'
+    );
+
+    expect(mcp.getDiagnosticBundleSnapshot().message).toContain('Bearer ***');
+    expect(mcp.getDiagnosticBundleSnapshot().message).not.toContain(
+      'sk-mcp-secret'
+    );
+    expect(exports.getDiagnosticBundleSnapshot()).toEqual({
+      surfaces: [
+        expect.objectContaining({
+          kind: 'bom',
+          status: 'error',
+          error: expect.stringContaining('token=***')
+        })
+      ]
+    });
+  });
+});

--- a/apps/vscode-extension/test/unit/stateStores.test.ts
+++ b/apps/vscode-extension/test/unit/stateStores.test.ts
@@ -131,10 +131,23 @@ describe('extension state stores', () => {
     const exports = new ExportStateStore();
 
     mcp.update({
-      kind: 'Disconnected',
+      kind: 'Connected',
       available: true,
-      connected: false,
-      message: 'Authorization: Bearer sk-mcp-secret'
+      connected: true,
+      message: 'Authorization: Bearer sk-mcp-secret',
+      server: {
+        version: '1.0.0',
+        compat: 'ok',
+        capturedAt: '2026-05-21T00:00:00.000Z',
+        capabilities: {
+          tools: [],
+          resources: [],
+          prompts: [],
+          serverInfo: {
+            diagnostics: ['password=raw-server-secret']
+          }
+        }
+      } as never
     });
     exports.fail(
       'bom',
@@ -146,6 +159,9 @@ describe('extension state stores', () => {
     expect(mcp.getDiagnosticBundleSnapshot().message).not.toContain(
       'sk-mcp-secret'
     );
+    expect(
+      mcp.getDiagnosticBundleSnapshot().server?.capabilities.serverInfo?.diagnostics
+    ).toEqual(['password=***']);
     expect(exports.getDiagnosticBundleSnapshot()).toEqual({
       surfaces: [
         expect.objectContaining({

--- a/apps/vscode-extension/test/unit/validationViewProvider.test.ts
+++ b/apps/vscode-extension/test/unit/validationViewProvider.test.ts
@@ -1,0 +1,56 @@
+import * as vscode from 'vscode';
+import { DiagnosticStateStore } from '../../src/state/stateStores';
+import { ValidationViewProvider } from '../../src/providers/validationViewProvider';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+function createDiagnosticsCollection(): vscode.DiagnosticCollection {
+  return {
+    name: 'kicad',
+    set: jest.fn(),
+    delete: jest.fn(),
+    clear: jest.fn(),
+    forEach: jest.fn(),
+    get: jest.fn(),
+    has: jest.fn(),
+    dispose: jest.fn(),
+    [Symbol.iterator]: jest.fn(() => [][Symbol.iterator]())
+  } as unknown as vscode.DiagnosticCollection;
+}
+
+describe('ValidationViewProvider', () => {
+  it('derives DRC and ERC rows from the shared diagnostic state', () => {
+    const diagnostics = new DiagnosticStateStore(createDiagnosticsCollection());
+    const provider = new ValidationViewProvider(diagnostics);
+    const board = vscode.Uri.file('/workspace/demo.kicad_pcb');
+    const schematic = vscode.Uri.file('/workspace/demo.kicad_sch');
+
+    diagnostics.applyValidationResult(board, [], {
+      file: board.fsPath,
+      errors: 0,
+      warnings: 0,
+      infos: 0,
+      source: 'drc',
+      capturedAt: '2026-05-21T05:00:00.000Z'
+    });
+    diagnostics.applyValidationResult(schematic, [], {
+      file: schematic.fsPath,
+      errors: 0,
+      warnings: 2,
+      infos: 1,
+      source: 'erc',
+      capturedAt: '2026-05-21T05:01:00.000Z'
+    });
+
+    const rows = provider.getChildren();
+
+    expect(rows.map((row) => row.label)).toEqual(['DRC', 'ERC']);
+    expect(provider.getTreeItem(rows[0]!).description).toContain('PASS');
+    expect(provider.getTreeItem(rows[1]!).description).toContain('WARN');
+    expect(provider.getTreeItem(rows[1]!).tooltip).toContain(
+      schematic.fsPath
+    );
+  });
+});

--- a/apps/vscode-extension/test/unit/viewerProviders.test.ts
+++ b/apps/vscode-extension/test/unit/viewerProviders.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { SchematicEditorProvider } from '../../src/providers/schematicEditorProvider';
 import { PcbEditorProvider } from '../../src/providers/pcbEditorProvider';
+import { ViewerStateStore } from '../../src/state/stateStores';
 import { __setConfiguration, window, workspace } from './vscodeMock';
 
 type ProviderCtor = new (
@@ -144,6 +145,37 @@ describe.each([
         })
       })
     );
+  });
+
+  it('keeps hidden viewers out of loading state until refresh becomes visible', async () => {
+    const viewerState = new ViewerStateStore();
+    const provider = new (ContextProvider as never as {
+      new (
+        context: vscode.ExtensionContext,
+        svgFallbackProvider: undefined,
+        viewerState: ViewerStateStore
+      ): InstanceType<typeof ContextProvider>;
+    })(
+      {
+        extensionUri: vscode.Uri.file('/extension')
+      } as vscode.ExtensionContext,
+      undefined,
+      viewerState
+    );
+    const panel = createPanel();
+    const document = {
+      uri: vscode.Uri.file(tempFile)
+    } as vscode.CustomDocument;
+
+    await provider.resolveCustomEditor(
+      document,
+      panel as unknown as vscode.WebviewPanel
+    );
+    panel.visible = false;
+
+    await (provider as any).refreshDocument(document.uri);
+
+    expect(viewerState.getSnapshot()).toEqual({ viewers: [] });
   });
 
   it('uses file metadata before full reads for oversized KiCad files', async () => {


### PR DESCRIPTION
## Summary
- add centralized project, diagnostic, viewer, MCP, and export state stores for the VS Code extension
- drive validation/status, viewer error lifecycle, MCP panels, and export flows from shared state boundaries
- add regression coverage for diagnostic snapshots, viewer reloads, blocked MCP panels, and validation rendering

## Tracking
- Linear: OASLANA-68
- Closes #69

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --dir apps/vscode-extension run lint`
- `corepack pnpm --dir apps/vscode-extension run typecheck`
- `corepack pnpm --dir apps/vscode-extension run test`
- `corepack pnpm --dir apps/vscode-extension run build`
- `uvx pre-commit run --all-files`
- `PATH="/tmp/codex-actionlint-1.7.12:$PATH" corepack pnpm run check`

## Notes
- Root `pnpm check` completed after providing `actionlint` v1.7.12 on PATH for workflow linting.
- Existing repository warnings observed during root checks remain the acknowledged PyPI reachability and pip-audit advisory output surfaced by the check script.