### PR TITLE
ci(kicad-studio): add Open VSX publish gate

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -6,24 +6,32 @@ on:
   workflow_dispatch:
     inputs:
       publish_vscode:
+        description: Publish to Visual Studio Marketplace.
         type: boolean
         default: true
       publish_openvsx:
+        description: Publish to Open VSX after Visual Studio Marketplace succeeds.
         type: boolean
         default: true
 
 permissions:
   contents: read
 
+env:
+  OPENVSX_PRERELEASE_TAG_SUFFIX: -openvsx
+
 jobs:
-  publish:
+  package:
     runs-on: ubuntu-24.04
-    environment: extension-marketplaces
     permissions:
       contents: read
       id-token: write
       attestations: write
       artifact-metadata: write
+    outputs:
+      is_prerelease: ${{ steps.release-policy.outputs.is_prerelease }}
+      openvsx_prerelease_allowed: ${{ steps.release-policy.outputs.openvsx_prerelease_allowed }}
+      release_tag: ${{ steps.release-policy.outputs.release_tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -38,6 +46,36 @@ jobs:
       - run: corepack pnpm --filter kicadstudio run package
       - run: corepack pnpm --filter kicadstudio run package:validate
       - run: corepack pnpm --filter kicadstudio run release:assets
+      - name: Evaluate Open VSX release policy
+        id: release-policy
+        shell: bash
+        env:
+          RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          release_tag="${RELEASE_TAG_NAME:-${GITHUB_REF_NAME:-}}"
+          is_prerelease="${RELEASE_IS_PRERELEASE:-false}"
+          openvsx_prerelease_allowed="true"
+
+          if [[ "$GITHUB_EVENT_NAME" == "release" && "$is_prerelease" == "true" && "$release_tag" != *"$OPENVSX_PRERELEASE_TAG_SUFFIX" ]]; then
+            openvsx_prerelease_allowed="false"
+          fi
+
+          {
+            echo "release_tag=${release_tag}"
+            echo "is_prerelease=${is_prerelease}"
+            echo "openvsx_prerelease_allowed=${openvsx_prerelease_allowed}"
+          } >> "$GITHUB_OUTPUT"
+      - name: Identify extension package
+        shell: bash
+        run: |
+          set -euo pipefail
+          VSIX_PATH="$(find apps/vscode-extension -maxdepth 2 -type f -name '*.vsix' | sort | tail -n1)"
+          test -n "$VSIX_PATH"
+          test -f "$VSIX_PATH"
+          echo "Packaged ${VSIX_PATH}"
       - name: Attest extension assets
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
@@ -51,23 +89,94 @@ jobs:
             apps/vscode-extension/*.vsix
             apps/vscode-extension/SHA256SUMS.txt
             apps/vscode-extension/sbom.cdx.json
+          if-no-files-found: error
           retention-days: 14
-      - name: Publish marketplaces
+
+  publish_vscode:
+    needs: package
+    if: ${{ github.event_name == 'release' || inputs.publish_vscode }}
+    runs-on: ubuntu-24.04
+    environment: extension-marketplaces
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - run: corepack enable
+      - run: corepack pnpm install --frozen-lockfile
+      - name: Download extension release evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: extension-release-evidence
+          path: release-assets/extension
+      - name: Publish Visual Studio Marketplace
         shell: bash
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
-          PUBLISH_VSCODE: ${{ github.event_name == 'release' || inputs.publish_vscode }}
-          PUBLISH_OPENVSX: ${{ github.event_name == 'release' || inputs.publish_openvsx }}
         run: |
           set -euo pipefail
-          VSIX_PATH="$(find apps/vscode-extension -maxdepth 2 -type f -name '*.vsix' | sort | tail -n1)"
+          VSIX_PATH="$(find release-assets/extension -type f -name '*.vsix' | sort | tail -n1)"
           test -n "$VSIX_PATH"
-          if [[ "$PUBLISH_VSCODE" == "true" ]]; then
-            test -n "$VSCE_PAT"
-            corepack pnpm --filter kicadstudio exec vsce publish --packagePath "$VSIX_PATH" --pat "$VSCE_PAT"
+          test -f "$VSIX_PATH"
+          test -n "$VSCE_PAT"
+          corepack pnpm --filter kicadstudio exec vsce publish --packagePath "$VSIX_PATH" --pat "$VSCE_PAT"
+
+  publish_openvsx:
+    needs: [package, publish_vscode]
+    if: ${{ (github.event_name == 'release' || inputs.publish_openvsx) && needs.publish_vscode.result == 'success' && needs.package.outputs.openvsx_prerelease_allowed == 'true' }}
+    continue-on-error: true
+    runs-on: ubuntu-24.04
+    environment: extension-marketplaces
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - run: corepack enable
+      - run: corepack pnpm install --frozen-lockfile
+      - name: Download extension release evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: extension-release-evidence
+          path: release-assets/extension
+      - name: Publish Open VSX
+        shell: bash
+        env:
+          BASE_CONTENT_URL: https://github.com/oaslananka/kicad-studio-kit/blob/${{ github.sha }}/apps/vscode-extension
+          BASE_IMAGES_URL: https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/${{ github.sha }}/apps/vscode-extension
+          IS_PRERELEASE: ${{ needs.package.outputs.is_prerelease }}
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          set -euo pipefail
+          VSIX_PATH="$(find release-assets/extension -type f -name '*.vsix' | sort | tail -n1)"
+          test -n "$VSIX_PATH"
+          test -f "$VSIX_PATH"
+          test -n "$OVSX_PAT"
+
+          publish_args=(
+            publish
+            "$VSIX_PATH"
+            -p
+            "$OVSX_PAT"
+            --baseContentUrl
+            "$BASE_CONTENT_URL"
+            --baseImagesUrl
+            "$BASE_IMAGES_URL"
+          )
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            publish_args+=(--pre-release)
           fi
-          if [[ "$PUBLISH_OPENVSX" == "true" ]]; then
-            test -n "$OVSX_PAT"
-            corepack pnpm --filter kicadstudio exec ovsx publish "$VSIX_PATH" -p "$OVSX_PAT"
-          fi
+
+          corepack pnpm --filter kicadstudio exec ovsx "${publish_args[@]}"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CodeQL](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/codeql.yml/badge.svg)](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/codeql.yml)
 [![Security](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/security.yml/badge.svg)](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/security.yml)
 [![MCP Registry](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/publish-mcp-registry.yml/badge.svg)](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/publish-mcp-registry.yml)
+[![Open VSX](https://img.shields.io/open-vsx/v/oaslananka/kicadstudio?label=Open%20VSX)](https://open-vsx.org/extension/oaslananka/kicadstudio)
 
 Monorepo for:
 

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -2,6 +2,8 @@
 
 # KiCad Studio
 
+[![Open VSX](https://img.shields.io/open-vsx/v/oaslananka/kicadstudio?label=Open%20VSX)](https://open-vsx.org/extension/oaslananka/kicadstudio)
+
 KiCad Studio turns VS Code into a focused KiCad workspace for project navigation, schematic and PCB inspection, DRC/ERC review, manufacturing handoff, and AI-assisted MCP workflows.
 
 Canonical repository: https://github.com/oaslananka/kicad-studio-kit/tree/main/apps/vscode-extension
@@ -70,6 +72,10 @@ KiCad Studio 1.0.0 supports `kicad-mcp-pro >=1.0.0 <2.0.0` and was tested agains
 ## Marketplace Listing Copy
 
 The manual Marketplace and Open VSX checklist, English short/long listing copy, and Turkish localized copy live in [docs/marketplace-listing.md](docs/marketplace-listing.md).
+
+## Release Notes
+
+Release notes for Marketplace and Open VSX users live in [CHANGELOG.md](CHANGELOG.md).
 
 ## Local Development
 

--- a/apps/vscode-extension/test/marketplace-assets.test.ts
+++ b/apps/vscode-extension/test/marketplace-assets.test.ts
@@ -151,9 +151,14 @@ describe('marketplace listing assets', () => {
     expectMarkdownSection(readme, 'Quick Start');
     expectMarkdownSection(readme, 'Feature Matrix');
     expectMarkdownSection(readme, 'KiCad CLI-Only Comparison');
+    expectMarkdownSection(readme, 'Release Notes');
     expectMarkdownSection(readme, 'Support and Sponsorship');
     expect(readme).toContain('assets/screenshots/project-tree.png');
     expect(readme).toContain('assets/screenshots/mcp-tools-dashboard.png');
+    expect(readme).toContain(
+      'https://open-vsx.org/extension/oaslananka/kicadstudio'
+    );
+    expect(readme).toContain('[CHANGELOG.md](CHANGELOG.md)');
     expect(readme).not.toMatch(/<details|<summary|<script|<style/iu);
 
     expectMarkdownSection(listingDoc, 'Manual Review Checklist');

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -51,6 +51,8 @@ Protocol or tool-schema changes must update compatibility metadata and release n
 
 Do not configure package registry tokens for PyPI, TestPyPI, or npm. Those publish paths use trusted publishing through OIDC.
 
+`VSCE_PAT` and `OVSX_PAT` must be scoped to the `extension-marketplaces` environment only. Rotate both tokens at least every 180 days, immediately after any maintainer access change, and immediately after any failed or suspicious publish attempt. Token rotation must update the environment secret before the old token is revoked so the next guarded workflow run can validate the replacement.
+
 ## Trusted Publisher Setup
 
 PyPI:
@@ -80,8 +82,15 @@ npm:
 Open VSX:
 
 - publisher namespace: `oaslananka`
+- extension URL: `https://open-vsx.org/extension/oaslananka/kicadstudio`
 - secret: `OVSX_PAT`
 - Eclipse account and Open VSX Publisher Agreement must be complete externally.
+- namespace ownership and token generation are managed in the Open VSX account settings.
+- the `publish-extension.yml` Open VSX job runs only after the Visual Studio Marketplace job succeeds.
+- the Open VSX job reuses the same VSIX artifact uploaded by the package job.
+- Open VSX failures are isolated from the Marketplace publish result and must be retried only after inspecting the guarded release log.
+- prerelease GitHub Releases skip Open VSX unless the release tag ends with `-openvsx`.
+- the packaged README points Open VSX users to `apps/vscode-extension/CHANGELOG.md` for release notes.
 
 VS Code Marketplace:
 
@@ -108,6 +117,7 @@ corepack pnpm --filter kicadstudio run build
 corepack pnpm --filter kicadstudio run package
 $vsix = Get-ChildItem -Path apps/vscode-extension -Filter *.vsix -Recurse | Sort-Object LastWriteTime | Select-Object -Last 1
 corepack pnpm --filter kicadstudio exec vsce ls --tree --no-dependencies
+corepack pnpm --filter kicadstudio exec ovsx publish --help
 ```
 
 CMD:
@@ -118,3 +128,5 @@ corepack pnpm install --frozen-lockfile
 corepack pnpm --filter kicadstudio run build
 corepack pnpm --filter kicadstudio run package
 ```
+
+The `ovsx publish --help` command is the safe Open VSX CLI smoke check for local preflight. Do not run `ovsx publish` with a token outside `.github/workflows/publish-extension.yml`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,8 +17,9 @@ Release PRs are created by `.github/workflows/release-please.yml` with separate 
 The publish workflows keep release evidence product-scoped:
 
 - `publish-extension.yml` validates the VSIX, emits `SHA256SUMS.txt` and a
-  CycloneDX SBOM, then creates GitHub artifact attestations for the checksummed
-  extension package.
+  CycloneDX SBOM, creates GitHub artifact attestations for the checksummed
+  extension package, publishes the shared VSIX to the Visual Studio Marketplace,
+  and then publishes the same VSIX to Open VSX in a separate non-blocking job.
 - `publish-python.yml` validates the wheel and source distribution, emits
   `packages/mcp-server/release-evidence/SHA256SUMS.txt`, uploads that checksum
   as `python-release-evidence`, and creates GitHub artifact attestations for the

--- a/scripts/check-publish-preflight.mjs
+++ b/scripts/check-publish-preflight.mjs
@@ -21,14 +21,28 @@ function run(command, args) {
 }
 
 const failures = [];
-const npm = run("npm", ["view", `@oaslananka/kicad-mcp-pro@${version}`, "version", "--json"]);
+const npm = run("npm", [
+  "view",
+  `@oaslananka/kicad-mcp-pro@${version}`,
+  "version",
+  "--json",
+]);
 if (npm.status === 0 && npm.stdout.trim()) {
-  failures.push(`npm package @oaslananka/kicad-mcp-pro@${version} already exists`);
+  failures.push(
+    `npm package @oaslananka/kicad-mcp-pro@${version} already exists`,
+  );
 }
 
 const pip = run("python", ["-m", "pip", "index", "versions", "kicad-mcp-pro"]);
-if (pip.status === 0 && new RegExp(`\\b${version.replaceAll(".", "\\.")}\\b`).test(`${pip.stdout}\n${pip.stderr}`)) {
-  failures.push(`Python package kicad-mcp-pro ${version} already appears in package index output`);
+if (
+  pip.status === 0 &&
+  new RegExp(`\\b${version.replaceAll(".", "\\.")}\\b`).test(
+    `${pip.stdout}\n${pip.stderr}`,
+  )
+) {
+  failures.push(
+    `Python package kicad-mcp-pro ${version} already appears in package index output`,
+  );
 }
 
 console.log("Required GitHub environments:");
@@ -38,9 +52,18 @@ for (const [env, secrets] of Object.entries(requiredSecrets)) {
   for (const secret of secrets) console.log(`- ${secret}: ${env}`);
 }
 console.log("Trusted publishers:");
-console.log("- PyPI/TestPyPI: owner oaslananka, repository kicad-studio-kit, workflow publish-python.yml, environments pypi/testpypi");
-console.log("- npm: package @oaslananka/kicad-mcp-pro, provider GitHub Actions, workflow publish-npm.yml, environment npm");
-console.log("- MCP Registry: io.github.oaslananka/kicad-mcp-pro via GitHub OIDC");
+console.log(
+  "- PyPI/TestPyPI: owner oaslananka, repository kicad-studio-kit, workflow publish-python.yml, environments pypi/testpypi",
+);
+console.log(
+  "- npm: package @oaslananka/kicad-mcp-pro, provider GitHub Actions, workflow publish-npm.yml, environment npm",
+);
+console.log(
+  "- MCP Registry: io.github.oaslananka/kicad-mcp-pro via GitHub OIDC",
+);
+console.log(
+  "- Open VSX: namespace oaslananka, workflow publish-extension.yml, environment extension-marketplaces, secret OVSX_PAT",
+);
 
 if (failures.length > 0) {
   console.error("Publish preflight failed:");
@@ -48,4 +71,6 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log("Publish preflight passed: target versions were not found in npm/PyPI checks.");
+console.log(
+  "Publish preflight passed: target versions were not found in npm/PyPI checks.",
+);


### PR DESCRIPTION
## Summary
- Split the VS Code extension publish workflow into package, Visual Studio Marketplace, and Open VSX jobs.
- Reuse the package job's VSIX/SBOM/checksum artifact for both marketplace publishers so Open VSX does not rebuild.
- Run Open VSX only after the Marketplace publish succeeds, isolate Open VSX failures with `continue-on-error`, and skip prerelease publishing unless the release tag ends in `-openvsx`.
- Add Open VSX badges, a packaged release notes pointer, and publishing documentation for namespace/token ownership and rotation.

Linear: OASLANA-104

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist` (blocked: root script is not defined in this repo)
- `corepack pnpm --filter kicadstudio run check:ci`
- `corepack pnpm --filter kicadstudio exec jest --runInBand test/marketplace-assets.test.ts`
- `corepack pnpm --filter kicadstudio run docs:check`
- `corepack pnpm --filter kicadstudio run workflows:lint`
- `corepack pnpm --filter kicadstudio run package`
- `corepack pnpm --filter kicadstudio run package:validate`
- `corepack pnpm --filter kicadstudio run release:assets`
- `corepack pnpm --filter kicadstudio run check:bundle-size`
- `corepack pnpm --filter kicadstudio exec vsce ls --tree --no-dependencies`
- `corepack pnpm --filter kicadstudio exec ovsx publish --help`
- `corepack pnpm audit --audit-level high`
- `uvx pre-commit run --all-files`
- `docker run --rm -v "$PWD:/repo" ghcr.io/gitleaks/gitleaks:v8.30.1 detect --source /repo --redact --verbose`

No releases, tags, or publish commands with tokens were run.
