### PR TITLE
feat(kicad-studio): add settings migration framework

### DIFF
--- a/apps/vscode-extension/l10n/bundle.l10n.tr.json
+++ b/apps/vscode-extension/l10n/bundle.l10n.tr.json
@@ -205,5 +205,7 @@
   "{count} errors": "{count} hata",
   "{count} warnings": "{count} uyarı",
   "{count} info": "{count} bilgi",
-  "Run {label}": "{label} çalıştır"
+  "Run {label}": "{label} çalıştır",
+  "KiCad Studio settings migration failed. Existing settings were left at the last successful schema version; check the KiCad Studio output for details.": "KiCad Studio ayar geçişi başarısız oldu. Mevcut ayarlar son başarılı şema sürümünde bırakıldı; ayrıntılar için KiCad Studio çıktısını kontrol edin.",
+  "KiCad Studio updated deprecated settings to the current schema.": "KiCad Studio, kullanımdan kaldırılmış ayarları geçerli şemaya güncelledi."
 }

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -81,6 +81,7 @@ import { KiCadTaskProvider } from './tasks/kicadTaskProvider';
 import { VariantProvider } from './variants/variantProvider';
 import { readConfiguredMcpProfile } from './commands/mcpProfilePicker';
 import { Logger } from './utils/logger';
