### PR TITLE
docs(studio): record VS Code Web compatibility decision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
       - run: corepack pnpm --filter kicadstudio run test:unit:coverage
       - run: corepack pnpm --filter kicadstudio run build
       - run: corepack pnpm --filter kicadstudio run package
-      - run: corepack pnpm --filter kicadstudio run package:validate
+      - name: Verify extension package and no VS Code Web target
+        run: corepack pnpm --filter kicadstudio run package:validate
 
   mcp-server:
     strategy:

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -57,6 +57,9 @@
   "homepage": "https://github.com/oaslananka/kicad-studio-kit/tree/main/apps/vscode-extension",
   "license": "MIT",
   "main": "./dist/extension.js",
+  "extensionKind": [
+    "workspace"
+  ],
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",
@@ -1893,7 +1896,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "audit:ci": "pnpm audit --audit-level high",
     "check:staged": "lint-staged",
-    "check": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test:unit && pnpm run build",
+    "check": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test:unit && pnpm run build && pnpm run package:validate",
     "check:workspace-trust": "node scripts/check-untrusted-workspace.js",
     "check:ci": "pnpm run audit:ci && pnpm run format:check && pnpm run docs:check && pnpm run workflows:lint && pnpm run lint && pnpm run typecheck && pnpm run check:workspace-trust && pnpm run test:unit:coverage && pnpm run build && pnpm run test:integration && pnpm run package && pnpm run package:validate && pnpm run release:dry-run && pnpm run check:bundle-size",
     "compile-tests": "tsc -p tsconfig.test.json",

--- a/apps/vscode-extension/scripts/validate-package.js
+++ b/apps/vscode-extension/scripts/validate-package.js
@@ -38,6 +38,26 @@ assert(
   pkg.main === './dist/extension.js',
   'extension entrypoint drifted unexpectedly'
 );
