### PR TITLE
ci(repo): add performance budget baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,41 @@ jobs:
       - run: corepack pnpm --dir packages/mcp-server run mcp:manifest:check
       - run: corepack pnpm --dir packages/mcp-server run package:check
 
+  performance-budgets:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          version-file: packages/mcp-server/uv.toml
+      - run: corepack enable
+      - run: corepack pnpm install --frozen-lockfile
+      - run: uv sync --all-extras --frozen --project packages/mcp-server
+      - name: Measure MCP performance budgets
+        env:
+          KICAD_PERFORMANCE_MEASUREMENTS_JSON: performance-results/mcp-tools-list.json
+        run: uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_benchmark_latency.py
+      - name: Check performance budgets
+        run: >-
+          node scripts/check-performance-budgets.mjs
+          --measurements performance-results/mcp-tools-list.json
+          --output performance-results/budget-report.json
+      - name: Upload performance budget artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: performance-budget-artifacts
+          path: performance-results
+          if-no-files-found: error
+          retention-days: 14
+
   real-pair-compatibility:
     runs-on: ubuntu-24.04
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ site/
 coverage/
 htmlcov/
 coverage.xml
+performance-results/
 .pytest-tmp*/
 *.vsix
 *.whl

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -1,0 +1,101 @@
+# Performance Baselines
+
+OASLANA-124 defines one performance budget catalog for KiCad Studio Kit:
+[`performance/baselines.json`](../performance/baselines.json). Benchmark
+producers emit measurement JSON against that catalog, then
+`scripts/check-performance-budgets.mjs` reports drift and rejects performance
+regressions before they merge.
+
+## Budget Policy
+
+The catalog uses one tolerance policy for every metric:
+
+| Measurement result          | Checker behavior                                      |
+| --------------------------- | ----------------------------------------------------- |
+| At or below 110% baseline   | Pass.                                                 |
+| Above 110% baseline         | Report a drift warning in the budget result artifact. |
+| Above 120% baseline         | Fail the budget check.                                |
+
+Measured data must name a catalog metric, keep its unit, and carry a positive
+value. CI-required metrics fail closed when a producer does not emit them.
+
+## Reference Environment
+
+PR enforcement uses the GitHub-hosted `ubuntu-24.04` x64 runner from
+`.github/workflows/ci.yml` as the reference machine. That lane reads the
+repository-pinned Node version from `.node-version` and the MCP Python toolchain
+selection from `packages/mcp-server/uv.toml`.
+
+The catalog still records platform-specific activation budgets for Windows and
+macOS/Linux because those budgets are product requirements. Cross-platform
+benchmark producers added by OASLANA-46 should capture their runner identity in
+their artifacts before they set another metric to `ciRequired`.
+
+The current catalog covers these surfaces:
+
+| Surface        | Metrics                                                                                 |
+| -------------- | --------------------------------------------------------------------------------------- |
+| Activation     | Cold Windows, cold POSIX, and warm extension activation                                  |
+| Project scan   | Single-project, medium workspace, and large workspace scan                               |
+| Viewer         | Schematic first render, PCB first render, large PCB first render, and reload              |
+| Validation     | Clean DRC, medium DRC, clean ERC, and cancellation response                              |
+| MCP            | `tools/list`, medium-board `pcb_get_board_summary`, and session establishment            |
+| Memory         | Idle extension memory and memory with a viewer open                                      |
+
+`mcp.tools_list.response_ms` is the first CI-required producer. OASLANA-46 can
+add extension host, viewer, validation, memory, and fixture-backed MCP
+producers without changing the budget schema.
+
+## Local Checks
+
+Validate catalog shape and checker behavior with:
+
+```bash
+corepack pnpm run check:performance-budgets
+```
+
+Create the same MCP measurement emitted by CI and evaluate its budget with:
+
+```bash
+KICAD_PERFORMANCE_MEASUREMENTS_JSON=performance-results/mcp-tools-list.json \
+  uv run --project packages/mcp-server --all-extras \
+  pytest packages/mcp-server/tests/unit/test_benchmark_latency.py
+node scripts/check-performance-budgets.mjs \
+  --measurements performance-results/mcp-tools-list.json \
+  --output performance-results/budget-report.json
+```
+
+The benchmark producer writes sample values so reviewers can distinguish one
+outlier from a repeatable shift. The budget report stores the measured value,
+baseline, statistic, warning limit, failure limit, and pass/warn/fail status for
+each measured metric.
+
+## CI Evidence
+
+`.github/workflows/ci.yml` runs the `performance-budgets` job on every pull
+request and on pushes to `main`. Its reference environment is the GitHub-hosted
+`ubuntu-24.04` runner listed in the catalog.
+
+The job uploads `performance-budget-artifacts` for 14 days:
+
+| Artifact path                                 | Contents                                              |
+| --------------------------------------------- | ----------------------------------------------------- |
+| `performance-results/mcp-tools-list.json`     | Raw MCP samples and the p95 measurement.              |
+| `performance-results/budget-report.json`      | Budget thresholds and checker result for each metric. |
+
+Keep reports from the relevant PR when investigating drift. Trend dashboards
+can consume the same JSON without coupling the producer to a hosted service.
+
+## Baseline Changes
+
+Update a baseline only with measurement evidence from the same surface and
+state why the new budget is intentional in the PR. Prefer implementation fixes
+when a code change crosses the 20 percent failure budget.
+
+When a new producer becomes PR-required:
+
+1. Add or update its metric in `performance/baselines.json`.
+2. Emit the schema version, metric ID, unit, statistic, samples, and value from
+   the producer.
+3. Set `ciRequired` only after the PR workflow actually emits the measurement.
+4. Keep the workflow artifact path stable so comparisons remain scriptable.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -13,6 +13,7 @@ notes can add detail, but they should not weaken these gates.
 | Gate                 | Trigger                                                              | Purpose                                                                                         | Required command                              |
 | -------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------- |
 | Fast PR gate         | Every pull request                                                   | Catch formatting, lint, type, unit, package, metadata, boundary, and compatibility regressions. | `corepack pnpm run check`                     |
