### PR TITLE
docs(repo): align ownership policy checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,5 @@
 /apps/vscode-extension/ @oaslananka
 /packages/mcp-server/ @oaslananka
 /packages/mcp-npm/ @oaslananka
+/packages/protocol-schemas/ @oaslananka
 /examples/ @oaslananka

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -34,34 +34,55 @@
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
           {
-            "context": "Full CI Pipeline (ubuntu-24.04)"
+            "context": "metadata"
           },
           {
-            "context": "Full CI Pipeline (windows-2025-vs2026)"
+            "context": "forbidden-refs"
           },
           {
-            "context": "Full CI Pipeline (macos-15)"
+            "context": "vscode-extension (ubuntu-24.04)"
           },
           {
-            "context": "Trivy (filesystem scan)"
+            "context": "vscode-extension (windows-2025-vs2026)"
           },
           {
-            "context": "pnpm audit"
+            "context": "vscode-extension (macos-15)"
           },
           {
-            "context": "Workflow security (zizmor)"
+            "context": "mcp-server (ubuntu-24.04)"
           },
           {
-            "context": "CodeQL (javascript-typescript)"
+            "context": "mcp-server (windows-2025-vs2026)"
           },
           {
-            "context": "Gitleaks"
+            "context": "mcp-server (macos-15)"
           },
           {
-            "context": "Scorecard analysis"
+            "context": "mcp-npm (ubuntu-24.04)"
           },
           {
-            "context": "Review Thread Gate"
+            "context": "mcp-npm (windows-2025-vs2026)"
+          },
+          {
+            "context": "mcp-npm (macos-15)"
+          },
+          {
+            "context": "real-pair-compatibility"
+          },
+          {
+            "context": "analyze (javascript-typescript)"
+          },
+          {
+            "context": "analyze (python)"
+          },
+          {
+            "context": "security"
+          },
+          {
+            "context": "scan"
+          },
+          {
+            "context": "build"
           }
         ]
       }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,12 @@ CODEOWNERS review should match the changed paths:
 - `apps/vscode-extension/` for KiCad Studio extension work.
 - `packages/mcp-server/` for KiCad MCP Pro server and MCP Registry metadata.
 - `packages/mcp-npm/` for npm launcher work.
+- `packages/protocol-schemas/` for protocol schemas and compatibility review.
 - `examples/` for user-facing KiCad examples.
 
-Branch protection policy is documented in [docs/architecture/branch-protection.md](docs/architecture/branch-protection.md).
+Branch protection policy is documented in
+[docs/architecture/branch-protection.md](docs/architecture/branch-protection.md)
+and encoded for import in [`.github/rulesets/main.json`](.github/rulesets/main.json).
 
 ## Regression coverage
 

--- a/apps/vscode-extension/docs/branch-protection.md
+++ b/apps/vscode-extension/docs/branch-protection.md
@@ -1,6 +1,8 @@
 # Branch Protection
 
-Branch protection rules are defined in `.github/rulesets/main.json`.
+The canonical branch protection policy is documented in
+`docs/architecture/branch-protection.md`. Import the matching ruleset from
+`.github/rulesets/main.json`.
 
 To apply them via GitHub CLI:
 
