### PR TITLE
fix(kicad-studio): let fallback viewer fit schematic

### DIFF
--- a/apps/vscode-extension/src/providers/viewerHtml.ts
+++ b/apps/vscode-extension/src/providers/viewerHtml.ts
@@ -1100,8 +1100,7 @@ export function createKiCanvasViewerHtml(
       const availableHeight = Math.max(1, fallbackSvgWrapper.clientHeight - 40);
       fallbackSvgFitScale = Math.min(
         availableWidth / fallbackSvgSize.width,
-        availableHeight / fallbackSvgSize.height,
-        1
+        availableHeight / fallbackSvgSize.height
       );
       fallbackSvgScale = fallbackSvgFitScale;
       applyFallbackSvgScale(resetScroll !== false);

--- a/apps/vscode-extension/test/unit/viewerHtml.test.ts
+++ b/apps/vscode-extension/test/unit/viewerHtml.test.ts
@@ -232,6 +232,29 @@ describe('createKiCanvasViewerHtml', () => {
     expect(html).toContain('.split(new RegExp(');
   });
 
+  it('lets fallback fit upscale CLI SVGs whose viewBox is smaller than the viewport', () => {
+    const html = createKiCanvasViewerHtml({
+      title: 'Viewer',
+      fileName: 'sample.kicad_sch',
+      fileType: 'schematic',
+      status: 'Opening interactive renderer...',
+      cspSource: 'vscode-resource:',
+      kicanvasUri: 'vscode-resource:/media/kicanvas/kicanvas.js',
+      base64: 'Zm9v',
+      disabledReason: ''
+    });
+
+    const fitSection = html.slice(
+      html.indexOf('function fitSvgFallback'),
+      html.indexOf('function applyFallbackPresentation')
+    );
+
+    expect(fitSection).toContain('fallbackSvgFitScale = Math.min(');
+    expect(fitSection).not.toMatch(
+      /availableHeight \/ fallbackSvgSize\.height,\s*1\s*\)/
+    );
+  });
+
   it('includes worker-safe CSP and typed inline sources', () => {
     const html = createKiCanvasViewerHtml({
       title: 'Viewer',


### PR DESCRIPTION
## Summary
- remove the SVG fallback fit cap that kept viewBox-sized schematic exports at thumbnail scale
- keep fallback fit driven by the actual viewport-to-SVG ratio so normal schematic exports can upscale on first render
- add a regression test that fails when fallback fit is capped at `1`
- rebuild the branch on current `main` with the required `kicad-studio` release scope after the monorepo Release Please policy landed

## Tracking
- Linear: OASLANA-16
- Closes #17

## Validation
- RED `npx --yes -p node@24 -c "corepack pnpm --dir apps/vscode-extension run test:unit -- viewerHtml.test.ts"` before the fit-scale change.
- PASS `corepack pnpm install --frozen-lockfile`.
- PASS `corepack pnpm run format:check`.
- PASS `corepack pnpm run lint`.
- PASS `corepack pnpm run typecheck`.
- PASS `corepack pnpm run test` after clearing stale generated `apps/vscode-extension/out` and `.vscode-test` output from the previous run.
- PASS `corepack pnpm run build`; the MCP npm wrapper printed the expected unpublished-PyPI advisory and exited 0.
- FAIL `corepack pnpm run verify:dist`: root package has no `verify:dist` script.
- PASS `corepack pnpm --dir apps/vscode-extension run test:unit -- viewerHtml.test.ts`.
- PASS `corepack pnpm run check:version`.
- PASS `corepack pnpm run check` after clearing generated VS Code download output and rebuilding the branch with `fix(kicad-studio)` commit scope.
- PASS `git diff --check`.
- PASS `uvx pre-commit run --all-files`.

## Notes
- Viewer code is changed only in fallback fit sizing and the regression test.
- The previous local full-test blocker from the Quality Gate contribution was cleared by the merged PR #102 base fix.
- No release, tag, or publish action was performed.