+| Performance budget   | Every pull request                                                   | Report shared baseline drift and fail measured lanes that exceed the regression budget.           | `corepack pnpm run check:performance-budgets` |
 | Product gate         | Product-scoped changes                                               | Prove the touched product still builds, tests, and packages independently.                      | Product commands below                        |
 | Contract gate        | Protocol, compatibility, or cross-product changes                    | Prove extension and MCP assumptions remain aligned.                                             | `corepack pnpm run test:contract`             |
 | Fixture gate         | Parser, diagnostics, command-builder, or KiCad file behavior changes | Prove deterministic KiCad corpus behavior stays stable.                                         | `corepack pnpm run test:fixtures`             |
@@ -34,6 +35,7 @@ notes can add detail, but they should not weaken these gates.
 | MCP unit tests                        | Pure Python helpers, tool metadata, routers, server startup, semantic gates, release guards.                                         | `packages/mcp-server/tests/unit/`                                        | pytest                                                         | Fast PR gate                                           |
 | MCP integration tests                 | File-backed KiCad behavior, export/manufacturing tools, project quality gates, simulation and routing tools.                         | `packages/mcp-server/tests/integration/`                                 | pytest plus optional `kicad-cli`                               | Nightly gate unless the fixture is pure and fast       |
 | MCP E2E tests                         | Server startup, stdio, journal/rollback, release-gate workflows.                                                                     | `packages/mcp-server/tests/e2e/`                                         | pytest                                                         | Nightly gate                                           |
+| Performance budgets                  | Shared activation, scan, viewer, validation, MCP, and memory baselines plus PR budget reports.                                       | `performance/baselines.json`, `performance-results/`                     | Node checker, benchmark producers, GitHub workflow artifacts   | Fast PR gate                                           |
 | KiCad CLI contract tests              | KiCad 10 primary behavior plus supported 9.x and deprecated 8.x compatibility where supported.                                       | Shared fixtures and MCP integration tests                                | `kicad-cli`                                                    | Nightly/canary gate                                    |
 | MCP transport contract tests          | Streamable HTTP initialize flow, session handling, stateless behavior, `MCP-Protocol-Version`, tool discovery, errors, and timeouts. | MCP tests and future shared contract package                             | pytest/http client                                             | Contract gate                                          |
 | Real-pair tests                       | Built VS Code extension connected to built MCP server against fixture workspaces.                                                    | Future shared harness                                                    | VS Code test host plus local MCP server                        | Nightly gate                                           |
@@ -85,6 +87,23 @@ Protocol, compatibility, or cross-product changes use:
 ```bash
 corepack pnpm run test:contract
 corepack pnpm run test:fixtures
+```
+
+## Performance Budgets
+
+`performance/baselines.json` is the shared performance budget catalog for
+activation, project scan, viewer, validation, MCP, and memory regressions. The
+policy and benchmark-producer contract live in
+[`docs/performance-baselines.md`](performance-baselines.md).
+
+Every PR runs the performance catalog check through the root gate and the CI
+`performance-budgets` job records benchmark measurements plus the budget report
+as workflow artifacts. A measured metric warns after 10 percent drift and fails
+after 20 percent drift. Use the dedicated budget check while changing baseline
+metadata:
+
+```bash
+corepack pnpm run check:performance-budgets
 ```
 
 ## Nightly Quality Gates