+import { runSettingsMigrations } from './settings/settingsMigrations';
 import {
   getAiSecretKey,
   isAiSecretProvider,
@@ -104,6 +105,7 @@ export async function activate(
   const logger = new Logger('KiCad Studio');
   extensionLogger = logger;
   logger.info('Activating KiCad Studio...');
+  await runSettingsMigrations(context, logger);
   await migrateDeprecatedSecretSettings(context, logger);
   let latestDrcRun:
     | {

--- a/apps/vscode-extension/src/i18n.ts
+++ b/apps/vscode-extension/src/i18n.ts
@@ -17,7 +17,11 @@ export const SOURCE_MESSAGES = {
   diagnosticErrors: '{count} errors',
   diagnosticWarnings: '{count} warnings',
   diagnosticInfos: '{count} info',
-  runValidation: 'Run {label}'
+  runValidation: 'Run {label}',
+  settingsMigrationFailed:
+    'KiCad Studio settings migration failed. Existing settings were left at the last successful schema version; check the KiCad Studio output for details.',
+  settingsMigrationUpdatedDeprecatedSettings:
+    'KiCad Studio updated deprecated settings to the current schema.'
 } as const;
 
 export type SourceMessageKey = keyof typeof SOURCE_MESSAGES;

--- a/apps/vscode-extension/src/settings/settingsMigrations.ts
+++ b/apps/vscode-extension/src/settings/settingsMigrations.ts
@@ -1,0 +1,231 @@
+import * as vscode from 'vscode';
+import { SETTINGS } from '../constants';
+import { localize } from '../i18n';
+import type { Logger } from '../utils/logger';
+
+export const SETTINGS_SCHEMA_VERSION_KEY = 'kicadstudio.settingsSchemaVersion';
+
+export interface SettingMigrationContext {
+  readonly extensionContext: vscode.ExtensionContext;
+  readonly config: vscode.WorkspaceConfiguration;
+  readonly logger: Pick<Logger, 'debug' | 'info' | 'warn' | 'error'>;
+}
+
+export interface SettingMigrationApplyResult {
+  readonly changed: boolean;
+  readonly destructive: boolean;
+}
+
+export interface SettingMigration {
+  readonly schemaVersion: number;
+  readonly id: string;
+  readonly destructive?: boolean;
+  describe(): string;
+  apply(
+    context: SettingMigrationContext
+  ): Promise<SettingMigrationApplyResult | void>;
+}
+
+export interface SettingsMigrationFailure {
+  readonly schemaVersion: number;
+  readonly id: string;
+  readonly error: unknown;
+}
+
+export interface SettingsMigrationRunResult {
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly appliedVersions: number[];
+  readonly destructiveChanges: boolean;
+  readonly failedMigration: SettingsMigrationFailure | undefined;
+}
+
+type ConfigurationScopeValueKey =
+  | 'globalValue'
+  | 'workspaceValue'
+  | 'workspaceFolderValue';
+
+const CONFIGURATION_SCOPES: Array<{
+  readonly label: string;
+  readonly target: vscode.ConfigurationTarget;
+  readonly valueKey: ConfigurationScopeValueKey;
+}> = [
+  {
+    label: 'global',
+    target: vscode.ConfigurationTarget.Global,
+    valueKey: 'globalValue'
+  },
+  {
+    label: 'workspace',
+    target: vscode.ConfigurationTarget.Workspace,
+    valueKey: 'workspaceValue'
+  },
+  {
+    label: 'workspace folder',
+    target: vscode.ConfigurationTarget.WorkspaceFolder,
+    valueKey: 'workspaceFolderValue'
+  }
+];
+
+export function createNoopSettingsMigration(
+  schemaVersion: number,
+  description = `Seed ${SETTINGS_SCHEMA_VERSION_KEY} at schema version ${schemaVersion}.`
+): SettingMigration {
+  return {
+    schemaVersion,
+    id: `settings-schema-v${schemaVersion}-seed`,
+    describe: () => description,
+    async apply() {
+      return { changed: false, destructive: false };
+    }
+  };
+}
+
+export function createRenameSettingMigration(args: {
+  readonly schemaVersion: number;
+  readonly from: string;
+  readonly to: string;
+  readonly description?: string;
+}): SettingMigration {
+  return {
+    schemaVersion: args.schemaVersion,
+    id: `rename-${args.from}-to-${args.to}`,
+    destructive: true,
+    describe: () =>
+      args.description ??
+      `Rename deprecated setting ${args.from} to ${args.to}.`,
+    async apply(context) {
+      const sourceInspection = context.config.inspect<unknown>(args.from);
+      if (!sourceInspection) {
+        context.logger.debug(
+          `Settings migration v${args.schemaVersion}: ${args.from} has no configured values.`
+        );
+        return { changed: false, destructive: false };
+      }
+
+      const targetInspection = context.config.inspect<unknown>(args.to);
+      let changed = false;
+
+      for (const scope of CONFIGURATION_SCOPES) {
+        const sourceValue = sourceInspection[scope.valueKey];
+        if (typeof sourceValue === 'undefined') {
+          continue;
+        }
+
+        const targetValue = targetInspection?.[scope.valueKey];
+        if (typeof targetValue === 'undefined') {
+          await context.config.update(args.to, sourceValue, scope.target);
+          context.logger.info(
+            `Settings migration v${args.schemaVersion}: copied ${args.from} to ${args.to} at ${scope.label} scope.`
+          );
+        } else {
+          context.logger.info(
+            `Settings migration v${args.schemaVersion}: kept existing ${args.to} at ${scope.label} scope.`
+          );
+        }
+
+        await context.config.update(args.from, undefined, scope.target);
+        context.logger.info(
+          `Settings migration v${args.schemaVersion}: cleared deprecated ${args.from} at ${scope.label} scope.`
+        );
+        changed = true;
+      }
+
+      return { changed, destructive: changed };
+    }
+  };
+}
+
+export const DEFAULT_SETTINGS_MIGRATIONS: readonly SettingMigration[] = [
+  createNoopSettingsMigration(1),
+  createRenameSettingMigration({
+    schemaVersion: 2,
+    from: 'kicadstudio.viewerTheme',
+    to: SETTINGS.viewerTheme,
+    description: `Rename legacy kicadstudio.viewerTheme to ${SETTINGS.viewerTheme}.`
+  })
+];
+
+export const CURRENT_SETTINGS_SCHEMA_VERSION =
+  DEFAULT_SETTINGS_MIGRATIONS.at(-1)?.schemaVersion ?? 0;
+
+export async function runSettingsMigrations(
+  extensionContext: vscode.ExtensionContext,
+  logger: Pick<Logger, 'debug' | 'info' | 'warn' | 'error'>,
+  migrations: readonly SettingMigration[] = DEFAULT_SETTINGS_MIGRATIONS,
+  config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration()
+): Promise<SettingsMigrationRunResult> {
+  const fromVersion = normalizeStoredSchemaVersion(
+    extensionContext.globalState.get<number>(SETTINGS_SCHEMA_VERSION_KEY, 0)
+  );
+  const appliedVersions: number[] = [];
+  let destructiveChanges = false;
+  let failedMigration: SettingsMigrationFailure | undefined;
+
+  for (const migration of [...migrations].sort(
+    (left, right) => left.schemaVersion - right.schemaVersion
+  )) {
+    if (migration.schemaVersion <= fromVersion) {
+      continue;
+    }
+
+    try {
+      logger.info(
+        `Running settings migration v${migration.schemaVersion}: ${migration.describe()}`
+      );
+      const result = await migration.apply({
+        extensionContext,
+        config,
+        logger
+      });
+      await extensionContext.globalState.update(
+        SETTINGS_SCHEMA_VERSION_KEY,
+        migration.schemaVersion
+      );
+      appliedVersions.push(migration.schemaVersion);
+
+      if (result?.changed && (result.destructive || migration.destructive)) {
+        destructiveChanges = true;
+      }
+
+      logger.info(`Settings migration v${migration.schemaVersion} applied.`);
+    } catch (error) {
+      failedMigration = {
+        schemaVersion: migration.schemaVersion,
+        id: migration.id,
+        error
+      };
+      logger.error(
+        `Settings migration v${migration.schemaVersion} failed: ${migration.describe()}`,
+        error
+      );
+      void vscode.window.showErrorMessage(localize('settingsMigrationFailed'));
+      break;
+    }
+  }
+
+  if (destructiveChanges && !failedMigration) {
+    void vscode.window.showInformationMessage(
+      localize('settingsMigrationUpdatedDeprecatedSettings')
+    );
+  }
+
+  return {
+    fromVersion,
+    toVersion: normalizeStoredSchemaVersion(
+      extensionContext.globalState.get<number>(
+        SETTINGS_SCHEMA_VERSION_KEY,
+        fromVersion
+      )
+    ),
+    appliedVersions,
+    destructiveChanges,
+    failedMigration
+  };
+}
+
+function normalizeStoredSchemaVersion(value: number | undefined): number {
+  return Number.isInteger(value) && typeof value === 'number' && value >= 0
+    ? value
+    : 0;
+}

--- a/apps/vscode-extension/test/unit/settingsMigrations.test.ts
+++ b/apps/vscode-extension/test/unit/settingsMigrations.test.ts
@@ -1,0 +1,231 @@
+import * as vscode from 'vscode';
+import {
+  createNoopSettingsMigration,
+  createRenameSettingMigration,
+  CURRENT_SETTINGS_SCHEMA_VERSION,
+  DEFAULT_SETTINGS_MIGRATIONS,
+  runSettingsMigrations,
+  SETTINGS_SCHEMA_VERSION_KEY,
+  type SettingMigration
+} from '../../src/settings/settingsMigrations';
+import { SETTINGS } from '../../src/constants';
+import { createExtensionContextMock, window } from './vscodeMock';
+
+function createLoggerMock() {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  };
+}
+
+describe('settings migrations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('runs pending migrations in order and stores each successful schema version', async () => {
+    const context = createExtensionContextMock();
+    const logger = createLoggerMock();
+    const applied: number[] = [];
+    const migrations: SettingMigration[] = [
+      {
+        schemaVersion: 1,
+        id: 'first',
+        describe: () => 'first migration',
+        apply: jest.fn(async () => {
+          applied.push(1);
+        })
+      },
+      {
+        schemaVersion: 2,
+        id: 'second',
+        describe: () => 'second migration',
+        apply: jest.fn(async () => {
+          applied.push(2);
+        })
+      }
+    ];
+
+    const result = await runSettingsMigrations(
+      context as never,
+      logger,
+      migrations
+    );
+
+    expect(applied).toEqual([1, 2]);
+    expect(context.globalState.update).toHaveBeenNthCalledWith(
+      1,
+      SETTINGS_SCHEMA_VERSION_KEY,
+      1
+    );
+    expect(context.globalState.update).toHaveBeenNthCalledWith(
+      2,
+      SETTINGS_SCHEMA_VERSION_KEY,
+      2
+    );
+    expect(context.globalState.get(SETTINGS_SCHEMA_VERSION_KEY)).toBe(2);
+    expect(result).toEqual(
+      expect.objectContaining({
+        fromVersion: 0,
+        toVersion: 2,
+        appliedVersions: [1, 2],
+        failedMigration: undefined
+      })
+    );
+  });
+
+  it('skips already-applied migrations without mutating global state', async () => {
+    const context = createExtensionContextMock();
+    await context.globalState.update(SETTINGS_SCHEMA_VERSION_KEY, 2);
+    (context.globalState.update as jest.Mock).mockClear();
+    const logger = createLoggerMock();
+    const apply = jest.fn();
+
+    const result = await runSettingsMigrations(context as never, logger, [
+      createNoopSettingsMigration(1),
+      {
+        schemaVersion: 2,
+        id: 'already-applied',
+        describe: () => 'already applied',
+        apply
+      }
+    ]);
+
+    expect(apply).not.toHaveBeenCalled();
+    expect(context.globalState.update).not.toHaveBeenCalled();
+    expect(result.appliedVersions).toEqual([]);
+    expect(result.fromVersion).toBe(2);
+    expect(result.toVersion).toBe(2);
+  });
+
+  it('does not advance past a failing migration', async () => {
+    const context = createExtensionContextMock();
+    const logger = createLoggerMock();
+    const failure = new Error('migration failed');
+
+    const result = await runSettingsMigrations(context as never, logger, [
+      createNoopSettingsMigration(1),
+      {
+        schemaVersion: 2,
+        id: 'failing',
+        describe: () => 'failing migration',
+        apply: jest.fn(async () => {
+          throw failure;
+        })
+      },
+      {
+        schemaVersion: 3,
+        id: 'never-runs',
+        describe: () => 'never runs',
+        apply: jest.fn()
+      }
+    ]);
+
+    expect(context.globalState.update).toHaveBeenCalledTimes(1);
+    expect(context.globalState.update).toHaveBeenCalledWith(
+      SETTINGS_SCHEMA_VERSION_KEY,
+      1
+    );
+    expect(context.globalState.get(SETTINGS_SCHEMA_VERSION_KEY)).toBe(1);
+    expect(result.failedMigration).toEqual(
+      expect.objectContaining({
+        schemaVersion: 2,
+        id: 'failing',
+        error: failure
+      })
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Settings migration v2 failed'),
+      failure
+    );
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('KiCad Studio settings migration failed')
+    );
+  });
+
+  it('renames configuration values per scope without overwriting existing targets', async () => {
+    const context = createExtensionContextMock();
+    const logger = createLoggerMock();
+    const updates: Array<[string, unknown, vscode.ConfigurationTarget]> = [];
+    const config = {
+      inspect: jest.fn((key: string) => {
+        if (key === 'kicadstudio.sample.old') {
+          return {
+            globalValue: 'global-old',
+            workspaceValue: 'workspace-old',
+            workspaceFolderValue: 'folder-old'
+          };
+        }
+        if (key === 'kicadstudio.sample.new') {
+          return {
+            workspaceValue: 'workspace-new'
+          };
+        }
+        return undefined;
+      }),
+      update: jest.fn(
+        async (
+          key: string,
+          value: unknown,
+          target: vscode.ConfigurationTarget
+        ) => {
+          updates.push([key, value, target]);
+        }
+      )
+    };
+
+    const result = await runSettingsMigrations(
+      context as never,
+      logger,
+      [
+        createRenameSettingMigration({
+          schemaVersion: 1,
+          from: 'kicadstudio.sample.old',
+          to: 'kicadstudio.sample.new',
+          description: 'rename sample setting'
+        })
+      ],
+      config as never
+    );
+
+    expect(updates).toEqual([
+      [
+        'kicadstudio.sample.new',
+        'global-old',
+        vscode.ConfigurationTarget.Global
+      ],
+      ['kicadstudio.sample.old', undefined, vscode.ConfigurationTarget.Global],
+      [
+        'kicadstudio.sample.old',
+        undefined,
+        vscode.ConfigurationTarget.Workspace
+      ],
+      [
+        'kicadstudio.sample.new',
+        'folder-old',
+        vscode.ConfigurationTarget.WorkspaceFolder
+      ],
+      [
+        'kicadstudio.sample.old',
+        undefined,
+        vscode.ConfigurationTarget.WorkspaceFolder
+      ]
+    ]);
+    expect(result.destructiveChanges).toBe(true);
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('KiCad Studio updated deprecated settings')
+    );
+  });
+
+  it('declares initial seed and template rename migrations', () => {
+    expect(
+      DEFAULT_SETTINGS_MIGRATIONS.map((migration) => migration.schemaVersion)
+    ).toEqual([1, 2]);
+    expect(CURRENT_SETTINGS_SCHEMA_VERSION).toBe(2);
+    expect(DEFAULT_SETTINGS_MIGRATIONS[1]?.describe()).toContain(
+      SETTINGS.viewerTheme
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a versioned settings migration runner backed by `ExtensionContext.globalState`.
- Add reusable migration helpers for no-op schema seeds and scoped setting renames.
- Wire migrations into extension activation and cover failure isolation, idempotency, and default migration registration with unit tests.
- Add localized user-facing messages for migration failure and deprecated-setting updates.

## Linear
- OASLANA-110: https://linear.app/oaslananka/issue/OASLANA-110/add-extension-settings-migration-framework-with-versioned-schema

## Validation
- `corepack pnpm install --frozen-lockfile` passed
- `corepack pnpm --filter kicadstudio exec jest test/unit/settingsMigrations.test.ts --runInBand --coverage=false` passed
- `corepack pnpm --filter kicadstudio exec jest test/unit/localizationManifest.test.ts test/unit/settingsMigrations.test.ts --runInBand --coverage=false` passed
- `corepack pnpm --filter kicadstudio run typecheck` passed
- `corepack pnpm --filter kicadstudio run lint` passed
- `corepack pnpm --filter kicadstudio run format:check` passed
- `corepack pnpm run lint` passed
- `corepack pnpm run typecheck` passed
- `corepack pnpm run test` passed
- `corepack pnpm run build` passed
- `corepack pnpm --dir packages/mcp-server run check:security` passed
- `uvx pre-commit run --all-files` passed
- `git diff --check` passed
- `corepack pnpm run verify:dist` could not run because the root workspace has no `verify:dist` script (`ERR_PNPM_NO_SCRIPT`)

## Freshness / Deprecation
- Checked VS Code Extension API docs through Context7 for `ExtensionContext.globalState`, `Memento`, and workspace configuration read/update behavior.
- No workflow files or dependencies changed; workflow deprecation grep found no `::set-output`, `::save-state`, insecure Node override, or deprecated Node runtime strings.