+assert(
+  JSON.stringify(pkg.extensionKind) === JSON.stringify(['workspace']),
+  'extensionKind must stay ["workspace"] until ADR-0006 accepts a web target'
+);
+assert(
+  pkg.browser === undefined,
+  'browser entrypoint must stay absent until ADR-0006 accepts a web target'
+);
+for (const scriptName of Object.keys(pkg.scripts ?? {})) {
+  assert(
+    !scriptName.includes('web'),
+    `web build script must not be introduced before ADR-0006 accepts it: ${scriptName}`
+  );
+}
+for (const file of ['web/extension.js', 'src/web/extension.ts']) {
+  assert(
+    !fs.existsSync(path.join(root, file)),
+    `web extension entrypoint must not exist before ADR-0006 accepts it: ${file}`
+  );
+}
 
 const requiredRuntimeFiles = [
   'dist/extension.js',

--- a/docs/adr/0006-vscode-web-compatibility.md
+++ b/docs/adr/0006-vscode-web-compatibility.md
@@ -1,0 +1,97 @@
+# ADR 0006: VS Code Web Compatibility
+
+Status: Accepted
+
+Date: 2026-05-21
+
+## Context
+
+KiCad Studio is a VS Code extension for local KiCad project work. The current
+extension runtime depends on Node.js extension-host capabilities for the core
+workflow:
+
+- KiCad CLI detection and command execution use Node child processes.
+- KiCad desktop launch helpers use local executable discovery.
+- MCP discovery and integration assume a local or workspace-side process.
+- Manufacturing exports, DRC/ERC, BOM/netlist extraction, and status reporting
+  depend on a trusted workspace with access to local files and installed KiCad
+  tooling.
+
+KiCanvas is browser-capable and can render schematic and PCB data inside a
+webview, but that does not make the complete extension a VS Code Web extension.
+The official VS Code Web Extensions guide says web extensions use a `browser`
+entry point, run in a browser WebWorker sandbox, cannot use Node.js APIs, and
+cannot create child processes or run executables. The VS Code Extension Host
+guide also distinguishes Node.js extension hosts from browser extension hosts
+and recommends `extensionKind: ["workspace"]` for extensions that need workspace
+contents. The Extension Manifest reference defines `extensionKind` as the
+manifest field that declares the preferred extension-host location.
+
+Sources checked on 2026-05-21: the official VS Code API Web Extensions guide,
+Extension Host guide, and Extension Manifest reference.
+
+## Decision
+
+Choose option 3 from OASLANA-111: KiCad Studio is desktop / remote workspace
+extension-host only and is not a VS Code Web target.
+
+The extension manifest must keep:
+
+```json
+"main": "./dist/extension.js",
+"extensionKind": ["workspace"]
+```
+
+The extension manifest must not add:
+
+```json
+"browser": "./dist/web/extension.js"
+```
+
+No `web/extension.js`, `src/web/extension.ts`, `compile-web`, `package-web`, or
+other web build target is supported until a future ADR accepts a web product
+mode with a separate feature matrix and tests.
+
+## Consequences
+
+### Build and bundling
+
+- The production bundle remains the Node.js extension-host bundle at
+  `dist/extension.js`.
+- No browser/WebWorker bundle is produced.
+- No browser polyfills are added for Node.js built-ins.
+- Web-specific bundler config and `@vscode/test-web` are intentionally absent.
+
+### Dependency choices
+
+- Runtime dependencies may continue to use Node.js APIs that are unavailable in
+  VS Code Web when those APIs are required for local KiCad workflows.
+- New dependencies must not introduce a hidden web target or browser bundle
+  path unless this ADR is superseded.
+
+### Feature matrix
+
+| Feature area                 | Desktop / remote workspace host | VS Code Web |
+| ---------------------------- | ------------------------------- | ----------- |
+| Syntax and JSON contribution | Supported                       | Not shipped |
+| KiCanvas schematic/PCB views | Supported                       | Not shipped |
+| KiCad CLI DRC/ERC            | Supported with workspace trust  | Unsupported |
+| KiCad desktop launch         | Supported with workspace trust  | Unsupported |
+| MCP server integration       | Supported with local tooling    | Unsupported |
+| Manufacturing exports        | Supported with KiCad CLI        | Unsupported |
+
+### CI and future change guard
+
+The VS Code extension package validation step is the no-web-target CI guard. It
+must fail if a future change adds a `browser` entry point, a web entry file, web
+build scripts, or an `extensionKind` that no longer requires the workspace
+extension host.
+
+Any future web support proposal must supersede this ADR and add all of the
+following before changing the manifest:
+
+- a separate web feature matrix,
+- a web entry point,
+- a browser/WebWorker build,
+- VS Code Web tests,
+- user-facing degraded-mode copy for unsupported KiCad CLI and MCP operations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,4 +16,5 @@ Detailed architecture documents:
 - [Branch protection](architecture/branch-protection.md)
 - [Testing strategy](architecture/testing-strategy.md)
 - [Migration phases](architecture/migration-phases.md)
+- [ADR 0006: VS Code Web compatibility](adr/0006-vscode-web-compatibility.md)
 - [KiCad Studio and MCP integration](integration/kicad-studio-mcp.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ KiCad Studio Kit is the canonical monorepo for the KiCad Studio VS Code extensio
 - [Release model](architecture/release-model.md)
 - [Branch protection](architecture/branch-protection.md)
 - [Testing strategy](testing-strategy.md)
+- [ADR 0006: VS Code Web compatibility](adr/0006-vscode-web-compatibility.md)
 - [KiCad fixture corpus](kicad-fixture-corpus.md)
 - [KiCad Studio and MCP integration](integration/kicad-studio-mcp.md)
 


### PR DESCRIPTION
## Summary

- Add ADR 0006 deciding KiCad Studio remains desktop / remote workspace extension-host only, not a VS Code Web target.
- Set the VS Code extension manifest `extensionKind` to `["workspace"]` and keep the Node extension-host entry point only.
- Harden package validation and CI naming so future browser/web entry points, web scripts, or unsupported extensionKind drift fail before merge.
- Link the ADR from the docs index and architecture index.

## Linked issue

Linear: OASLANA-111

## Type of change

- [ ] type:bug
- [ ] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [x] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm --filter kicadstudio run package:validate` - failed before manifest update with expected `extensionKind must stay ["workspace"] until ADR-0006 accepts a web target`, then passed after the manifest and guard update.
- `corepack pnpm exec prettier --check .github/workflows/ci.yml apps/vscode-extension/package.json apps/vscode-extension/scripts/validate-package.js docs/adr/0006-vscode-web-compatibility.md docs/architecture.md docs/index.md` - passed after formatting ADR.
- `corepack pnpm install --frozen-lockfile` - passed.
- `corepack pnpm run lint` - passed.
- `corepack pnpm run typecheck` - passed.
- `corepack pnpm run build` - passed.
- `corepack pnpm --filter kicadstudio run package:validate` - passed.
- `corepack pnpm --filter kicadstudio run workflows:lint` - passed.
- `uvx yamllint .github/workflows/ci.yml` - passed.
- `corepack pnpm --filter kicadstudio run audit:ci` - passed, no known vulnerabilities.
- `PATH="/tmp/codex-tools/actionlint:$PATH" corepack pnpm run check` - passed with actionlint v1.7.12 downloaded from the official rhysd/actionlint GitHub release.
- `PATH="/tmp/codex-tools/actionlint:$PATH" uvx pre-commit run --all-files` - passed.

Known local validation notes:

- `corepack pnpm run test` fails in the existing VS Code integration test `Quality Gate Integration` because the test expects `kicadstudio.qualityGate` to use `when: kicadstudio.hasProject`; `origin/main` already has `when: kicadstudio.mcpConnected && kicadstudio.hasProject`. This branch does not touch the quality gate view or that test.
- `corepack pnpm run verify:dist` cannot run because the repository has no root `verify:dist` script. The OASLANA-111 dist/manifest guard is covered by `package:validate` and the root `check` run above.
- `act -l` could not run because `act` is not installed locally.
- `packages/mcp-server` submission readiness emits the existing PyPI reachability warning for version `1.0.0`; the root `check` command still passed.

## Freshness / deprecation verification

- Checked official VS Code API docs for Web Extensions, Extension Host, and Extension Manifest on 2026-05-21.
- Inspected pinned action metadata for the touched `ci.yml` actions: `actions/checkout`, `actions/setup-node`, `astral-sh/setup-uv`, and `actions/upload-artifact` all resolve to `runs.using: node24` at the pinned SHAs.
- Checked official `rhysd/actionlint` GitHub releases and used latest stable `v1.7.12` for local workflow linting.

## Protocol / MCP impact

- [x] Not applicable; reason: VS Code extension architecture decision and package guard only.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [ ] Release notes considered for both products
- [ ] Backward compatibility impact documented

No MCP protocol, schema, server, or adapter behavior changed.

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally, except the documented pre-existing `corepack pnpm run test` integration mismatch above
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