@@ -168,6 +187,7 @@ or artifact.
 | OASLANA-64 | Supply-chain regressions in both products and artifacts.                        | Security workflow, package validation, audit, and provenance checks        |
 | OASLANA-81 | VS Code runtime/API compatibility regressions.                                  | Scheduled VS Code stable/insiders/minimum canary lane                      |
 | OASLANA-82 | KiCad CLI/file-format compatibility regressions.                                | Scheduled KiCad version canary lane                                        |
+| OASLANA-124 | Performance regressions without shared limits or PR evidence.                  | Shared baselines, CI budget report artifacts, and drift thresholds         |
 
 ## Local Commands
 
@@ -177,6 +197,7 @@ before pushing.
 | Change type                    | Narrow command                                                                                              | Broad command                                  |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
 | Root docs or governance        | `corepack pnpm run check:testing-strategy`                                                                  | `corepack pnpm run check`                      |
+| Performance baselines          | `corepack pnpm run check:performance-budgets`                                                               | CI `performance-budgets` artifact lane         |
 | Extension unit behavior        | `corepack pnpm --filter kicadstudio run test:unit -- <test file>`                                           | `corepack pnpm run check:kicad-studio`         |
 | Extension integration behavior | `corepack pnpm --filter kicadstudio run test:integration`                                                   | `corepack pnpm run check:kicad-studio`         |
 | Extension webview/E2E behavior | `corepack pnpm --filter kicadstudio run test:e2e`                                                           | Nightly quality gate once snapshots are stable |
@@ -210,7 +231,7 @@ corepack pnpm run test:fixtures
 CI ownership follows product boundaries:
 
 - `.github/workflows/ci.yml` owns fast PR lanes for metadata, extension, MCP
-  server, npm wrapper, and forbidden reference checks.
+  server, MCP performance budgets, npm wrapper, and forbidden reference checks.
 - `.github/workflows/security.yml`, `.github/workflows/gitleaks.yml`, and
   `.github/workflows/codeql.yml` own security and static analysis lanes.
 - `.github/workflows/nightly-quality-gates.yml` owns the non-release scheduled

--- a/package.json
+++ b/package.json
@@ -48,9 +48,10 @@
     "check:compatibility": "uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/check_compatibility_matrix.py",
     "check:governance": "node scripts/sync-governance-project-items.mjs --self-test",
     "check:testing-strategy": "node scripts/check-testing-strategy.mjs",
+    "check:performance-budgets": "node scripts/check-performance-budgets.mjs && node --test scripts/check-performance-budgets.test.mjs",
     "check:publish": "node scripts/check-publish-preflight.mjs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run release:dry-run && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run check:performance-budgets && pnpm run release:dry-run && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.0",

--- a/packages/mcp-server/tests/fixtures/benchmark_latency_baseline.json
+++ b/packages/mcp-server/tests/fixtures/benchmark_latency_baseline.json
@@ -1,3 +1,0 @@
-{
-  "kicad_list_tool_categories_p95_ms": 200.0
-}

--- a/packages/mcp-server/tests/unit/test_benchmark_latency.py
+++ b/packages/mcp-server/tests/unit/test_benchmark_latency.py
@@ -8,42 +8,54 @@ from pathlib import Path
 import pytest
 
 from kicad_mcp.server import build_server
-from tests.conftest import call_tool_text
+
+PERFORMANCE_CATALOG_PATH = Path(__file__).resolve().parents[4] / "performance" / "baselines.json"
+MEASUREMENT_OUTPUT_ENV = "KICAD_PERFORMANCE_MEASUREMENTS_JSON"
+TOOLS_LIST_METRIC = "mcp.tools_list.response_ms"
 
 
 @pytest.mark.benchmark
 @pytest.mark.anyio
-async def test_tool_catalog_latency_against_baseline(sample_project: Path) -> None:
+async def test_tools_list_latency_against_shared_budget(
+    sample_project: Path,
+) -> None:
     _ = sample_project
-    baseline = json.loads(
-        Path("tests/fixtures/benchmark_latency_baseline.json").read_text(encoding="utf-8")
-    )
+    baseline = json.loads(PERFORMANCE_CATALOG_PATH.read_text(encoding="utf-8"))["metrics"][
+        TOOLS_LIST_METRIC
+    ]
     server = build_server("full")
     samples_ms: list[float] = []
 
     for _index in range(5):
         start = time.perf_counter()
-        await call_tool_text(server, "kicad_list_tool_categories", {})
+        await server.list_tools()
         samples_ms.append((time.perf_counter() - start) * 1000.0)
 
     p95_ms = sorted(samples_ms)[-1]
