### PR TITLE
feat(kicad-studio): add AI provider secret vault

### DIFF
--- a/apps/vscode-extension/docs/AI_PROVIDERS.md
+++ b/apps/vscode-extension/docs/AI_PROVIDERS.md
@@ -2,12 +2,14 @@
 
 ## Supported Providers
 
-KiCad Studio supports four AI provider paths:
+KiCad Studio supports six direct AI provider paths:
 
 - Claude
 - OpenAI
+- OpenRouter
 - GitHub Copilot
 - Gemini
+- local OpenAI-compatible endpoints
 
 For compatible VS Code builds, KiCad Studio can also contribute:
 
@@ -27,6 +29,13 @@ For compatible VS Code builds, KiCad Studio can also contribute:
 - The default model comes from the extension's shared provider constants and can be overridden with `kicadstudio.ai.model`.
 - API mode can be `responses` or `chat-completions`.
 
+## OpenRouter
+
+- Set `kicadstudio.ai.provider` to `openrouter`.
+- Store the OpenRouter API key with `KiCad: Set AI API Key`.
+- Set `kicadstudio.ai.model` to an OpenRouter model ID when overriding the shared default.
+- OpenRouter requests use its chat-completions endpoint from the extension host.
+
 ## GitHub Copilot
 
 - Set `kicadstudio.ai.provider` to `copilot`.
@@ -36,8 +45,15 @@ For compatible VS Code builds, KiCad Studio can also contribute:
 ## Gemini
 
 - Set `kicadstudio.ai.provider` to `gemini`.
-- Requires Gemini availability through the VS Code Language Model API in the user environment.
-- No separate API key is stored by KiCad Studio.
+- Store the Gemini API key with `KiCad: Set AI API Key`.
+- The default model comes from the extension's shared provider constants and can be overridden with `kicadstudio.ai.model`.
+
+## Local
+
+- Set `kicadstudio.ai.provider` to `local`.
+- Set `kicadstudio.ai.localEndpoint` to the base URL of a local OpenAI-compatible chat endpoint, for example one that exposes `/v1/chat/completions`.
+- Set `kicadstudio.ai.model` to the model ID expected by that endpoint.
+- KiCad Studio does not store or send an API key for the local provider. Without a configured local endpoint, provider selection falls back to an unconfigured state.
 
 ## Response Language
 
@@ -74,7 +90,8 @@ Use `KiCad: Manage Chat Provider` to:
 
 ## Security Model
 
-- KiCad Studio stores external API keys in VS Code SecretStorage.
+- KiCad Studio stores external API keys in VS Code SecretStorage under provider-specific keys.
+- Legacy plaintext AI and Octopart/Nexar settings are migrated into SecretStorage and cleared from settings during activation.
 - Webviews do not call AI providers directly.
 - Network calls stay in the extension host.
 - Debug logging must never print raw API keys; larger request bodies are redacted.

--- a/apps/vscode-extension/docs/ARCHITECTURE.md
+++ b/apps/vscode-extension/docs/ARCHITECTURE.md
@@ -35,8 +35,9 @@ The extension is activated from KiCad project, schematic, PCB, jobset, or DRC ru
 ## AI Layer
 
 - `AIProviderRegistry` resolves the configured provider and model selection.
-- Claude and OpenAI providers call their remote APIs from the extension host only.
-- Copilot and Gemini providers use the VS Code Language Model API when available.
+- Claude, OpenAI, OpenRouter, and Gemini providers call their remote APIs from the extension host only.
+- The local provider routes to an explicitly configured OpenAI-compatible endpoint without a stored API key.
+- Copilot and Codex providers use the VS Code Language Model API when available.
 - `KiCadChatPanel` is the multi-turn chat UI and can render MCP tool suggestions embedded in assistant replies.
 - Prompt construction in `src/ai/prompts.ts` is KiCad 10-aware and injects active variant / MCP context when available.
 - `src/lm/languageModelTools.ts` registers agent-callable KiCad tools for supported VS Code hosts.

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1265,8 +1265,10 @@
             "none",
             "claude",
             "openai",
+            "openrouter",
             "copilot",
             "gemini",
+            "local",
             "codex"
           ],
           "description": "AI provider for circuit analysis and error explanation."
