### PR TITLE
ci(kicad-mcp-pro): add KiCad canary workflow

### DIFF
--- a/.github/workflows/kicad-canary.yml
+++ b/.github/workflows/kicad-canary.yml
@@ -1,0 +1,128 @@
+name: KiCad Canary
+
+on:
+  workflow_dispatch:
+    inputs:
+      include-manual-lanes:
+        description: Include deprecated compatibility lanes marked manual.
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    - cron: "41 5 * * 4"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kicad-canary-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      lanes: ${{ steps.lanes.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          version-file: packages/mcp-server/uv.toml
+      - run: uv sync --all-extras --frozen --project packages/mcp-server
+      - name: Build KiCad canary matrix
+        id: lanes
+        env:
+          INCLUDE_MANUAL_LANES: ${{ inputs['include-manual-lanes'] || 'false' }}
+        run: |
+          args=()
+          if [ "$INCLUDE_MANUAL_LANES" = "true" ]; then
+            args+=(--include-manual)
+          fi
+          matrix="$(uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/kicad_canary.py matrix "${args[@]}")"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  cli:
+    needs: matrix
+    runs-on: ubuntu-24.04
+    continue-on-error: ${{ matrix.continue_on_error }}
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.matrix.outputs.lanes) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          version-file: packages/mcp-server/uv.toml
+      - run: uv sync --all-extras --frozen --project packages/mcp-server
+      - name: Install KiCad lane
+        env:
+          KICAD_PACKAGE: ${{ matrix.package }}
+          KICAD_PPA: ${{ matrix.ppa }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes software-properties-common
+          sudo add-apt-repository --yes "$KICAD_PPA"
+          sudo apt-get update
+          sudo apt-get install --yes "$KICAD_PACKAGE"
+      - name: Run KiCad CLI canary
+        env:
+          KICAD_CANARY_RANGE: ${{ matrix.range }}
+        run: |
+          uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/kicad_canary.py run \
+            --artifacts "artifacts/kicad-canary/${{ matrix.id }}" \
+            --kicad-range "$KICAD_CANARY_RANGE"
+      - name: Upload KiCad canary artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: kicad-canary-${{ matrix.id }}
+          path: artifacts/kicad-canary/${{ matrix.id }}
+          if-no-files-found: warn
+          retention-days: 14
+      - name: Open or update compatibility issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KICAD_CANARY_CI: ${{ matrix.ci }}
+          KICAD_CANARY_ID: ${{ matrix.id }}
+          KICAD_CANARY_RANGE: ${{ matrix.range }}
+          KICAD_CANARY_STATE: ${{ matrix.state }}
+        run: |
+          body="$(mktemp)"
+          {
+            echo "KiCad canary lane \`$KICAD_CANARY_ID\` failed."
+            echo
+            echo "- Compatibility range: \`$KICAD_CANARY_RANGE\`"
+            echo "- Lifecycle state: \`$KICAD_CANARY_STATE\`"
+            echo "- CI mode: \`$KICAD_CANARY_CI\`"
+            echo "- Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "- Artifact: \`kicad-canary-$KICAD_CANARY_ID\`"
+            echo
+            echo "Inspect \`summary.json\`, command logs, generated reports, and \`failing-fixtures.txt\` in the uploaded artifact before changing support status."
+          } > "$body"
+          issue_number="$(gh issue list --state open --label compatibility --search 'KiCad canary compatibility failure in:title' --json number --jq '.[0].number // empty')"
+          if [ -n "$issue_number" ]; then
+            gh issue comment "$issue_number" --body-file "$body"
+            if [ "$KICAD_CANARY_STATE" = "primary" ]; then
+              gh issue edit "$issue_number" --add-label release-blocker
+            fi
+          else
+            labels="compatibility,needs:reproduction,ci,product:repo"
+            if [ "$KICAD_CANARY_STATE" = "primary" ]; then
+              labels="$labels,release-blocker"
+            fi
+            gh issue create \
+              --title "KiCad canary compatibility failure" \
+              --label "$labels" \
+              --body-file "$body"
+          fi

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -18,6 +18,7 @@ notes can add detail, but they should not weaken these gates.
 | Fixture gate         | Parser, diagnostics, command-builder, or KiCad file behavior changes | Prove deterministic KiCad corpus behavior stays stable.                                         | `corepack pnpm run test:fixtures`             |
 | Nightly quality gate | Scheduled and manual workflow                                        | Re-run the repository gate plus contract and fixture gates outside the fast PR path.            | `.github/workflows/nightly-quality-gates.yml` |
 | VS Code canary       | Scheduled and manual workflow                                        | Check supported VS Code host lanes before runtime/API changes reach users.                      | `.github/workflows/vscode-canary.yml`         |
+| KiCad canary         | Scheduled and manual workflow                                        | Check supported KiCad CLI lanes against real fixture exports without publishing packages.       | `.github/workflows/kicad-canary.yml`          |
 | Manual smoke         | Release candidate only                                               | Final human inspection where automation is not practical.                                       | PR notes must name the exact manual check     |
 
 ## Test Layers
@@ -115,6 +116,20 @@ As the M1-M4 roadmap lands, extend this workflow in focused PRs:
 | VS Code canary             | OASLANA-81     | Run current stable, insiders, and minimum supported VS Code versions.                                                          |
 | KiCad canary               | OASLANA-82     | Run primary, supported, deprecated, and prerelease KiCad CLI lanes where practical.                                            |
 
+## KiCad Canary
+
+`.github/workflows/kicad-canary.yml` runs real `kicad-cli` compatibility lanes
+from `compatibility.yaml` every week and on manual dispatch. Required and
+scheduled lanes run by default; manual dispatch can opt into deprecated lanes
+that remain documented but should not block normal scheduled canaries.
+
+Each lane writes command logs, KiCad reports, manufacturing export outputs,
+`summary.json`, and `failing-fixtures.txt` into an artifact named after the
+lane. Manufacturing exports are enabled only when the matrix feature gate lists
+that KiCad range. Primary-lane failures fail the workflow and create or update a
+compatibility issue with the `release-blocker` label; prerelease and deprecated
+lanes report artifacts and issue comments without blocking the default branch.
+
 ## VS Code Canary
 
 `.github/workflows/vscode-canary.yml` launches a focused extension host smoke
@@ -201,6 +216,8 @@ CI ownership follows product boundaries:
 - `.github/workflows/nightly-quality-gates.yml` owns the non-release scheduled
   quality gate.
 - `.github/workflows/vscode-canary.yml` owns scheduled/manual VS Code
+  compatibility lanes sourced from `compatibility.yaml`.
+- `.github/workflows/kicad-canary.yml` owns scheduled/manual real KiCad CLI
   compatibility lanes sourced from `compatibility.yaml`.
 - Product-specific validation remains inside each product package so the root
   workflow can compose it without direct source imports between products.

--- a/packages/mcp-server/scripts/kicad_canary.py
+++ b/packages/mcp-server/scripts/kicad_canary.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Generate KiCad canary lanes and run artifact-producing CLI smoke checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+MCP_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = MCP_ROOT.parents[1]
+FIXTURE_ROOT = REPO_ROOT / "apps" / "vscode-extension" / "test" / "fixtures" / "kicad"
+DEFAULT_TIMEOUT_SECONDS = 180
+KICAD_VIOLATION_EXIT_CODE = 5
+
+INSTALLERS = {
+    "10.0.x": {
+        "release_ppa": "ppa:kicad/kicad-10.0-releases",
+        "nightly_ppa": "ppa:kicad/kicad-10.0-nightly",
+        "package": "kicad",
+    },
+    "9.x": {
+        "release_ppa": "ppa:kicad/kicad-9.0-releases",
+        "package": "kicad",
+    },
+    "8.x": {
+        "release_ppa": "ppa:kicad/kicad-8.0-releases",
+        "package": "kicad",
+    },
+}
+
+
+@dataclass(frozen=True)
+class CanaryStep:
+    """One KiCad CLI canary command and its artifact expectations."""
+
+    name: str
+    fixture: str
+    args: tuple[str, ...]
+    outputs: tuple[Path, ...] = ()
+    expects_violations: bool = False
+
+
+def _read_compatibility_matrix() -> dict[str, Any]:
+    data = yaml.safe_load((REPO_ROOT / "compatibility.yaml").read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise TypeError("compatibility.yaml must contain a YAML mapping")
+    return data
+
+
+def _entry_value(entry: object, key: str) -> str:
+    if not isinstance(entry, dict):
+        raise TypeError(f"KiCad compatibility entry must be a mapping, got {entry!r}")
+    value = entry.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"KiCad compatibility entry missing string {key!r}: {entry!r}")
+    return value
+
+
+def _lane_id(kicad_range: str, state: str) -> str:
+    major = _expected_major(kicad_range)
+    return f"kicad-{major}-{state}"
+
+
+def _expected_major(kicad_range: str) -> int:
+    match = re.match(r"(?P<major>\d+)", kicad_range)
+    if match is None:
+        raise ValueError(f"Cannot derive KiCad major version from range {kicad_range!r}")
+    return int(match.group("major"))
+
+
+def _release_lane(entry: object) -> dict[str, object]:
+    kicad_range = _entry_value(entry, "range")
+    state = _entry_value(entry, "state")
+    ci_mode = _entry_value(entry, "ci")
+    installer = INSTALLERS.get(kicad_range)
+    if installer is None:
+        raise ValueError(f"No canary installer metadata for KiCad range {kicad_range!r}")
+    return {
+        "id": _lane_id(kicad_range, state),
+        "range": kicad_range,
+        "state": state,
+        "ci": ci_mode,
+        "ppa": installer["release_ppa"],
+        "package": installer["package"],
+        "continue_on_error": state == "deprecated",
+    }
+
+
+def _nightly_lane(primary_range: str) -> dict[str, object]:
+    installer = INSTALLERS.get(primary_range)
+    if installer is None or "nightly_ppa" not in installer:
+        raise ValueError(f"No nightly canary installer metadata for {primary_range!r}")
+    return {
+        "id": f"kicad-{_expected_major(primary_range)}-nightly",
+        "range": primary_range,
+        "state": "prerelease",
+        "ci": "scheduled",
+        "ppa": installer["nightly_ppa"],
+        "package": installer["package"],
+        "continue_on_error": True,
+    }
+
+
+def build_canary_matrix(
+    compatibility: dict[str, Any],
+    *,
+    include_manual: bool,
+) -> dict[str, list[dict[str, object]]]:
+    """Return GitHub Actions matrix lanes derived from compatibility metadata."""
+    kicad = compatibility.get("kicad")
+    if not isinstance(kicad, dict):
+        raise ValueError("compatibility metadata missing kicad mapping")
+    entries = kicad.get("supported")
+    if not isinstance(entries, list):
+        raise ValueError("compatibility metadata missing kicad.supported list")
+
+    lanes = [
+        _release_lane(entry)
+        for entry in entries
+        if (ci_mode := _entry_value(entry, "ci")) in {"required", "scheduled"}
+        or include_manual
+        and ci_mode == "manual"
+    ]
+    primary = kicad.get("primary")
+    if not isinstance(primary, str) or not primary:
+        raise ValueError("compatibility metadata missing kicad.primary")
+    lanes.append(_nightly_lane(primary))
+    return {"include": lanes}
+
+
+def supports_feature_gate(
+    compatibility: dict[str, Any],
+    feature_name: str,
+    kicad_range: str,
+) -> bool:
+    """Return whether a KiCad range is included in a compatibility feature gate."""
+    feature_gates = compatibility.get("featureGates")
+    if not isinstance(feature_gates, dict):
+        return False
+    feature = feature_gates.get(feature_name)
+    if not isinstance(feature, dict):
+        return False
+    ranges = feature.get("kicad")
+    return isinstance(ranges, list) and kicad_range in ranges
+
+
+def _project_file(fixture: str, suffix: str) -> Path:
+    matches = sorted((FIXTURE_ROOT / fixture).glob(f"*{suffix}"))
+    if len(matches) != 1:
+        raise FileNotFoundError(
+            f"Expected one {suffix} file in fixture {fixture!r}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _command_plan(
+    artifacts: Path,
+    compatibility: dict[str, Any],
+    kicad_range: str,
+) -> list[CanaryStep]:
+    clean_schematic = _project_file("clean-led-kicad10", ".kicad_sch")
+    clean_board = _project_file("clean-led-kicad10", ".kicad_pcb")
+    dirty_erc = _project_file("erc-power-pin-error", ".kicad_sch")
+    dirty_drc = _project_file("drc-courtyard-error", ".kicad_pcb")
+
+    reports = artifacts / "reports"
+    manufacturing = artifacts / "manufacturing"
+    steps = [
+        CanaryStep(name="version", fixture="compatibility", args=("version",)),
+        CanaryStep(
+            name="clean-erc",
+            fixture="clean-led-kicad10",
+            args=(
+                "sch",
+                "erc",
+                "--format",
+                "json",
+                "--severity-all",
+                "--output",
+                str(reports / "clean-erc.json"),
+                str(clean_schematic),
+            ),
+            outputs=(reports / "clean-erc.json",),
+        ),
+        CanaryStep(
+            name="dirty-erc",
+            fixture="erc-power-pin-error",
+            args=(
+                "sch",
+                "erc",
+                "--format",
+                "json",
+                "--severity-all",
+                "--exit-code-violations",
+                "--output",
+                str(reports / "dirty-erc.json"),
+                str(dirty_erc),
+            ),
+            outputs=(reports / "dirty-erc.json",),
+            expects_violations=True,
+        ),
+        CanaryStep(
+            name="clean-drc",
+            fixture="clean-led-kicad10",
+            args=(
+                "pcb",
+                "drc",
+                "--format",
+                "json",
+                "--severity-all",
+                "--output",
+                str(reports / "clean-drc.json"),
+                str(clean_board),
+            ),
+            outputs=(reports / "clean-drc.json",),
+        ),
+        CanaryStep(
+            name="dirty-drc",
+            fixture="drc-courtyard-error",
+            args=(
+                "pcb",
+                "drc",
+                "--format",
+                "json",
+                "--severity-all",
+                "--exit-code-violations",
+                "--output",
+                str(reports / "dirty-drc.json"),
+                str(dirty_drc),
+            ),
+            outputs=(reports / "dirty-drc.json",),
+            expects_violations=True,
+        ),
+        CanaryStep(
+            name="bom",
+            fixture="clean-led-kicad10",
+            args=(
+                "sch",
+                "export",
+                "bom",
+                "--format-preset",
+                "CSV",
+                "--output",
+                str(reports / "bom.csv"),
+                str(clean_schematic),
+            ),
+            outputs=(reports / "bom.csv",),
+        ),
+        CanaryStep(
+            name="netlist",
+            fixture="clean-led-kicad10",
+            args=(
+                "sch",
+                "export",
+                "netlist",
+                "--format",
+                "kicadsexpr",
+                "--output",
+                str(reports / "netlist.net"),
+                str(clean_schematic),
+            ),
+            outputs=(reports / "netlist.net",),
+        ),
+        CanaryStep(
+            name="board-stats",
+            fixture="clean-led-kicad10",
+            args=(
+                "pcb",
+                "export",
+                "stats",
+                "--output",
+                str(reports / "board-stats.txt"),
+                str(clean_board),
+            ),
+            outputs=(reports / "board-stats.txt",),
+        ),
+    ]
+    if supports_feature_gate(compatibility, "manufacturingExports", kicad_range):
+        steps.extend(
+            [
+                CanaryStep(
+                    name="gerbers",
+                    fixture="clean-led-kicad10",
+                    args=(
+                        "pcb",
+                        "export",
+                        "gerbers",
+                        "--layers",
+                        "F.Cu,B.Cu,F.Silkscreen,B.Silkscreen,F.Mask,B.Mask,Edge.Cuts",
+                        "--output",
+                        str(manufacturing / "gerbers"),
+                        str(clean_board),
+                    ),
+                ),
+                CanaryStep(
+                    name="drill",
+                    fixture="clean-led-kicad10",
+                    args=(
+                        "pcb",
+                        "export",
+                        "drill",
+                        "--output",
+                        str(manufacturing / "drill"),
+                        str(clean_board),
+                    ),
+                ),
+            ]
+        )
+    return steps
+
+
+def _cli_candidates() -> list[Path]:
+    candidates: list[Path] = []
+    for name in ("KICAD_CANARY_KICAD_CLI", "KICAD_MCP_KICAD_CLI", "KICAD_CLI_PATH"):
+        raw = os.environ.get(name, "").strip()
+        if raw:
+            candidates.append(Path(raw).expanduser())
+    discovered = shutil.which("kicad-cli")
+    if discovered:
+        candidates.append(Path(discovered))
+    return candidates
+
+
+def _resolve_cli() -> Path:
+    for candidate in _cli_candidates():
+        if candidate.exists() and candidate.is_file():
+            return candidate.resolve()
+    searched = ", ".join(str(candidate) for candidate in _cli_candidates()) or "<none>"
+    raise FileNotFoundError(f"kicad-cli not found via canary env or PATH. Candidates: {searched}")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _subprocess_output_text(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="ignore")
+    return str(value)
+
+
+def _run_step(cli: Path, step: CanaryStep, artifacts: Path) -> dict[str, object]:
+    command = [str(cli), *step.args]
+    error: str | None = None
+    try:
+        result = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+            check=False,
+        )
+        stdout = result.stdout
+        stderr = result.stderr
+        returncode = result.returncode
+    except subprocess.TimeoutExpired as exc:
+        stdout = _subprocess_output_text(exc.stdout or exc.output)
+        stderr = _subprocess_output_text(exc.stderr)
+        error = f"Command timed out after {exc.timeout} seconds"
+        if stderr and not stderr.endswith("\n"):
+            stderr += "\n"
+        stderr += f"{error}\n"
+        returncode = -1
+    except (OSError, subprocess.SubprocessError) as exc:
+        stdout = ""
+        error = f"{type(exc).__name__}: {exc}"
+        stderr = f"{error}\n"
+        returncode = -1
+
+    logs = artifacts / "logs"
+    _write_text(logs / f"{step.name}.command.txt", shlex.join(command) + "\n")
+    _write_text(logs / f"{step.name}.stdout.log", stdout)
+    _write_text(logs / f"{step.name}.stderr.log", stderr)
+
+    outputs_exist = all(path.exists() and path.stat().st_size > 0 for path in step.outputs)
+    command_ok = (
+        returncode == KICAD_VIOLATION_EXIT_CODE if step.expects_violations else returncode == 0
+    )
+    step_result: dict[str, object] = {
+        "name": step.name,
+        "fixture": step.fixture,
+        "returncode": returncode,
+        "expectsViolations": step.expects_violations,
+        "outputs": [str(path.relative_to(artifacts)) for path in step.outputs],
+        "ok": command_ok and outputs_exist,
+    }
+    if error is not None:
+        step_result["error"] = error
+    return step_result
+
+
+def _version_range_error(version_result: dict[str, object], kicad_range: str) -> str | None:
+    stdout_path = Path(str(version_result["stdout"]))
+    stderr_path = Path(str(version_result["stderr"]))
+    output = "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore")
+        for path in (stdout_path, stderr_path)
+        if path.exists()
+    )
+    match = re.search(r"\b(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?\b", output)
+    if match is None:
+        return f"Could not read KiCad version from canary logs for {kicad_range}"
+
+    range_match = re.fullmatch(r"(?P<major>\d+)(?:\.(?P<minor>\d+))?\.x", kicad_range)
+    if range_match is None:
+        return f"Unsupported KiCad canary range {kicad_range}"
+
+    actual_major = int(match.group("major"))
+    actual_minor = int(match.group("minor"))
+    expected_major = int(range_match.group("major"))
+    expected_minor = range_match.group("minor")
+    if actual_major != expected_major:
+        return f"KiCad version output does not match configured range {kicad_range}: {output}"
+    if expected_minor is not None and actual_minor != int(expected_minor):
+        return f"KiCad version output does not match configured range {kicad_range}: {output}"
+    return None
+
+
+def _assert_version_matches_range(version_result: dict[str, object], kicad_range: str) -> None:
+    error = _version_range_error(version_result, kicad_range)
+    if error is not None:
+        raise RuntimeError(error)
+
+
+def run_canary(artifacts: Path, kicad_range: str) -> int:
+    """Run the KiCad CLI canary plan and write reports and logs to artifacts."""
+    compatibility = _read_compatibility_matrix()
+    cli = _resolve_cli()
+    artifacts.mkdir(parents=True, exist_ok=True)
+
+    steps = _command_plan(artifacts, compatibility, kicad_range)
+    results = [_run_step(cli, step, artifacts) for step in steps]
+    version = next(result for result in results if result["name"] == "version")
+    version["stdout"] = str(artifacts / "logs" / "version.stdout.log")
+    version["stderr"] = str(artifacts / "logs" / "version.stderr.log")
+    version_error = _version_range_error(version, kicad_range)
+    if version_error is not None:
+        version["ok"] = False
+        version["error"] = version_error
+
+    failing_fixtures = sorted(
+        {str(result["fixture"]) for result in results if not bool(result["ok"])}
+    )
+    summary = {
+        "kicadRange": kicad_range,
+        "kicadCli": str(cli),
+        "manufacturingExports": supports_feature_gate(
+            compatibility,
+            "manufacturingExports",
+            kicad_range,
+        ),
+        "results": results,
+        "failingFixtures": failing_fixtures,
+    }
+    _write_text(artifacts / "summary.json", json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    _write_text(artifacts / "failing-fixtures.txt", "\n".join(failing_fixtures) + "\n")
+
+    if failing_fixtures:
+        print(f"KiCad canary failed for fixture(s): {', '.join(failing_fixtures)}", file=sys.stderr)
+        return 1
+    print(f"KiCad canary passed for {kicad_range}; artifacts written to {artifacts}.")
+    return 0
+
+
+def _write_matrix(include_manual: bool) -> int:
+    matrix = build_canary_matrix(_read_compatibility_matrix(), include_manual=include_manual)
+    print(json.dumps(matrix, separators=(",", ":")))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    matrix_parser = subcommands.add_parser("matrix", help="Print the GitHub Actions canary matrix.")
+    matrix_parser.add_argument(
+        "--include-manual",
+        action="store_true",
+        help="Include compatibility lanes marked manual.",
+    )
+
+    run_parser = subcommands.add_parser("run", help="Run KiCad CLI canary commands.")
+    run_parser.add_argument("--artifacts", type=Path, required=True)
+    run_parser.add_argument("--kicad-range", required=True)
+
+    args = parser.parse_args(argv)
+    if args.command == "matrix":
+        return _write_matrix(args.include_manual)
+    if args.command == "run":
+        return run_canary(args.artifacts, args.kicad_range)
+    raise AssertionError(f"Unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/mcp-server/tests/unit/test_kicad_canary.py
+++ b/packages/mcp-server/tests/unit/test_kicad_canary.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from scripts import kicad_canary
+from scripts.kicad_canary import CanaryStep, build_canary_matrix, supports_feature_gate
+
+
+def _compatibility_matrix() -> dict[str, object]:
+    return {
+        "kicad": {
+            "primary": "10.0.x",
+            "supported": [
+                {
+                    "range": "10.0.x",
+                    "state": "primary",
+                    "ci": "required",
+                },
+                {
+                    "range": "9.x",
+                    "state": "supported",
+                    "ci": "scheduled",
+                },
+                {
+                    "range": "8.x",
+                    "state": "deprecated",
+                    "ci": "manual",
+                },
+            ],
+        },
+        "featureGates": {
+            "manufacturingExports": {
+                "kicad": ["9.x", "10.0.x"],
+            }
+        },
+    }
+
+
+def test_kicad_canary_matrix_uses_scheduled_compatibility_lanes() -> None:
+    matrix = build_canary_matrix(_compatibility_matrix(), include_manual=False)
+
+    assert matrix == {
+        "include": [
+            {
+                "id": "kicad-10-primary",
+                "range": "10.0.x",
+                "state": "primary",
+                "ci": "required",
+                "ppa": "ppa:kicad/kicad-10.0-releases",
+                "package": "kicad",
+                "continue_on_error": False,
+            },
+            {
+                "id": "kicad-9-supported",
+                "range": "9.x",
+                "state": "supported",
+                "ci": "scheduled",
+                "ppa": "ppa:kicad/kicad-9.0-releases",
+                "package": "kicad",
+                "continue_on_error": False,
+            },
+            {
+                "id": "kicad-10-nightly",
+                "range": "10.0.x",
+                "state": "prerelease",
+                "ci": "scheduled",
+                "ppa": "ppa:kicad/kicad-10.0-nightly",
+                "package": "kicad",
+                "continue_on_error": True,
+            },
+        ]
+    }
+
+
+def test_kicad_canary_matrix_exposes_manual_deprecated_lane_on_dispatch() -> None:
+    matrix = build_canary_matrix(_compatibility_matrix(), include_manual=True)
+
+    assert matrix["include"][2] == {
+        "id": "kicad-8-deprecated",
+        "range": "8.x",
+        "state": "deprecated",
+        "ci": "manual",
+        "ppa": "ppa:kicad/kicad-8.0-releases",
+        "package": "kicad",
+        "continue_on_error": True,
+    }
+    assert matrix["include"][3]["id"] == "kicad-10-nightly"
+
+
+def test_kicad_canary_gates_manufacturing_exports_by_compatibility_range() -> None:
+    compatibility = _compatibility_matrix()
+
+    assert supports_feature_gate(compatibility, "manufacturingExports", "10.0.x")
+    assert supports_feature_gate(compatibility, "manufacturingExports", "9.x")
+    assert not supports_feature_gate(compatibility, "manufacturingExports", "8.x")
+
+
+def test_violation_step_only_accepts_documented_kicad_exit_code(tmp_path: Path) -> None:
+    cli = Path(sys.executable)
+    script = tmp_path / "fake_kicad_cli.py"
+    script.write_text("import sys\nsys.exit(2)\n", encoding="utf-8")
+
+    result = kicad_canary._run_step(
+        cli,
+        CanaryStep(
+            name="dirty-drc",
+            fixture="dirty",
+            args=(str(script),),
+            expects_violations=True,
+        ),
+        tmp_path / "artifacts",
+    )
+
+    assert result["returncode"] == 2
+    assert result["ok"] is False
+
+
+def test_timeout_step_writes_artifact_logs(tmp_path: Path, monkeypatch) -> None:
+    cli = Path(sys.executable)
+    script = tmp_path / "hanging_kicad_cli.py"
+    script.write_text(
+        "import time\nprint('started', flush=True)\ntime.sleep(1)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(kicad_canary, "DEFAULT_TIMEOUT_SECONDS", 0.01)
+    artifacts = tmp_path / "artifacts"
+
+    result = kicad_canary._run_step(
+        cli,
+        CanaryStep(name="version", fixture="compatibility", args=(str(script),)),
+        artifacts,
+    )
+
+    assert result["ok"] is False
+    assert result["returncode"] == -1
+    assert "timed out" in (artifacts / "logs" / "version.stderr.log").read_text(encoding="utf-8")
+
+
+def test_version_range_rejects_wrong_minor_for_minor_pinned_range(tmp_path: Path) -> None:
+    stdout = tmp_path / "version.stdout.log"
+    stderr = tmp_path / "version.stderr.log"
+    stdout.write_text("KiCad 10.1.0\n", encoding="utf-8")
+    stderr.write_text("", encoding="utf-8")
+
+    error = kicad_canary._version_range_error(
+        {"stdout": str(stdout), "stderr": str(stderr)},
+        "10.0.x",
+    )
+
+    assert error is not None
+    assert "10.0.x" in error
+
+
+def test_run_canary_writes_summary_when_version_range_fails(tmp_path: Path, monkeypatch) -> None:
+    cli = Path(sys.executable)
+    script = tmp_path / "version_kicad_cli.py"
+    script.write_text("print('KiCad 10.1.0')\n", encoding="utf-8")
+
+    monkeypatch.setattr(kicad_canary, "_resolve_cli", lambda: cli)
+    monkeypatch.setattr(kicad_canary, "_read_compatibility_matrix", _compatibility_matrix)
+    monkeypatch.setattr(
+        kicad_canary,
+        "_command_plan",
+        lambda artifacts, compatibility, kicad_range: [
+            CanaryStep(name="version", fixture="compatibility", args=(str(script),))
+        ],
+    )
+
+    artifacts = tmp_path / "artifacts"
+    exit_code = kicad_canary.run_canary(artifacts, "10.0.x")
+
+    assert exit_code == 1
+    assert (artifacts / "summary.json").exists()
+    assert (artifacts / "failing-fixtures.txt").read_text(encoding="utf-8") == ("compatibility\n")


### PR DESCRIPTION
## Summary

- add a scheduled/manual KiCad canary workflow sourced from `compatibility.yaml` lane metadata
- add the artifact-producing `kicad_canary.py` runner for version, ERC/DRC, BOM/netlist, board stats, and feature-gated manufacturing export smoke checks
- harden canary failure handling so timeouts, launch failures, wrong minor versions, and non-5 violation exits produce failing summaries instead of false-green results
- document the canary gate and cover matrix/manual-lane/feature-gate/error behavior with unit tests

## Linked issue

Closes #83
Linear: OASLANA-82

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- PASS `corepack pnpm install --frozen-lockfile`
- PASS `corepack pnpm run format:check`
- PASS `corepack pnpm run lint`
- PASS `corepack pnpm run typecheck`
- PASS `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_kicad_canary.py -q`
- PASS `uv run --project packages/mcp-server --all-extras ruff format packages/mcp-server/scripts/kicad_canary.py packages/mcp-server/tests/unit/test_kicad_canary.py`
- PASS `uv run --project packages/mcp-server --all-extras ruff check packages/mcp-server/scripts/kicad_canary.py packages/mcp-server/tests/unit/test_kicad_canary.py`
- PASS `corepack pnpm run test`
- PASS `corepack pnpm run build`
- PASS `(cd packages/mcp-server && uv sync --all-extras --frozen && uv run --all-extras pytest)`
- PASS `uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/check_workflows.py --actionlint`
- PASS `uvx yamllint .github/workflows/kicad-canary.yml`
- PASS `npx --yes -p node@24 -c 'corepack pnpm --dir packages/mcp-server run workflows:security'`
- PASS `npx --yes -p node@24 -c 'corepack pnpm --dir apps/vscode-extension run workflows:lint'`
- PASS `npx --yes -p node@24 -c 'corepack pnpm run check:testing-strategy'`
- PASS `npx --yes -p node@24 -c 'corepack pnpm run check'` after removing ignored local `.vscode-test/` downloaded by the integration test host
- PASS `uvx pre-commit run --all-files`
- PASS `corepack pnpm audit --audit-level high`
- PASS `git diff --check`
- BLOCKED `corepack pnpm run verify:dist`: root package has no `verify:dist` script
- BLOCKED `act -l`: `act` is not installed locally

## Protocol / MCP impact

- [x] Not applicable; reason: workflow and KiCad CLI canary runner only
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [x] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