-    allowed_ms = float(baseline["kicad_list_tool_categories_p95_ms"]) * 1.2
-    output_path = os.environ.get("KICAD_MCP_BENCHMARK_JSON")
+    allowed_ms = float(baseline["baseline"]) * 1.2
+    output_path = os.environ.get(MEASUREMENT_OUTPUT_ENV)
     if output_path:
         path = Path(output_path)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
             json.dumps(
                 {
-                    "benchmark": "kicad_list_tool_categories",
-                    "samples_ms": samples_ms,
-                    "p95_ms": p95_ms,
-                    "allowed_ms": allowed_ms,
-                    "baseline_ms": float(baseline["kicad_list_tool_categories_p95_ms"]),
+                    "schemaVersion": 1,
+                    "source": "packages/mcp-server/tests/unit/test_benchmark_latency.py",
+                    "measurements": [
+                        {
+                            "metric": TOOLS_LIST_METRIC,
+                            "value": p95_ms,
+                            "unit": baseline["unit"],
+                            "statistic": "p95",
+                            "samples": len(samples_ms),
+                            "sampleValues": samples_ms,
+                        }
+                    ],
                 },
                 indent=2,
             )
             + "\n",
             encoding="utf-8",
         )
-    assert p95_ms <= allowed_ms, f"tool catalog p95 {p95_ms:.2f} ms > {allowed_ms:.2f} ms"
+    assert p95_ms <= allowed_ms, f"tools/list p95 {p95_ms:.2f} ms > {allowed_ms:.2f} ms"

--- a/performance/baselines.json
+++ b/performance/baselines.json
@@ -1,0 +1,146 @@
+{
+  "schemaVersion": 1,
+  "tolerance": {
+    "warningRatio": 1.1,
+    "failureRatio": 1.2
+  },
+  "reference": {
+    "ciRunner": "GitHub-hosted ubuntu-24.04",
+    "methodology": "docs/performance-baselines.md"
+  },
+  "metrics": {
+    "extension.activation.cold.windows_ms": {
+      "baseline": 800,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "Cold extension activation on Windows.",
+      "source": "OASLANA-46 activation performance harness"
+    },
+    "extension.activation.cold.posix_ms": {
+      "baseline": 600,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "Cold extension activation on macOS or Linux.",
+      "source": "OASLANA-46 activation performance harness"
+    },
+    "extension.activation.warm_ms": {
+      "baseline": 200,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "Warm extension activation.",
+      "source": "OASLANA-46 activation performance harness"
+    },
+    "extension.project_scan.single_ms": {
+      "baseline": 300,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "Project scan for one five-file fixture project.",
+      "source": "OASLANA-46 project scan performance harness"
+    },
+    "extension.project_scan.medium_ms": {
+      "baseline": 1000,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "Project scan for four fixture projects and about twenty files.",
+      "source": "OASLANA-46 project scan performance harness"
+    },
+    "extension.project_scan.large_ms": {
+      "baseline": 3000,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "Project scan for ten fixture projects and at least one hundred files.",
+      "source": "OASLANA-46 project scan performance harness"
+    },
+    "extension.viewer.schematic_first_render_ms": {
+      "baseline": 500,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "KiCanvas schematic first render for the clean fixture.",
+      "source": "OASLANA-46 viewer performance harness"
+    },
+    "extension.viewer.pcb_first_render_ms": {
+      "baseline": 800,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "KiCanvas PCB first render for the clean fixture.",
+      "source": "OASLANA-46 viewer performance harness"
+    },
+    "extension.viewer.large_pcb_first_render_ms": {
+      "baseline": 2000,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "KiCanvas first render for a large four-layer PCB fixture.",
+      "source": "OASLANA-46 viewer performance harness"
+    },
+    "extension.viewer.reload_ms": {
+      "baseline": 300,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "Viewer reload after the first render.",
+      "source": "OASLANA-46 viewer performance harness"
+    },
+    "extension.validation.drc.clean_ms": {
+      "baseline": 2000,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "DRC on the clean PCB fixture.",
+      "source": "OASLANA-46 validation performance harness"
+    },
+    "extension.validation.drc.medium_ms": {
+      "baseline": 8000,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "DRC on the medium PCB fixture.",
+      "source": "OASLANA-46 validation performance harness"
+    },
+    "extension.validation.erc.clean_ms": {
+      "baseline": 1000,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "ERC on the clean schematic fixture.",
+      "source": "OASLANA-46 validation performance harness"
+    },
+    "extension.validation.cancel_ms": {
+      "baseline": 200,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "Validation command cancellation response after user action.",
+      "source": "OASLANA-46 validation performance harness"
+    },
+    "mcp.tools_list.response_ms": {
+      "baseline": 100,
+      "unit": "ms",
+      "ciRequired": true,
+      "summary": "MCP tools/list response latency.",
+      "source": "packages/mcp-server/tests/unit/test_benchmark_latency.py"
+    },
+    "mcp.pcb_board_summary.medium_ms": {
+      "baseline": 500,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "pcb_get_board_summary on a medium PCB fixture.",
+      "source": "OASLANA-46 MCP performance harness"
+    },
+    "mcp.session.establishment_ms": {
+      "baseline": 200,
+      "unit": "ms",
+      "ciRequired": false,
+      "summary": "MCP session establishment.",
+      "source": "OASLANA-46 MCP performance harness"
+    },
+    "extension.memory.idle_mb": {
+      "baseline": 150,
+      "unit": "MB",
+      "ciRequired": false,
+      "summary": "Idle extension memory.",
+      "source": "OASLANA-46 memory performance harness"
+    },
+    "extension.memory.viewer_open_mb": {
+      "baseline": 350,
+      "unit": "MB",
+      "ciRequired": false,
+      "summary": "Extension memory while a viewer is open.",
+      "source": "OASLANA-46 memory performance harness"
+    }
+  }
+}

