### PR TITLE
test(kicad-studio/kicad-mcp-pro): add path regression suite

### DIFF
--- a/apps/vscode-extension/src/cli/kicadCliRunner.ts
+++ b/apps/vscode-extension/src/cli/kicadCliRunner.ts
@@ -15,6 +15,9 @@ import { redactSensitiveText } from '../utils/secrets';
 import { KiCadCliDetector } from './kicadCliDetector';
 
 const CLI_OUTPUT_LIMIT_BYTES = 10 * 1024 * 1024;
+const FILE_LIKE_CLI_ARG_PATTERN =
+  /\.(?:kicad_(?:pro|sch|pcb|dru|jobset)|gbr|drl|pdf|svg|zip|csv|xlsx|json|html|net)$/i;
+const URL_LIKE_CLI_ARG_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
 
 /**
  * Runs kicad-cli commands with progress reporting and request de-duplication.
@@ -417,13 +420,23 @@ function isSensitiveCliPath(value: string): boolean {
   if (!value) {
     return false;
   }
+  if (URL_LIKE_CLI_ARG_PATTERN.test(value)) {
+    return false;
+  }
   return (
     path.isAbsolute(value) ||
     path.win32.isAbsolute(value) ||
-    /[/\\]/.test(value) ||
-    /\.(?:kicad_(?:pro|sch|pcb|dru|jobset)|gbr|drl|pdf|svg|zip|csv|xlsx|json|html|net)$/i.test(
-      value
-    )
+    FILE_LIKE_CLI_ARG_PATTERN.test(value) ||
+    isRelativeLocalPath(value)
+  );
+}
+
+function isRelativeLocalPath(value: string): boolean {
+  return (
+    !value.startsWith('-') &&
+    !/\s/.test(value) &&
+    /[/\\]/.test(value) &&
+    !URL_LIKE_CLI_ARG_PATTERN.test(value)
   );
 }
 

--- a/apps/vscode-extension/src/cli/kicadCliRunner.ts
+++ b/apps/vscode-extension/src/cli/kicadCliRunner.ts
@@ -102,12 +102,24 @@ export class KiCadCliRunner {
     this.controllers.add(controller);
     const startedAt = Date.now();
     const fullArgs = [...(detected.args ?? []), ...command];
-    this.logger.info(formatCliCommand(detected.path, fullArgs));
+    const sensitiveCliPaths = collectSensitiveCliPaths(
+      detected.path,
+      options.cwd,
+      fullArgs
+    );
+    this.logger.info(
+      formatCliCommand(detected.path, fullArgs, sensitiveCliPaths)
+    );
 
     return new Promise<CliResult>((resolve, reject) => {
       const child = spawn(detected.path, fullArgs, {
         cwd: options.cwd,
-        env: { ...process.env, LANGUAGE: 'en', LANG: 'en_US.UTF-8', KICAD_LANGUAGE: 'en' },
+        env: {
+          ...process.env,
+          LANGUAGE: 'en',
+          LANG: 'en_US.UTF-8',
+          KICAD_LANGUAGE: 'en'
+        },
         signal,
         stdio: ['ignore', 'pipe', 'pipe']
       });
@@ -122,7 +134,7 @@ export class KiCadCliRunner {
       const timeout = setTimeout(() => {
         controller.abort(
           new KiCadCliTimeoutError(
-            redactCliArgs(command).join(' '),
+            redactCliArgs(command, sensitiveCliPaths).join(' '),
             CLI_TIMEOUT_MS
           )
         );
@@ -136,7 +148,7 @@ export class KiCadCliRunner {
 
       child.stdout.on('data', (chunk: Buffer) => {
         const text = chunk.toString('utf8');
-        const redactedText = redactSensitiveText(text);
+        const redactedText = redactSensitiveText(text, sensitiveCliPaths);
         const appended = appendBoundedOutput({
           current: stdout,
           chunk,
@@ -159,7 +171,7 @@ export class KiCadCliRunner {
 
       child.stderr.on('data', (chunk: Buffer) => {
         const text = chunk.toString('utf8');
-        const redactedText = redactSensitiveText(text);
+        const redactedText = redactSensitiveText(text, sensitiveCliPaths);
         const appended = appendBoundedOutput({
           current: stderr,
           chunk,
@@ -182,7 +194,12 @@ export class KiCadCliRunner {
 
       child.on('error', (error) => {
         finish(() =>
-          reject(this.normalizeError(error, redactCliArgs(command).join(' ')))
+          reject(
+            this.normalizeError(
+              error,
+              redactCliArgs(command, sensitiveCliPaths).join(' ')
+            )
+          )
         );
       });
 
@@ -201,11 +218,11 @@ export class KiCadCliRunner {
           if ((exitCode ?? -1) !== 0) {
             reject(
               new CliExitError({
-                command: redactCliArgs(command).join(' '),
+                command: redactCliArgs(command, sensitiveCliPaths).join(' '),
                 code: exitCode ?? -1,
-                stdout: redactSensitiveText(stdout),
+                stdout: redactSensitiveText(stdout, sensitiveCliPaths),
                 stderr: this.normalizeCliFailure(
-                  redactSensitiveText(stderr || stdout || '')
+                  redactSensitiveText(stderr || stdout || '', sensitiveCliPaths)
                 )
               })
             );
@@ -353,11 +370,18 @@ function safeRealpath(targetPath: string): string {
   }
 }
 
-function formatCliCommand(command: string, args: string[]): string {
-  return `Running ${redactSensitiveText(command)} ${redactCliArgs(args).join(' ')}`;
+function formatCliCommand(
+  command: string,
+  args: string[],
+  sensitivePaths: readonly string[]
+): string {
+  return `Running ${redactSensitiveText(command, sensitivePaths)} ${redactCliArgs(args, sensitivePaths).join(' ')}`;
 }
 
-function redactCliArgs(args: string[]): string[] {
+function redactCliArgs(
+  args: string[],
+  sensitivePaths: readonly string[] = []
+): string[] {
   const redacted: string[] = [];
   for (let index = 0; index < args.length; index += 1) {
     const current = args[index] ?? '';
@@ -366,9 +390,41 @@ function redactCliArgs(args: string[]): string[] {
       redacted.push(`${key}=***`);
       continue;
     }
-    redacted.push(redactSensitiveText(current));
+    redacted.push(redactSensitiveText(current, sensitivePaths));
   }
   return redacted;
+}
+
+function collectSensitiveCliPaths(
+  cliPath: string,
+  cwd: string,
+  args: readonly string[]
+): string[] {
+  const values = new Set<string>();
+  for (const value of [cliPath, cwd, ...args]) {
+    if (isSensitiveCliPath(value)) {
+      values.add(value);
+      values.add(value.replaceAll('\\', '/'));
+      values.add(value.replaceAll('/', '\\'));
+    }
+  }
+  return [...values]
+    .filter(Boolean)
+    .sort((left, right) => right.length - left.length);
+}
+
+function isSensitiveCliPath(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+  return (
+    path.isAbsolute(value) ||
+    path.win32.isAbsolute(value) ||
+    /[/\\]/.test(value) ||
+    /\.(?:kicad_(?:pro|sch|pcb|dru|jobset)|gbr|drl|pdf|svg|zip|csv|xlsx|json|html|net)$/i.test(
+      value
+    )
+  );
 }
 
 function appendBoundedOutput(options: {

--- a/apps/vscode-extension/src/utils/pathUtils.ts
+++ b/apps/vscode-extension/src/utils/pathUtils.ts
@@ -27,7 +27,10 @@ export function getWorkspaceRoot(uri?: vscode.Uri): string | undefined {
 }
 
 export function toPosixPath(value: string): string {
-  return value.split(path.sep).join(path.posix.sep);
+  return value
+    .replaceAll('\\', path.posix.sep)
+    .split(path.sep)
+    .join(path.posix.sep);
 }
 
 export function relativeToWorkspace(

--- a/apps/vscode-extension/test/unit/kicadCliRunner.test.ts
+++ b/apps/vscode-extension/test/unit/kicadCliRunner.test.ts
@@ -352,6 +352,7 @@ describe('KiCadCliRunner', () => {
     const projectRoot = path.join(tempDir, 'project #&%+ Türkçe');
     const boardFile = path.join(projectRoot, 'board #&%+.kicad_pcb');
     const outputDir = path.join(projectRoot, 'fab reports');
+    const referenceUrl = 'https://example.test/path#board';
     fs.mkdirSync(projectRoot, { recursive: true });
     fs.writeFileSync(boardFile, '', 'utf8');
     __setConfiguration({});
@@ -385,7 +386,15 @@ describe('KiCadCliRunner', () => {
 
     const runner = new KiCadCliRunner(detector as never, logger as never);
     await runner.run({
-      command: ['pcb', 'drc', boardFile, '--output', outputDir],
+      command: [
+        'pcb',
+        'drc',
+        boardFile,
+        '--output',
+        outputDir,
+        '--reference',
+        referenceUrl
+      ],
       cwd: projectRoot,
       progressTitle: 'DRC',
       onProgress
@@ -406,6 +415,7 @@ describe('KiCadCliRunner', () => {
     expect(logOutput).not.toContain(projectRoot);
     expect(logOutput).not.toContain(boardFile);
     expect(logOutput).not.toContain(outputDir);
+    expect(logOutput).toContain(referenceUrl);
   });
 
   it('fails fast when no kicad-cli installation can be detected', async () => {

--- a/apps/vscode-extension/test/unit/kicadCliRunner.test.ts
+++ b/apps/vscode-extension/test/unit/kicadCliRunner.test.ts
@@ -348,6 +348,66 @@ describe('KiCadCliRunner', () => {
     expect(progressOutput).toContain('api_token=***');
   });
 
+  it('redacts absolute project paths from command and subprocess logs without changing spawned args', async () => {
+    const projectRoot = path.join(tempDir, 'project #&%+ Türkçe');
+    const boardFile = path.join(projectRoot, 'board #&%+.kicad_pcb');
+    const outputDir = path.join(projectRoot, 'fab reports');
+    fs.mkdirSync(projectRoot, { recursive: true });
+    fs.writeFileSync(boardFile, '', 'utf8');
+    __setConfiguration({});
+    const detector = {
+      detect: jest.fn().mockResolvedValue({
+        path: '/usr/bin/kicad-cli',
+        version: '10.0.1',
+        versionLabel: 'KiCad 10.0.1',
+        source: 'path'
+      })
+    };
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn()
+    };
+    const onProgress = jest.fn();
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock.mockImplementation(() => {
+      const child = createChildProcessMock();
+      queueMicrotask(() => {
+        child.stdout.emit(
+          'data',
+          Buffer.from(`Generated ${boardFile} under ${outputDir}`)
+        );
+        child.emit('close', 0);
+      });
+      return child;
+    });
+
+    const runner = new KiCadCliRunner(detector as never, logger as never);
+    await runner.run({
+      command: ['pcb', 'drc', boardFile, '--output', outputDir],
+      cwd: projectRoot,
+      progressTitle: 'DRC',
+      onProgress
+    });
+
+    const spawnedArgs = spawnMock.mock.calls[0]?.[1] as string[];
+    expect(spawnedArgs).toEqual(
+      expect.arrayContaining([boardFile, '--output', outputDir])
+    );
+
+    const logOutput = [
+      ...logger.info.mock.calls.flat(),
+      ...logger.warn.mock.calls.flat(),
+      ...onProgress.mock.calls.flat()
+    ].join('\n');
+    expect(logOutput).toContain('***');
+    expect(logOutput).not.toContain('/usr/bin/kicad-cli');
+    expect(logOutput).not.toContain(projectRoot);
+    expect(logOutput).not.toContain(boardFile);
+    expect(logOutput).not.toContain(outputDir);
+  });
+
   it('fails fast when no kicad-cli installation can be detected', async () => {
     __setConfiguration({});
     const runner = new KiCadCliRunner(

--- a/apps/vscode-extension/test/unit/pathRegressionSuite.test.ts
+++ b/apps/vscode-extension/test/unit/pathRegressionSuite.test.ts
@@ -25,6 +25,7 @@ interface PathRegressionScenario {
 }
 
 const scenarios = pathRegressionCases.scenarios as PathRegressionScenario[];
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
 const fixtureScenarios = scenarios.filter(
   (scenario) =>
     scenario.expectedGroups &&
@@ -113,7 +114,7 @@ describe('cross-platform path regression suite', () => {
 
   it('is covered by the existing Linux, Windows, and macOS unit-test CI matrix', () => {
     const workflow = fs.readFileSync(
-      path.join(process.cwd(), '..', '..', '.github', 'workflows', 'ci.yml'),
+      path.join(REPO_ROOT, '.github', 'workflows', 'ci.yml'),
       'utf8'
     );
 

--- a/apps/vscode-extension/test/unit/pathRegressionSuite.test.ts
+++ b/apps/vscode-extension/test/unit/pathRegressionSuite.test.ts
@@ -1,0 +1,214 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import pathRegressionCases from '../../../../test-fixtures/path-regression-cases.json';
+import { KiCadProjectTreeProvider } from '../../src/providers/projectTreeProvider';
+import type { ProjectTreeNode } from '../../src/types';
+import { toPosixPath } from '../../src/utils/pathUtils';
+import { __setConfiguration, Uri, workspace } from './vscodeMock';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+interface PathRegressionScenario {
+  id: string;
+  directoryName?: string;
+  linkName?: string;
+  fileBase?: string;
+  rawRelativePath?: string;
+  expectedPosixPath?: string;
+  expectedNonWindowsError?: string;
+  minimumPathLength?: number;
+  expectedGroups?: Record<string, string[]>;
+  tags: string[];
+}
+
+const scenarios = pathRegressionCases.scenarios as PathRegressionScenario[];
+const fixtureScenarios = scenarios.filter(
+  (scenario) =>
+    scenario.expectedGroups &&
+    !scenario.minimumPathLength &&
+    !scenario.tags.includes('symlink')
+);
+
+function childrenFor(
+  root: ProjectTreeNode | undefined,
+  label: string
+): ProjectTreeNode[] {
+  return root?.children?.find((node) => node.label === label)?.children ?? [];
+}
+
+function labelsFor(root: ProjectTreeNode | undefined, label: string): string[] {
+  return childrenFor(root, label).map((node) => node.label);
+}
+
+function writeKiCadProject(projectRoot: string, fileBase: string): void {
+  fs.mkdirSync(projectRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, `${fileBase}.kicad_pro`),
+    '{}',
+    'utf8'
+  );
+  fs.writeFileSync(path.join(projectRoot, `${fileBase}.kicad_sch`), '', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, `${fileBase}.kicad_pcb`), '', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, `${fileBase}.kicad_dru`), '', 'utf8');
+}
+
+async function buildWorkspace(
+  projectRoot: string
+): Promise<ProjectTreeNode | undefined> {
+  workspace.workspaceFolders = [{ uri: Uri.file(projectRoot) }] as never;
+  const provider = new KiCadProjectTreeProvider();
+  const [root] = await provider.getChildren();
+  return root;
+}
+
+function expectGoldenGroups(
+  root: ProjectTreeNode | undefined,
+  scenario: PathRegressionScenario
+): void {
+  for (const [group, expectedLabels] of Object.entries(
+    scenario.expectedGroups ?? {}
+  )) {
+    expect(labelsFor(root, group)).toEqual(expectedLabels);
+  }
+}
+
+describe('cross-platform path regression suite', () => {
+  const originalWorkspaceFolders = workspace.workspaceFolders;
+  let tempDir: string;
+
+  beforeEach(() => {
+    __setConfiguration({});
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kicad-path-regression-'));
+    workspace.workspaceFolders = originalWorkspaceFolders;
+  });
+
+  afterEach(() => {
+    workspace.workspaceFolders = originalWorkspaceFolders;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('keeps a fixture and golden expectation for every required path scenario', () => {
+    expect(scenarios.map((scenario) => scenario.id)).toEqual([
+      'project-path-with-spaces',
+      'unicode-project-path',
+      'reserved-url-characters',
+      'mixed-separators',
+      'long-path',
+      'symlinked-project-root',
+      'windows-unc-path'
+    ]);
+
+    for (const scenario of scenarios) {
+      expect(scenario.tags.length).toBeGreaterThan(0);
+      expect(
+        scenario.expectedGroups ??
+          scenario.expectedPosixPath ??
+          scenario.expectedNonWindowsError
+      ).toBeDefined();
+    }
+  });
+
+  it('is covered by the existing Linux, Windows, and macOS unit-test CI matrix', () => {
+    const workflow = fs.readFileSync(
+      path.join(process.cwd(), '..', '..', '.github', 'workflows', 'ci.yml'),
+      'utf8'
+    );
+
+    expect(pathRegressionCases.ciMatrix).toEqual([
+      'ubuntu-24.04',
+      'windows-2025-vs2026',
+      'macos-15'
+    ]);
+    expect(workflow).toContain(
+      'os: [ubuntu-24.04, windows-2025-vs2026, macos-15]'
+    );
+    expect(workflow).toContain(
+      'corepack pnpm --filter kicadstudio run test:unit:coverage'
+    );
+  });
+
+  it.each(fixtureScenarios)(
+    'discovers $id project fixtures with golden groups',
+    async (scenario) => {
+      const projectRoot = path.join(
+        tempDir,
+        scenario.directoryName ?? scenario.id
+      );
+      writeKiCadProject(projectRoot, scenario.fileBase ?? scenario.id);
+
+      const root = await buildWorkspace(projectRoot);
+
+      expect(root?.label).toBe(path.basename(projectRoot));
+      expectGoldenGroups(root, scenario);
+    }
+  );
+
+  it('normalizes mixed Windows and POSIX separators for UI-relative paths', () => {
+    const mixed = scenarios.find(
+      (scenario) => scenario.id === 'mixed-separators'
+    );
+
+    expect(mixed).toBeDefined();
+    expect(toPosixPath(mixed!.rawRelativePath ?? '')).toBe(
+      mixed!.expectedPosixPath
+    );
+  });
+
+  it('discovers project files through symlinked workspace roots when the OS permits symlinks', async () => {
+    const scenario = scenarios.find(
+      (entry) => entry.id === 'symlinked-project-root'
+    )!;
+    const targetRoot = path.join(tempDir, scenario.directoryName ?? 'target');
+    const linkRoot = path.join(tempDir, scenario.linkName ?? 'linked');
+    writeKiCadProject(targetRoot, scenario.fileBase ?? scenario.id);
+
+    try {
+      fs.symlinkSync(
+        targetRoot,
+        linkRoot,
+        process.platform === 'win32' ? 'junction' : 'dir'
+      );
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toMatch(
+        /EPERM|EACCES|ENOTSUP|EINVAL/
+      );
+      return;
+    }
+
+    const root = await buildWorkspace(linkRoot);
+
+    expect(root?.label).toBe(path.basename(linkRoot));
+    expectGoldenGroups(root, scenario);
+  });
+
+  it('discovers long project paths or records the platform path-length limit as a graceful skip', async () => {
+    const scenario = scenarios.find((entry) => entry.id === 'long-path')!;
+    let projectRoot = path.join(tempDir, scenario.directoryName ?? 'long-path');
+    while (
+      path.join(projectRoot, `${scenario.fileBase ?? scenario.id}.kicad_pro`)
+        .length <= (scenario.minimumPathLength ?? 260)
+    ) {
+      projectRoot = path.join(projectRoot, 'deep-segment-with-extra-length');
+    }
+
+    try {
+      writeKiCadProject(projectRoot, scenario.fileBase ?? scenario.id);
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toMatch(
+        /ENAMETOOLONG|ENOENT|EINVAL/
+      );
+      return;
+    }
+
+    const root = await buildWorkspace(projectRoot);
+
+    expect(
+      path.join(projectRoot, `${scenario.fileBase ?? scenario.id}.kicad_pro`)
+        .length
+    ).toBeGreaterThan(scenario.minimumPathLength ?? 260);
+    expectGoldenGroups(root, scenario);
+  });
+});

--- a/apps/vscode-extension/test/unit/pathUtils.test.ts
+++ b/apps/vscode-extension/test/unit/pathUtils.test.ts
@@ -45,6 +45,9 @@ describe('pathUtils', () => {
     const sample = ['folder', 'child', 'file.kicad_pcb'].join(path.sep);
 
     expect(toPosixPath(sample)).toBe('folder/child/file.kicad_pcb');
+    expect(toPosixPath('folder\\child/mixed.kicad_pcb')).toBe(
+      'folder/child/mixed.kicad_pcb'
+    );
     expect(
       relativeToWorkspace(
         path.join(process.cwd(), 'folder', 'board.kicad_pcb'),

--- a/packages/mcp-server/src/kicad_mcp/path_safety.py
+++ b/packages/mcp-server/src/kicad_mcp/path_safety.py
@@ -57,7 +57,7 @@ def reject_foreign_windows_path(raw_path: str | Path) -> None:
         return
 
     windows_path = PureWindowsPath(str(raw_path))
-    if windows_path.is_absolute() or windows_path.drive:
+    if windows_path.is_absolute():
         raise UnsafePathError(
             "Windows drive or UNC paths are not valid on this platform; provide a path "
             "inside the configured workspace root using this operating system's path format."

--- a/packages/mcp-server/src/kicad_mcp/path_safety.py
+++ b/packages/mcp-server/src/kicad_mcp/path_safety.py
@@ -53,10 +53,10 @@ def relative_subpath(raw_path: str | Path) -> Path:
 
 def reject_foreign_windows_path(raw_path: str | Path) -> None:
     """Reject Windows drive/UNC paths before POSIX treats backslashes as filename bytes."""
-    if os.name == "nt" or not isinstance(raw_path, str):
+    if os.name == "nt":
         return
 
-    windows_path = PureWindowsPath(raw_path)
+    windows_path = PureWindowsPath(str(raw_path))
     if windows_path.is_absolute() or windows_path.drive:
         raise UnsafePathError(
             "Windows drive or UNC paths are not valid on this platform; provide a path "

--- a/packages/mcp-server/src/kicad_mcp/path_safety.py
+++ b/packages/mcp-server/src/kicad_mcp/path_safety.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import os
+from pathlib import Path, PureWindowsPath
 
 from .errors import UnsafePathError
 
@@ -28,6 +29,7 @@ def assert_within(root: Path, path: Path) -> None:
 
 def resolve_under(root: Path, raw_path: str | Path, *, allow_absolute: bool = True) -> Path:
     """Resolve ``raw_path`` under ``root`` and block traversal outside it."""
+    reject_foreign_windows_path(raw_path)
     candidate = Path(raw_path).expanduser()
     if candidate.is_absolute():
         _ = allow_absolute
@@ -40,9 +42,23 @@ def resolve_under(root: Path, raw_path: str | Path, *, allow_absolute: bool = Tr
 
 def relative_subpath(raw_path: str | Path) -> Path:
     """Return a safe relative subpath."""
+    reject_foreign_windows_path(raw_path)
     candidate = Path(raw_path).expanduser()
     if candidate.is_absolute():
         raise UnsafePathError("Output subdirectories must be relative to the output directory.")
     if any(part == ".." for part in candidate.parts):
         raise UnsafePathError("Output subdirectories cannot contain parent traversal.")
     return candidate
+
+
+def reject_foreign_windows_path(raw_path: str | Path) -> None:
+    """Reject Windows drive/UNC paths before POSIX treats backslashes as filename bytes."""
+    if os.name == "nt" or not isinstance(raw_path, str):
+        return
+
+    windows_path = PureWindowsPath(raw_path)
+    if windows_path.is_absolute() or windows_path.drive:
+        raise UnsafePathError(
+            "Windows drive or UNC paths are not valid on this platform; provide a path "
+            "inside the configured workspace root using this operating system's path format."
+        )

--- a/packages/mcp-server/tests/unit/test_path_safety.py
+++ b/packages/mcp-server/tests/unit/test_path_safety.py
@@ -145,6 +145,15 @@ def test_mcp_path_safety_rejects_windows_unc_paths_on_non_windows_hosts(tmp_path
         resolve_under(tmp_path, Path(scenario["rawPath"]))
 
 
+def test_mcp_path_safety_accepts_posix_colon_relative_paths(tmp_path: Path) -> None:
+    if os.name == "nt":
+        pytest.skip("Colon-separated relative paths are POSIX-specific.")
+
+    expected = tmp_path / "a:b" / "board.kicad_pcb"
+
+    assert resolve_under(tmp_path, "a:b/board.kicad_pcb") == expected.resolve()
+
+
 def test_mcp_path_safety_handles_long_paths_or_surfaces_platform_limit(
     tmp_path: Path, fake_cli: Path
 ) -> None:

--- a/packages/mcp-server/tests/unit/test_path_safety.py
+++ b/packages/mcp-server/tests/unit/test_path_safety.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
 
 import pytest
@@ -7,6 +9,11 @@ import pytest
 from kicad_mcp.config import KiCadMCPConfig
 from kicad_mcp.errors import KiCadNotRunningError, UnsafePathError, error_payload
 from kicad_mcp.utils.paths import relative_subpath, resolve_under
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+PATH_REGRESSION_CASES = json.loads(
+    (REPO_ROOT / "test-fixtures" / "path-regression-cases.json").read_text(encoding="utf-8")
+)
 
 
 def test_resolve_within_project_blocks_traversal(sample_project: Path) -> None:
@@ -45,6 +52,119 @@ def test_path_utils_wrapper_resolves_safe_paths(tmp_path: Path) -> None:
     assert resolve_under(workspace, "project/board.kicad_pcb") == nested
     assert resolve_under(workspace, nested) == nested
     assert relative_subpath("exports/gerbers") == Path("exports/gerbers")
+
+
+def test_cross_platform_path_fixture_covers_required_mcp_scenarios() -> None:
+    assert PATH_REGRESSION_CASES["linearIssue"] == "OASLANA-112"
+    assert [scenario["id"] for scenario in PATH_REGRESSION_CASES["scenarios"]] == [
+        "project-path-with-spaces",
+        "unicode-project-path",
+        "reserved-url-characters",
+        "mixed-separators",
+        "long-path",
+        "symlinked-project-root",
+        "windows-unc-path",
+    ]
+    assert "windows-2025-vs2026" in PATH_REGRESSION_CASES["ciMatrix"]
+
+
+@pytest.mark.parametrize(
+    ("scenario_id", "directory_name", "file_base"),
+    [
+        (
+            scenario["id"],
+            scenario["directoryName"],
+            scenario["fileBase"],
+        )
+        for scenario in PATH_REGRESSION_CASES["scenarios"]
+        if {"directoryName", "fileBase"}.issubset(scenario)
+        and "symlink" not in scenario["tags"]
+        and "long-path" not in scenario["tags"]
+    ],
+)
+def test_mcp_project_paths_accept_spaces_unicode_and_special_characters(
+    tmp_path: Path,
+    fake_cli: Path,
+    scenario_id: str,
+    directory_name: str,
+    file_base: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    project = workspace / directory_name
+    project.mkdir(parents=True)
+    board = project / f"{file_base}.kicad_pcb"
+    board.write_text("(kicad_pcb)", encoding="utf-8")
+
+    cfg = KiCadMCPConfig(kicad_cli=fake_cli, workspace_root=workspace, project_dir=project)
+
+    assert scenario_id
+    assert cfg.resolve_within_project(board.name) == board.resolve()
+
+
+def test_mcp_path_safety_accepts_symlinked_project_roots_when_the_os_allows_symlinks(
+    tmp_path: Path, fake_cli: Path
+) -> None:
+    scenario = next(
+        scenario
+        for scenario in PATH_REGRESSION_CASES["scenarios"]
+        if scenario["id"] == "symlinked-project-root"
+    )
+    workspace = tmp_path / "workspace"
+    target = workspace / scenario["directoryName"]
+    link = workspace / scenario["linkName"]
+    target.mkdir(parents=True)
+    board = target / f"{scenario['fileBase']}.kicad_pcb"
+    board.write_text("(kicad_pcb)", encoding="utf-8")
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError as exc:
+        assert exc.errno is not None
+        return
+
+    cfg = KiCadMCPConfig(kicad_cli=fake_cli, workspace_root=workspace, project_dir=link)
+
+    assert cfg.resolve_within_project(board.name) == board.resolve()
+
+
+def test_mcp_path_safety_rejects_windows_unc_paths_on_non_windows_hosts(tmp_path: Path) -> None:
+    scenario = next(
+        scenario
+        for scenario in PATH_REGRESSION_CASES["scenarios"]
+        if scenario["id"] == "windows-unc-path"
+    )
+    if os.name == "nt":
+        pytest.skip("Windows hosts validate UNC paths with native pathlib semantics.")
+
+    with pytest.raises(UnsafePathError, match=scenario["expectedNonWindowsError"]):
+        resolve_under(tmp_path, scenario["rawPath"])
+
+    with pytest.raises(UnsafePathError, match=scenario["expectedNonWindowsError"]):
+        relative_subpath(scenario["rawPath"])
+
+
+def test_mcp_path_safety_handles_long_paths_or_surfaces_platform_limit(
+    tmp_path: Path, fake_cli: Path
+) -> None:
+    scenario = next(
+        scenario for scenario in PATH_REGRESSION_CASES["scenarios"] if scenario["id"] == "long-path"
+    )
+    workspace = tmp_path / "workspace"
+    project = workspace / scenario["directoryName"]
+    board = project / f"{scenario['fileBase']}.kicad_pcb"
+    while len(str(board)) <= scenario["minimumPathLength"]:
+        project = project / "deep-segment-with-extra-length"
+        board = project / f"{scenario['fileBase']}.kicad_pcb"
+    try:
+        project.mkdir(parents=True)
+        board.write_text("(kicad_pcb)", encoding="utf-8")
+    except OSError as exc:
+        assert exc.errno is not None
+        return
+
+    cfg = KiCadMCPConfig(kicad_cli=fake_cli, workspace_root=workspace, project_dir=project)
+
+    assert len(str(board)) > scenario["minimumPathLength"]
+    assert cfg.resolve_within_project(board.name) == board.resolve()
 
 
 def test_error_payload_masks_domain_shape() -> None:

--- a/packages/mcp-server/tests/unit/test_path_safety.py
+++ b/packages/mcp-server/tests/unit/test_path_safety.py
@@ -141,6 +141,9 @@ def test_mcp_path_safety_rejects_windows_unc_paths_on_non_windows_hosts(tmp_path
     with pytest.raises(UnsafePathError, match=scenario["expectedNonWindowsError"]):
         relative_subpath(scenario["rawPath"])
 
+    with pytest.raises(UnsafePathError, match=scenario["expectedNonWindowsError"]):
+        resolve_under(tmp_path, Path(scenario["rawPath"]))
+
 
 def test_mcp_path_safety_handles_long_paths_or_surfaces_platform_limit(
     tmp_path: Path, fake_cli: Path

--- a/test-fixtures/path-regression-cases.json
+++ b/test-fixtures/path-regression-cases.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": 1,
+  "linearIssue": "OASLANA-112",
+  "ciMatrix": ["ubuntu-24.04", "windows-2025-vs2026", "macos-15"],
+  "scenarios": [
+    {
+      "id": "project-path-with-spaces",
+      "directoryName": "project with spaces",
+      "fileBase": "board with spaces",
+      "expectedGroups": {
+        "Project Files": ["board with spaces.kicad_pro"],
+        "Schematic Sheets": ["board with spaces.kicad_sch"],
+        "PCB": ["board with spaces.kicad_pcb"],
+        "Design Rules": ["board with spaces.kicad_dru"]
+      },
+      "tags": ["project-discovery", "kicad-cli", "mcp", "spaces"]
+    },
+    {
+      "id": "unicode-project-path",
+      "directoryName": "Türkçe-路径-é",
+      "fileBase": "çin-é-board",
+      "expectedGroups": {
+        "Project Files": ["çin-é-board.kicad_pro"],
+        "Schematic Sheets": ["çin-é-board.kicad_sch"],
+        "PCB": ["çin-é-board.kicad_pcb"],
+        "Design Rules": ["çin-é-board.kicad_dru"]
+      },
+      "tags": ["project-discovery", "kicad-cli", "mcp", "unicode"]
+    },
+    {
+      "id": "reserved-url-characters",
+      "directoryName": "path #&%+ chars",
+      "fileBase": "board #&%+",
+      "expectedGroups": {
+        "Project Files": ["board #&%+.kicad_pro"],
+        "Schematic Sheets": ["board #&%+.kicad_sch"],
+        "PCB": ["board #&%+.kicad_pcb"],
+        "Design Rules": ["board #&%+.kicad_dru"]
+      },
+      "tags": ["project-discovery", "kicad-cli", "mcp", "special-chars"]
+    },
+    {
+      "id": "mixed-separators",
+      "rawRelativePath": "nested\\mixed/path board.kicad_pcb",
+      "expectedPosixPath": "nested/mixed/path board.kicad_pcb",
+      "tags": ["path-normalization", "mixed-slashes"]
+    },
+    {
+      "id": "long-path",
+      "directoryName": "long-path",
+      "fileBase": "long-board",
+      "minimumPathLength": 260,
+      "expectedGroups": {
+        "Project Files": ["long-board.kicad_pro"],
+        "Schematic Sheets": ["long-board.kicad_sch"],
+        "PCB": ["long-board.kicad_pcb"],
+        "Design Rules": ["long-board.kicad_dru"]
+      },
+      "tags": ["project-discovery", "kicad-cli", "mcp", "long-path"]
+    },
+    {
+      "id": "symlinked-project-root",
+      "directoryName": "symlink-target",
+      "linkName": "symlinked project root",
+      "fileBase": "linked-board",
+      "expectedGroups": {
+        "Project Files": ["linked-board.kicad_pro"],
+        "Schematic Sheets": ["linked-board.kicad_sch"],
+        "PCB": ["linked-board.kicad_pcb"],
+        "Design Rules": ["linked-board.kicad_dru"]
+      },
+      "tags": ["project-discovery", "mcp", "symlink"]
+    },
+    {
+      "id": "windows-unc-path",
+      "rawPath": "\\\\server\\share\\project\\board.kicad_pcb",
+      "expectedNonWindowsError": "Windows drive or UNC paths are not valid on this platform",
+      "tags": ["mcp", "windows", "unc"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a shared OASLANA-112 path-regression fixture matrix for spaces, Unicode, reserved URL characters, mixed separators, long paths, symlinked roots, and Windows UNC inputs.
- Adds VS Code extension regression coverage for project discovery, path normalization, symlinked roots, long paths, and the existing Linux/Windows/macOS CI unit-test matrix.
- Adds MCP path-safety regression coverage and rejects foreign Windows drive/UNC paths on non-Windows hosts before POSIX path handling can treat backslashes as normal filename bytes.
- Redacts absolute CLI/project/output paths from KiCad CLI logs, progress, and failure surfaces while preserving the actual spawned arguments.

## Linear
- OASLANA-112: https://linear.app/oaslananka/issue/OASLANA-112/add-cross-platform-path-handling-regression-suite-windowsmacoslinux

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run format:check`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test` *(direct headless run failed when VS Code/Electron integration tests had no `$DISPLAY`; unit tests completed before the expected display failure)*
- `xvfb-run -a corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist` *(blocked: root script is missing, `ERR_PNPM_NO_SCRIPT`)*
- `uv sync --project packages/mcp-server --all-extras --frozen`
- `uv run --all-extras pytest tests` from `packages/mcp-server`
- `corepack pnpm run check`
- `corepack pnpm audit --audit-level high`
- `git diff --check`
- `uvx pre-commit run --all-files`
