### PR TITLE
fix(kicad-studio): clarify project tree roles

### DIFF
--- a/apps/vscode-extension/src/providers/projectTreeProvider.ts
+++ b/apps/vscode-extension/src/providers/projectTreeProvider.ts
@@ -14,8 +14,10 @@ class KiCadTreeItem extends vscode.TreeItem {
     if (node.uri) {
       this.resourceUri = node.uri;
     }
-    this.tooltip = node.uri?.fsPath ?? node.label;
-    this.iconPath = new vscode.ThemeIcon(iconForNode(node));
+    const diagnostics = diagnosticsForNode(node);
+    this.description = descriptionForNode(node, diagnostics);
+    this.tooltip = tooltipForNode(node, diagnostics);
+    this.iconPath = new vscode.ThemeIcon(iconForNode(node, diagnostics));
 
     if (
       node.uri &&
@@ -98,18 +100,21 @@ export class KiCadProjectTreeProvider implements vscode.TreeDataProvider<Project
     ]);
 
     const children: ProjectTreeNode[] = [
-      ...projectFiles.map(
-        (file): ProjectTreeNode => ({
-          label: path.basename(file),
-          type: file.endsWith('.kicad_sch')
-            ? 'schematic'
-            : file.endsWith('.kicad_pcb')
-              ? 'pcb'
-              : file.endsWith('.kicad_dru')
-                ? 'drc-rule'
-                : 'file',
-          uri: vscode.Uri.file(file)
-        })
+      groupProjectNodes(
+        'Project Files',
+        projectFiles.filter((file) => hasExtension(file, '.kicad_pro'))
+      ),
+      groupProjectNodes(
+        'Schematic Sheets',
+        projectFiles.filter((file) => hasExtension(file, '.kicad_sch'))
+      ),
+      groupProjectNodes(
+        'PCB',
+        projectFiles.filter((file) => hasExtension(file, '.kicad_pcb'))
+      ),
+      groupProjectNodes(
+        'Design Rules',
+        projectFiles.filter((file) => hasExtension(file, '.kicad_dru'))
       ),
       {
         label: 'Jobsets',
@@ -177,7 +182,176 @@ export class KiCadProjectTreeProvider implements vscode.TreeDataProvider<Project
   }
 }
 
-function iconForNode(node: ProjectTreeNode): string {
+interface TreeDiagnostics {
+  errors: number;
+  warnings: number;
+  total: number;
+}
+
+function groupProjectNodes(label: string, files: string[]): ProjectTreeNode {
+  return {
+    label,
+    type: 'folder',
+    children: files.map(projectFileNode)
+  };
+}
+
+function projectFileNode(file: string): ProjectTreeNode {
+  const extension = normalizedExtension(file);
+  return {
+    label: path.basename(file),
+    type: extension === '.kicad_sch'
+      ? 'schematic'
+      : extension === '.kicad_pcb'
+        ? 'pcb'
+        : extension === '.kicad_dru'
+          ? 'drc-rule'
+          : 'file',
+    uri: vscode.Uri.file(file)
+  };
+}
+
+function diagnosticsForNode(node: ProjectTreeNode): TreeDiagnostics {
+  if (node.children && node.children.length > 0) {
+    return node.children.reduce<TreeDiagnostics>(
+      (state, child) => {
+        const childDiagnostics = diagnosticsForNode(child);
+        return {
+          errors: state.errors + childDiagnostics.errors,
+          warnings: state.warnings + childDiagnostics.warnings,
+          total: state.total + childDiagnostics.total
+        };
+      },
+      { errors: 0, warnings: 0, total: 0 }
+    );
+  }
+
+  if (!node.uri || node.type === 'project' || node.type === 'folder') {
+    return { errors: 0, warnings: 0, total: 0 };
+  }
+
+  const diagnostics = vscode.languages.getDiagnostics(node.uri);
+  return diagnostics.reduce(
+    (state, diagnostic) => ({
+      errors:
+        state.errors +
+        (diagnostic.severity === vscode.DiagnosticSeverity.Error ? 1 : 0),
+      warnings:
+        state.warnings +
+        (diagnostic.severity === vscode.DiagnosticSeverity.Warning ? 1 : 0),
+      total: state.total + 1
+    }),
+    { errors: 0, warnings: 0, total: 0 }
+  );
+}
+
+function descriptionForNode(
+  node: ProjectTreeNode,
+  diagnostics: TreeDiagnostics
+): string {
+  const description = roleForNode(node);
+  const diagnosticState = diagnosticSummary(diagnostics);
+  return diagnosticState ? `${description} | ${diagnosticState}` : description;
+}
+
+function tooltipForNode(
+  node: ProjectTreeNode,
+  diagnostics: TreeDiagnostics
+): string {
+  const diagnosticState = diagnosticSummary(diagnostics);
+  const detail = [
+    `Role: ${roleForNode(node)}`,
+    node.uri ? `Path: ${node.uri.fsPath}` : undefined,
+    node.children
+      ? `State: ${node.children.length} visible item${node.children.length === 1 ? '' : 's'}${diagnosticState ? ` | ${diagnosticState}` : ''}`
+      : `State: ${diagnosticState ?? 'No diagnostics reported'}`,
+    node.uri && node.type !== 'project'
+      ? 'Source control: VS Code file decorations reflect working tree changes.'
+      : undefined
+  ].filter(Boolean);
+
+  return detail.join('\n');
+}
+
+function hasExtension(file: string, extension: string): boolean {
+  return normalizedExtension(file) === extension;
+}
+
+function normalizedExtension(file: string): string {
+  return path.extname(file).toLowerCase();
+}
+
+function diagnosticSummary(diagnostics: TreeDiagnostics): string | undefined {
+  if (diagnostics.errors > 0) {
+    return `${diagnostics.errors} error${diagnostics.errors === 1 ? '' : 's'}`;
+  }
+  if (diagnostics.warnings > 0) {
+    return `${diagnostics.warnings} warning${diagnostics.warnings === 1 ? '' : 's'}`;
+  }
+  if (diagnostics.total > 0) {
+    return `${diagnostics.total} diagnostic${diagnostics.total === 1 ? '' : 's'}`;
+  }
+  return undefined;
+}
+
+function roleForNode(node: ProjectTreeNode): string {
+  switch (node.type) {
+    case 'project':
+      return 'KiCad workspace';
+    case 'schematic':
+      return 'Schematic sheet';
+    case 'pcb':
+      return 'PCB layout';
+    case 'drc-rule':
+      return 'Design rules';
+    case 'jobset':
+      return node.children ? 'Jobset group' : 'Jobset';
+    case 'symbol-library':
+      return 'Schematic library group';
+    case 'footprint-library':
+      return 'Footprint library group';
+    case 'fab-output':
+      return 'Fabrication output group';
+    case 'model':
+      return '3D model group';
+    case 'folder':
+      return `${node.label} group`;
+    case 'file':
+      return roleForFile(node.label);
+  }
+}
+
+function roleForFile(label: string): string {
+  switch (path.extname(label).toLowerCase()) {
+    case '.kicad_pro':
+      return 'KiCad project file';
+    case '.kicad_sym':
+      return 'Symbol library';
+    case '.kicad_mod':
+      return 'Footprint library';
+    case '.gbr':
+    case '.drl':
+      return 'Fabrication output';
+    case '.step':
+    case '.stp':
+    case '.wrl':
+      return '3D model';
+    default:
+      return 'KiCad file';
+  }
+}
+
+function iconForNode(
+  node: ProjectTreeNode,
+  diagnostics: TreeDiagnostics
+): string {
+  if (diagnostics.errors > 0) {
+    return 'error';
+  }
+  if (diagnostics.warnings > 0) {
+    return 'warning';
+  }
+
   switch (node.type) {
     case 'project':
       return 'repo';

--- a/apps/vscode-extension/test/unit/projectTreeProvider.test.ts
+++ b/apps/vscode-extension/test/unit/projectTreeProvider.test.ts
@@ -1,11 +1,59 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { KiCadProjectTreeProvider } from '../../src/providers/projectTreeProvider';
-import { Uri } from './vscodeMock';
+import type { ProjectTreeNode } from '../../src/types';
+import {
+  Diagnostic,
+  DiagnosticSeverity,
+  languages,
+  Range,
+  Uri
+} from './vscodeMock';
 
 jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
   virtual: true
 });
 
 describe('KiCadProjectTreeProvider', () => {
+  it('groups core KiCad files by semantic project role', async () => {
+    const rootPath = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kicadstudio-project-tree-')
+    );
+    fs.writeFileSync(path.join(rootPath, 'demo.kicad_pro'), '{}', 'utf8');
+    fs.writeFileSync(path.join(rootPath, 'demo.kicad_sch'), '', 'utf8');
+    fs.writeFileSync(path.join(rootPath, 'upper.KICAD_SCH'), '', 'utf8');
+    fs.writeFileSync(path.join(rootPath, 'demo.kicad_pcb'), '', 'utf8');
+    fs.writeFileSync(path.join(rootPath, 'demo.kicad_dru'), '', 'utf8');
+
+    const provider = new KiCadProjectTreeProvider();
+    const project = await (
+      provider as unknown as {
+        buildWorkspaceNode(path: string): Promise<ProjectTreeNode>;
+      }
+    ).buildWorkspaceNode(rootPath);
+
+    expect(project.children?.map((node) => node.label)).toEqual([
+      'Project Files',
+      'Schematic Sheets',
+      'PCB',
+      'Design Rules'
+    ]);
+    expect(project.children?.[0]?.children?.map((node) => node.label)).toEqual([
+      'demo.kicad_pro'
+    ]);
+    expect(project.children?.[1]?.children).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'upper.KICAD_SCH',
+          type: 'schematic'
+        })
+      ])
+    );
+
+    fs.rmSync(rootPath, { recursive: true, force: true });
+  });
+
   it('uses distinct icons and open commands for KiCad file types', () => {
     const provider = new KiCadProjectTreeProvider();
 
@@ -35,5 +83,57 @@ describe('KiCadProjectTreeProvider', () => {
     );
     expect(rules.iconPath).toEqual(expect.objectContaining({ id: 'law' }));
     expect(rules.command).toEqual(expect.objectContaining({ command: 'vscode.open' }));
+  });
+
+  it('explains file roles and diagnostic state with tooltips and ThemeIcons', () => {
+    const provider = new KiCadProjectTreeProvider();
+    (languages.getDiagnostics as jest.Mock).mockReturnValueOnce([
+      new Diagnostic(
+        new Range(0, 0, 0, 1),
+        'Unconnected pin',
+        DiagnosticSeverity.Error
+      )
+    ]);
+
+    const schematic = provider.getTreeItem({
+      label: 'demo.kicad_sch',
+      type: 'schematic',
+      uri: Uri.file('/project/demo.kicad_sch') as never
+    });
+
+    expect(schematic.description).toContain('Schematic sheet');
+    expect(schematic.tooltip).toContain('Schematic sheet');
+    expect(schematic.tooltip).toContain('1 error');
+    expect(schematic.iconPath).toEqual(expect.objectContaining({ id: 'error' }));
+  });
+
+  it('aggregates diagnostics into project groups', () => {
+    const provider = new KiCadProjectTreeProvider();
+    (languages.getDiagnostics as jest.Mock).mockReturnValueOnce([
+      new Diagnostic(
+        new Range(0, 0, 0, 1),
+        'Unconnected net',
+        DiagnosticSeverity.Warning
+      )
+    ]);
+
+    const schematicGroup = provider.getTreeItem({
+      label: 'Schematic Sheets',
+      type: 'folder',
+      children: [
+        {
+          label: 'demo.kicad_sch',
+          type: 'schematic',
+          uri: Uri.file('/project/demo.kicad_sch') as never
+        }
+      ]
+    });
+
+    expect(schematicGroup.description).toContain('1 warning');
+    expect(schematicGroup.tooltip).toContain('1 visible item');
+    expect(schematicGroup.tooltip).toContain('1 warning');
+    expect(schematicGroup.iconPath).toEqual(
+      expect.objectContaining({ id: 'warning' })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- group core KiCad project files by semantic role in the project tree
- explain file role and state through tree descriptions and tooltips
- surface diagnostic severity through VS Code ThemeIcon error/warning icons, including semantic folder aggregation
- keep uppercase KiCad file extensions in the same project-role grouping and commands as lowercase files
- rebuild the branch on current `main` with a release-policy-compliant `fix(kicad-studio)` commit

## Tracking
- Linear: OASLANA-20
- Closes #21

## Validation
- PASS `corepack pnpm install --frozen-lockfile`
- PASS `corepack pnpm run format:check`
- PASS `corepack pnpm run lint`
- PASS `corepack pnpm run typecheck`
- PASS `corepack pnpm --dir apps/vscode-extension run test:unit -- projectTreeProvider.test.ts`
- PASS `corepack pnpm run check:version`
- PASS `corepack pnpm run test`
- PASS `corepack pnpm run build`
- PASS `git diff --check origin/main...HEAD`
- PASS `uvx pre-commit run --all-files`
- PASS `corepack pnpm run check`
- FAIL `corepack pnpm run verify:dist`
  - Root script is not defined in this repository.

## Notes
- No release, tag, publish, or release-bot PR work is included.
- The previously documented Quality Gate integration blocker is cleared on current `main`; the full root test now passes.