--- a/scripts/check-performance-budgets.mjs
+++ b/scripts/check-performance-budgets.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_ROOT = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = dirname(SCRIPT_ROOT);
+const DEFAULT_CATALOG_PATH = resolve(
+  DEFAULT_REPO_ROOT,
+  "performance",
+  "baselines.json",
+);
+
+export const REQUIRED_PERFORMANCE_METRIC_IDS = Object.freeze([
+  "extension.activation.cold.windows_ms",
+  "extension.activation.cold.posix_ms",
+  "extension.activation.warm_ms",
+  "extension.project_scan.single_ms",
+  "extension.project_scan.medium_ms",
+  "extension.project_scan.large_ms",
+  "extension.viewer.schematic_first_render_ms",
+  "extension.viewer.pcb_first_render_ms",
+  "extension.viewer.large_pcb_first_render_ms",
+  "extension.viewer.reload_ms",
+  "extension.validation.drc.clean_ms",
+  "extension.validation.drc.medium_ms",
+  "extension.validation.erc.clean_ms",
+  "extension.validation.cancel_ms",
+  "mcp.tools_list.response_ms",
+  "mcp.pcb_board_summary.medium_ms",
+  "mcp.session.establishment_ms",
+  "extension.memory.idle_mb",
+  "extension.memory.viewer_open_mb",
+]);
+
+const SUPPORTED_UNITS = new Set(["ms", "MB"]);
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPositiveNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function formatMeasurement(value, unit) {
+  return `${value.toFixed(2)} ${unit}`;
+}
+
+function multiplyThreshold(baseline, ratio) {
+  return Number((baseline * ratio).toFixed(6));
+}
+
+export function loadRepositoryPerformanceCatalog(repoRoot = DEFAULT_REPO_ROOT) {
+  return readJson(resolve(repoRoot, "performance", "baselines.json"));
+}
+
+export function validatePerformanceCatalog(catalog) {
+  const errors = [];
+
+  if (!isRecord(catalog)) {
+    return ["Performance catalog must be a JSON object."];
+  }
+  if (catalog.schemaVersion !== 1) {
+    errors.push("Performance catalog schemaVersion must be 1.");
+  }
+  if (!isRecord(catalog.tolerance)) {
+    errors.push("Performance catalog tolerance must be an object.");
+  } else {
+    if (!isPositiveNumber(catalog.tolerance.warningRatio)) {
+      errors.push("Performance catalog warningRatio must be a positive number.");
+    }
+    if (!isPositiveNumber(catalog.tolerance.failureRatio)) {
+      errors.push("Performance catalog failureRatio must be a positive number.");
+    }
+    if (
+      isPositiveNumber(catalog.tolerance.warningRatio) &&
+      isPositiveNumber(catalog.tolerance.failureRatio) &&
+      catalog.tolerance.warningRatio >= catalog.tolerance.failureRatio
+    ) {
+      errors.push("Performance catalog warningRatio must be lower than failureRatio.");
+    }
+  }
+  if (!isRecord(catalog.metrics)) {
+    errors.push("Performance catalog metrics must be an object.");
+    return errors;
+  }
+
+  for (const metricId of REQUIRED_PERFORMANCE_METRIC_IDS) {
+    if (!isRecord(catalog.metrics[metricId])) {
+      errors.push(`Performance catalog is missing metric ${metricId}.`);
+    }
+  }
+
+  for (const [metricId, metric] of Object.entries(catalog.metrics)) {
+    if (!isRecord(metric)) {
+      errors.push(`Performance metric ${metricId} must be an object.`);
+      continue;
+    }
+    if (!REQUIRED_PERFORMANCE_METRIC_IDS.includes(metricId)) {
+      errors.push(`Performance catalog has unknown metric ${metricId}.`);
+    }
+    if (!isPositiveNumber(metric.baseline)) {
+      errors.push(`Performance metric ${metricId} baseline must be a positive number.`);
+    }
+    if (!SUPPORTED_UNITS.has(metric.unit)) {
+      errors.push(`Performance metric ${metricId} unit must be ms or MB.`);
+    }
+    if (typeof metric.ciRequired !== "boolean") {
+      errors.push(`Performance metric ${metricId} ciRequired must be boolean.`);
+    }
+    if (typeof metric.summary !== "string" || metric.summary.trim() === "") {
+      errors.push(`Performance metric ${metricId} summary must be non-empty.`);
+    }
+    if (typeof metric.source !== "string" || metric.source.trim() === "") {
+      errors.push(`Performance metric ${metricId} source must be non-empty.`);
+    }
+  }
+
+  return errors;
+}
+
+export function evaluatePerformanceMeasurements(catalog, measurements) {
+  const errors = validatePerformanceCatalog(catalog);
+  const metrics = [];
+  const summary = {
+    pass: 0,
+    warn: 0,
+    fail: 0,
+  };
+
+  if (!isRecord(measurements)) {
+    return {
+      errors: [...errors, "Performance measurements must be a JSON object."],
+      metrics,
+      summary,
+    };
+  }
+  if (measurements.schemaVersion !== 1) {
+    errors.push("Performance measurements schemaVersion must be 1.");
+  }
+  if (!Array.isArray(measurements.measurements)) {
+    errors.push("Performance measurements must include a measurements array.");
+    return { errors, metrics, summary };
+  }
+
+  const measurementsByMetric = new Map();
+  for (const measurement of measurements.measurements) {
+    if (!isRecord(measurement) || typeof measurement.metric !== "string") {
+      errors.push("Every performance measurement must name a metric.");
+      continue;
+    }
+    if (measurementsByMetric.has(measurement.metric)) {
+      errors.push(`Duplicate performance measurement: ${measurement.metric}.`);
+      continue;
+    }
+    measurementsByMetric.set(measurement.metric, measurement);
+  }
+
+  for (const [metricId, measurement] of measurementsByMetric) {
+    const metric = catalog.metrics?.[metricId];
+    if (!isRecord(metric)) {
+      errors.push(`Unknown performance measurement metric: ${metricId}.`);
+      continue;
+    }
+    if (measurement.unit !== metric.unit) {
+      errors.push(`${metricId} must use ${metric.unit}, received ${measurement.unit}.`);
+      continue;
+    }
+    if (!isPositiveNumber(measurement.value)) {
+      errors.push(`${metricId} must report a positive numeric value.`);
+      continue;
+    }
+
+    const warningLimit = multiplyThreshold(
+      metric.baseline,
+      catalog.tolerance.warningRatio,
+    );
+    const failureLimit = multiplyThreshold(
+      metric.baseline,
+      catalog.tolerance.failureRatio,
+    );
+    let status = "pass";
+    if (measurement.value > failureLimit) {
+      status = "fail";
+      errors.push(
+        `${metricId} exceeded performance budget: ${formatMeasurement(
+          measurement.value,
+          metric.unit,
+        )} > ${formatMeasurement(failureLimit, metric.unit)}.`,
+      );
+    } else if (measurement.value > warningLimit) {
+      status = "warn";
+    }
+    summary[status] += 1;
+    metrics.push({
+      metric: metricId,
+      status,
+      value: measurement.value,
+      baseline: metric.baseline,
+      unit: metric.unit,
+      statistic: measurement.statistic,
+      samples: measurement.samples,
+      warningLimit,
+      failureLimit,
+    });
+  }
+
+  for (const [metricId, metric] of Object.entries(catalog.metrics ?? {})) {
+    if (metric.ciRequired && !measurementsByMetric.has(metricId)) {
+      errors.push(`Missing CI-required performance measurement: ${metricId}.`);
+    }
+  }
+
+  return { errors, metrics, summary };
+}
+
+function parseArgs(argv) {
+  const options = {
+    catalog: DEFAULT_CATALOG_PATH,
+    measurements: undefined,
+    output: undefined,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (arg === "--catalog" && value) {
+      options.catalog = resolve(value);
+      index += 1;
+    } else if (arg === "--measurements" && value) {
+      options.measurements = resolve(value);
+      index += 1;
+    } else if (arg === "--output" && value) {
+      options.output = resolve(value);
+      index += 1;
+    } else {
+      throw new Error(`Unknown or incomplete argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function writeReport(outputPath, report) {
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+}
+
+function runCli() {
+  const options = parseArgs(process.argv.slice(2));
+  const catalog = readJson(options.catalog);
+  if (!options.measurements) {
+    const errors = validatePerformanceCatalog(catalog);
+    if (errors.length > 0) {
+      throw new Error(errors.join("\n"));
+    }
+    console.log(`Performance catalog is valid: ${options.catalog}`);
+    return;
+  }
+
+  const report = evaluatePerformanceMeasurements(
+    catalog,
+    readJson(options.measurements),
+  );
+  if (options.output) {
+    writeReport(options.output, report);
+  }
+  console.log(
+    `Performance budget results: ${report.summary.pass} pass, ${report.summary.warn} warning, ${report.summary.fail} failure.`,
+  );
+  if (report.errors.length > 0) {
+    throw new Error(report.errors.join("\n"));
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    runCli();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-performance-budgets.test.mjs
+++ b/scripts/check-performance-budgets.test.mjs
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  REQUIRED_PERFORMANCE_METRIC_IDS,
+  evaluatePerformanceMeasurements,
+  loadRepositoryPerformanceCatalog,
+  validatePerformanceCatalog,
+} from "./check-performance-budgets.mjs";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const SAMPLE_CATALOG = {
+  schemaVersion: 1,
+  tolerance: {
+    warningRatio: 1.1,
+    failureRatio: 1.2,
+  },
+  metrics: Object.fromEntries(
+    REQUIRED_PERFORMANCE_METRIC_IDS.map((metricId) => [
+      metricId,
+      {
+        baseline: metricId.endsWith("_mb") ? 100 : 1000,
+        unit: metricId.endsWith("_mb") ? "MB" : "ms",
+        ciRequired: false,
+        summary: `${metricId} fixture budget.`,
+        source: "test fixture",
+      },
+    ]),
+  ),
+};
+
+Object.assign(SAMPLE_CATALOG.metrics, {
+  "mcp.tools_list.response_ms": {
+    baseline: 100,
+    unit: "ms",
+    ciRequired: true,
+    summary: "Streamable HTTP tools/list response.",
+    source: "packages/mcp-server/tests/unit/test_benchmark_latency.py",
+  },
+  "extension.project_scan.single_ms": {
+    baseline: 300,
+    unit: "ms",
+    ciRequired: false,
+    summary: "Single project scan.",
+    source: "OASLANA-46",
+  },
+});
+
+test("repository performance catalog defines every OASLANA-124 metric", () => {
+  const catalog = loadRepositoryPerformanceCatalog(REPO_ROOT);
+  const errors = validatePerformanceCatalog(catalog);
+
+  assert.deepEqual(errors, []);
+  assert.deepEqual(
+    Object.keys(catalog.metrics).sort(),
+    [...REQUIRED_PERFORMANCE_METRIC_IDS].sort(),
+  );
+  assert.equal(catalog.metrics["mcp.tools_list.response_ms"].ciRequired, true);
+  assert.equal(
+    catalog.metrics["extension.viewer.large_pcb_first_render_ms"].unit,
+    "ms",
+  );
+  assert.equal(catalog.metrics["extension.memory.viewer_open_mb"].unit, "MB");
+});
+
+test("root check includes performance budget catalog validation", () => {
+  const packageJson = JSON.parse(
+    readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"),
+  );
+
+  assert.equal(
+    packageJson.scripts["check:performance-budgets"],
+    "node scripts/check-performance-budgets.mjs && node --test scripts/check-performance-budgets.test.mjs",
+  );
+  assert.match(packageJson.scripts.check, /pnpm run check:performance-budgets/);
+});
+
+test("budget evaluation warns at 10 percent drift and fails above 20 percent", () => {
+  const result = evaluatePerformanceMeasurements(SAMPLE_CATALOG, {
+    schemaVersion: 1,
+    measurements: [
+      {
+        metric: "mcp.tools_list.response_ms",
+        value: 111,
+        unit: "ms",
+        statistic: "p95",
+        samples: 5,
+      },
+    ],
+  });
+
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.summary.warn, 1);
+  assert.equal(result.summary.fail, 0);
+  assert.equal(result.metrics[0].status, "warn");
+  assert.equal(result.metrics[0].warningLimit, 110);
+  assert.equal(result.metrics[0].failureLimit, 120);
+
+  const failure = evaluatePerformanceMeasurements(SAMPLE_CATALOG, {
+    schemaVersion: 1,
+    measurements: [
+      {
+        metric: "mcp.tools_list.response_ms",
+        value: 121,
+        unit: "ms",
+        statistic: "p95",
+        samples: 5,
+      },
+    ],
+  });
+
+  assert.equal(failure.summary.fail, 1);
+  assert.match(failure.errors.join("\n"), /mcp\.tools_list\.response_ms/);
+  assert.match(failure.errors.join("\n"), /121\.00 ms > 120\.00 ms/);
+});
+
+test("budget evaluation requires CI measurements and rejects unit drift", () => {
+  const missing = evaluatePerformanceMeasurements(SAMPLE_CATALOG, {
+    schemaVersion: 1,
+    measurements: [],
+  });
+
+  assert.match(
+    missing.errors.join("\n"),
+    /Missing CI-required performance measurement: mcp\.tools_list\.response_ms/,
+  );
+
+  const mismatched = evaluatePerformanceMeasurements(SAMPLE_CATALOG, {
+    schemaVersion: 1,
+    measurements: [
+      {
+        metric: "mcp.tools_list.response_ms",
+        value: 50,
+        unit: "MB",
+        statistic: "p95",
+        samples: 5,
+      },
+    ],
+  });
+
+  assert.match(
+    mismatched.errors.join("\n"),
+    /mcp\.tools_list\.response_ms must use ms, received MB/,
+  );
+});

--- a/scripts/check-testing-strategy.mjs
+++ b/scripts/check-testing-strategy.mjs
@@ -17,6 +17,7 @@ const requiredSections = [
   "## Gate Summary",
   "## Test Layers",
   "## Fast PR Gates",
+  "## Performance Budgets",
   "## Nightly Quality Gates",
   "## Regression Coverage Map",
   "## Local Commands",
@@ -38,8 +39,10 @@ const requiredPhrases = [
   "corepack pnpm run build:kicad-mcp-pro",
   "corepack pnpm run package:kicad-mcp-pro",
   "corepack pnpm run check:mcp-npm",
+  "corepack pnpm run check:performance-budgets",
   "corepack pnpm run test:contract",
   "corepack pnpm run test:fixtures",
+  "docs/performance-baselines.md",
   "@vscode/test-electron",
   "Playwright",
   "toHaveScreenshot",
@@ -66,6 +69,7 @@ const roadmapIssueIds = [
   "OASLANA-64",
   "OASLANA-81",
   "OASLANA-82",
+  "OASLANA-124",
 ];
 
 function readText(filePath) {


### PR DESCRIPTION
## Summary

- define the shared OASLANA-124 performance budget catalog for activation, project scan, viewer, validation, MCP, and memory surfaces
- add a budget checker with 10% warning / 20% failure thresholds and migrate the MCP `tools/list` benchmark to emit CI measurement JSON against it
- add the PR `performance-budgets` CI job, artifact reports, and baseline methodology/testing strategy docs

## Linked issue

Linear: [OASLANA-124](https://linear.app/oaslananka/issue/OASLANA-124/define-performance-baselines-and-ci-budgets-for-activation-viewer)

## Type of change

- [ ] type:bug
- [ ] type:feature
- [x] type:docs
- [ ] type:refactor
- [x] type:perf
- [ ] type:security
- [x] type:chore
- [ ] breaking

## Test evidence

Passed locally:

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run format`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `xvfb-run -a corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run check`
- `corepack pnpm run check:testing-strategy`
- `corepack pnpm run check:performance-budgets`
- `KICAD_PERFORMANCE_MEASUREMENTS_JSON=performance-results/mcp-tools-list.json uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_benchmark_latency.py`
- `node scripts/check-performance-budgets.mjs --measurements performance-results/mcp-tools-list.json --output performance-results/budget-report.json`
- `uv sync --all-extras && uv run --all-extras pytest` from `packages/mcp-server` (646 passed)
- `uvx pre-commit run --all-files`
- `uvx yamllint .github/workflows/ci.yml`
- checksum-verified official `actionlint` v1.7.12 on `.github/workflows/ci.yml`
- checksum-verified official `gitleaks` v8.30.1 redacted repository scan
- checksum-verified official `act` v0.2.88 dry-run for CI job `performance-budgets`

Command-path notes:

- direct `corepack pnpm run test` reaches VS Code Electron without a Linux display here and fails with missing `DISPLAY`; the documented `xvfb-run` rerun passed
- root `corepack pnpm run verify:dist` is unavailable because this package has no `verify:dist` script
- literal package-dir `uv sync && uv run pytest` drops optional Hypothesis test dependencies; the repository all-extras pytest path above passed

## Protocol / MCP impact

- [x] Not applicable; reason: CI budgets, shared benchmark metadata, docs, and MCP benchmark test output only
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [ ] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