@@ -1274,7 +1276,12 @@
         "kicadstudio.ai.model": {
           "type": "string",
           "default": "",
-          "description": "Optional AI model override. Leave empty to use the provider default: claude-sonnet-4-6 for Claude, gpt-5.5 for OpenAI, or gemini-2.5-pro for Gemini."
+          "description": "Optional AI model override. Leave empty to use the provider default when the provider has one."
+        },
+        "kicadstudio.ai.localEndpoint": {
+          "type": "string",
+          "default": "",
+          "description": "OpenAI-compatible local chat endpoint base URL. KiCad Studio enables the local provider only after this endpoint is configured."
         },
         "kicadstudio.ai.openaiApiMode": {
           "type": "string",

--- a/apps/vscode-extension/src/ai/aiProvider.ts
+++ b/apps/vscode-extension/src/ai/aiProvider.ts
@@ -3,6 +3,7 @@ import { AI_SECRET_KEY_LEGACY, SETTINGS } from '../constants';
 import type { AIProvider } from '../types';
 import {
   getAiSecretKey,
+  getAiSecretProviders,
   isAiSecretProvider,
   migrateLegacyAiSecret,
   type AiSecretProvider
@@ -10,8 +11,10 @@ import {
 import { ClaudeProvider } from './claudeProvider';
 import { CodexProvider, CopilotProvider } from './copilotProvider';
 import { GeminiProvider } from './geminiProvider';
+import { LocalProvider } from './localProvider';
 import { getDefaultModel } from './modelCatalog';
 import { OpenAIProvider } from './openaiProvider';
+import { OpenRouterProvider } from './openrouterProvider';
 import {
   DEFAULT_CLAUDE_MODEL,
   DEFAULT_GEMINI_MODEL,
@@ -55,6 +58,14 @@ export class AIProviderRegistry {
       return new CodexProvider();
     }
 
+    if (selected === 'local') {
+      const endpoint = vscode.workspace
+        .getConfiguration()
+        .get<string>(SETTINGS.aiLocalEndpoint, '')
+        .trim();
+      return endpoint ? new LocalProvider(endpoint, model) : undefined;
+    }
+
     if (selected === 'claude') {
       const apiKey = await this.getApiKey('claude');
       if (!apiKey) {
@@ -72,6 +83,16 @@ export class AIProviderRegistry {
         apiKey,
         model || DEFAULT_OPENAI_MODEL,
         apiMode === 'chat-completions' ? 'chat-completions' : 'responses'
+      );
+    }
+    if (selected === 'openrouter') {
+      const apiKey = await this.getApiKey('openrouter');
+      if (!apiKey) {
+        return undefined;
+      }
+      return new OpenRouterProvider(
+        apiKey,
+        model || getDefaultModel('openrouter')
       );
     }
     if (selected === 'gemini') {
@@ -102,9 +123,7 @@ export class AIProviderRegistry {
 
   async clearAllApiKeys(): Promise<void> {
     await Promise.all([
-      ...(['claude', 'openai', 'gemini'] as AiSecretProvider[]).map(
-        (provider) => this.clearApiKey(provider)
-      ),
+      ...getAiSecretProviders().map((provider) => this.clearApiKey(provider)),
       this.context.secrets.delete(AI_SECRET_KEY_LEGACY)
     ]);
   }
@@ -112,8 +131,10 @@ export class AIProviderRegistry {
   getDefaultModel(provider: string): string {
     return provider === 'claude' ||
       provider === 'openai' ||
+      provider === 'openrouter' ||
       provider === 'copilot' ||
       provider === 'gemini' ||
+      provider === 'local' ||
       provider === 'codex'
       ? getDefaultModel(provider)
       : '';

--- a/apps/vscode-extension/src/ai/claudeProvider.ts
+++ b/apps/vscode-extension/src/ai/claudeProvider.ts
@@ -47,6 +47,10 @@ interface ClaudeErrorResponse {
  */
 export class ClaudeProvider implements AIProvider {
   readonly name = 'Claude';
+  readonly capabilities = {
+    requiresApiKey: true,
+    supportsStreaming: true
+  };
 
   constructor(
     private readonly apiKey: string,

--- a/apps/vscode-extension/src/ai/copilotProvider.ts
+++ b/apps/vscode-extension/src/ai/copilotProvider.ts
@@ -28,6 +28,10 @@ interface MessageFactory {
 abstract class BaseLanguageModelProvider implements AIProvider {
   abstract readonly name: string;
   protected abstract readonly selectors: Array<Record<string, string>>;
+  readonly capabilities = {
+    requiresApiKey: false,
+    supportsStreaming: true
+  };
 
   isConfigured(): boolean {
     return Boolean(this.getLmApi());

--- a/apps/vscode-extension/src/ai/geminiProvider.ts
+++ b/apps/vscode-extension/src/ai/geminiProvider.ts
@@ -31,6 +31,10 @@ interface GeminiErrorResponse {
 
 export class GeminiProvider implements AIProvider {
   readonly name = 'Gemini';
+  readonly capabilities = {
+    requiresApiKey: true,
+    supportsStreaming: true
+  };
 
   constructor(
     private readonly apiKey: string,

--- a/apps/vscode-extension/src/ai/localProvider.ts
+++ b/apps/vscode-extension/src/ai/localProvider.ts
@@ -1,0 +1,18 @@
+import { OpenAIProvider } from './openaiProvider';
+
+export class LocalProvider extends OpenAIProvider {
+  constructor(endpoint: string, model: string) {
+    super('', model, 'chat-completions', {
+      chatCompletionsUrl: toChatCompletionsUrl(endpoint),
+      name: 'Local',
+      requiresApiKey: false
+    });
+  }
+}
+
+function toChatCompletionsUrl(endpoint: string): string {
+  const normalized = endpoint.trim().replace(/\/+$/, '');
+  return normalized.endsWith('/chat/completions')
+    ? normalized
+    : `${normalized}/chat/completions`;
+}

--- a/apps/vscode-extension/src/ai/modelCatalog.ts
+++ b/apps/vscode-extension/src/ai/modelCatalog.ts
@@ -1,4 +1,11 @@
-export type AiProviderId = 'claude' | 'openai' | 'copilot' | 'gemini' | 'codex';
+export type AiProviderId =
+  | 'claude'
+  | 'openai'
+  | 'openrouter'
+  | 'copilot'
+  | 'gemini'
+  | 'local'
+  | 'codex';
 
 export interface ModelInfo {
   id: string;
@@ -164,6 +171,19 @@ export const GEMINI_MODELS: AiModelInfo[] = [
   }
 ];
 
+export const OPENROUTER_MODELS: AiModelInfo[] = [
+  {
+    id: 'openai/gpt-4o',
+    provider: 'openrouter',
+    label: 'OpenAI GPT-4o through OpenRouter',
+    maxTokens: 16384,
+    supportsStreaming: true,
+    contextWindow: 128000,
+    recommended: true,
+    default: true
+  }
+];
+
 export const COPILOT_MODELS: AiModelInfo[] = [
   {
     id: 'copilot/default',
@@ -190,11 +210,15 @@ export const CODEX_MODELS: AiModelInfo[] = [
   }
 ];
 
+export const LOCAL_MODELS: AiModelInfo[] = [];
+
 export const MODEL_CATALOG: Record<AiProviderId, AiModelInfo[]> = {
   claude: CLAUDE_MODELS,
   openai: OPENAI_MODELS,
+  openrouter: OPENROUTER_MODELS,
   gemini: GEMINI_MODELS,
   copilot: COPILOT_MODELS,
+  local: LOCAL_MODELS,
   codex: CODEX_MODELS
 };
 

--- a/apps/vscode-extension/src/ai/openaiProvider.ts
+++ b/apps/vscode-extension/src/ai/openaiProvider.ts
@@ -12,6 +12,13 @@ import { createManagedAbortSignal, readEventStream } from './providerUtils';
 
 export type OpenAIApiMode = 'responses' | 'chat-completions';
 
+export interface OpenAIProviderOptions {
+  chatCompletionsUrl?: string;
+  name?: string;
+  requiresApiKey?: boolean;
+  responsesUrl?: string;
+}
+
 interface OpenAITextPart {
   text?: string;
 }
@@ -50,16 +57,33 @@ interface OpenAIStreamEvent {
  * OpenAI provider for KiCad analysis requests.
  */
 export class OpenAIProvider implements AIProvider {
-  readonly name = 'OpenAI';
+  readonly name: string;
+  readonly capabilities: AIProvider['capabilities'];
+  private readonly chatCompletionsUrl: string;
+  private readonly requiresApiKey: boolean;
+  private readonly responsesUrl: string;
 
   constructor(
     private readonly apiKey: string,
     private readonly model: string,
-    private readonly mode: OpenAIApiMode = 'responses'
-  ) {}
+    private readonly mode: OpenAIApiMode = 'responses',
+    options: OpenAIProviderOptions = {}
+  ) {
+    this.name = options.name ?? 'OpenAI';
+    this.requiresApiKey = options.requiresApiKey ?? true;
+    this.capabilities = {
+      requiresApiKey: this.requiresApiKey,
+      supportsStreaming: true
+    };
+    this.chatCompletionsUrl =
+      options.chatCompletionsUrl ??
+      'https://api.openai.com/v1/chat/completions';
+    this.responsesUrl =
+      options.responsesUrl ?? 'https://api.openai.com/v1/responses';
+  }
 
   isConfigured(): boolean {
-    return Boolean(this.apiKey);
+    return this.requiresApiKey ? Boolean(this.apiKey) : true;
   }
 
   async analyze(
@@ -81,7 +105,7 @@ export class OpenAIProvider implements AIProvider {
   ): Promise<void> {
     if (this.mode === 'chat-completions') {
       const response = await this.request(
-        'https://api.openai.com/v1/chat/completions',
+        this.chatCompletionsUrl,
         {
           model: this.model,
           stream: true,
@@ -115,7 +139,7 @@ export class OpenAIProvider implements AIProvider {
     }
 
     const response = await this.request(
-      'https://api.openai.com/v1/responses',
+      this.responsesUrl,
       {
         model: this.model,
         max_output_tokens: AI_MAX_TOKENS,
@@ -209,10 +233,10 @@ export class OpenAIProvider implements AIProvider {
 
     const json = (await response.json()) as OpenAIResponsesResponse;
     if (Array.isArray(json.output_text)) {
-      return json.output_text.join('\n').trim() || 'No response from OpenAI.';
+      return json.output_text.join('\n').trim() || `No response from ${this.name}.`;
     }
     if (typeof json.output_text === 'string') {
-      return json.output_text.trim() || 'No response from OpenAI.';
+      return json.output_text.trim() || `No response from ${this.name}.`;
     }
 
     const output = json.output
@@ -220,7 +244,7 @@ export class OpenAIProvider implements AIProvider {
       .map((part) => part.text)
       .filter((text): text is string => Boolean(text?.trim()))
       .join('\n');
-    return output?.trim() || 'No response from OpenAI.';
+    return output?.trim() || `No response from ${this.name}.`;
   }
 
   private async analyzeWithChatCompletions(
@@ -229,7 +253,7 @@ export class OpenAIProvider implements AIProvider {
     systemPrompt: string
   ): Promise<string> {
     const response = await this.request(
-      'https://api.openai.com/v1/chat/completions',
+      this.chatCompletionsUrl,
       {
         model: this.model,
         // Newer OpenAI models (gpt-4.5, gpt-5, gpt-5-mini, o-series) require
@@ -244,7 +268,8 @@ export class OpenAIProvider implements AIProvider {
 
     const json = (await response.json()) as OpenAIChatResponse;
     return (
-      json.choices?.[0]?.message?.content?.trim() || 'No response from OpenAI.'
+      json.choices?.[0]?.message?.content?.trim() ||
+      `No response from ${this.name}.`
     );
   }
 
@@ -263,13 +288,17 @@ export class OpenAIProvider implements AIProvider {
       signal
     );
     try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json'
+      };
+      if (this.apiKey) {
+        headers['Authorization'] = `Bearer ${this.apiKey}`;
+      }
+
       const response = await fetch(url, {
         method: 'POST',
         signal: managedSignal.signal,
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.apiKey}`
-        },
+        headers,
         body: JSON.stringify(body)
       });
 
@@ -301,9 +330,12 @@ export class OpenAIProvider implements AIProvider {
       }
       throw error instanceof Error
         ? new Error(redactApiKey(error.message, this.apiKey), { cause: error })
-        : new Error('OpenAI request failed due to an unknown network error.', {
-            cause: error
-          });
+        : new Error(
+            `${this.name} request failed due to an unknown network error.`,
+            {
+              cause: error
+            }
+          );
     } finally {
       managedSignal.cleanup();
     }
@@ -324,12 +356,12 @@ export class OpenAIProvider implements AIProvider {
 
     const prefix =
       response.status === 401
-        ? 'OpenAI authentication failed. Check the stored API key.'
+        ? `${this.name} authentication failed. Check the stored API key.`
         : response.status === 429
-          ? 'OpenAI rate limit reached. Wait and try again, or choose a different model.'
+          ? `${this.name} rate limit reached. Wait and try again, or choose a different model.`
           : response.status >= 500
-            ? 'OpenAI service returned a server error.'
-            : `OpenAI request failed with HTTP ${response.status}.`;
+            ? `${this.name} service returned a server error.`
+            : `${this.name} request failed with HTTP ${response.status}.`;
     return apiMessage
       ? `${prefix} ${redactApiKey(apiMessage, this.apiKey)}`
       : prefix;

--- a/apps/vscode-extension/src/ai/openrouterProvider.ts
+++ b/apps/vscode-extension/src/ai/openrouterProvider.ts
@@ -1,0 +1,13 @@
+import { OpenAIProvider } from './openaiProvider';
+
+const OPENROUTER_CHAT_COMPLETIONS_URL =
+  'https://openrouter.ai/api/v1/chat/completions';
+
+export class OpenRouterProvider extends OpenAIProvider {
+  constructor(apiKey: string, model: string) {
+    super(apiKey, model, 'chat-completions', {
+      chatCompletionsUrl: OPENROUTER_CHAT_COMPLETIONS_URL,
+      name: 'OpenRouter'
+    });
+  }
+}

--- a/apps/vscode-extension/src/commands/aiCommands.ts
+++ b/apps/vscode-extension/src/commands/aiCommands.ts
@@ -125,7 +125,7 @@ export function registerAiCommands(
           {
             label: 'Pick AI provider',
             description:
-              'Choose Claude, OpenAI, Copilot, Gemini, or disable AI.',
+              'Choose a configured remote, VS Code, or local provider.',
             action: 'pick-provider'
           },
           {
@@ -141,7 +141,7 @@ export function registerAiCommands(
           {
             label: 'Clear all AI API keys',
             description:
-              'Remove Claude, OpenAI, and Gemini keys from SecretStorage.',
+              'Remove Claude, OpenAI, OpenRouter, and Gemini keys from SecretStorage.',
             action: 'clear-all'
           },
           {
@@ -172,8 +172,10 @@ export function registerAiCommands(
             { label: 'Disabled', provider: 'none' },
             { label: 'Claude', provider: 'claude' },
             { label: 'OpenAI', provider: 'openai' },
+            { label: 'OpenRouter', provider: 'openrouter' },
             { label: 'GitHub Copilot', provider: 'copilot' },
-            { label: 'Gemini', provider: 'gemini' }
+            { label: 'Gemini', provider: 'gemini' },
+            { label: 'Local OpenAI-compatible', provider: 'local' }
           ],
           {
             title: 'AI provider',
@@ -234,16 +236,20 @@ export function registerAiCommands(
         const provider = (
           selectedProvider === 'claude' ||
           selectedProvider === 'openai' ||
+          selectedProvider === 'openrouter' ||
           selectedProvider === 'copilot' ||
-          selectedProvider === 'gemini'
+          selectedProvider === 'gemini' ||
+          selectedProvider === 'local'
             ? selectedProvider
             : 'claude'
         ) as AiProviderId;
         const knownModels =
           provider === 'claude' ||
           provider === 'openai' ||
+          provider === 'openrouter' ||
           provider === 'copilot' ||
-          provider === 'gemini'
+          provider === 'gemini' ||
+          provider === 'local'
             ? getProviderModels(provider)
             : [];
         const currentModel = vscode.workspace

--- a/apps/vscode-extension/src/commands/secretCommands.ts
+++ b/apps/vscode-extension/src/commands/secretCommands.ts
@@ -122,6 +122,8 @@ async function pickAiSecretProvider(): Promise<AiSecretProvider | undefined> {
 function formatProviderName(provider: AiSecretProvider): string {
   return provider === 'openai'
     ? 'OpenAI'
+    : provider === 'openrouter'
+      ? 'OpenRouter'
     : provider === 'gemini'
       ? 'Gemini'
       : 'Claude';

--- a/apps/vscode-extension/src/constants.ts
+++ b/apps/vscode-extension/src/constants.ts
@@ -33,6 +33,7 @@ export const OCTOPART_SECRET_KEY = 'kicadstudio.secrets.octopart';
 export const AI_SECRET_KEYS = {
   claude: 'kicadstudio.secrets.ai.claude',
   openai: 'kicadstudio.secrets.ai.openai',
+  openrouter: 'kicadstudio.secrets.ai.openrouter',
   gemini: 'kicadstudio.secrets.ai.gemini'
 } as const;
 export type AiProviderName = keyof typeof AI_SECRET_KEYS;
@@ -186,6 +187,7 @@ export const SETTINGS = {
   aiProvider: 'kicadstudio.ai.provider',
   aiApiKey: 'kicadstudio.ai.apiKey',
   aiModel: 'kicadstudio.ai.model',
+  aiLocalEndpoint: 'kicadstudio.ai.localEndpoint',
   aiLanguage: 'kicadstudio.ai.language',
   aiAllowTools: 'kicadstudio.ai.allowTools',
   aiOpenAIApiMode: 'kicadstudio.ai.openaiApiMode',

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -81,7 +81,11 @@ import { KiCadTaskProvider } from './tasks/kicadTaskProvider';
 import { VariantProvider } from './variants/variantProvider';
 import { readConfiguredMcpProfile } from './commands/mcpProfilePicker';
 import { Logger } from './utils/logger';
-import { getAiSecretKey, isAiSecretProvider } from './utils/secrets';
+import {
+  getAiSecretKey,
+  isAiSecretProvider,
+  migratePlaintextSettingToSecret
+} from './utils/secrets';
 import {
   getActiveResourceUri,
   workspaceHasVariants
@@ -880,7 +884,11 @@ async function migrateDeprecatedSecretSettings(
   });
 }
 
-function getConfiguredAiSecretProvider(): 'claude' | 'openai' | 'gemini' {
+function getConfiguredAiSecretProvider():
+  | 'claude'
+  | 'openai'
+  | 'openrouter'
+  | 'gemini' {
   const provider = vscode.workspace
     .getConfiguration()
     .get<string>(SETTINGS.aiProvider, 'claude');
@@ -894,44 +902,32 @@ async function migrateDeprecatedSecretSetting(args: {
   secretKey: string;
   label: string;
 }): Promise<void> {
-  const config = vscode.workspace.getConfiguration();
-  const plaintextValue = config.get<string>(args.settingKey, '').trim();
-  if (!plaintextValue) {
+  const migrated = await migratePlaintextSettingToSecret({
+    config: vscode.workspace.getConfiguration(),
+    secrets: args.context.secrets,
+    settingKey: args.settingKey,
+    secretKey: args.secretKey,
+    clearTargets: [
+      vscode.ConfigurationTarget.Global,
+      vscode.ConfigurationTarget.Workspace,
+      vscode.ConfigurationTarget.WorkspaceFolder
+    ],
+    onClearError: (target, error) => {
+      args.logger.debug(
+        `Could not clear deprecated setting ${args.settingKey} at target ${String(target)}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  });
+  if (!migrated) {
     return;
   }
 
-  const existingSecret = await args.context.secrets.get(args.secretKey);
-  if (!existingSecret) {
-    await args.context.secrets.store(args.secretKey, plaintextValue);
-  }
-
-  await clearDeprecatedSetting(config, args.settingKey, args.logger);
   args.logger.warn(
     `${args.label} API key was migrated from deprecated plaintext settings to VS Code SecretStorage.`
   );
   void vscode.window.showInformationMessage(
     `${args.label} API key was moved from deprecated settings to VS Code SecretStorage. Plaintext runtime fallback is disabled in KiCad Studio v2.`
   );
-}
-
-async function clearDeprecatedSetting(
-  config: vscode.WorkspaceConfiguration,
-  settingKey: string,
-  logger: Logger
-): Promise<void> {
-  for (const target of [
-    vscode.ConfigurationTarget.Global,
-    vscode.ConfigurationTarget.Workspace,
-    vscode.ConfigurationTarget.WorkspaceFolder
-  ]) {
-    try {
-      await config.update(settingKey, undefined, target);
-    } catch (error) {
-      logger.debug(
-        `Could not clear deprecated setting ${settingKey} at target ${String(target)}: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-    }
-  }
 }

--- a/apps/vscode-extension/src/settings/settingsHtml.ts
+++ b/apps/vscode-extension/src/settings/settingsHtml.ts
@@ -207,14 +207,20 @@ export function buildSettingsHtml(options: SettingsHtmlOptions): string {
             <option value="none">Disabled</option>
             <option value="claude">Claude</option>
             <option value="openai">OpenAI</option>
+            <option value="openrouter">OpenRouter</option>
             <option value="copilot">GitHub Copilot</option>
             <option value="gemini">Gemini</option>
+            <option value="local">Local OpenAI-compatible</option>
             <option value="codex">Codex (VS Code)</option>
           </select>
         </div>
         <div class="field">
           <label for="kicadstudio.ai.model">Model</label>
           <input id="kicadstudio.ai.model" data-setting="kicadstudio.ai.model" type="text" placeholder="Provider default">
+        </div>
+        <div class="field">
+          <label for="kicadstudio.ai.localEndpoint">Local endpoint</label>
+          <input id="kicadstudio.ai.localEndpoint" data-setting="kicadstudio.ai.localEndpoint" type="text" placeholder="http://127.0.0.1:11434/v1">
         </div>
         <div class="field">
           <label for="kicadstudio.ai.openaiApiMode">OpenAI API mode</label>

--- a/apps/vscode-extension/src/settings/settingsPanel.ts
+++ b/apps/vscode-extension/src/settings/settingsPanel.ts
@@ -34,6 +34,7 @@ const SETTINGS_KEYS = [
   SETTINGS.viewerEnableSnapshotExport,
   SETTINGS.aiProvider,
   SETTINGS.aiModel,
+  SETTINGS.aiLocalEndpoint,
   SETTINGS.aiOpenAIApiMode,
   SETTINGS.aiGeminiApiMode,
   SETTINGS.aiMaxTokens,

--- a/apps/vscode-extension/src/types.ts
+++ b/apps/vscode-extension/src/types.ts
@@ -198,6 +198,11 @@ export interface AIConnectionResult {
   error?: string | undefined;
 }
 
+export interface AIProviderCapabilities {
+  requiresApiKey: boolean;
+  supportsStreaming: boolean;
+}
+
 export interface DiagnosticSummary {
   file: string;
   errors: number;
@@ -233,6 +238,7 @@ export interface ProjectTreeNode {
 
 export interface AIProvider {
   name: string;
+  capabilities: AIProviderCapabilities;
   analyze(
     prompt: string,
     context: string,

--- a/apps/vscode-extension/src/utils/secrets.ts
+++ b/apps/vscode-extension/src/utils/secrets.ts
@@ -15,7 +15,12 @@ const SECRET_ASSIGNMENT_PATTERN =
   /\b([A-Za-z0-9_.-]*(?:api[_-]?key|token|secret|password|passwd|auth)[A-Za-z0-9_.-]*)=([^\s,;&]+)/gi;
 
 export function isAiSecretProvider(value: string): value is AiSecretProvider {
-  return value === 'claude' || value === 'openai' || value === 'gemini';
+  return (
+    value === 'claude' ||
+    value === 'openai' ||
+    value === 'openrouter' ||
+    value === 'gemini'
+  );
 }
 
 export function getAiSecretKey(provider: AiSecretProvider): string {
@@ -23,7 +28,7 @@ export function getAiSecretKey(provider: AiSecretProvider): string {
 }
 
 export function getAiSecretProviders(): AiSecretProvider[] {
-  return ['claude', 'openai', 'gemini'];
+  return ['claude', 'openai', 'openrouter', 'gemini'];
 }
 
 export function redactApiKey(value: string, apiKey?: string): string {
@@ -109,4 +114,42 @@ export async function migrateLegacyAiSecret(args: {
   await args.secrets.store(providerKey, legacy);
   await args.secrets.delete(AI_SECRET_KEY_LEGACY);
   return legacy;
+}
+
+export async function migratePlaintextSettingToSecret<TTarget>(args: {
+  config: {
+    get(key: string, fallback: string): string;
+    update(
+      key: string,
+      value: undefined,
+      target: TTarget
+    ): Thenable<void> | Promise<void>;
+  };
+  secrets: {
+    get(key: string): Thenable<string | undefined>;
+    store(key: string, value: string): Thenable<void>;
+  };
+  settingKey: string;
+  secretKey: string;
+  clearTargets: readonly TTarget[];
+  onClearError?: (target: TTarget, error: unknown) => void;
+}): Promise<boolean> {
+  const plaintextValue = args.config.get(args.settingKey, '').trim();
+  if (!plaintextValue) {
+    return false;
+  }
+
+  if (!(await args.secrets.get(args.secretKey))) {
+    await args.secrets.store(args.secretKey, plaintextValue);
+  }
+
+  for (const target of args.clearTargets) {
+    try {
+      await args.config.update(args.settingKey, undefined, target);
+    } catch (error) {
+      args.onClearError?.(target, error);
+    }
+  }
+
+  return true;
 }

--- a/apps/vscode-extension/test/unit/aiProvider.perKey.test.ts
+++ b/apps/vscode-extension/test/unit/aiProvider.perKey.test.ts
@@ -1,5 +1,5 @@
 import { AIProviderRegistry } from '../../src/ai/aiProvider';
-import { AI_SECRET_KEY_LEGACY } from '../../src/constants';
+import { AI_SECRET_KEY_LEGACY, SETTINGS } from '../../src/constants';
 import { getAiSecretKey } from '../../src/utils/secrets';
 import { __setConfiguration, createExtensionContextMock } from './vscodeMock';
 
@@ -12,15 +12,17 @@ describe('AIProviderRegistry per-provider keys', () => {
     const context = createExtensionContextMock();
     const registry = new AIProviderRegistry(context as never);
 
-    await registry.setApiKey('openai', 'openai-key');
+    await registry.setApiKey('openrouter', 'openrouter-key');
 
-    await expect(registry.getApiKey('openai')).resolves.toBe('openai-key');
-    await expect(registry.hasApiKey('openai')).resolves.toBe(true);
+    await expect(registry.getApiKey('openrouter')).resolves.toBe(
+      'openrouter-key'
+    );
+    await expect(registry.hasApiKey('openrouter')).resolves.toBe(true);
     await expect(registry.hasApiKey('claude')).resolves.toBe(false);
 
-    await registry.clearApiKey('openai');
+    await registry.clearApiKey('openrouter');
 
-    await expect(registry.hasApiKey('openai')).resolves.toBe(false);
+    await expect(registry.hasApiKey('openrouter')).resolves.toBe(false);
   });
 
   it('migrates the legacy shared key only to the selected provider secret', async () => {
@@ -98,5 +100,37 @@ describe('AIProviderRegistry per-provider keys', () => {
     await expect(
       context.secrets.get(AI_SECRET_KEY_LEGACY)
     ).resolves.toBeUndefined();
+  });
+
+  it('selects OpenRouter and falls back when local configuration is absent', async () => {
+    const context = createExtensionContextMock();
+    const registry = new AIProviderRegistry(context as never);
+    await registry.setApiKey('openrouter', 'openrouter-key');
+
+    const openRouter = await registry.getProviderForSelection('openrouter');
+    const missingLocal = await registry.getProviderForSelection('local');
+
+    __setConfiguration({
+      [SETTINGS.aiLocalEndpoint]: 'http://127.0.0.1:11434/v1'
+    });
+    const local = await registry.getProviderForSelection('local', 'qwen3');
+
+    expect(openRouter?.name).toBe('OpenRouter');
+    expect(openRouter?.capabilities).toEqual(
+      expect.objectContaining({
+        supportsStreaming: true,
+        requiresApiKey: true
+      })
+    );
+    expect(missingLocal).toBeUndefined();
+    expect(local?.name).toBe('Local');
+    expect(local?.capabilities).toEqual(
+      expect.objectContaining({
+        supportsStreaming: true,
+        requiresApiKey: false
+      })
+    );
+    expect(registry.isKeyedProvider('openrouter')).toBe(true);
+    expect(registry.isKeyedProvider('local')).toBe(false);
   });
 });

--- a/apps/vscode-extension/test/unit/secrets.test.ts
+++ b/apps/vscode-extension/test/unit/secrets.test.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { AI_SECRET_KEY_LEGACY } from '../../src/constants';
 import {
   getAiSecretKey,
+  migratePlaintextSettingToSecret,
   migrateLegacyAiSecret,
   redactApiKey,
   redactSensitiveText
@@ -61,5 +62,38 @@ describe('AI secret utilities', () => {
 
     expect(store.get(getAiSecretKey('gemini'))).toBe('legacy-secret');
     expect(store.has(AI_SECRET_KEY_LEGACY)).toBe(false);
+  });
+
+  it('moves deprecated plaintext settings into SecretStorage and clears targets', async () => {
+    const secretStore = new Map<string, string>();
+    const config = {
+      get: jest.fn(() => 'plaintext-key'),
+      update: jest.fn(async () => undefined)
+    };
+    const secrets = {
+      get: jest.fn(async (key: string) => secretStore.get(key)),
+      store: jest.fn(async (key: string, value: string) => {
+        secretStore.set(key, value);
+      })
+    };
+
+    await expect(
+      migratePlaintextSettingToSecret({
+        config,
+        secrets,
+        settingKey: 'kicadstudio.ai.apiKey',
+        secretKey: getAiSecretKey('openrouter'),
+        clearTargets: ['global', 'workspace', 'workspaceFolder']
+      })
+    ).resolves.toBe(true);
+
+    expect(secretStore.get(getAiSecretKey('openrouter'))).toBe(
+      'plaintext-key'
+    );
+    expect(config.update.mock.calls).toEqual([
+      ['kicadstudio.ai.apiKey', undefined, 'global'],
+      ['kicadstudio.ai.apiKey', undefined, 'workspace'],
+      ['kicadstudio.ai.apiKey', undefined, 'workspaceFolder']
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- add OpenRouter and local OpenAI-compatible AI provider implementations behind the shared provider registry
- add provider capability metadata and keep keyed provider selection backed by VS Code SecretStorage
- migrate deprecated plaintext AI settings through a unit-tested SecretStorage helper and clear old settings targets
- expose OpenRouter/local provider settings and document the provider/key storage model

## Linked issue

Linear: https://linear.app/oaslananka/issue/OASLANA-109/add-ai-provider-abstraction-and-secretstorage-vault-for-api-keys

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [x] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm --dir apps/vscode-extension exec jest --runInBand --coverage=false --runTestsByPath test/unit/aiProvider.perKey.test.ts test/unit/secrets.test.ts` passed
- `corepack pnpm --dir apps/vscode-extension run typecheck` passed
- `corepack pnpm --dir apps/vscode-extension run lint` passed
- `corepack pnpm --dir apps/vscode-extension run test:unit` passed
- `corepack pnpm --dir apps/vscode-extension run docs:check` passed
- `corepack pnpm --dir apps/vscode-extension run format` passed
- `corepack pnpm install --frozen-lockfile` passed
- `corepack pnpm run lint` passed
- `corepack pnpm run typecheck` passed
- direct `corepack pnpm run test` needs an X server for VS Code Electron integration; `xvfb-run -a corepack pnpm run test` passed
- `corepack pnpm run build` passed
- `corepack pnpm run verify:dist` is unavailable at the root and returns `ERR_PNPM_NO_SCRIPT`
- `corepack pnpm run check` passed
- `uvx pre-commit run --all-files` passed
- `git diff --check` passed
- workflow deprecation grep across `.github/workflows` passed
- `gitleaks v8.30.1 detect --source . --redact --verbose` passed

## Protocol / MCP impact

- [x] Not applicable; reason: VS Code extension AI provider and SecretStorage surfaces only
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
