### PR TITLE
feat(kicad-studio): isolate multi-project workspace state

### DIFF
--- a/apps/vscode-extension/src/commands/aiCommands.ts
+++ b/apps/vscode-extension/src/commands/aiCommands.ts
@@ -38,7 +38,9 @@ export function registerAiCommands(
         if (!(await requireWorkspaceTrust('Run proactive DRC analysis'))) {
           return;
         }
-        const file = await resolveTargetFile(undefined, '.kicad_pcb');
+        const file = await resolveTargetFile(undefined, '.kicad_pcb', {
+          projectRoot: services.projectState.getActiveProject()?.rootPath
+        });
         if (!file) {
           return;
         }

--- a/apps/vscode-extension/src/commands/checkCommands.ts
+++ b/apps/vscode-extension/src/commands/checkCommands.ts
@@ -14,7 +14,9 @@ export function registerCheckCommands(
     registerTrustedCommand(
       COMMANDS.runDRC,
       async (resource?: vscode.Uri) => {
-        const file = await resolveTargetFile(resource, '.kicad_pcb');
+        const file = await resolveTargetFile(resource, '.kicad_pcb', {
+          projectRoot: services.projectState.getActiveProject()?.rootPath
+        });
         if (!file) {
           return;
         }
@@ -59,7 +61,9 @@ export function registerCheckCommands(
     registerTrustedCommand(
       COMMANDS.runERC,
       async (resource?: vscode.Uri) => {
-        const file = await resolveTargetFile(resource, '.kicad_sch');
+        const file = await resolveTargetFile(resource, '.kicad_sch', {
+          projectRoot: services.projectState.getActiveProject()?.rootPath
+        });
         if (!file) {
           return;
         }
@@ -104,7 +108,10 @@ function applyValidationResult(
     services.diagnosticState.applyValidationResult(
       uri,
       result.diagnostics,
-      result.summary
+      result.summary,
+      {
+        project: services.projectState.findProjectForResource(uri)
+      }
     );
     return;
   }

--- a/apps/vscode-extension/src/commands/types.ts
+++ b/apps/vscode-extension/src/commands/types.ts
@@ -20,8 +20,11 @@ import type { McpLogger } from '../mcp/mcpLogger';
 import type { QualityGateProvider } from '../providers/qualityGateProvider';
 import type { KiCadProjectTreeProvider } from '../providers/projectTreeProvider';
 import type { Logger } from '../utils/logger';
-import type { DiagnosticSummary } from '../types';
-import type { DiagnosticStateStore } from '../state/stateStores';
+import type { DiagnosticSummary, ProjectContext } from '../types';
+import type {
+  DiagnosticStateStore,
+  ProjectStateStore
+} from '../state/stateStores';
 
 /**
  * Shared service dependencies that are passed to all command registration
@@ -36,6 +39,7 @@ export interface CommandServices {
   diffEditorProvider: DiffEditorProvider;
   fixQueueProvider: FixQueueProvider;
   diagnosticsCollection: vscode.DiagnosticCollection;
+  projectState: ProjectStateStore;
   diagnosticState?: DiagnosticStateStore | undefined;
   statusBar: KiCadStatusBar;
   componentSearch: ComponentSearchService;
@@ -67,6 +71,7 @@ export interface CommandServices {
   }) => void;
   setAiHealthy: (value: boolean | undefined) => void;
   pushStudioContext: () => Promise<void>;
+  selectActiveProject: (project: ProjectContext | string) => Promise<void>;
   refreshContexts: () => Promise<void>;
   refreshMcpState: () => Promise<void>;
 }

--- a/apps/vscode-extension/src/commands/viewerCommands.ts
+++ b/apps/vscode-extension/src/commands/viewerCommands.ts
@@ -16,6 +16,7 @@ import { resolveKiCadExecutable, launchDetached } from './kicadLauncher';
 import { buildStatusMenuItems } from './viewerStatusMenu';
 import type { CommandServices } from './types';
 import { findFirstWorkspaceFile, getWorkspaceRoot } from '../utils/pathUtils';
+import type { ProjectContext, ProjectTreeNode } from '../types';
 
 /**
  * Register viewer, tree, library, variant, and general navigation commands.
@@ -44,6 +45,21 @@ export function registerViewerCommands(
         );
       }
     }),
+
+    vscode.commands.registerCommand(
+      COMMANDS.selectActiveProject,
+      async (
+        target?: vscode.Uri | ProjectContext | ProjectTreeNode | string
+      ) => {
+        const directProject = resolveCommandProject(services, target);
+        const project =
+          directProject ?? (await pickProjectFromQuickPick(services));
+        if (!project) {
+          return;
+        }
+        await services.selectActiveProject(project);
+      }
+    ),
 
     vscode.commands.registerCommand(
       COMMANDS.openSchematic,
@@ -183,6 +199,54 @@ export function registerViewerCommands(
       'Import .kicad_dru template'
     )
   ];
+}
+
+function resolveCommandProject(
+  services: CommandServices,
+  target: vscode.Uri | ProjectContext | ProjectTreeNode | string | undefined
+): ProjectContext | undefined {
+  if (!target) {
+    return undefined;
+  }
+  if (typeof target === 'string') {
+    return services.projectState.findProjectById(target);
+  }
+  if ('projectFile' in target) {
+    return target;
+  }
+  if ('project' in target && target.project) {
+    return target.project;
+  }
+  if ('fsPath' in target) {
+    return services.projectState.findProjectForResource(target);
+  }
+  return undefined;
+}
+
+async function pickProjectFromQuickPick(
+  services: CommandServices
+): Promise<ProjectContext | undefined> {
+  const projects = services.projectState.getProjects();
+  if (!projects.length) {
+    void vscode.window.showWarningMessage(
+      'No KiCad project file was found in this workspace.'
+    );
+    return undefined;
+  }
+  if (projects.length === 1) {
+    return projects[0];
+  }
+
+  const picked = await vscode.window.showQuickPick(
+    projects.map((project) => ({
+      label: project.name,
+      description: path.relative(project.workspaceFolder, project.rootPath),
+      detail: project.projectFile,
+      project
+    })),
+    { title: 'Select Active KiCad Project' }
+  );
+  return picked?.project;
 }
 
 type DrcTemplate = 'default' | 'fabrication';

--- a/apps/vscode-extension/src/constants.ts
+++ b/apps/vscode-extension/src/constants.ts
@@ -64,6 +64,7 @@ export const KICAD_FILE_EXTENSIONS = [
 ] as const;
 export const COMMANDS = {
   showStatusMenu: 'kicadstudio.showStatusMenu',
+  selectActiveProject: 'kicadstudio.selectActiveProject',
   openSchematic: 'kicadstudio.openSchematic',
   openPCB: 'kicadstudio.openPCB',
   openInKiCad: 'kicadstudio.openInKiCad',

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -92,7 +92,17 @@ import {
   workspaceHasVariants
 } from './utils/workspaceUtils';
 import { isWorkspaceTrusted } from './utils/workspaceTrust';
-import type { DiagnosticSummary, McpInstallStatus } from './types';
+import type {
+  DiagnosticSummary,
+  McpInstallStatus,
+  ProjectContext,
+  StudioContext
+} from './types';
+import {
+  ACTIVE_PROJECT_STORAGE_KEY,
+  discoverKiCadProjects,
+  pickActiveProject
+} from './workspace/projectContext';
 
 let extensionLogger: Logger | undefined;
 let extensionMcpClient: McpClient | undefined;
@@ -160,12 +170,14 @@ export async function activate(
   const schematicEditorProvider = new SchematicEditorProvider(
     context,
     async (resource) => exportService.renderViewerSvg(resource),
-    viewerState
+    viewerState,
+    (resource) => projectState.findProjectForResource(resource)
   );
   const pcbEditorProvider = new PcbEditorProvider(
     context,
     async (resource) => exportService.renderViewerSvg(resource),
-    viewerState
+    viewerState,
+    (resource) => projectState.findProjectForResource(resource)
   );
   const gitDiffDetector = new GitDiffDetector(parser);
   const diffEditorProvider = new DiffEditorProvider(context, gitDiffDetector);
@@ -177,7 +189,9 @@ export async function activate(
     logger: mcpLogger
   });
   extensionMcpClient = mcpClient;
-  const mcpToolAdapter = new McpToolAdapter(mcpClient);
+  const mcpToolAdapter = new McpToolAdapter(mcpClient, () =>
+    projectState.getActiveProject()
+  );
   const contextBridge = new ContextBridge(mcpToolAdapter);
   const mcpToolsProvider = new McpToolsProvider(mcpState);
   const variantProvider = new VariantProvider(mcpToolAdapter);
@@ -399,6 +413,7 @@ export async function activate(
     fixQueueProvider,
     qualityGateProvider,
     diagnosticsCollection,
+    projectState,
     diagnosticState,
     statusBar,
     componentSearch,
@@ -416,7 +431,9 @@ export async function activate(
     treeProvider,
     context,
     logger,
-    getLatestDrcRun: () => latestDrcRun,
+    getLatestDrcRun: () =>
+      diagnosticState.getLatestDrcRun(projectState.getActiveProject()?.id) ??
+      latestDrcRun,
     setLatestDrcRun: (value) => {
       latestDrcRun = value;
     },
@@ -424,6 +441,7 @@ export async function activate(
       aiHealthy = value;
     },
     pushStudioContext: () => pushStudioContext('default'),
+    selectActiveProject,
     refreshContexts,
     refreshMcpState
   });
@@ -439,6 +457,7 @@ export async function activate(
       variantProvider,
       diagnosticsCollection,
       diagnosticState,
+      projectState,
       getStudioContext: buildStudioContext,
       setLatestDrcRun: (value) => {
         latestDrcRun = value;
@@ -490,40 +509,36 @@ export async function activate(
 
   async function refreshContexts(): Promise<void> {
     const activeUri = getActiveResourceUri();
+    const projects = await discoverKiCadProjects(vscode.workspace.workspaceFolders);
     const hasProject =
-      (
-        await vscode.workspace.findFiles(
-          '**/*.kicad_pro',
-          '**/node_modules/**',
-          1
-        )
-      ).length > 0 ||
-      (
-        await vscode.workspace.findFiles(
-          '**/*.kicad_sch',
-          '**/node_modules/**',
-          1
-        )
-      ).length > 0 ||
-      (
-        await vscode.workspace.findFiles(
-          '**/*.kicad_pcb',
-          '**/node_modules/**',
-          1
-        )
-      ).length > 0;
+      projects.length > 0 ||
+      (await vscode.workspace.findFiles('**/*.kicad_sch', '**/node_modules/**', 1))
+        .length > 0 ||
+      (await vscode.workspace.findFiles('**/*.kicad_pcb', '**/node_modules/**', 1))
+        .length > 0;
     const trusted = isWorkspaceTrusted();
     const provider = await aiProviders.getProvider();
     const cli = trusted ? await cliDetector.detect() : undefined;
     const kicadVersionMajor = Number(cli?.version.split('.')[0] ?? '0');
     const hasVariants = await workspaceHasVariants();
     const mcpProfile = readConfiguredMcpProfile();
+    const persistedProjectId = context.workspaceState.get<string>(
+      ACTIVE_PROJECT_STORAGE_KEY
+    );
+    const activeProject = pickActiveProject(projects, {
+      previousActiveProjectId: projectState.getActiveProject()?.id,
+      persistedActiveProjectId: persistedProjectId,
+      activeResourcePath: activeUri?.fsPath
+    });
     const projectSnapshot = projectState.update({
       activeResource: activeUri,
+      projects,
+      activeProject,
       hasProject,
       hasVariants,
       workspaceTrusted: trusted
     });
+    diagnosticState.setActiveProject(projectSnapshot.activeProject?.id);
     await vscode.commands.executeCommand(
       'setContext',
       CONTEXT_KEYS.hasProject,
@@ -572,8 +587,34 @@ export async function activate(
     statusBar.update({
       aiConfigured: Boolean(provider?.isConfigured()),
       aiHealthy,
-      mcpProfile
+      mcpProfile,
+      activeProjectName: projectSnapshot.activeProject?.name,
+      drc: diagnosticState.getSnapshot().drc,
+      erc: diagnosticState.getSnapshot().erc
     });
+  }
+
+  async function selectActiveProject(
+    projectOrId: ProjectContext | string
+  ): Promise<void> {
+    const project =
+      typeof projectOrId === 'string'
+        ? projectState.findProjectById(projectOrId)
+        : projectOrId;
+    if (!project) {
+      return;
+    }
+    await context.workspaceState.update(ACTIVE_PROJECT_STORAGE_KEY, project.id);
+    const snapshot = projectState.update({ activeProject: project });
+    diagnosticState.setActiveProject(project.id);
+    const diagnostics = diagnosticState.getSnapshot();
+    statusBar.update({
+      activeProjectName: snapshot.activeProject?.name,
+      drc: diagnostics.drc,
+      erc: diagnostics.erc
+    });
+    treeProvider.refresh();
+    await pushStudioContext('focus');
   }
 
   async function runConfiguredSaveChecks(
@@ -598,7 +639,10 @@ export async function activate(
       diagnosticState.applyValidationResult(
         vscode.Uri.file(document.fileName),
         result.diagnostics,
-        result.summary
+        result.summary,
+        {
+          project: projectState.findProjectForResource(document.fileName)
+        }
       );
       if (shouldRunDrc) {
         latestDrcRun = {
@@ -759,35 +803,14 @@ export async function activate(
     }
   }
 
-  async function buildStudioContext(): Promise<{
-    activeFile: string | undefined;
-    fileType: 'schematic' | 'pcb' | 'other';
-    drcErrors: string[];
-    selectedNet?: string | undefined;
-    selectedReference?: string | undefined;
-    selectedArea?:
-      | {
-          x1: number;
-          y1: number;
-          x2: number;
-          y2: number;
-        }
-      | undefined;
-    activeVariant?: string | undefined;
-    mcpConnected?: boolean | undefined;
-    cursorPosition?:
-      | {
-          line: number;
-          character: number;
-        }
-      | undefined;
-    activeSheetPath?: string | undefined;
-    visibleLayers?: string[] | undefined;
-    kicadVersion?: string | undefined;
-    designBlocks?: string[] | undefined;
-  }> {
+  async function buildStudioContext(): Promise<StudioContext> {
     const activeUri = getActiveResourceUri();
     const activeEditor = vscode.window.activeTextEditor;
+    const selectedProject = projectState.getActiveProject();
+    const resourceProject = activeUri
+      ? projectState.findProjectForResource(activeUri)
+      : undefined;
+    const activeProject = selectedProject ?? resourceProject;
     const fileType = activeUri?.fsPath.endsWith('.kicad_sch')
       ? 'schematic'
       : activeUri?.fsPath.endsWith('.kicad_pcb')
@@ -801,11 +824,18 @@ export async function activate(
           : undefined;
     const mcpState = isWorkspaceTrusted() ? mcpClient.getState() : undefined;
     const cli = isWorkspaceTrusted() ? await cliDetector.detect() : undefined;
+    const latestProjectDrcRun =
+      diagnosticState.getLatestDrcRun(activeProject?.id) ?? latestDrcRun;
     return {
       activeFile: activeUri?.fsPath,
       fileType,
+      project: activeProject,
+      projectId: activeProject?.id,
+      projectName: activeProject?.name,
+      projectRoot: activeProject?.rootPath,
+      projectFile: activeProject?.projectFile,
       drcErrors:
-        latestDrcRun?.diagnostics
+        latestProjectDrcRun?.diagnostics
           .map((diagnostic) => diagnostic.message)
           .slice(0, 20) ?? [],
       selectedReference: viewerState?.selectedReference,
@@ -819,7 +849,9 @@ export async function activate(
       activeSheetPath:
         fileType === 'schematic' && activeUri
           ? path.relative(
-              vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '',
+              activeProject?.rootPath ??
+                vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ??
+                '',
               activeUri.fsPath
             )
           : undefined,

--- a/apps/vscode-extension/src/lm/languageModelTools.ts
+++ b/apps/vscode-extension/src/lm/languageModelTools.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import * as vscode from 'vscode';
 import {
   buildCliExportCommands,
@@ -16,7 +17,10 @@ import { isWorkspaceTrusted } from '../utils/workspaceTrust';
 import { KiCadCheckService } from '../cli/checkCommands';
 import { KiCadCliDetector } from '../cli/kicadCliDetector';
 import { KiCadCliRunner } from '../cli/kicadCliRunner';
-import type { DiagnosticStateStore } from '../state/stateStores';
+import type {
+  DiagnosticStateStore,
+  ProjectStateStore
+} from '../state/stateStores';
 import {
   createLanguageModelTextPart,
   createLanguageModelToolResult,
@@ -73,6 +77,7 @@ export interface LanguageModelToolServices {
   variantProvider: VariantProvider;
   diagnosticsCollection: vscode.DiagnosticCollection;
   diagnosticState?: DiagnosticStateStore | undefined;
+  projectState?: ProjectStateStore | undefined;
   getStudioContext(): Promise<StudioContext>;
   setLatestDrcRun(value: {
     file: string;
@@ -170,7 +175,11 @@ function createRunDrcTool(
       };
     },
     async invoke(options) {
-      const file = await resolveTargetFile(options.input.pcbPath, '.kicad_pcb');
+      const file = await resolveTargetFile(
+        options.input.pcbPath,
+        '.kicad_pcb',
+        services.projectState?.getActiveProject()?.rootPath
+      );
       if (!file) {
         throw new Error(
           'No KiCad PCB file is available. Provide an absolute pcbPath or open a .kicad_pcb file.'
@@ -207,7 +216,11 @@ function createRunErcTool(
       };
     },
     async invoke(options) {
-      const file = await resolveTargetFile(options.input.schPath, '.kicad_sch');
+      const file = await resolveTargetFile(
+        options.input.schPath,
+        '.kicad_sch',
+        services.projectState?.getActiveProject()?.rootPath
+      );
       if (!file) {
         throw new Error(
           'No KiCad schematic file is available. Provide an absolute schPath or open a .kicad_sch file.'
@@ -242,7 +255,10 @@ function applyValidationResult(
     services.diagnosticState.applyValidationResult(
       uri,
       result.diagnostics,
-      result.summary
+      result.summary,
+      {
+        project: services.projectState?.findProjectForResource(uri)
+      }
     );
     return;
   }
@@ -271,7 +287,11 @@ function createExportGerbersTool(
       };
     },
     async invoke(options, token) {
-      const file = await resolveTargetFile(options.input.pcbPath, '.kicad_pcb');
+      const file = await resolveTargetFile(
+        options.input.pcbPath,
+        '.kicad_pcb',
+        services.projectState?.getActiveProject()?.rootPath
+      );
       if (!file) {
         throw new Error(
           'No KiCad PCB file is available. Provide an absolute pcbPath or open a .kicad_pcb file.'
@@ -547,7 +567,8 @@ function serializeDiagnostic(
 
 async function resolveTargetFile(
   requestedPath: string | undefined,
-  extension: '.kicad_pcb' | '.kicad_sch'
+  extension: '.kicad_pcb' | '.kicad_sch',
+  projectRoot?: string | undefined
 ): Promise<string | undefined> {
   if (requestedPath?.trim()) {
     const candidate = requestedPath.trim();
@@ -560,8 +581,18 @@ async function resolveTargetFile(
   }
 
   const active = vscode.window.activeTextEditor?.document.uri.fsPath;
-  if (active?.endsWith(extension)) {
+  if (
+    active?.endsWith(extension) &&
+    (!projectRoot || belongsToProjectRoot(projectRoot, active))
+  ) {
     return active;
+  }
+
+  if (projectRoot) {
+    const projectFile = findFirstProjectFile(projectRoot, extension);
+    if (projectFile) {
+      return projectFile;
+    }
   }
 
   const files = await vscode.workspace.findFiles(
@@ -571,6 +602,100 @@ async function resolveTargetFile(
   );
   return files[0]?.fsPath;
 }
+
+function findFirstProjectFile(
+  rootPath: string,
+  extension: '.kicad_pcb' | '.kicad_sch'
+): string | undefined {
+  try {
+    const resolvedRoot = path.resolve(rootPath);
+    const files = collectProjectFiles(resolvedRoot, extension, resolvedRoot);
+    return files[0];
+  } catch {
+    return undefined;
+  }
+}
+
+function collectProjectFiles(
+  currentPath: string,
+  extension: '.kicad_pcb' | '.kicad_sch',
+  rootPath: string
+): string[] {
+  const entries = fs.readdirSync(currentPath, { withFileTypes: true });
+  if (
+    currentPath !== rootPath &&
+    entries.some(
+      (entry) =>
+        entry.isFile() && path.extname(entry.name).toLowerCase() === '.kicad_pro'
+    )
+  ) {
+    return [];
+  }
+  return entries
+    .flatMap((entry) => {
+      const absolute = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        return LM_IGNORED_DIRECTORY_NAMES.has(entry.name.toLowerCase())
+          ? []
+          : collectProjectFiles(absolute, extension, rootPath);
+      }
+      return path.extname(entry.name).toLowerCase() === extension
+        ? [absolute]
+        : [];
+    })
+    .sort();
+}
+
+function isWithinDirectory(rootPath: string, filePath: string): boolean {
+  const relative = path.relative(path.resolve(rootPath), path.resolve(filePath));
+  return !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+function belongsToProjectRoot(rootPath: string, filePath: string): boolean {
+  const resolvedRoot = path.resolve(rootPath);
+  let currentPath = path.dirname(path.resolve(filePath));
+  while (isWithinDirectory(resolvedRoot, currentPath)) {
+    if (directoryHasProjectFile(currentPath)) {
+      return path.resolve(currentPath) === resolvedRoot;
+    }
+    const parent = path.dirname(currentPath);
+    if (parent === currentPath) {
+      break;
+    }
+    currentPath = parent;
+  }
+  return true;
+}
+
+function directoryHasProjectFile(directoryPath: string): boolean {
+  try {
+    return fs
+      .readdirSync(directoryPath, { withFileTypes: true })
+      .some(
+        (entry) =>
+          entry.isFile() &&
+          path.extname(entry.name).toLowerCase() === '.kicad_pro'
+      );
+  } catch {
+    return false;
+  }
+}
+
+const LM_IGNORED_DIRECTORY_NAMES = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'out',
+  'build',
+  'coverage',
+  '.history',
+  '.code-backups',
+  'generated',
+  'temp',
+  'tmp',
+  'backups',
+  'backup'
+]);
 
 function resolveOutputDir(file: string): string {
   const configured = vscode.workspace

--- a/apps/vscode-extension/src/mcp/mcpClient.ts
+++ b/apps/vscode-extension/src/mcp/mcpClient.ts
@@ -305,7 +305,9 @@ export class McpClient {
     }
   }
 
-  async fetchFixQueue(): Promise<FixItem[]> {
+  async fetchFixQueue(
+    args: Record<string, unknown> = {}
+  ): Promise<FixItem[]> {
     const resource = await this.readResource('kicad://project/fix_queue');
     const items =
       (Array.isArray(resource?.['items']) ? resource['items'] : undefined) ??
@@ -315,7 +317,7 @@ export class McpClient {
       return items.map((item, index) => normalizeFixItem(item, index));
     }
 
-    const toolResult = await this.callTool('project_get_fix_queue', {});
+    const toolResult = await this.callTool('project_get_fix_queue', args);
     const fixItems =
       (Array.isArray(toolResult?.['items'])
         ? toolResult['items']
@@ -327,33 +329,43 @@ export class McpClient {
     return fixItems.map((item, index) => normalizeFixItem(item, index));
   }
 
-  async runProjectQualityGate(): Promise<QualityGateResult[]> {
-    const result = await this.callTool('project_quality_gate_report', {});
+  async runProjectQualityGate(
+    args: Record<string, unknown> = {}
+  ): Promise<QualityGateResult[]> {
+    const result = await this.callTool('project_quality_gate_report', args);
     return normalizeProjectGateResults(result);
   }
 
-  async runPlacementQualityGate(): Promise<QualityGateResult> {
+  async runPlacementQualityGate(
+    args: Record<string, unknown> = {}
+  ): Promise<QualityGateResult> {
     const result =
-      (await this.callTool('pcb_placement_quality_report', {})) ??
-      (await this.callTool('pcb_placement_quality_gate', {})) ??
+      (await this.callTool('pcb_placement_quality_report', args)) ??
+      (await this.callTool('pcb_placement_quality_gate', args)) ??
       {};
     return normalizeSingleGate('placement', 'Placement', result);
   }
 
-  async runTransferQualityGate(): Promise<QualityGateResult> {
-    const result = await this.callTool('pcb_transfer_quality_gate', {});
+  async runTransferQualityGate(
+    args: Record<string, unknown> = {}
+  ): Promise<QualityGateResult> {
+    const result = await this.callTool('pcb_transfer_quality_gate', args);
     return normalizeSingleGate('transfer', 'PCB Transfer', result ?? {});
   }
 
-  async runManufacturingQualityGate(): Promise<QualityGateResult> {
-    const result = await this.callTool('manufacturing_quality_gate', {});
+  async runManufacturingQualityGate(
+    args: Record<string, unknown> = {}
+  ): Promise<QualityGateResult> {
+    const result = await this.callTool('manufacturing_quality_gate', args);
     return normalizeSingleGate('manufacturing', 'Manufacturing', result ?? {});
   }
 
   async exportManufacturingPackage(
-    variant: string | undefined
+    variant: string | undefined,
+    args: Record<string, unknown> = {}
   ): Promise<Record<string, unknown> | undefined> {
     return this.callTool('export_manufacturing_package', {
+      ...args,
       ...(variant ? { variant } : {})
     });
   }

--- a/apps/vscode-extension/src/mcp/mcpToolAdapter.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolAdapter.ts
@@ -4,11 +4,13 @@ import type {
   McpInstallStatus,
   McpServerCard,
   McpToolCall,
+  ProjectContext,
   QualityGateResult,
   StudioContext
 } from '../types';
 import type { McpClient } from './mcpClient';
 import { mapMcpError, type McpMappedError } from './mcpErrorMapper';
+import { mcpProjectArguments } from '../workspace/projectContext';
 
 export interface McpConnectionAdapter {
   detectInstall(): Promise<McpInstallStatus>;
@@ -129,7 +131,10 @@ export type McpAdapterClient = Pick<
 >;
 
 export class McpToolAdapter implements StudioMcpAdapter {
-  constructor(private readonly client: McpAdapterClient) {}
+  constructor(
+    private readonly client: McpAdapterClient,
+    private readonly getActiveProject?: () => ProjectContext | undefined
+  ) {}
 
   detectInstall(): Promise<McpInstallStatus> {
     return this.client.detectInstall();
@@ -156,103 +161,141 @@ export class McpToolAdapter implements StudioMcpAdapter {
   }
 
   fetchFixQueue(): Promise<FixItem[]> {
-    return this.client.fetchFixQueue();
+    return this.client.fetchFixQueue(this.withProjectContext({}));
   }
 
   previewToolCall(toolCall: McpToolCall): Promise<string> {
-    return this.client.previewToolCall(toolCall);
+    return this.client.previewToolCall(this.withToolCallProject(toolCall));
   }
 
   executeToolCall(
     toolCall: McpToolCall
   ): Promise<Record<string, unknown> | undefined> {
-    return this.client.callTool(toolCall.name, toolCall.arguments);
+    const next = this.withToolCallProject(toolCall);
+    return this.client.callTool(next.name, next.arguments);
   }
 
   async applyFixTool(item: FixItem): Promise<void> {
     await this.client.callTool(
       item.tool || 'apply_fix',
-      item.tool ? item.args : { id: item.id }
+      this.withProjectContext(item.tool ? item.args : { id: item.id })
     );
   }
 
   async applyFixById(id: string): Promise<void> {
-    await this.client.callTool('apply_fix', { id });
+    await this.client.callTool('apply_fix', this.withProjectContext({ id }));
   }
 
   runProjectQualityGate(): Promise<QualityGateResult[]> {
-    return this.client.runProjectQualityGate();
+    return this.client.runProjectQualityGate(this.withProjectContext({}));
   }
 
   runPlacementQualityGate(): Promise<QualityGateResult> {
-    return this.client.runPlacementQualityGate();
+    return this.client.runPlacementQualityGate(this.withProjectContext({}));
   }
 
   runTransferQualityGate(): Promise<QualityGateResult> {
-    return this.client.runTransferQualityGate();
+    return this.client.runTransferQualityGate(this.withProjectContext({}));
   }
 
   runManufacturingQualityGate(): Promise<QualityGateResult> {
-    return this.client.runManufacturingQualityGate();
+    return this.client.runManufacturingQualityGate(this.withProjectContext({}));
   }
 
   exportManufacturingPackage(
     variant: string | undefined
   ): Promise<Record<string, unknown> | undefined> {
-    return this.client.exportManufacturingPackage(variant);
+    return this.client.exportManufacturingPackage(
+      variant,
+      this.withProjectContext({})
+    );
   }
 
   async setActiveVariant(name: string): Promise<void> {
-    await this.client.callTool('variant_set_active', { name });
+    await this.client.callTool(
+      'variant_set_active',
+      this.withProjectContext({ name })
+    );
   }
 
   async upsertDrcRule(rule: DrcRuleUpdate): Promise<void> {
-    await this.client.callTool('drc_rule_upsert', { ...rule });
+    await this.client.callTool(
+      'drc_rule_upsert',
+      this.withProjectContext({ ...rule })
+    );
   }
 
   async deleteDrcRule(name: string): Promise<void> {
-    await this.client.callTool('drc_rule_delete', { name });
+    await this.client.callTool(
+      'drc_rule_delete',
+      this.withProjectContext({ name })
+    );
   }
 
   runDrc(
     args: Record<string, unknown> = {}
   ): Promise<Record<string, unknown> | undefined> {
-    return this.client.callTool('run_drc', args);
+    return this.client.callTool('run_drc', this.withProjectContext(args));
   }
 
   runErc(
     args: Record<string, unknown> = {}
   ): Promise<Record<string, unknown> | undefined> {
-    return this.client.callTool('run_erc', args);
+    return this.client.callTool('run_erc', this.withProjectContext(args));
   }
 
   getDesignIntent(): Promise<Record<string, unknown> | undefined> {
-    return this.client.callTool('project_get_design_intent', {});
+    return this.client.callTool(
+      'project_get_design_intent',
+      this.withProjectContext({})
+    );
   }
 
   async setDesignIntent(intent: Record<string, unknown>): Promise<void> {
-    await this.client.callTool('project_set_design_intent', intent);
+    await this.client.callTool(
+      'project_set_design_intent',
+      this.withProjectContext(intent)
+    );
   }
 
   exportBom(
     args: Record<string, unknown> = {}
   ): Promise<Record<string, unknown> | undefined> {
-    return this.client.callTool('export_bom', args);
+    return this.client.callTool('export_bom', this.withProjectContext(args));
   }
 
   exportNetlist(
     args: Record<string, unknown> = {}
   ): Promise<Record<string, unknown> | undefined> {
-    return this.client.callTool('export_netlist', args);
+    return this.client.callTool('export_netlist', this.withProjectContext(args));
   }
 
   exportSpiceNetlist(
     args: Record<string, unknown> = {}
   ): Promise<Record<string, unknown> | undefined> {
-    return this.client.callTool('export_spice_netlist', args);
+    return this.client.callTool(
+      'export_spice_netlist',
+      this.withProjectContext(args)
+    );
   }
 
   mapError(error: unknown): McpMappedError {
     return mapMcpError(error);
+  }
+
+  private withToolCallProject(toolCall: McpToolCall): McpToolCall {
+    return {
+      ...toolCall,
+      arguments: this.withProjectContext(toolCall.arguments)
+    };
+  }
+
+  private withProjectContext(
+    args: Record<string, unknown>
+  ): Record<string, unknown> {
+    return {
+      ...mcpProjectArguments(this.getActiveProject?.()),
+      ...args
+    };
   }
 }

--- a/apps/vscode-extension/src/providers/baseKiCanvasEditorProvider.ts
+++ b/apps/vscode-extension/src/providers/baseKiCanvasEditorProvider.ts
@@ -8,7 +8,7 @@ import {
   VIEWER_HIDDEN_CACHE_RELEASE_MS,
   WEBVIEW_MESSAGE_DEBOUNCE_MS
 } from '../constants';
-import type { ViewerMetadata, ViewerState } from '../types';
+import type { ProjectContext, ViewerMetadata, ViewerState } from '../types';
 import { ViewerStateStore } from '../state/stateStores';
 import { bufferToBase64 } from '../utils/fileUtils';
 import {
@@ -57,6 +57,9 @@ interface PanelInfo {
 type ViewerSvgFallbackProvider = (
   uri: vscode.Uri
 ) => Promise<string | undefined>;
+type ViewerProjectResolver = (
+  uri: vscode.Uri
+) => ProjectContext | undefined;
 
 /**
  * Shared custom editor provider for KiCanvas-backed viewers.
@@ -84,7 +87,8 @@ export abstract class BaseKiCanvasEditorProvider
   constructor(
     protected readonly context: vscode.ExtensionContext,
     private readonly svgFallbackProvider?: ViewerSvgFallbackProvider,
-    private readonly viewerState = new ViewerStateStore()
+    private readonly viewerState = new ViewerStateStore(),
+    private readonly resolveProject?: ViewerProjectResolver
   ) {
     this.disposables.push(
       vscode.workspace.onDidSaveTextDocument((document) => {
@@ -211,10 +215,12 @@ export abstract class BaseKiCanvasEditorProvider
           }
           if (message.type === 'viewerState') {
             const info = this.panelInfo.get(webviewPanel);
-            const nextState = readViewerState(message.payload);
-            if (info && nextState) {
-              info.state = nextState;
-              this.viewerState.updateState(document.uri, info.state);
+              const nextState = readViewerState(message.payload);
+              if (info && nextState) {
+                info.state = nextState;
+              this.viewerState.updateState(document.uri, info.state, {
+                project: this.resolveProject?.(document.uri)
+              });
             }
           }
           if (message.type === 'selectionChanged') {
@@ -225,7 +231,9 @@ export abstract class BaseKiCanvasEditorProvider
                 ...(info.state ?? { zoom: 1, grid: false, theme: this.theme }),
                 ...payload
               };
-              this.viewerState.updateState(document.uri, info.state);
+              this.viewerState.updateState(document.uri, info.state, {
+                project: this.resolveProject?.(document.uri)
+              });
             }
           }
           if (message.type === 'exportPng') {
@@ -250,7 +258,9 @@ export abstract class BaseKiCanvasEditorProvider
                 ...(info.state ?? { zoom: 1, grid: false, theme: this.theme }),
                 selectedReference: reference ?? info.state?.selectedReference
               };
-              this.viewerState.updateState(document.uri, info.state);
+              this.viewerState.updateState(document.uri, info.state, {
+                project: this.resolveProject?.(document.uri)
+              });
             }
           }
           if (message.type === 'requestSvgFallback') {
@@ -291,7 +301,9 @@ export abstract class BaseKiCanvasEditorProvider
       );
       await this.postFile(webviewPanel, document.uri);
     } catch (error) {
-      this.viewerState.recordError(document.uri, error);
+      this.viewerState.recordError(document.uri, error, {
+        project: this.resolveProject?.(document.uri)
+      });
       webviewPanel.webview.html = createViewerErrorHtml(
         path.basename(document.uri.fsPath),
         error,
@@ -317,7 +329,9 @@ export abstract class BaseKiCanvasEditorProvider
       return;
     }
 
-    this.viewerState.beginReload(uri);
+    this.viewerState.beginReload(uri, {
+      project: this.resolveProject?.(uri)
+    });
     try {
       const payload = await this.buildViewerPayload(uri);
       for (const panel of visiblePanels) {
@@ -330,7 +344,9 @@ export abstract class BaseKiCanvasEditorProvider
         });
       }
     } catch (error) {
-      this.viewerState.recordError(uri, error);
+      this.viewerState.recordError(uri, error, {
+        project: this.resolveProject?.(uri)
+      });
       throw error;
     }
   }

--- a/apps/vscode-extension/src/providers/projectTreeProvider.ts
+++ b/apps/vscode-extension/src/providers/projectTreeProvider.ts
@@ -2,7 +2,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { COMMANDS } from '../constants';
-import type { ProjectTreeNode } from '../types';
+import type { ProjectContext, ProjectTreeNode } from '../types';
+import { discoverKiCadProjects } from '../workspace/projectContext';
 
 class KiCadTreeItem extends vscode.TreeItem {
   constructor(
@@ -20,6 +21,16 @@ class KiCadTreeItem extends vscode.TreeItem {
     this.iconPath = new vscode.ThemeIcon(iconForNode(node, diagnostics));
 
     if (
+      node.project &&
+      node.uri &&
+      hasExtension(node.uri.fsPath, '.kicad_pro')
+    ) {
+      this.command = {
+        command: COMMANDS.selectActiveProject,
+        title: `Set Active Project: ${node.project.name}`,
+        arguments: [node]
+      };
+    } else if (
       node.uri &&
       (node.type === 'schematic' ||
         node.type === 'pcb' ||
@@ -92,7 +103,8 @@ export class KiCadProjectTreeProvider implements vscode.TreeDataProvider<Project
       symbolFiles,
       footprintFiles,
       models,
-      fabFiles
+      fabFiles,
+      discoveredProjects
     ] = await Promise.all([
       collectFiles(
         rootPath,
@@ -106,13 +118,21 @@ export class KiCadProjectTreeProvider implements vscode.TreeDataProvider<Project
       collectFiles(
         resolvedOutputPath,
         /\.(gbr|drl|pdf|svg|zip|glb|csv|xlsx|json|html|net)$/i
-      )
+      ),
+      discoverKiCadProjects([{ uri: vscode.Uri.file(rootPath) }] as never)
     ]);
+    const projectByFile = new Map(
+      discoveredProjects.map((project) => [
+        pathComparisonKey(project.projectFile),
+        project
+      ])
+    );
 
     const children: ProjectTreeNode[] = [
       groupProjectNodes(
         'Project Files',
-        projectFiles.filter((file) => hasExtension(file, '.kicad_pro'))
+        projectFiles.filter((file) => hasExtension(file, '.kicad_pro')),
+        projectByFile
       ),
       groupProjectNodes(
         'Schematic Sheets',
@@ -198,15 +218,22 @@ interface TreeDiagnostics {
   total: number;
 }
 
-function groupProjectNodes(label: string, files: string[]): ProjectTreeNode {
+function groupProjectNodes(
+  label: string,
+  files: string[],
+  projectsByFile?: ReadonlyMap<string, ProjectContext>
+): ProjectTreeNode {
   return {
     label,
     type: 'folder',
-    children: files.map(projectFileNode)
+    children: files.map((file) => projectFileNode(file, projectsByFile))
   };
 }
 
-function projectFileNode(file: string): ProjectTreeNode {
+function projectFileNode(
+  file: string,
+  projectsByFile?: ReadonlyMap<string, ProjectContext>
+): ProjectTreeNode {
   const extension = normalizedExtension(file);
   return {
     label: path.basename(file),
@@ -217,7 +244,11 @@ function projectFileNode(file: string): ProjectTreeNode {
         : extension === '.kicad_dru'
           ? 'drc-rule'
           : 'file',
-    uri: vscode.Uri.file(file)
+    uri: vscode.Uri.file(file),
+    project:
+      extension === '.kicad_pro'
+        ? projectsByFile?.get(pathComparisonKey(file))
+        : undefined
   };
 }
 

--- a/apps/vscode-extension/src/state/stateStores.ts
+++ b/apps/vscode-extension/src/state/stateStores.ts
@@ -4,13 +4,20 @@ import type {
   McpCapabilityCard,
   McpConnectionState,
   McpInstallStatus,
+  ProjectContext,
   McpServerCard,
   ViewerState
 } from '../types';
 import { redactSensitiveText } from '../utils/secrets';
+import {
+  cloneProjectContext,
+  findProjectForResource
+} from '../workspace/projectContext';
 
 export interface ProjectStateSnapshot {
   activeResource: string | undefined;
+  activeProject: ProjectContext | undefined;
+  projects: ProjectContext[];
   hasProject: boolean;
   hasVariants: boolean;
   workspaceTrusted: boolean;
@@ -18,6 +25,8 @@ export interface ProjectStateSnapshot {
 
 interface ProjectState extends Omit<ProjectStateSnapshot, 'activeResource'> {
   activeResource: vscode.Uri | undefined;
+  activeProject: ProjectContext | undefined;
+  projects: ProjectContext[];
 }
 
 export class ProjectStateStore implements vscode.Disposable {
@@ -26,6 +35,8 @@ export class ProjectStateStore implements vscode.Disposable {
   readonly onDidChange = this.onDidChangeEmitter.event;
   private state: ProjectState = {
     activeResource: undefined,
+    activeProject: undefined,
+    projects: [],
     hasProject: false,
     hasVariants: false,
     workspaceTrusted: false
@@ -41,10 +52,37 @@ export class ProjectStateStore implements vscode.Disposable {
   getSnapshot(): ProjectStateSnapshot {
     return {
       activeResource: this.state.activeResource?.toString(),
+      activeProject: this.state.activeProject
+        ? cloneProjectContext(this.state.activeProject)
+        : undefined,
+      projects: this.state.projects.map(cloneProjectContext),
       hasProject: this.state.hasProject,
       hasVariants: this.state.hasVariants,
       workspaceTrusted: this.state.workspaceTrusted
     };
+  }
+
+  getProjects(): ProjectContext[] {
+    return this.state.projects.map(cloneProjectContext);
+  }
+
+  getActiveProject(): ProjectContext | undefined {
+    return this.state.activeProject
+      ? cloneProjectContext(this.state.activeProject)
+      : undefined;
+  }
+
+  findProjectById(id: string | undefined): ProjectContext | undefined {
+    const project = id
+      ? this.state.projects.find((entry) => entry.id === id)
+      : undefined;
+    return project ? cloneProjectContext(project) : undefined;
+  }
+
+  findProjectForResource(
+    resource: vscode.Uri | string | undefined
+  ): ProjectContext | undefined {
+    return findProjectForResource(this.state.projects, resource);
   }
 
   getDiagnosticBundleSnapshot(): ProjectStateSnapshot {
@@ -59,12 +97,24 @@ export class ProjectStateStore implements vscode.Disposable {
 export interface DiagnosticStateSnapshot {
   drc: DiagnosticSummary | undefined;
   erc: DiagnosticSummary | undefined;
+  activeProjectId: string | undefined;
+  projects: Array<{
+    projectId: string;
+    drc: DiagnosticSummary | undefined;
+    erc: DiagnosticSummary | undefined;
+  }>;
 }
 
 interface LatestDrcRun {
   file: string;
   diagnostics: vscode.Diagnostic[];
   summary: DiagnosticSummary;
+}
+
+interface ProjectDiagnostics {
+  drc: DiagnosticSummary | undefined;
+  erc: DiagnosticSummary | undefined;
+  latestDrcRun: LatestDrcRun | undefined;
 }
 
 export class DiagnosticStateStore implements vscode.Disposable {
@@ -74,16 +124,35 @@ export class DiagnosticStateStore implements vscode.Disposable {
   private drc: DiagnosticSummary | undefined;
   private erc: DiagnosticSummary | undefined;
   private latestDrcRun: LatestDrcRun | undefined;
+  private activeProjectId: string | undefined;
+  private readonly projectDiagnostics = new Map<string, ProjectDiagnostics>();
 
   constructor(private readonly diagnostics: vscode.DiagnosticCollection) {}
+
+  setActiveProject(projectId: string | undefined): DiagnosticStateSnapshot {
+    this.activeProjectId = projectId;
+    const snapshot = this.getSnapshot();
+    this.onDidChangeEmitter.fire(snapshot);
+    return snapshot;
+  }
 
   applyValidationResult(
     uri: vscode.Uri,
     diagnostics: readonly vscode.Diagnostic[],
-    summary: DiagnosticSummary
+    summary: DiagnosticSummary,
+    options: { project?: ProjectContext | undefined; projectId?: string } = {}
   ): DiagnosticStateSnapshot {
     this.diagnostics.set(uri, diagnostics);
     const nextSummary = cloneSummary(summary);
+    const projectId = options.project?.id ?? options.projectId;
+    const projectState = projectId
+      ? (this.projectDiagnostics.get(projectId) ?? {
+          drc: undefined,
+          erc: undefined,
+          latestDrcRun: undefined
+        })
+      : undefined;
+
     if (summary.source === 'drc') {
       this.drc = nextSummary;
       this.latestDrcRun = {
@@ -91,29 +160,76 @@ export class DiagnosticStateStore implements vscode.Disposable {
         diagnostics: [...diagnostics],
         summary: nextSummary
       };
+      if (projectState) {
+        projectState.drc = nextSummary;
+        projectState.latestDrcRun = {
+          file: summary.file,
+          diagnostics: [...diagnostics],
+          summary: nextSummary
+        };
+      }
     }
     if (summary.source === 'erc') {
       this.erc = nextSummary;
+      if (projectState) {
+        projectState.erc = nextSummary;
+      }
+    }
+    if (projectId && projectState) {
+      this.projectDiagnostics.set(projectId, projectState);
     }
     const snapshot = this.getSnapshot();
     this.onDidChangeEmitter.fire(snapshot);
     return snapshot;
   }
 
-  getLatestDrcRun(): LatestDrcRun | undefined {
-    return this.latestDrcRun
+  getLatestDrcRun(projectId?: string | undefined): LatestDrcRun | undefined {
+    const latest = projectId
+      ? this.projectDiagnostics.get(projectId)?.latestDrcRun
+      : this.activeProjectId
+        ? (this.projectDiagnostics.get(this.activeProjectId)?.latestDrcRun ??
+          this.latestDrcRun)
+        : this.latestDrcRun;
+    return latest
       ? {
-          file: this.latestDrcRun.file,
-          diagnostics: [...this.latestDrcRun.diagnostics],
-          summary: cloneSummary(this.latestDrcRun.summary)
+          file: latest.file,
+          diagnostics: [...latest.diagnostics],
+          summary: cloneSummary(latest.summary)
         }
       : undefined;
   }
 
-  getSnapshot(): DiagnosticStateSnapshot {
+  getSnapshot(
+    options: { projectId?: string | undefined } = {}
+  ): DiagnosticStateSnapshot {
+    const projectId = options.projectId ?? this.activeProjectId;
+    const projectState = projectId
+      ? this.projectDiagnostics.get(projectId)
+      : undefined;
+    const useProjectScope = Boolean(projectId);
     return {
-      drc: this.drc ? cloneSummary(this.drc) : undefined,
-      erc: this.erc ? cloneSummary(this.erc) : undefined
+      drc: projectState?.drc
+        ? cloneSummary(projectState.drc)
+        : useProjectScope
+          ? undefined
+          : this.drc
+          ? cloneSummary(this.drc)
+          : undefined,
+      erc: projectState?.erc
+        ? cloneSummary(projectState.erc)
+        : useProjectScope
+          ? undefined
+          : this.erc
+          ? cloneSummary(this.erc)
+          : undefined,
+      activeProjectId: this.activeProjectId,
+      projects: [...this.projectDiagnostics.entries()].map(
+        ([entryProjectId, state]) => ({
+          projectId: entryProjectId,
+          drc: state.drc ? cloneSummary(state.drc) : undefined,
+          erc: state.erc ? cloneSummary(state.erc) : undefined
+        })
+      )
     };
   }
 
@@ -130,6 +246,7 @@ type ViewerSurfaceStatus = 'idle' | 'loading' | 'ready' | 'error';
 
 interface ViewerSurfaceState {
   uri: vscode.Uri;
+  project: ProjectContext | undefined;
   state: ViewerState | undefined;
   error: string | undefined;
   status: ViewerSurfaceStatus;
@@ -138,6 +255,7 @@ interface ViewerSurfaceState {
 export interface ViewerStateSnapshot {
   viewers: Array<{
     uri: string;
+    project: ProjectContext | undefined;
     state: ViewerState | undefined;
     error: string | undefined;
     status: ViewerSurfaceStatus;
@@ -150,22 +268,36 @@ export class ViewerStateStore implements vscode.Disposable {
   readonly onDidChange = this.onDidChangeEmitter.event;
   private readonly viewers = new Map<string, ViewerSurfaceState>();
 
-  beginReload(uri: vscode.Uri): ViewerStateSnapshot {
+  beginReload(
+    uri: vscode.Uri,
+    options: { project?: ProjectContext | undefined } = {}
+  ): ViewerStateSnapshot {
     return this.updateSurface(uri, {
+      project: options.project,
       error: undefined,
       status: 'loading'
     });
   }
 
-  recordError(uri: vscode.Uri, error: unknown): ViewerStateSnapshot {
+  recordError(
+    uri: vscode.Uri,
+    error: unknown,
+    options: { project?: ProjectContext | undefined } = {}
+  ): ViewerStateSnapshot {
     return this.updateSurface(uri, {
+      project: options.project,
       error: error instanceof Error ? error.message : String(error),
       status: 'error'
     });
   }
 
-  updateState(uri: vscode.Uri, state: ViewerState): ViewerStateSnapshot {
+  updateState(
+    uri: vscode.Uri,
+    state: ViewerState,
+    options: { project?: ProjectContext | undefined } = {}
+  ): ViewerStateSnapshot {
     return this.updateSurface(uri, {
+      project: options.project,
       error: undefined,
       state: cloneViewerState(state),
       status: 'ready'
@@ -181,6 +313,7 @@ export class ViewerStateStore implements vscode.Disposable {
     return {
       viewers: [...this.viewers.values()].map((viewer) => ({
         uri: viewer.uri.toString(),
+        project: viewer.project ? cloneProjectContext(viewer.project) : undefined,
         state: viewer.state ? cloneViewerState(viewer.state) : undefined,
         error: viewer.error,
         status: viewer.status
@@ -207,12 +340,14 @@ export class ViewerStateStore implements vscode.Disposable {
     update: Partial<Omit<ViewerSurfaceState, 'uri'>>
   ): ViewerStateSnapshot {
     const previous = this.viewers.get(uri.toString());
+    const { project, ...rest } = update;
     this.viewers.set(uri.toString(), {
       uri,
+      project: project ?? previous?.project,
       state: previous?.state,
       error: previous?.error,
       status: previous?.status ?? 'idle',
-      ...update
+      ...rest
     });
     const snapshot = this.getSnapshot();
     this.onDidChangeEmitter.fire(snapshot);

--- a/apps/vscode-extension/src/statusbar/kicadStatusBar.ts
+++ b/apps/vscode-extension/src/statusbar/kicadStatusBar.ts
@@ -11,6 +11,7 @@ import type {
 // Priority decreases left-to-right within Left-aligned items.
 // Higher number = further left.
 const P = {
+  project: 510,
   kicad: 500,
   drc: 490,
   erc: 480,
@@ -22,6 +23,7 @@ const P = {
 } as const;
 
 export class KiCadStatusBar implements vscode.Disposable {
+  private readonly projectItem: vscode.StatusBarItem;
   private readonly kicadItem: vscode.StatusBarItem;
   private readonly drcItem: vscode.StatusBarItem;
   private readonly ercItem: vscode.StatusBarItem;
@@ -43,9 +45,15 @@ export class KiCadStatusBar implements vscode.Disposable {
   private mcpVersion: string | undefined;
   private mcpMessage: string | undefined;
   private mcpProfile: string | undefined;
+  private activeProjectName: string | undefined;
   private activeVariant: string | undefined;
 
   constructor(_context: vscode.ExtensionContext) {
+    this.projectItem = this.make(
+      P.project,
+      COMMANDS.selectActiveProject,
+      'Select Active KiCad Project'
+    );
     this.kicadItem = this.make(
       P.kicad,
       COMMANDS.showStatusMenu,
@@ -81,6 +89,7 @@ export class KiCadStatusBar implements vscode.Disposable {
     mcpConnected?: boolean;
     mcpState?: McpConnectionState | undefined;
     mcpProfile?: string | undefined;
+    activeProjectName?: string | undefined;
     activeVariant?: string | undefined;
   }): void {
     this.cli = update.cli ?? this.cli;
@@ -99,6 +108,10 @@ export class KiCadStatusBar implements vscode.Disposable {
       this.mcpMessage = update.mcpState.message;
     }
     this.mcpProfile = update.mcpProfile ?? this.mcpProfile;
+    this.activeProjectName =
+      'activeProjectName' in update
+        ? update.activeProjectName
+        : this.activeProjectName;
     this.activeVariant = update.activeVariant ?? this.activeVariant;
     this.render();
   }
@@ -115,6 +128,7 @@ export class KiCadStatusBar implements vscode.Disposable {
     mcpCompat: McpCompatStatus | undefined;
     mcpVersion: string | undefined;
     mcpProfile: string | undefined;
+    activeProjectName: string | undefined;
   } {
     return {
       cli: this.cli,
@@ -127,7 +141,8 @@ export class KiCadStatusBar implements vscode.Disposable {
       mcpKind: this.mcpKind,
       mcpCompat: this.mcpCompat,
       mcpVersion: this.mcpVersion,
-      mcpProfile: this.mcpProfile
+      mcpProfile: this.mcpProfile,
+      activeProjectName: this.activeProjectName
     };
   }
 
@@ -140,6 +155,7 @@ export class KiCadStatusBar implements vscode.Disposable {
   // ── render ────────────────────────────────────────────────────────────────
 
   private render(): void {
+    this.renderProject();
     this.renderKicad();
     this.renderDrc();
     this.renderErc();
@@ -147,6 +163,19 @@ export class KiCadStatusBar implements vscode.Disposable {
     this.renderAi();
     this.renderMcp();
     this.renderVariant();
+  }
+
+  private renderProject(): void {
+    if (!this.activeProjectName) {
+      this.projectItem.hide();
+      this.projectItem.backgroundColor = undefined;
+      return;
+    }
+    this.projectItem.show();
+    this.projectItem.text = `$(repo) ${this.activeProjectName}`;
+    this.projectItem.tooltip = `Active KiCad project: ${this.activeProjectName}. Click to switch.`;
+    this.projectItem.command = COMMANDS.selectActiveProject;
+    this.projectItem.backgroundColor = undefined;
   }
 
   private renderKicad(): void {
@@ -339,6 +368,7 @@ export class KiCadStatusBar implements vscode.Disposable {
 
   private allItems(): vscode.StatusBarItem[] {
     return [
+      this.projectItem,
       this.kicadItem,
       this.drcItem,
       this.ercItem,

--- a/apps/vscode-extension/src/types.ts
+++ b/apps/vscode-extension/src/types.ts
@@ -212,6 +212,14 @@ export interface DiagnosticSummary {
   capturedAt?: string | undefined;
 }
 
+export interface ProjectContext {
+  id: string;
+  name: string;
+  rootPath: string;
+  projectFile: string;
+  workspaceFolder: string;
+}
+
 export interface KiCadTaskDefinition extends vscode.TaskDefinition {
   task: string;
   file: string;
@@ -233,6 +241,7 @@ export interface ProjectTreeNode {
     | 'folder'
     | 'drc-rule';
   uri?: vscode.Uri | undefined;
+  project?: ProjectContext | undefined;
   children?: ProjectTreeNode[] | undefined;
 }
 
@@ -454,6 +463,11 @@ export interface StudioContext {
   activeFile: string | undefined;
   fileType: 'schematic' | 'pcb' | 'other';
   drcErrors: string[];
+  project?: ProjectContext | undefined;
+  projectId?: string | undefined;
+  projectName?: string | undefined;
+  projectRoot?: string | undefined;
+  projectFile?: string | undefined;
   selectedNet?: string | undefined;
   selectedReference?: string | undefined;
   selectedArea?:

--- a/apps/vscode-extension/src/utils/workspaceUtils.ts
+++ b/apps/vscode-extension/src/utils/workspaceUtils.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { findFirstWorkspaceFile } from './pathUtils';
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 /**
  * Returns the URI of the currently active editor resource, falling back to
@@ -25,14 +26,25 @@ export function getActiveResourceUri(): vscode.Uri | undefined {
  */
 export async function resolveTargetFile(
   resource: vscode.Uri | undefined,
-  extname: string
+  extname: string,
+  options: { projectRoot?: string | undefined } = {}
 ): Promise<string | undefined> {
   if (resource?.fsPath.endsWith(extname)) {
     return resource.fsPath;
   }
   const active = getActiveResourceUri();
-  if (active?.fsPath.endsWith(extname)) {
+  if (
+    active?.fsPath.endsWith(extname) &&
+    (!options.projectRoot ||
+      belongsToProjectRoot(options.projectRoot, active.fsPath))
+  ) {
     return active.fsPath;
+  }
+  if (options.projectRoot) {
+    const projectFile = await findFirstProjectFile(options.projectRoot, extname);
+    if (projectFile) {
+      return projectFile;
+    }
   }
   const files = await vscode.workspace.findFiles(
     `**/*${extname}`,
@@ -40,6 +52,97 @@ export async function resolveTargetFile(
     1
   );
   return files[0]?.fsPath;
+}
+
+async function findFirstProjectFile(
+  rootPath: string,
+  extname: string
+): Promise<string | undefined> {
+  const resolvedRoot = path.resolve(rootPath);
+  try {
+    await fs.promises.access(resolvedRoot);
+  } catch {
+    return undefined;
+  }
+
+  const entries = await collectFiles(resolvedRoot, extname, resolvedRoot);
+  return entries[0];
+}
+
+async function collectFiles(
+  currentPath: string,
+  extname: string,
+  rootPath: string
+): Promise<string[]> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(currentPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  if (
+    currentPath !== rootPath &&
+    entries.some(
+      (entry) =>
+        entry.isFile() && path.extname(entry.name).toLowerCase() === '.kicad_pro'
+    )
+  ) {
+    return [];
+  }
+
+  const matches: string[] = [];
+  for (const entry of entries) {
+    const absolute = path.join(currentPath, entry.name);
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRECTORY_NAMES.has(entry.name.toLowerCase())) {
+        matches.push(...(await collectFiles(absolute, extname, rootPath)));
+      }
+      continue;
+    }
+    if (
+      path.extname(entry.name).toLowerCase() === extname.toLowerCase() &&
+      !entry.name.toLowerCase().endsWith('.lck')
+    ) {
+      matches.push(absolute);
+    }
+  }
+  return matches.sort();
+}
+
+function isWithinDirectory(rootPath: string, filePath: string): boolean {
+  const relative = path.relative(path.resolve(rootPath), path.resolve(filePath));
+  return !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+function belongsToProjectRoot(rootPath: string, filePath: string): boolean {
+  const resolvedRoot = path.resolve(rootPath);
+  let currentPath = path.dirname(path.resolve(filePath));
+  while (isWithinDirectory(resolvedRoot, currentPath)) {
+    if (directoryHasProjectFile(currentPath)) {
+      return path.resolve(currentPath) === resolvedRoot;
+    }
+    const parent = path.dirname(currentPath);
+    if (parent === currentPath) {
+      break;
+    }
+    currentPath = parent;
+  }
+  return true;
+}
+
+function directoryHasProjectFile(directoryPath: string): boolean {
+  try {
+    return fs
+      .readdirSync(directoryPath, { withFileTypes: true })
+      .some(
+        (entry) =>
+          entry.isFile() &&
+          path.extname(entry.name).toLowerCase() === '.kicad_pro'
+      );
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -65,3 +168,19 @@ export async function workspaceHasVariants(): Promise<boolean> {
     return false;
   }
 }
+
+const IGNORED_DIRECTORY_NAMES = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'out',
+  'build',
+  'coverage',
+  '.history',
+  '.code-backups',
+  'generated',
+  'temp',
+  'tmp',
+  'backups',
+  'backup'
+]);

--- a/apps/vscode-extension/src/workspace/projectContext.ts
+++ b/apps/vscode-extension/src/workspace/projectContext.ts
@@ -1,0 +1,220 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import type { ProjectContext } from '../types';
+
+export const ACTIVE_PROJECT_STORAGE_KEY = 'kicadstudio.activeProjectId';
+
+interface ActiveProjectPickOptions {
+  requestedProjectId?: string | undefined;
+  previousActiveProjectId?: string | undefined;
+  persistedActiveProjectId?: string | undefined;
+  activeResourcePath?: string | undefined;
+}
+
+export async function discoverKiCadProjects(
+  workspaceFolders: readonly vscode.WorkspaceFolder[] | undefined
+): Promise<ProjectContext[]> {
+  const folders = workspaceFolders ?? [];
+  const projects: ProjectContext[] = [];
+
+  for (const folder of folders) {
+    const workspaceFolder = path.resolve(folder.uri.fsPath);
+    const projectFiles = await collectProjectFiles(workspaceFolder);
+    for (const projectFile of projectFiles) {
+      projects.push(createProjectContext(workspaceFolder, projectFile));
+    }
+  }
+
+  return projects.sort((left, right) =>
+    pathComparisonKey(left.projectFile).localeCompare(
+      pathComparisonKey(right.projectFile)
+    )
+  );
+}
+
+export function pickActiveProject(
+  projects: readonly ProjectContext[],
+  options: ActiveProjectPickOptions = {}
+): ProjectContext | undefined {
+  if (!projects.length) {
+    return undefined;
+  }
+
+  for (const id of [
+    options.requestedProjectId,
+    options.previousActiveProjectId,
+    options.persistedActiveProjectId
+  ]) {
+    const match = id ? projects.find((project) => project.id === id) : undefined;
+    if (match) {
+      return cloneProjectContext(match);
+    }
+  }
+
+  const resourceProject = findProjectForResource(
+    projects,
+    options.activeResourcePath
+  );
+  if (resourceProject) {
+    return resourceProject;
+  }
+
+  return cloneProjectContext(projects[0]!);
+}
+
+export function findProjectForResource(
+  projects: readonly ProjectContext[],
+  resource: vscode.Uri | string | undefined
+): ProjectContext | undefined {
+  const resourcePath =
+    typeof resource === 'string' ? resource : resource?.fsPath;
+  if (!resourcePath) {
+    return undefined;
+  }
+  const resolvedResource = path.resolve(resourcePath);
+  const candidates = projects
+    .filter(
+      (project) =>
+        samePath(project.projectFile, resolvedResource) ||
+        isWithinDirectory(project.rootPath, resolvedResource)
+    )
+    .sort((left, right) => right.rootPath.length - left.rootPath.length);
+
+  return candidates[0] ? cloneProjectContext(candidates[0]) : undefined;
+}
+
+export function cloneProjectContext(project: ProjectContext): ProjectContext {
+  return { ...project };
+}
+
+export function mcpProjectArguments(
+  project: ProjectContext | undefined
+): Record<string, unknown> {
+  if (!project) {
+    return {};
+  }
+
+  const context = cloneProjectContext(project);
+  return {
+    project: context,
+    projectId: context.id,
+    projectName: context.name,
+    projectRoot: context.rootPath,
+    projectFile: context.projectFile
+  };
+}
+
+function createProjectContext(
+  workspaceFolder: string,
+  projectFile: string
+): ProjectContext {
+  const resolvedProjectFile = path.resolve(projectFile);
+  const rootPath = path.dirname(resolvedProjectFile);
+  return {
+    id: vscode.Uri.file(resolvedProjectFile).toString(),
+    name: path.basename(resolvedProjectFile, '.kicad_pro'),
+    rootPath,
+    projectFile: resolvedProjectFile,
+    workspaceFolder
+  };
+}
+
+async function collectProjectFiles(rootPath: string): Promise<string[]> {
+  try {
+    await fs.promises.access(rootPath);
+  } catch {
+    return [];
+  }
+
+  const result: string[] = [];
+  const visit = async (currentPath: string): Promise<void> => {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(currentPath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const absolute = path.join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        if (!shouldIgnoreDirectory(entry.name)) {
+          await visit(absolute);
+        }
+        continue;
+      }
+
+      if (
+        !shouldIgnoreFile(entry.name) &&
+        path.extname(entry.name).toLowerCase() === '.kicad_pro'
+      ) {
+        result.push(absolute);
+      }
+    }
+  };
+
+  await visit(rootPath);
+  return result.sort((left, right) =>
+    pathComparisonKey(left).localeCompare(pathComparisonKey(right))
+  );
+}
+
+function shouldIgnoreDirectory(name: string): boolean {
+  const normalizedName = name.toLowerCase();
+  return (
+    IGNORED_DIRECTORY_NAMES.has(normalizedName) ||
+    normalizedName.endsWith('-backups')
+  );
+}
+
+function shouldIgnoreFile(name: string): boolean {
+  const normalizedName = name.toLowerCase();
+  return (
+    normalizedName.endsWith('.bak') ||
+    normalizedName.endsWith('.backup') ||
+    normalizedName.endsWith('.lck') ||
+    normalizedName.endsWith('.lock') ||
+    normalizedName.endsWith('.tmp') ||
+    normalizedName.endsWith('~')
+  );
+}
+
+function isWithinDirectory(rootPath: string, filePath: string): boolean {
+  const relative = path.relative(rootPath, filePath);
+  return Boolean(relative) && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+function samePath(left: string, right: string): boolean {
+  return pathComparisonKey(left) === pathComparisonKey(right);
+}
+
+function pathComparisonKey(filePath: string): string {
+  const normalizedPath = path.normalize(filePath);
+  return CASE_INSENSITIVE_PLATFORM_PATHS
+    ? normalizedPath.toLowerCase()
+    : normalizedPath;
+}
+
+const CASE_INSENSITIVE_PLATFORM_PATHS =
+  process.platform === 'win32' || process.platform === 'darwin';
+
+const IGNORED_DIRECTORY_NAMES = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'out',
+  'build',
+  'coverage',
+  '.nyc_output',
+  'generated',
+  'temp',
+  'tmp',
+  'backups',
+  'backup',
+  '.vscode',
+  '.github',
+  '.husky',
+  '.history',
+  '.code-backups'
+]);

--- a/apps/vscode-extension/test/unit/kicadStatusBar.test.ts
+++ b/apps/vscode-extension/test/unit/kicadStatusBar.test.ts
@@ -68,12 +68,27 @@ function makeBar(): KiCadStatusBar {
   return new KiCadStatusBar({} as never);
 }
 
-// Indices in allItems(): kicad=0, drc=1, erc=2, sep1=3, ai=4, mcp=5, sep2=6, variant=7
+// Existing item helper preserves the pre-project indices used by these tests:
+// kicad=0, drc=1, erc=2, sep1=3, ai=4, mcp=5, sep2=6, variant=7.
 function item(index: number) {
-  return Object.values(items)[index]!;
+  return Object.values(items)[index + 1]!;
+}
+
+function projectItem() {
+  return Object.values(items)[0]!;
 }
 
 describe('KiCadStatusBar', () => {
+  describe('Project item', () => {
+    it('shows active project name and switch command', () => {
+      const bar = makeBar();
+      bar.update({ activeProjectName: 'alpha' });
+      expect(projectItem().text).toContain('alpha');
+      expect(projectItem().command).toBe('kicadstudio.selectActiveProject');
+      bar.dispose();
+    });
+  });
+
   describe('KiCad CLI item (index 0)', () => {
     it('shows warning when kicad-cli not found', () => {
       const bar = makeBar();

--- a/apps/vscode-extension/test/unit/mcpToolAdapter.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolAdapter.test.ts
@@ -164,7 +164,72 @@ describe('McpToolAdapter', () => {
       output: 'sim.cir'
     });
     expect(client.exportManufacturingPackage).toHaveBeenCalledWith(
-      'Assembly-A'
+      'Assembly-A',
+      {}
+    );
+  });
+
+  it('adds active project context to every MCP tool call boundary', async () => {
+    const project = {
+      id: 'file:///workspace/alpha/alpha.kicad_pro',
+      name: 'alpha',
+      rootPath: '/workspace/alpha',
+      projectFile: '/workspace/alpha/alpha.kicad_pro',
+      workspaceFolder: '/workspace'
+    };
+    const client = {
+      callTool: jest.fn().mockResolvedValue({ ok: true }),
+      previewToolCall: jest.fn().mockResolvedValue('preview'),
+      runProjectQualityGate: jest.fn().mockResolvedValue([]),
+      exportManufacturingPackage: jest.fn().mockResolvedValue({ ok: true })
+    };
+    const adapter = new McpToolAdapter(client as never, () => project);
+
+    await adapter.previewToolCall({
+      name: 'inspect',
+      arguments: { mode: 'readonly' }
+    });
+    await adapter.executeToolCall({
+      name: 'route',
+      arguments: { net: 'GND' }
+    });
+    await adapter.runDrc({ save_report: true });
+    await adapter.runProjectQualityGate();
+    await adapter.exportManufacturingPackage('Assembly-A');
+
+    expect(client.previewToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        arguments: expect.objectContaining({
+          mode: 'readonly',
+          projectId: project.id,
+          projectRoot: project.rootPath,
+          projectFile: project.projectFile,
+          project: expect.objectContaining({ name: 'alpha' })
+        })
+      })
+    );
+    expect(client.callTool).toHaveBeenCalledWith(
+      'route',
+      expect.objectContaining({
+        net: 'GND',
+        projectId: project.id,
+        projectRoot: project.rootPath
+      })
+    );
+    expect(client.callTool).toHaveBeenCalledWith(
+      'run_drc',
+      expect.objectContaining({
+        save_report: true,
+        projectId: project.id,
+        projectRoot: project.rootPath
+      })
+    );
+    expect(client.runProjectQualityGate).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: project.id })
+    );
+    expect(client.exportManufacturingPackage).toHaveBeenCalledWith(
+      'Assembly-A',
+      expect.objectContaining({ projectId: project.id })
     );
   });
 

--- a/apps/vscode-extension/test/unit/multiProjectWorkspace.test.ts
+++ b/apps/vscode-extension/test/unit/multiProjectWorkspace.test.ts
@@ -1,0 +1,282 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import {
+  discoverKiCadProjects,
+  findProjectForResource,
+  pickActiveProject
+} from '../../src/workspace/projectContext';
+import {
+  DiagnosticStateStore,
+  ProjectStateStore,
+  ViewerStateStore
+} from '../../src/state/stateStores';
+import type { ProjectContext } from '../../src/types';
+import { resolveTargetFile } from '../../src/utils/workspaceUtils';
+import {
+  Diagnostic,
+  DiagnosticSeverity,
+  Range,
+  Uri,
+  window
+} from './vscodeMock';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+function createDiagnosticsCollection(): vscode.DiagnosticCollection {
+  return {
+    name: 'kicad',
+    set: jest.fn(),
+    delete: jest.fn(),
+    clear: jest.fn(),
+    forEach: jest.fn(),
+    get: jest.fn(),
+    has: jest.fn(),
+    dispose: jest.fn(),
+    [Symbol.iterator]: jest.fn(() => [][Symbol.iterator]())
+  } as unknown as vscode.DiagnosticCollection;
+}
+
+function writeProject(workspaceRoot: string, relativeRoot: string): string {
+  const projectRoot = path.join(workspaceRoot, relativeRoot);
+  const name = path.basename(projectRoot);
+  fs.mkdirSync(projectRoot, { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, `${name}.kicad_pro`), '{}', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, `${name}.kicad_sch`), '', 'utf8');
+  fs.writeFileSync(path.join(projectRoot, `${name}.kicad_pcb`), '', 'utf8');
+  return projectRoot;
+}
+
+function createDiagnostic(message: string): vscode.Diagnostic {
+  const diagnostic = new Diagnostic(
+    new Range(0, 0, 0, 1),
+    message,
+    DiagnosticSeverity.Error
+  ) as unknown as vscode.Diagnostic;
+  diagnostic.source = 'kicad-cli:drc';
+  return diagnostic;
+}
+
+function byName(projects: readonly ProjectContext[], name: string): ProjectContext {
+  const project = projects.find((entry) => entry.name === name);
+  if (!project) {
+    throw new Error(`Missing project ${name}`);
+  }
+  return project;
+}
+
+describe('multi-project workspace state', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kicadstudio-multi-'));
+  });
+
+  afterEach(() => {
+    window.activeTextEditor = undefined;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('discovers a deterministic four-project workspace', async () => {
+    for (const project of ['alpha', 'beta', 'delta', 'gamma']) {
+      writeProject(tempDir, project);
+    }
+
+    const projects = await discoverKiCadProjects([
+      { uri: Uri.file(tempDir) }
+    ] as never);
+
+    expect(projects.map((project) => project.name)).toEqual([
+      'alpha',
+      'beta',
+      'delta',
+      'gamma'
+    ]);
+    expect(new Set(projects.map((project) => project.id)).size).toBe(4);
+    expect(projects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'alpha',
+          projectFile: path.join(tempDir, 'alpha', 'alpha.kicad_pro'),
+          rootPath: path.join(tempDir, 'alpha')
+        })
+      ])
+    );
+  });
+
+  it('resolves nested projects and firmware hardware folders to the nearest project', async () => {
+    writeProject(tempDir, 'alpha');
+    const nestedRoot = writeProject(tempDir, 'alpha/submodule/nested');
+    const hardwareRoot = writeProject(tempDir, 'firmware/hardware');
+    fs.mkdirSync(path.join(tempDir, 'firmware/src'), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, 'firmware/src/main.c'), 'int main(){}', 'utf8');
+
+    const projects = await discoverKiCadProjects([
+      { uri: Uri.file(tempDir) }
+    ] as never);
+
+    expect(findProjectForResource(projects, path.join(nestedRoot, 'nested.kicad_pcb'))).toEqual(
+      expect.objectContaining({ name: 'nested' })
+    );
+    expect(
+      findProjectForResource(
+        projects,
+        path.join(hardwareRoot, 'hardware.kicad_sch')
+      )
+    ).toEqual(expect.objectContaining({ name: 'hardware' }));
+    expect(findProjectForResource(projects, path.join(tempDir, 'firmware/src/main.c'))).toBeUndefined();
+  });
+
+  it('targets the active project when live validation starts from another open project', async () => {
+    const alphaRoot = writeProject(tempDir, 'alpha');
+    const nestedRoot = writeProject(tempDir, 'alpha/submodule/nested');
+    window.activeTextEditor = {
+      document: {
+        uri: Uri.file(path.join(nestedRoot, 'nested.kicad_pcb'))
+      }
+    } as never;
+
+    await expect(
+      resolveTargetFile(undefined, '.kicad_pcb', {
+        projectRoot: alphaRoot
+      })
+    ).resolves.toBe(path.join(alphaRoot, 'alpha.kicad_pcb'));
+  });
+
+  it('restores persisted active project and falls back when that project closes', async () => {
+    writeProject(tempDir, 'alpha');
+    writeProject(tempDir, 'beta');
+    writeProject(tempDir, 'gamma');
+    const projects = await discoverKiCadProjects([
+      { uri: Uri.file(tempDir) }
+    ] as never);
+    const beta = byName(projects, 'beta');
+
+    expect(
+      pickActiveProject(projects, {
+        persistedActiveProjectId: beta.id
+      })
+    ).toEqual(expect.objectContaining({ name: 'beta' }));
+
+    const remaining = projects.filter((project) => project.id !== beta.id);
+    expect(
+      pickActiveProject(remaining, {
+        previousActiveProjectId: beta.id,
+        persistedActiveProjectId: beta.id
+      })
+    ).toEqual(expect.objectContaining({ name: 'alpha' }));
+  });
+
+  it('keeps diagnostics isolated while two project validations finish out of order', async () => {
+    const collection = createDiagnosticsCollection();
+    const diagnostics = new DiagnosticStateStore(collection);
+    const projectState = new ProjectStateStore();
+    const alpha: ProjectContext = {
+      id: 'project-alpha',
+      name: 'alpha',
+      rootPath: '/workspace/alpha',
+      projectFile: '/workspace/alpha/alpha.kicad_pro',
+      workspaceFolder: '/workspace'
+    };
+    const beta: ProjectContext = {
+      id: 'project-beta',
+      name: 'beta',
+      rootPath: '/workspace/beta',
+      projectFile: '/workspace/beta/beta.kicad_pro',
+      workspaceFolder: '/workspace'
+    };
+    projectState.update({
+      projects: [alpha, beta],
+      activeProject: alpha,
+      hasProject: true
+    });
+    diagnostics.setActiveProject(alpha.id);
+
+    await Promise.all([
+      Promise.resolve().then(() =>
+        diagnostics.applyValidationResult(
+          vscode.Uri.file('/workspace/beta/beta.kicad_pcb'),
+          [createDiagnostic('Beta clearance')],
+          {
+            file: '/workspace/beta/beta.kicad_pcb',
+            errors: 7,
+            warnings: 0,
+            infos: 0,
+            source: 'drc'
+          },
+          { project: beta }
+        )
+      ),
+      Promise.resolve().then(() =>
+        diagnostics.applyValidationResult(
+          vscode.Uri.file('/workspace/alpha/alpha.kicad_pcb'),
+          [createDiagnostic('Alpha clearance')],
+          {
+            file: '/workspace/alpha/alpha.kicad_pcb',
+            errors: 2,
+            warnings: 0,
+            infos: 0,
+            source: 'drc'
+          },
+          { project: alpha }
+        )
+      )
+    ]);
+
+    expect(diagnostics.getSnapshot().drc?.errors).toBe(2);
+    expect(diagnostics.getSnapshot({ projectId: alpha.id }).drc?.errors).toBe(2);
+    expect(diagnostics.getSnapshot({ projectId: beta.id }).drc?.errors).toBe(7);
+
+    diagnostics.setActiveProject(beta.id);
+    expect(diagnostics.getSnapshot().drc?.errors).toBe(7);
+    expect(diagnostics.getLatestDrcRun(alpha.id)?.summary.errors).toBe(2);
+    expect(diagnostics.getLatestDrcRun(beta.id)?.summary.errors).toBe(7);
+  });
+
+  it('binds viewer surfaces to their owning project instead of the last active project', () => {
+    const viewerState = new ViewerStateStore();
+    const alpha: ProjectContext = {
+      id: 'project-alpha',
+      name: 'alpha',
+      rootPath: '/workspace/alpha',
+      projectFile: '/workspace/alpha/alpha.kicad_pro',
+      workspaceFolder: '/workspace'
+    };
+    const beta: ProjectContext = {
+      id: 'project-beta',
+      name: 'beta',
+      rootPath: '/workspace/beta',
+      projectFile: '/workspace/beta/beta.kicad_pro',
+      workspaceFolder: '/workspace'
+    };
+
+    viewerState.updateState(
+      vscode.Uri.file('/workspace/alpha/alpha.kicad_pcb'),
+      { zoom: 1.5, grid: true, theme: 'dark' },
+      { project: alpha }
+    );
+    viewerState.updateState(
+      vscode.Uri.file('/workspace/beta/beta.kicad_pcb'),
+      { zoom: 0.75, grid: false, theme: 'light' },
+      { project: beta }
+    );
+
+    expect(viewerState.getSnapshot().viewers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          uri: '/workspace/alpha/alpha.kicad_pcb',
+          project: expect.objectContaining({ id: 'project-alpha' }),
+          state: expect.objectContaining({ zoom: 1.5 })
+        }),
+        expect.objectContaining({
+          uri: '/workspace/beta/beta.kicad_pcb',
+          project: expect.objectContaining({ id: 'project-beta' }),
+          state: expect.objectContaining({ zoom: 0.75 })
+        })
+      ])
+    );
+  });
+});

--- a/apps/vscode-extension/test/unit/stateStores.test.ts
+++ b/apps/vscode-extension/test/unit/stateStores.test.ts
@@ -73,7 +73,9 @@ describe('extension state stores', () => {
     });
     expect(store.getDiagnosticBundleSnapshot()).toEqual({
       drc: expect.objectContaining({ errors: 0, source: 'drc' }),
-      erc: undefined
+      erc: undefined,
+      activeProjectId: undefined,
+      projects: []
     });
   });
 
@@ -90,6 +92,8 @@ describe('extension state stores', () => {
 
     expect(store.getSnapshot()).toEqual({
       activeResource: activeResource.toString(),
+      activeProject: undefined,
+      projects: [],
       hasProject: true,
       hasVariants: false,
       workspaceTrusted: true
@@ -119,6 +123,7 @@ describe('extension state stores', () => {
       viewers: [
         expect.objectContaining({
           uri: boardUri.toString(),
+          project: undefined,
           error: undefined,
           status: 'loading'
         })

--- a/apps/vscode-extension/test/unit/statusBar.test.ts
+++ b/apps/vscode-extension/test/unit/statusBar.test.ts
@@ -5,16 +5,17 @@
 import { KiCadStatusBar } from '../../src/statusbar/kicadStatusBar';
 import { window } from './vscodeMock';
 
-// Item indices in allItems(): kicad=0, drc=1, erc=2, sep1=3, ai=4, mcp=5, sep2=6, variant=7
+// Item indices in allItems(): project=0, kicad=1, drc=2, erc=3, sep1=4, ai=5, mcp=6, sep2=7, variant=8
 const IDX = {
-  kicad: 0,
-  drc: 1,
-  erc: 2,
-  sep1: 3,
-  ai: 4,
-  mcp: 5,
-  sep2: 6,
-  variant: 7
+  project: 0,
+  kicad: 1,
+  drc: 2,
+  erc: 3,
+  sep1: 4,
+  ai: 5,
+  mcp: 6,
+  sep2: 7,
+  variant: 8
 };
 
 function getItems() {
@@ -36,10 +37,10 @@ describe('KiCadStatusBar', () => {
     jest.clearAllMocks();
   });
 
-  it('creates eight status bar items', () => {
+  it('creates nine status bar items', () => {
     const bar = new KiCadStatusBar({} as never);
     expect((window.createStatusBarItem as jest.Mock).mock.calls).toHaveLength(
-      8
+      9
     );
     bar.dispose();
   });
@@ -47,10 +48,20 @@ describe('KiCadStatusBar', () => {
   it('shows warning on kicad item and hides inactive drc/erc by default', () => {
     const bar = new KiCadStatusBar({} as never);
     const items = getItems();
+    expect(items[IDX.project]!.hide).toHaveBeenCalled();
     expect(items[IDX.kicad]!.text).toContain('warning');
     expect(items[IDX.drc]!.hide).toHaveBeenCalled();
     expect(items[IDX.erc]!.hide).toHaveBeenCalled();
     expect(items[IDX.sep1]!.hide).toHaveBeenCalled();
+    bar.dispose();
+  });
+
+  it('renders active project as a switchable status bar item', () => {
+    const bar = new KiCadStatusBar({} as never);
+    bar.update({ activeProjectName: 'alpha' });
+    const items = getItems();
+    expect(items[IDX.project]!.text).toContain('alpha');
+    expect(items[IDX.project]!.tooltip).toContain('Active KiCad project');
     bar.dispose();
   });
 


### PR DESCRIPTION
## Summary
- add explicit KiCad project discovery, active project selection, and workspaceState persistence
- scope diagnostics, latest DRC/ERC summaries, viewer surfaces, and MCP tool calls by project context
- add multi-project regression coverage for four sibling projects, nested projects, firmware/hardware layouts, persistence fallback, concurrent validation, and viewer binding

## Linear
- OASLANA-121: https://linear.app/oaslananka/issue/OASLANA-121/define-and-test-multi-project-workspace-behavior-with-isolated-state

## Verification
- PASS corepack pnpm install --frozen-lockfile
- PASS corepack pnpm run format:check
- PASS corepack pnpm run lint
- PASS corepack pnpm run typecheck
- PASS corepack pnpm run test
- PASS corepack pnpm run build
- FAIL-EXPECTED corepack pnpm run verify:dist (root script is not defined in this repo)
- PASS corepack pnpm --filter kicadstudio run package
- PASS corepack pnpm --filter kicadstudio run package:validate
- PASS corepack pnpm --filter kicadstudio run check:bundle-size
- PASS corepack pnpm --filter kicadstudio run check:workspace-trust
- PASS corepack pnpm --filter kicadstudio run docs:check
- PASS corepack pnpm --filter kicadstudio run marketplace:check
- PASS corepack pnpm --filter kicadstudio run audit:ci
- PASS corepack pnpm --dir packages/mcp-server run security
- PASS git diff --check
- PASS uvx pre-commit run --all-files
- PASS gitleaks v8.30.1 detect --source . --redact --verbose
- FAIL-EXPECTED cd packages/mcp-server && uv sync && uv run pytest (uv sync without extras removes test/dev optional dependencies; pytest collection misses opentelemetry.exporter, hypothesis, opentelemetry.sdk)
- PASS cd packages/mcp-server && uv sync --all-extras && uv run pytest (662 passed)

## Freshness / deprecation
- Checked official VS Code Extension API docs for workspaceState/Memento, TreeDataProvider/TreeItem command wiring, commands.registerCommand, showQuickPick, StatusBarItem, and workspace folder behavior.
- No dependency, runtime, workflow, or package-manager changes were introduced.
- Workflow deprecation grep returned no set-output/save-state/insecure node override/node12/node16/node20 hits.
- No in-scope deprecation warnings observed in successful validation output.