@@ -9,4 +11,9 @@ To apply them via GitHub CLI:
 gh api -X POST /repos/oaslananka/kicad-studio-kit/rulesets --input .github/rulesets/main.json
 ```
 
-Note: If the ruleset already exists, use `PATCH` instead of `POST` and include the ruleset ID.
+If the ruleset already exists, update it by id:
+
+```bash
+gh api /repos/oaslananka/kicad-studio-kit/rulesets
+gh api -X PUT /repos/oaslananka/kicad-studio-kit/rulesets/<id> --input .github/rulesets/main.json
+```

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -27,6 +27,12 @@ workflows:
 - `scan`
 - `build`
 
+Every required check above must keep reporting on every pull request. Do not add
+path filters, branch filters, or commit-message skip behavior to a workflow that
+owns one of these required contexts. If product CI later becomes path-filtered,
+keep an always-on required gate that reports for every pull request and update
+this document plus `.github/rulesets/main.json` together.
+
 Scorecard should stay enabled as a repository health signal. It can be required once the repository has stable branch protection and token permissions.
 
 ## Review ownership
@@ -49,5 +55,9 @@ Enable CODEOWNERS review. Path ownership is declared in `.github/CODEOWNERS`:
 - Require signed commits if the account policy supports it.
 - Disallow force pushes and branch deletion for `main`.
 - Restrict who can bypass required pull requests and required checks.
+
+The strict up-to-date rule currently favors a current green `main` integration
+point over merge throughput. Re-evaluate it with the required-check set if the
+repository adopts a merge queue or concurrent merge volume grows.
 
 Release PR #16 remains user-owned. Do not merge release automation while product/release policy work is still being reviewed.

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -1,18 +1,31 @@
 # Branch Protection Policy
 
-Apply this policy to `main` after the repository environments and required checks are available.
+Apply this policy to `main` after the repository environments and required
+checks are available. The importable ruleset lives in
+`.github/rulesets/main.json`.
 
 ## Required status checks
 
-- `CI / metadata`
-- `CI / vscode-extension`
-- `CI / mcp-server`
-- `CI / mcp-npm`
-- `CI / forbidden-refs`
-- `CodeQL / analyze`
-- `Security / security`
-- `Gitleaks / scan`
-- `Docs / build`
+The ruleset uses the check-run contexts reported by the current monorepo
+workflows:
+
+- `metadata`
+- `forbidden-refs`
+- `vscode-extension (ubuntu-24.04)`
+- `vscode-extension (windows-2025-vs2026)`
+- `vscode-extension (macos-15)`
+- `mcp-server (ubuntu-24.04)`
+- `mcp-server (windows-2025-vs2026)`
+- `mcp-server (macos-15)`
+- `mcp-npm (ubuntu-24.04)`
+- `mcp-npm (windows-2025-vs2026)`
+- `mcp-npm (macos-15)`
+- `real-pair-compatibility`
+- `analyze (javascript-typescript)`
+- `analyze (python)`
+- `security`
+- `scan`
+- `build`
 
 Scorecard should stay enabled as a repository health signal. It can be required once the repository has stable branch protection and token permissions.
 
@@ -25,6 +38,7 @@ Enable CODEOWNERS review. Path ownership is declared in `.github/CODEOWNERS`:
 - `apps/vscode-extension/`: KiCad Studio extension.
 - `packages/mcp-server/`: KiCad MCP Pro Python server and MCP Registry metadata.
 - `packages/mcp-npm/`: npm launcher.
+- `packages/protocol-schemas/`: protocol schemas and compatibility contracts.
 - `examples/`: user-facing KiCad examples and smoke-test projects.
 
 ## Protection settings

--- a/docs/architecture/product-boundaries.md
+++ b/docs/architecture/product-boundaries.md
@@ -42,4 +42,7 @@ corepack pnpm run check:boundaries
 
 The checker fails when a product source file imports or path-references another product workspace implementation. CI runs the same check in the metadata job.
 
-Ownership is declared in `.github/CODEOWNERS` for `.github/`, architecture docs, examples, the extension, the MCP server, and the npm wrapper. Branch protection guidance is documented in [branch-protection.md](branch-protection.md).
+Ownership is declared in `.github/CODEOWNERS` for `.github/`, architecture docs,
+examples, the extension, the MCP server, the npm wrapper, and shared protocol
+schemas. Branch protection guidance is documented in
+[branch-protection.md](branch-protection.md).

--- a/docs/architecture/repo-structure.md
+++ b/docs/architecture/repo-structure.md
@@ -37,4 +37,6 @@ npm launcher changes belong under `packages/mcp-npm` unless they update Python p
 
 ## Shared work
 
-Shared contracts are repository-level assets until a dedicated shared package exists. When a shared package is added, it must live under `packages/` and must not import from any product workspace.
+Shared contracts live under repository-level compatibility metadata and
+`packages/protocol-schemas`. Shared packages must stay under `packages/` and
+must not import from any product workspace.

--- a/packages/mcp-server/docs/branch-protection.md
+++ b/packages/mcp-server/docs/branch-protection.md
@@ -15,9 +15,9 @@ gh api /repos/oaslananka/kicad-studio-kit/rulesets
 gh api -X PUT /repos/oaslananka/kicad-studio-kit/rulesets/<id> --input .github/rulesets/main.json
 ```
 
-The current policy requires pull requests, one review, code owner
-review, signed commits, and non-fast-forward protection.
+The current policy requires pull requests, one review, code owner review,
+signed commits, non-fast-forward protection, and the current monorepo workflow
+check-run contexts listed in `docs/architecture/branch-protection.md`.
 
-`required_status_checks` is empty in the committed JSON by default. After the
-canonical workflows have run at least once, add the actual check names that
-GitHub reports for this repository.
+When a required workflow job name changes, update the root branch-protection
+document and `.github/rulesets/main.json` together before applying the ruleset.


### PR DESCRIPTION
## Summary

- add explicit protocol schema ownership to CODEOWNERS and contribution guidance
- align the importable `main` ruleset and branch-protection docs with the current monorepo check-run contexts
- point product docs at the canonical root branch-protection policy and ruleset update path

## Linked issue

Closes #64
Linear: OASLANA-63

## Type of change

- [ ] type:bug
- [ ] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [x] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `git diff --check` - passed
- `jq -e . .github/rulesets/main.json` - passed
- `npx --yes -p node@24 -c "corepack pnpm exec prettier --ignore-unknown --no-error-on-unmatched-pattern --check CONTRIBUTING.md docs/architecture/branch-protection.md docs/architecture/product-boundaries.md docs/architecture/repo-structure.md .github/rulesets/main.json apps/vscode-extension/docs/branch-protection.md packages/mcp-server/docs/branch-protection.md"` - passed
- `uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/check_workflows.py` - passed
- `PATH=/tmp/actionlint-v1.7.12:$PATH npx --yes -p node@24 -c "corepack pnpm run check"` - passed
- `uvx pre-commit run --all-files` - passed

## Protocol / MCP impact

- [x] Not applicable; reason: repository ownership and branch-protection policy only
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [ ] Release notes considered for both products
- [ ] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [x] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
