### PR TITLE
ci(kicad-studio/kicad-mcp-pro): add VS Code canary workflow

### DIFF
--- a/.github/workflows/vscode-canary.yml
+++ b/.github/workflows/vscode-canary.yml
@@ -1,0 +1,106 @@
+name: VS Code Canary
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 4 * * 2"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vscode-canary-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      lanes: ${{ steps.lanes.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          version-file: packages/mcp-server/uv.toml
+      - run: uv sync --all-extras --frozen --project packages/mcp-server
+      - name: Build VS Code canary matrix
+        id: lanes
+        run: |
+          matrix="$(uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/vscode_canary.py matrix)"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  extension-host:
+    needs: matrix
+    runs-on: ubuntu-24.04
+    continue-on-error: ${{ matrix.continue_on_error }}
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.lanes) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - run: corepack enable
+      - run: corepack pnpm install --frozen-lockfile
+      - name: Run VS Code canary unit smokes
+        run: corepack pnpm --filter kicadstudio run test:unit
+      - name: Run VS Code extension host canary
+        env:
+          KICADSTUDIO_VSCODE_TEST_SUITE: canary
+          KICADSTUDIO_VSCODE_VERSION: ${{ matrix.version }}
+        run: xvfb-run -a corepack pnpm --filter kicadstudio run test:integration
+      - name: Upload VS Code canary artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: vscode-canary-${{ matrix.id }}
+          path: |
+            apps/vscode-extension/test-results
+            apps/vscode-extension/.vscode-test/logs
+          if-no-files-found: ignore
+          retention-days: 14
+      - name: Open or update compatibility issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VSCODE_CANARY_ID: ${{ matrix.id }}
+          VSCODE_CANARY_STATE: ${{ matrix.state }}
+          VSCODE_CANARY_VERSION: ${{ matrix.version }}
+        run: |
+          body="$(mktemp)"
+          {
+            echo "VS Code canary lane \`$VSCODE_CANARY_ID\` failed."
+            echo
+            echo "- Tested version selector: \`$VSCODE_CANARY_VERSION\`"
+            echo "- Lifecycle state: \`$VSCODE_CANARY_STATE\`"
+            echo "- Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "- Artifact: \`vscode-canary-$VSCODE_CANARY_ID\`"
+            echo
+            echo "Inspect the extension-host logs and uploaded test artifacts before changing the VS Code support matrix."
+          } > "$body"
+          issue_number="$(gh issue list --state open --label compatibility --search 'VS Code canary compatibility failure in:title' --json number --jq '.[0].number // empty')"
+          if [ -n "$issue_number" ]; then
+            gh issue comment "$issue_number" --body-file "$body"
+            if [ "$VSCODE_CANARY_STATE" = "primary" ]; then
+              gh issue edit "$issue_number" --add-label release-blocker
+            fi
+          else
+            labels="compatibility,needs:reproduction,ci,product:repo"
+            if [ "$VSCODE_CANARY_STATE" = "primary" ]; then
+              labels="$labels,release-blocker"
+            fi
+            gh issue create \
+              --title "VS Code canary compatibility failure" \
+              --label "$labels" \
+              --body-file "$body"
+          fi

--- a/apps/vscode-extension/test/canarySuite/index.ts
+++ b/apps/vscode-extension/test/canarySuite/index.ts
@@ -1,0 +1,24 @@
+import * as path from 'node:path';
+import Mocha from 'mocha';
+
+export async function run(): Promise<void> {
+  const mocha = new Mocha({
+    ui: 'tdd',
+    color: true,
+    timeout: 20000
+  });
+
+  mocha.addFile(
+    path.resolve(__dirname, '..', 'integration', 'canaryCompatibility.test.js')
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    mocha.run((failures: number) => {
+      if (failures > 0) {
+        reject(new Error(`${failures} VS Code canary smoke tests failed.`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}

--- a/apps/vscode-extension/test/integration/canaryCompatibility.test.ts
+++ b/apps/vscode-extension/test/integration/canaryCompatibility.test.ts
@@ -1,0 +1,138 @@
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+
+type ViewContribution = {
+  id?: string;
+  when?: string;
+};
+
+suite('VS Code Canary Compatibility', () => {
+  let extension: vscode.Extension<unknown>;
+  let workspaceRoot: string;
+
+  suiteSetup(() => {
+    const canaryExtension = vscode.extensions.getExtension(
+      'oaslananka.kicadstudio'
+    );
+    assert.ok(canaryExtension, 'Expected KiCad Studio extension to load.');
+    extension = canaryExtension;
+
+    const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    assert.ok(root, 'Expected test workspace root to be available.');
+    workspaceRoot = root;
+  });
+
+  setup(async () => {
+    await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+  });
+
+  teardown(async () => {
+    await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+  });
+
+  test('activates command, context-key, tree, and MCP Tools surfaces', async () => {
+    await extension.activate();
+
+    const commands = await vscode.commands.getCommands(true);
+    for (const command of [
+      'kicadstudio.openSchematic',
+      'kicadstudio.openPCB',
+      'kicadstudio.runDRC',
+      'kicadstudio.runERC',
+      'kicadstudio.mcp.retry'
+    ]) {
+      assert.ok(commands.includes(command), `Missing command ${command}`);
+    }
+
+    const sidebarViews =
+      (extension.packageJSON?.contributes?.views?.[
+        'kicadstudio-sidebar'
+      ] as ViewContribution[] | undefined) ?? [];
+    assert.ok(
+      sidebarViews.some((view) => view.id === 'kicadstudio.projectTree'),
+      'Missing projectTree view contribution.'
+    );
+    assert.ok(
+      sidebarViews.some((view) => view.id === 'kicadstudio.mcpTools'),
+      'Missing mcpTools view contribution.'
+    );
+
+    const qualityGateView = sidebarViews.find(
+      (view) => view.id === 'kicadstudio.qualityGate'
+    );
+    const qualityGateWhen = qualityGateView?.when ?? '';
+    assert.ok(
+      qualityGateWhen.includes('kicadstudio.hasProject'),
+      'Expected project-gated quality gate contribution.'
+    );
+    assert.ok(
+      !qualityGateWhen.includes('kicadstudio.mcpConnected'),
+      'Expected quality gate to remain available before MCP connects.'
+    );
+  });
+
+  test('registers custom editors and bootstraps the schematic webview host', async () => {
+    const customEditors = extension.packageJSON?.contributes?.customEditors ?? [];
+    assert.ok(
+      customEditors.some(
+        (item: { viewType?: string }) =>
+          item.viewType === 'kicadstudio.schematicViewer'
+      )
+    );
+    assert.ok(
+      customEditors.some(
+        (item: { viewType?: string }) =>
+          item.viewType === 'kicadstudio.pcbViewer'
+      )
+    );
+
+    const resource = vscode.Uri.file(
+      path.join(workspaceRoot, 'sample.kicad_sch')
+    );
+    await vscode.commands.executeCommand(
+      'vscode.openWith',
+      resource,
+      'kicadstudio.schematicViewer'
+    );
+
+    const tab = await waitForCustomTab(resource, 'kicadstudio.schematicViewer');
+    assert.ok(tab.isActive, 'Expected the canary custom editor tab to activate.');
+  });
+
+  test('opens a KiCad document through the diagnostics lifecycle smoke path', async () => {
+    const resource = vscode.Uri.file(
+      path.join(workspaceRoot, 'sample.kicad_sch')
+    );
+    const document = await vscode.workspace.openTextDocument(resource);
+
+    assert.strictEqual(document.languageId, 'kicad-schematic');
+    assert.ok(Array.isArray(vscode.languages.getDiagnostics(resource)));
+  });
+});
+
+async function waitForCustomTab(
+  resource: vscode.Uri,
+  viewType: string
+): Promise<vscode.Tab> {
+  const timeoutAt = Date.now() + 20000;
+
+  while (Date.now() < timeoutAt) {
+    const tab = vscode.window.tabGroups.all
+      .flatMap((group) => group.tabs)
+      .find(
+        (candidate) =>
+          candidate.input instanceof vscode.TabInputCustom &&
+          candidate.input.viewType === viewType &&
+          candidate.input.uri.fsPath === resource.fsPath
+      );
+    if (tab) {
+      return tab;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error(
+    `Timed out waiting for custom editor ${viewType} (${resource.fsPath}).`
+  );
+}

--- a/apps/vscode-extension/test/runTest.ts
+++ b/apps/vscode-extension/test/runTest.ts
@@ -4,12 +4,22 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+import {
+  resolveVsCodeTestSuite,
+  resolveVsCodeTestVersion
+} from './vscodeTestRuntime';
 
 async function main(): Promise<void> {
   const extensionDevelopmentPath = path.resolve(__dirname, '..', '..');
-  const extensionTestsPath = path.resolve(__dirname, 'suite', 'index');
+  const extensionTestsPath = path.resolve(
+    __dirname,
+    resolveVsCodeTestSuite(),
+    'index'
+  );
   const workspacePath = path.resolve(__dirname, '..', '..', 'test', 'fixtures');
-  const vscodeExecutablePath = await downloadAndUnzipVSCode('1.115.0');
+  const vscodeExecutablePath = await downloadAndUnzipVSCode(
+    resolveVsCodeTestVersion()
+  );
   const userDataDir = await mkdtemp(
     path.join(tmpdir(), 'kicadstudio-vscode-user-')
   );

--- a/apps/vscode-extension/test/unit/vscodeTestRuntime.test.ts
+++ b/apps/vscode-extension/test/unit/vscodeTestRuntime.test.ts
@@ -1,0 +1,33 @@
+import {
+  DEFAULT_VSCODE_TEST_VERSION,
+  resolveVsCodeTestSuite,
+  resolveVsCodeTestVersion
+} from '../vscodeTestRuntime';
+
+describe('VS Code test runtime', () => {
+  it('uses the pinned local host version without a canary override', () => {
+    expect(resolveVsCodeTestVersion({})).toBe(DEFAULT_VSCODE_TEST_VERSION);
+  });
+
+  it('passes explicit canary lane selectors through to test-electron', () => {
+    expect(
+      resolveVsCodeTestVersion({
+        KICADSTUDIO_VSCODE_VERSION: ' insiders '
+      })
+    ).toBe('insiders');
+    expect(
+      resolveVsCodeTestVersion({
+        KICADSTUDIO_VSCODE_VERSION: '1.99.0'
+      })
+    ).toBe('1.99.0');
+  });
+
+  it('selects the dedicated canary host suite only when requested', () => {
+    expect(resolveVsCodeTestSuite({})).toBe('suite');
+    expect(
+      resolveVsCodeTestSuite({
+        KICADSTUDIO_VSCODE_TEST_SUITE: ' canary '
+      })
+    ).toBe('canarySuite');
+  });
+});

--- a/apps/vscode-extension/test/vscodeTestRuntime.ts
+++ b/apps/vscode-extension/test/vscodeTestRuntime.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_VSCODE_TEST_VERSION = '1.115.0';
+
+type TestEnvironment = Record<string, string | undefined>;
+
+export type VsCodeTestSuite = 'suite' | 'canarySuite';
+
+export function resolveVsCodeTestVersion(
+  env: TestEnvironment = process.env
+): string {
+  return (
+    env['KICADSTUDIO_VSCODE_VERSION']?.trim() || DEFAULT_VSCODE_TEST_VERSION
+  );
+}
+
+export function resolveVsCodeTestSuite(
+  env: TestEnvironment = process.env
+): VsCodeTestSuite {
+  return env['KICADSTUDIO_VSCODE_TEST_SUITE']?.trim() === 'canary'
+    ? 'canarySuite'
+    : 'suite';
+}

--- a/apps/vscode-extension/tsconfig.test.json
+++ b/apps/vscode-extension/tsconfig.test.json
@@ -10,6 +10,7 @@
   "include": [
     "test/runTest.ts",
     "test/runRealPairHostTest.ts",
+    "test/canarySuite/**/*.ts",
     "test/suite/**/*.ts",
     "test/realPairSuite/**/*.ts",
     "test/integration/**/*.ts",

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -16,7 +16,7 @@
 | Surface      | Primary    | Supported             | Deprecated | Gate                                     |
 | ------------ | ---------- | --------------------- | ---------- | ---------------------------------------- |
 | KiCad        | 10.0.x     | 9.x                   | 8.x        | `compatibility.yaml` + release preflight |
-| VS Code      | current    | `engines.vscode` 1.99 | none       | extension manifest + matrix validation   |
+| VS Code      | current    | `engines.vscode` 1.99 | none       | extension manifest + VS Code canary      |
 | MCP protocol | 2025-11-25 | 2025-11-25            | older      | well-known server card + matrix          |
 | Node         | 24.x       | `>=24.11.0 <25`       | older      | root and extension package metadata      |
 | pnpm         | 11.x       | `>=11.0.0 <12`        | older      | root package metadata                    |

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -17,6 +17,7 @@ notes can add detail, but they should not weaken these gates.
 | Contract gate        | Protocol, compatibility, or cross-product changes                    | Prove extension and MCP assumptions remain aligned.                                             | `corepack pnpm run test:contract`             |
 | Fixture gate         | Parser, diagnostics, command-builder, or KiCad file behavior changes | Prove deterministic KiCad corpus behavior stays stable.                                         | `corepack pnpm run test:fixtures`             |
 | Nightly quality gate | Scheduled and manual workflow                                        | Re-run the repository gate plus contract and fixture gates outside the fast PR path.            | `.github/workflows/nightly-quality-gates.yml` |
+| VS Code canary       | Scheduled and manual workflow                                        | Check supported VS Code host lanes before runtime/API changes reach users.                      | `.github/workflows/vscode-canary.yml`         |
 | Manual smoke         | Release candidate only                                               | Final human inspection where automation is not practical.                                       | PR notes must name the exact manual check     |
 
 ## Test Layers
@@ -114,6 +115,22 @@ As the M1-M4 roadmap lands, extend this workflow in focused PRs:
 | VS Code canary             | OASLANA-81     | Run current stable, insiders, and minimum supported VS Code versions.                                                          |
 | KiCad canary               | OASLANA-82     | Run primary, supported, deprecated, and prerelease KiCad CLI lanes where practical.                                            |
 
+## VS Code Canary
+
+`.github/workflows/vscode-canary.yml` launches a focused extension host smoke
+suite every week and on manual dispatch against the VS Code lanes from
+`compatibility.yaml`: current stable, the minimum `engines.vscode` host, and
+insiders. The smoke suite covers activation, commands, context-gated views,
+custom editor/webview bootstrap, diagnostics lifecycle access, and project/MCP
+view registration. Unit smokes keep the mock MCP Tools and provider paths in
+the same lane. The stable and minimum lanes fail the workflow; the insiders
+lane keeps reporting prerelease breakage without blocking stable support.
+
+Each lane uploads the Extension Development Host logs and available test
+artifacts. A failing lane opens or updates a compatibility issue. Stable-lane
+failures add the `release-blocker` label because the release gate lists VS Code
+stable compatibility as required.
+
 ## Regression Coverage Map
 
 Every bug fix should add an automated regression when practical. If automation
@@ -183,6 +200,8 @@ CI ownership follows product boundaries:
   `.github/workflows/codeql.yml` own security and static analysis lanes.
 - `.github/workflows/nightly-quality-gates.yml` owns the non-release scheduled
   quality gate.
+- `.github/workflows/vscode-canary.yml` owns scheduled/manual VS Code
+  compatibility lanes sourced from `compatibility.yaml`.
 - Product-specific validation remains inside each product package so the root
   workflow can compose it without direct source imports between products.
 

--- a/packages/mcp-server/scripts/vscode_canary.py
+++ b/packages/mcp-server/scripts/vscode_canary.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Generate VS Code canary lanes from repository compatibility metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+MCP_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = MCP_ROOT.parents[1]
+
+
+def _read_compatibility_matrix() -> dict[str, Any]:
+    data = yaml.safe_load((REPO_ROOT / "compatibility.yaml").read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise TypeError("compatibility.yaml must contain a YAML mapping")
+    return data
+
+
+def _vscode_value(vscode: dict[str, Any], key: str) -> str:
+    value = vscode.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"compatibility metadata missing vscode.{key}")
+    return value
+
+
+def _channel_version(value: str, channel: str) -> str:
+    return channel if value == "current" else value
+
+
+def build_canary_matrix(compatibility: dict[str, Any]) -> dict[str, list[dict[str, object]]]:
+    """Return GitHub Actions matrix lanes derived from VS Code compatibility metadata."""
+    vscode = compatibility.get("vscode")
+    if not isinstance(vscode, dict):
+        raise ValueError("compatibility metadata missing vscode mapping")
+
+    return {
+        "include": [
+            {
+                "id": "vscode-stable",
+                "state": "primary",
+                "version": _channel_version(_vscode_value(vscode, "stable"), "stable"),
+                "continue_on_error": False,
+            },
+            {
+                "id": "vscode-minimum",
+                "state": "supported",
+                "version": _vscode_value(vscode, "minimum"),
+                "continue_on_error": False,
+            },
+            {
+                "id": "vscode-insiders",
+                "state": "prerelease",
+                "version": _channel_version(_vscode_value(vscode, "insiders"), "insiders"),
+                "continue_on_error": True,
+            },
+        ]
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("matrix",))
+    args = parser.parse_args(argv)
+
+    if args.command == "matrix":
+        print(json.dumps(build_canary_matrix(_read_compatibility_matrix()), separators=(",", ":")))
+        return 0
+
+    parser.error(f"Unsupported command {args.command!r}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/mcp-server/tests/unit/test_vscode_canary.py
+++ b/packages/mcp-server/tests/unit/test_vscode_canary.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from scripts.vscode_canary import build_canary_matrix
+
+
+def test_vscode_canary_matrix_uses_compatibility_metadata() -> None:
+    matrix = build_canary_matrix(
+        {
+            "vscode": {
+                "minimum": "1.99.0",
+                "stable": "current",
+                "insiders": "current",
+            }
+        }
+    )
+
+    assert matrix == {
+        "include": [
+            {
+                "id": "vscode-stable",
+                "state": "primary",
+                "version": "stable",
+                "continue_on_error": False,
+            },
+            {
+                "id": "vscode-minimum",
+                "state": "supported",
+                "version": "1.99.0",
+                "continue_on_error": False,
+            },
+            {
+                "id": "vscode-insiders",
+                "state": "prerelease",
+                "version": "insiders",
+                "continue_on_error": True,
+            },
+        ]
+    }
+
+
+def test_vscode_canary_matrix_preserves_explicit_channel_versions() -> None:
+    matrix = build_canary_matrix(
+        {
+            "vscode": {
+                "minimum": "1.99.0",
+                "stable": "1.116.0",
+                "insiders": "1.117.0-insider",
+            }
+        }
+    )
+
+    assert matrix["include"][0]["version"] == "1.116.0"
+    assert matrix["include"][2]["version"] == "1.117.0-insider"


### PR DESCRIPTION
## Summary

- add a scheduled/manual VS Code compatibility canary matrix sourced from `compatibility.yaml`
- add focused extension-host canary smokes and runtime selectors for stable, insiders, and minimum supported VS Code lanes
- add the Python canary matrix generator and docs for release triage and support-matrix visibility
- rebuild the PR on current `main` as one policy-compliant cross-product CI commit

## Linked issue

Closes #82
Linear: OASLANA-81

## Type of change

- [ ] type:bug
- [ ] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [x] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm install --frozen-lockfile` - passed
- `uv sync --all-extras --frozen --project packages/mcp-server` - passed
- `corepack pnpm run format:check` - passed
- `corepack pnpm run lint` - passed
- `corepack pnpm run typecheck` - passed
- `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_vscode_canary.py -q` - passed
- `corepack pnpm --dir apps/vscode-extension run test:unit -- vscodeTestRuntime.test.ts` - passed
- `uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/check_workflows.py --actionlint` - passed
- `KICADSTUDIO_VSCODE_TEST_SUITE=canary xvfb-run -a corepack pnpm --filter kicadstudio run test:integration` - passed after updating the stale quality-gate manifest assertion
- `corepack pnpm run test` - passed
- `corepack pnpm run build` - passed; MCP npm wrapper emitted the expected unpublished-PyPI advisory and exited 0
- `uv sync --all-extras --frozen && uv run --all-extras pytest` from `packages/mcp-server` - passed, 631 tests
- `uvx yamllint .github/workflows/vscode-canary.yml` - passed
- `corepack pnpm run check:version` - passed
- `corepack pnpm run check` - passed
- `uvx pre-commit run --all-files` - passed
- `corepack pnpm audit --audit-level high` - passed
- `git diff --check origin/main...HEAD` - passed

Notes:
- `corepack pnpm run verify:dist` is not available in this repo; the root package has no `verify:dist` script.
- `act -l` could not run locally because `act` is not installed in this environment.
- `gitleaks` and `trufflehog` are not installed locally; workflow/security checks ran through repository scripts.

## Protocol / MCP impact

- [x] Not applicable; reason: workflow/test runner and canary matrix generator only
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [x] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
