### PR TITLE
ci(kicad-mcp-pro): validate registry metadata

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,6 +1,15 @@
 name: Publish MCP Registry
 
 on:
+  pull_request:
+    paths:
+      - "apps/kicad-mcp-pro/**"
+      - "packages/mcp-server/**"
+      - "packages/mcp-npm/**"
+      - ".github/workflows/publish-mcp-registry.yml"
+      - "compatibility.yaml"
+      - "package.json"
+      - "pnpm-lock.yaml"
   release:
     types: [published]
   workflow_dispatch:
@@ -11,12 +20,40 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          version-file: packages/mcp-server/uv.toml
+      - run: corepack enable
+      - run: corepack pnpm install --frozen-lockfile
+      - run: uv sync --all-extras --frozen --project packages/mcp-server
+      - run: corepack pnpm --dir packages/mcp-server run metadata:check
+      - run: corepack pnpm --dir packages/mcp-server run mcp:manifest:check
+      - run: corepack pnpm --dir packages/mcp-server run publish:mcp:dry-run
+
   publish:
+    needs: validate
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
     runs-on: ubuntu-24.04
     environment: mcp-registry
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: packages/mcp-server
@@ -38,9 +75,5 @@ jobs:
           sudo install -m 0755 "${tmp}/mcp-publisher" /usr/local/bin/mcp-publisher
       - run: mcp-publisher --help
       - run: mcp-publisher login github-oidc
-      - name: Dry-run publish
-        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
-        run: mcp-publisher publish --dry-run
       - name: Publish
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         run: mcp-publisher publish

--- a/packages/mcp-server/docs/publishing.md
+++ b/packages/mcp-server/docs/publishing.md
@@ -85,14 +85,17 @@ uv run python scripts/sync_mcp_metadata.py --check
 uv run python scripts/validate_mcp_manifest.py
 ```
 
-Publishing is handled by `.github/workflows/mcp-registry.yml`. The workflow
-validates metadata on pull requests and relevant pushes. Real publishing is
-manual only, requires `publish=true`, uses the protected `release` environment,
-and requires `MCP_REGISTRY_TOKEN` when a token-backed target is configured.
+Publishing is handled by `.github/workflows/publish-mcp-registry.yml`. The
+workflow validates metadata and runs the registry adapter in dry-run mode on
+pull requests that touch the MCP server, npm wrapper, or registry workflow
+configuration. Real publishing runs only for published GitHub Releases or a
+manual workflow dispatch with `dry_run=false`, and uses the protected
+`mcp-registry` environment.
 
 If an official target is selected, the workflow uses `mcp-publisher` with
-GitHub OIDC. If a generic or third-party target is selected without a configured
-URL, the adapter fails fast instead of pretending to publish.
+GitHub OIDC. No long-lived token is required for the official target. If a
+generic or third-party target is selected without a configured URL, the adapter
+fails fast instead of pretending to publish.
 
 ## Homebrew
 
@@ -145,18 +148,17 @@ the package must be configured in npm before a guarded workflow is added.
 
 Required GitHub environment:
 
-- `release`
+- `mcp-registry`
 
 Required GitHub secrets:
 
-- `MCP_REGISTRY_TOKEN`
 - `PACKAGE_MANAGER_TOKEN`
 - `NPM_TOKEN` only if npm trusted publishing is not used for a future wrapper
   publish workflow
 
 Required GitHub variables:
 
-- `MCP_REGISTRY_URL`
+- `MCP_REGISTRY_URL` only for generic or third-party registry adapters
 
 ## Install Examples
 

--- a/packages/mcp-server/mcp.json
+++ b/packages/mcp-server/mcp.json
@@ -10,6 +10,22 @@
     "subfolder": "packages/mcp-server"
   },
   "websiteUrl": "https://oaslananka.github.io/kicad-studio-kit",
+  "icons": [
+    {
+      "src": "https://oaslananka.github.io/kicad-studio-kit/assets/icon-512.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    },
+    {
+      "src": "https://oaslananka.github.io/kicad-studio-kit/assets/icon.svg",
+      "mimeType": "image/svg+xml",
+      "sizes": [
+        "any"
+      ]
+    }
+  ],
   "packages": [
     {
       "registryType": "pypi",
@@ -48,5 +64,84 @@
     "resources": true,
     "prompts": true
   },
-  "license": "MIT"
+  "license": "MIT",
+  "_meta": {
+    "io.github.oaslananka/kicad-mcp-pro": {
+      "longDescription": "KiCad MCP Pro connects MCP clients to production KiCad EDA workflows. It exposes project setup, schematic analysis, PCB inspection, DRC/ERC validation, BOM/netlist generation, routing review, simulation, DFM, and manufacturing export tools. KiCad CLI must be installed for file-backed validation and export operations; live editing capabilities depend on the KiCad IPC runtime available in KiCad 9 and newer.",
+      "categories": [
+        "developer-tools",
+        "electronic-design-automation",
+        "manufacturing"
+      ],
+      "tags": [
+        "kicad",
+        "pcb",
+        "schematic",
+        "drc",
+        "erc",
+        "bom",
+        "netlist",
+        "gerber",
+        "manufacturing",
+        "eda",
+        "mcp"
+      ],
+      "screenshots": [
+        {
+          "src": "https://oaslananka.github.io/kicad-studio-kit/assets/screenshots/01-claude-desktop-quality-gate.png",
+          "caption": "Claude Desktop quality gate workflow"
+        },
+        {
+          "src": "https://oaslananka.github.io/kicad-studio-kit/assets/screenshots/02-cursor-schematic-build.png",
+          "caption": "Cursor schematic automation workflow"
+        },
+        {
+          "src": "https://oaslananka.github.io/kicad-studio-kit/assets/screenshots/03-vscode-pcb-inspection.png",
+          "caption": "VS Code PCB inspection workflow"
+        },
+        {
+          "src": "https://oaslananka.github.io/kicad-studio-kit/assets/screenshots/04-tools-reference.png",
+          "caption": "Generated MCP tools reference"
+        },
+        {
+          "src": "https://oaslananka.github.io/kicad-studio-kit/assets/screenshots/05-export-manufacturing.png",
+          "caption": "Manufacturing export automation"
+        }
+      ],
+      "toolCatalog": {
+        "summary": "EDA automation tools for KiCad project setup, schematic analysis, PCB inspection, DRC/ERC validation, BOM/netlist generation, routing review, simulation, DFM, and manufacturing export.",
+        "reference": "https://github.com/oaslananka/kicad-studio-kit/blob/main/packages/mcp-server/docs/tools-reference.generated.md"
+      },
+      "prerequisites": [
+        "KiCad CLI 8.x, 9.x, or 10.x available on PATH for file-backed DRC, ERC, and export tools."
+      ],
+      "supportedMcpProtocolVersions": [
+        "2025-11-25"
+      ],
+      "maintainer": {
+        "name": "Osman Aslan",
+        "url": "https://github.com/oaslananka"
+      },
+      "canonicalRepository": "https://github.com/oaslananka/kicad-studio-kit/tree/main/packages/mcp-server",
+      "license": "MIT",
+      "changelog": "https://github.com/oaslananka/kicad-studio-kit/blob/main/packages/mcp-server/CHANGELOG.md",
+      "releaseNotes": "https://github.com/oaslananka/kicad-studio-kit/blob/main/packages/mcp-server/CHANGELOG.md",
+      "serverInfo": {
+        "schemaVersion": "1.1.0",
+        "mcpProtocolVersion": "2025-11-25",
+        "toolSchemaVersion": "1.0.0",
+        "capabilities": [
+          "fileBackedDrc",
+          "fileBackedErc",
+          "fileBackedExports",
+          "livePcbRead",
+          "livePcbWrite",
+          "liveSchematicRead",
+          "liveSchematicWrite",
+          "chatgptConnectorCompatible",
+          "cliExports"
+        ]
+      }
+    }
+  }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -10,7 +10,7 @@
     "assets:icons:check": "uv run --all-extras python scripts/check_icon_assets.py",
     "assets:demo": "uv run --all-extras python scripts/generate_synthetic_demo.py --convert-if-available",
     "assets:screenshots": "uv run --all-extras python scripts/render_screenshots.py",
-    "mcp:manifest:check": "uv run --all-extras python scripts/validate_mcp_manifest.py",
+    "mcp:manifest:check": "uv run --all-extras python scripts/validate_mcp_manifest.py server.json && uv run --all-extras python scripts/validate_mcp_manifest.py mcp.json",
     "docker:metadata:check": "uv run --all-extras python scripts/check_docker_metadata.py",
     "publish:mcp:dry-run": "uv run --all-extras python scripts/publish_mcp_registry.py --dry-run",
     "release:check": "uv run --all-extras python scripts/check_release_preflight.py",

--- a/packages/mcp-server/scripts/publish_mcp_registry.py
+++ b/packages/mcp-server/scripts/publish_mcp_registry.py
@@ -18,7 +18,7 @@ from urllib.request import Request, urlopen
 from validate_mcp_manifest import ManifestValidationError, validate_manifest_file
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_MANIFEST = ROOT / "mcp.json"
+DEFAULT_MANIFEST = ROOT / "server.json"
 SUPPORTED_TARGETS = frozenset({"official", "generic", "smithery", "glama", "pulsemcp"})
 NOT_CONFIGURED = (
     "MCP registry publish API is not configured; set MCP_REGISTRY_URL or implement target adapter."

--- a/packages/mcp-server/scripts/sync_mcp_metadata.py
+++ b/packages/mcp-server/scripts/sync_mcp_metadata.py
@@ -20,6 +20,46 @@ MCP_SERVER_NAME = "io.github.oaslananka/kicad-mcp-pro"
 REPOSITORY = "https://github.com/oaslananka/kicad-studio-kit"
 WEBSITE = "https://oaslananka.github.io/kicad-studio-kit"
 GHCR_IMAGE = "ghcr.io/oaslananka/kicad-studio-kit/kicad-mcp-pro"
+REGISTRY_META_KEY = "io.github.oaslananka/kicad-mcp-pro"
+CANONICAL_PACKAGE_URL = f"{REPOSITORY}/tree/main/packages/mcp-server"
+CHANGELOG_URL = f"{REPOSITORY}/blob/main/packages/mcp-server/CHANGELOG.md"
+TOOLS_REFERENCE_URL = (
+    f"{REPOSITORY}/blob/main/packages/mcp-server/docs/tools-reference.generated.md"
+)
+MCP_PROTOCOL_VERSION = "2025-11-25"
+SERVER_INFO_SCHEMA_VERSION = "1.1.0"
+TOOL_SCHEMA_VERSION = "1.0.0"
+SERVER_INFO_CAPABILITIES = [
+    "fileBackedDrc",
+    "fileBackedErc",
+    "fileBackedExports",
+    "livePcbRead",
+    "livePcbWrite",
+    "liveSchematicRead",
+    "liveSchematicWrite",
+    "chatgptConnectorCompatible",
+    "cliExports",
+]
+REGISTRY_TAGS = [
+    "kicad",
+    "pcb",
+    "schematic",
+    "drc",
+    "erc",
+    "bom",
+    "netlist",
+    "gerber",
+    "manufacturing",
+    "eda",
+    "mcp",
+]
+SCREENSHOTS = [
+    ("01-claude-desktop-quality-gate.png", "Claude Desktop quality gate workflow"),
+    ("02-cursor-schematic-build.png", "Cursor schematic automation workflow"),
+    ("03-vscode-pcb-inspection.png", "VS Code PCB inspection workflow"),
+    ("04-tools-reference.png", "Generated MCP tools reference"),
+    ("05-export-manufacturing.png", "Manufacturing export automation"),
+]
 
 
 def _license_text(project: dict[str, Any]) -> str:
@@ -65,6 +105,18 @@ def _registry_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
             "subfolder": "packages/mcp-server",
         },
         "websiteUrl": WEBSITE,
+        "icons": [
+            {
+                "src": f"{WEBSITE}/assets/icon-512.png",
+                "mimeType": "image/png",
+                "sizes": ["512x512"],
+            },
+            {
+                "src": f"{WEBSITE}/assets/icon.svg",
+                "mimeType": "image/svg+xml",
+                "sizes": ["any"],
+            },
+        ],
         "packages": [
             {
                 "registryType": "pypi",
@@ -98,6 +150,58 @@ def _registry_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
             "prompts": True,
         },
         "license": metadata["license"],
+        "_meta": {
+            REGISTRY_META_KEY: {
+                "longDescription": (
+                    "KiCad MCP Pro connects MCP clients to production KiCad EDA workflows. "
+                    "It exposes project setup, schematic analysis, PCB inspection, DRC/ERC "
+                    "validation, BOM/netlist generation, routing review, simulation, DFM, "
+                    "and manufacturing export tools. KiCad CLI must be installed for "
+                    "file-backed validation and export operations; live editing capabilities "
+                    "depend on the KiCad IPC runtime available in KiCad 9 and newer."
+                ),
+                "categories": [
+                    "developer-tools",
+                    "electronic-design-automation",
+                    "manufacturing",
+                ],
+                "tags": REGISTRY_TAGS,
+                "screenshots": [
+                    {
+                        "src": f"{WEBSITE}/assets/screenshots/{filename}",
+                        "caption": caption,
+                    }
+                    for filename, caption in SCREENSHOTS
+                ],
+                "toolCatalog": {
+                    "summary": (
+                        "EDA automation tools for KiCad project setup, schematic analysis, "
+                        "PCB inspection, DRC/ERC validation, BOM/netlist generation, "
+                        "routing review, simulation, DFM, and manufacturing export."
+                    ),
+                    "reference": TOOLS_REFERENCE_URL,
+                },
+                "prerequisites": [
+                    "KiCad CLI 8.x, 9.x, or 10.x available on PATH for file-backed DRC, "
+                    "ERC, and export tools."
+                ],
+                "supportedMcpProtocolVersions": [MCP_PROTOCOL_VERSION],
+                "maintainer": {
+                    "name": "Osman Aslan",
+                    "url": "https://github.com/oaslananka",
+                },
+                "canonicalRepository": CANONICAL_PACKAGE_URL,
+                "license": metadata["license"],
+                "changelog": CHANGELOG_URL,
+                "releaseNotes": CHANGELOG_URL,
+                "serverInfo": {
+                    "schemaVersion": SERVER_INFO_SCHEMA_VERSION,
+                    "mcpProtocolVersion": MCP_PROTOCOL_VERSION,
+                    "toolSchemaVersion": TOOL_SCHEMA_VERSION,
+                    "capabilities": SERVER_INFO_CAPABILITIES,
+                },
+            }
+        },
     }
 
 
@@ -115,7 +219,9 @@ def _updated_init(metadata: dict[str, Any], original: str) -> str:
     return "\n".join(rendered) + "\n"
 
 
-def _updated_npm_wrapper_package(metadata: dict[str, Any], original: dict[str, Any]) -> dict[str, Any]:
+def _updated_npm_wrapper_package(
+    metadata: dict[str, Any], original: dict[str, Any]
+) -> dict[str, Any]:
     updated = deepcopy(original)
     updated["version"] = metadata["version"]
     updated["homepage"] = WEBSITE
@@ -162,7 +268,10 @@ def main(argv: list[str] | None = None) -> int:
                 path.write_text(rendered, encoding="utf-8")
 
     if drift and args.check:
-        rel = ", ".join(str(path.relative_to(ROOT)) if path.is_relative_to(ROOT) else str(path) for path in drift)
+        rel = ", ".join(
+            str(path.relative_to(ROOT)) if path.is_relative_to(ROOT) else str(path)
+            for path in drift
+        )
         print(f"MCP metadata is out of sync: {rel}", file=sys.stderr)
         print("Run: pnpm run metadata:sync", file=sys.stderr)
         return 1

--- a/packages/mcp-server/scripts/validate_mcp_manifest.py
+++ b/packages/mcp-server/scripts/validate_mcp_manifest.py
@@ -10,12 +10,57 @@ import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
+
+import jsonschema
 
 ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = ROOT.parents[1]
 DEFAULT_MANIFEST = ROOT / "mcp.json"
+SERVER_SCHEMA = ROOT / "scripts" / "schemas" / "server.schema.json"
 SUPPORTED_TRANSPORTS = frozenset({"stdio", "streamable-http", "sse"})
 NAME_RE = re.compile(r"^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$")
+REGISTRY_META_KEY = "io.github.oaslananka/kicad-mcp-pro"
+REPOSITORY = "https://github.com/oaslananka/kicad-studio-kit"
+WEBSITE = "https://oaslananka.github.io/kicad-studio-kit"
+VALID_SPDX_LICENSES = frozenset(
+    {
+        "MIT",
+        "Apache-2.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "ISC",
+        "MPL-2.0",
+        "GPL-3.0-only",
+        "LGPL-3.0-only",
+    }
+)
+SERVER_INFO_CAPABILITIES = [
+    "fileBackedDrc",
+    "fileBackedErc",
+    "fileBackedExports",
+    "livePcbRead",
+    "livePcbWrite",
+    "liveSchematicRead",
+    "liveSchematicWrite",
+    "chatgptConnectorCompatible",
+    "cliExports",
+]
+REQUIRED_META_FIELDS = (
+    "longDescription",
+    "categories",
+    "tags",
+    "screenshots",
+    "toolCatalog",
+    "prerequisites",
+    "supportedMcpProtocolVersions",
+    "maintainer",
+    "canonicalRepository",
+    "license",
+    "changelog",
+    "releaseNotes",
+    "serverInfo",
+)
 
 
 class ManifestValidationError(ValueError):
@@ -44,6 +89,27 @@ def _url_errors(field: str, value: object) -> list[str]:
     return []
 
 
+def _schema_path(path: Sequence[object]) -> str:
+    if not path:
+        return "<root>"
+    return ".".join(str(part) for part in path)
+
+
+def _official_schema_errors(manifest: Mapping[str, Any]) -> list[str]:
+    try:
+        schema = json.loads(SERVER_SCHEMA.read_text(encoding="utf-8"))
+        validator_cls = jsonschema.validators.validator_for(schema)
+        validator_cls.check_schema(schema)
+        validator = validator_cls(schema, format_checker=jsonschema.FormatChecker())
+        errors = sorted(validator.iter_errors(manifest), key=lambda error: list(error.path))
+    except (OSError, json.JSONDecodeError, jsonschema.SchemaError) as exc:
+        return [f"official MCP Registry schema could not be loaded: {exc}"]
+    return [
+        f"official MCP Registry schema {_schema_path(error.path)}: {error.message}"
+        for error in errors
+    ]
+
+
 def _repository_url(manifest: Mapping[str, Any]) -> object:
     repository = manifest.get("repository")
     if isinstance(repository, str):
@@ -51,6 +117,41 @@ def _repository_url(manifest: Mapping[str, Any]) -> object:
     if _is_object(repository):
         return repository.get("url")
     return None
+
+
+def _local_path_for_url(url: str) -> Path | None:
+    github_blob = f"{REPOSITORY}/blob/main/"
+    github_tree = f"{REPOSITORY}/tree/main/"
+    if url.startswith(github_blob):
+        return REPO_ROOT / unquote(url[len(github_blob) :])
+    if url.startswith(github_tree):
+        return REPO_ROOT / unquote(url[len(github_tree) :])
+    if url.startswith(f"{WEBSITE}/"):
+        return ROOT / "docs" / unquote(url[len(WEBSITE) + 1 :])
+    return None
+
+
+def _link_errors(field: str, value: object) -> list[str]:
+    errors = _url_errors(field, value)
+    if errors:
+        return errors
+
+    url = _string(value)
+    local_path = _local_path_for_url(url)
+    if local_path is None or local_path.exists():
+        return []
+
+    link_type = "repository" if url.startswith(REPOSITORY) else "website"
+    rel = local_path.relative_to(REPO_ROOT) if local_path.is_relative_to(REPO_ROOT) else local_path
+    return [f"{field} broken {link_type} link: {url} -> {rel} does not exist."]
+
+
+def _list_of_strings(value: object) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(item, str) and item for item in value)
+    )
 
 
 def _transport_type(package: Mapping[str, Any]) -> str:
@@ -102,7 +203,113 @@ def _has_command(manifest: Mapping[str, Any], packages: Sequence[Mapping[str, An
     mcp = manifest.get("mcp")
     if _is_object(mcp) and _string(mcp.get("command")):
         return True
-    return any(_string(package.get("command")) or _string(package.get("runtimeHint")) for package in packages)
+    return any(
+        _string(package.get("command")) or _string(package.get("runtimeHint"))
+        for package in packages
+    )
+
+
+def _registry_metadata_errors(manifest: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    icons = manifest.get("icons")
+    if not isinstance(icons, list) or not icons:
+        errors.append("icons must include at least one public registry icon.")
+    else:
+        for index, icon in enumerate(icons):
+            if not _is_object(icon):
+                errors.append(f"icons[{index}] must be an object.")
+                continue
+            errors.extend(_link_errors(f"icons[{index}].src", icon.get("src")))
+
+    meta_root = manifest.get("_meta")
+    if not _is_object(meta_root) or not _is_object(meta_root.get(REGISTRY_META_KEY)):
+        errors.append(
+            f"_meta.{REGISTRY_META_KEY} is required for public registry listing metadata."
+        )
+        return errors
+
+    meta = meta_root[REGISTRY_META_KEY]
+    for field in REQUIRED_META_FIELDS:
+        if field not in meta:
+            errors.append(f"_meta.{REGISTRY_META_KEY}.{field} is required.")
+
+    if not _string(meta.get("longDescription")):
+        errors.append(f"_meta.{REGISTRY_META_KEY}.longDescription must be a non-empty string.")
+    if not _list_of_strings(meta.get("categories")):
+        errors.append(f"_meta.{REGISTRY_META_KEY}.categories must be a non-empty string list.")
+    if not _list_of_strings(meta.get("tags")):
+        errors.append(f"_meta.{REGISTRY_META_KEY}.tags must be a non-empty string list.")
+    if not _list_of_strings(meta.get("prerequisites")):
+        errors.append(f"_meta.{REGISTRY_META_KEY}.prerequisites must be a non-empty string list.")
+    if not _list_of_strings(meta.get("supportedMcpProtocolVersions")):
+        errors.append(
+            f"_meta.{REGISTRY_META_KEY}.supportedMcpProtocolVersions must be a "
+            "non-empty string list."
+        )
+
+    screenshots = meta.get("screenshots")
+    if not isinstance(screenshots, list) or not screenshots:
+        errors.append(f"_meta.{REGISTRY_META_KEY}.screenshots must be a non-empty list.")
+    else:
+        for index, screenshot in enumerate(screenshots):
+            if not _is_object(screenshot):
+                errors.append(f"_meta.{REGISTRY_META_KEY}.screenshots[{index}] must be an object.")
+                continue
+            if not _string(screenshot.get("caption")):
+                errors.append(
+                    f"_meta.{REGISTRY_META_KEY}.screenshots[{index}].caption "
+                    "must be a non-empty string."
+                )
+            errors.extend(
+                _link_errors(
+                    f"_meta.{REGISTRY_META_KEY}.screenshots[{index}].src", screenshot.get("src")
+                )
+            )
+
+    tool_catalog = meta.get("toolCatalog")
+    if not _is_object(tool_catalog):
+        errors.append(f"_meta.{REGISTRY_META_KEY}.toolCatalog must be an object.")
+    else:
+        if not _string(tool_catalog.get("summary")):
+            errors.append(f"_meta.{REGISTRY_META_KEY}.toolCatalog.summary is required.")
+        errors.extend(
+            _link_errors(
+                f"_meta.{REGISTRY_META_KEY}.toolCatalog.reference", tool_catalog.get("reference")
+            )
+        )
+
+    maintainer = meta.get("maintainer")
+    if not _is_object(maintainer):
+        errors.append(f"_meta.{REGISTRY_META_KEY}.maintainer must be an object.")
+    else:
+        if not _string(maintainer.get("name")):
+            errors.append(f"_meta.{REGISTRY_META_KEY}.maintainer.name is required.")
+        errors.extend(
+            _link_errors(f"_meta.{REGISTRY_META_KEY}.maintainer.url", maintainer.get("url"))
+        )
+
+    for field in ("canonicalRepository", "changelog", "releaseNotes"):
+        errors.extend(_link_errors(f"_meta.{REGISTRY_META_KEY}.{field}", meta.get(field)))
+
+    meta_license = _string(meta.get("license"))
+    if meta_license != _string(manifest.get("license")):
+        errors.append(f"_meta.{REGISTRY_META_KEY}.license must match license.")
+
+    server_info = meta.get("serverInfo")
+    if not _is_object(server_info):
+        errors.append(f"_meta.{REGISTRY_META_KEY}.serverInfo must be an object.")
+    else:
+        if server_info.get("capabilities") != SERVER_INFO_CAPABILITIES:
+            errors.append(
+                f"_meta.{REGISTRY_META_KEY}.serverInfo.capabilities must match "
+                "the server-info contract."
+            )
+        for field in ("schemaVersion", "mcpProtocolVersion", "toolSchemaVersion"):
+            if not _string(server_info.get(field)):
+                errors.append(f"_meta.{REGISTRY_META_KEY}.serverInfo.{field} is required.")
+
+    return errors
 
 
 def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
@@ -116,10 +323,13 @@ def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
 def validate_manifest(manifest: Mapping[str, Any]) -> list[str]:
     """Return validation errors for an MCP manifest."""
     errors: list[str] = []
+    errors.extend(_official_schema_errors(manifest))
 
     for field in ("name", "description", "version", "license"):
         if not _string(manifest.get(field)):
             errors.append(f"{field} is required.")
+    if _string(manifest.get("license")) and manifest.get("license") not in VALID_SPDX_LICENSES:
+        errors.append("license must be a valid SPDX license identifier.")
 
     name = _string(manifest.get("name"))
     if name and NAME_RE.fullmatch(name) is None:
@@ -183,6 +393,8 @@ def validate_manifest(manifest: Mapping[str, Any]) -> list[str]:
             for transport in transports:
                 if transport not in SUPPORTED_TRANSPORTS:
                     errors.append(f"mcp.transports contains unsupported transport {transport!r}.")
+
+    errors.extend(_registry_metadata_errors(manifest))
 
     return errors
 

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -10,6 +10,22 @@
     "subfolder": "packages/mcp-server"
   },
   "websiteUrl": "https://oaslananka.github.io/kicad-studio-kit",
+  "icons": [
+    {
+      "src": "https://oaslananka.github.io/kicad-studio-kit/assets/icon-512.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "512x512"
+      ]
+    },
+    {
+      "src": "https://oaslananka.github.io/kicad-studio-kit/assets/icon.svg",
+      "mimeType": "image/svg+xml",
+      "sizes": [
+        "any"
+      ]
+    }
+  ],
   "packages": [
     {
       "registryType": "pypi",
@@ -48,5 +64,84 @@
     "resources": true,
     "prompts": true
   },
-  "license": "MIT"
+  "license": "MIT",
+  "_meta": {
+    "io.github.oaslananka/kicad-mcp-pro": {
+      "longDescription": "KiCad MCP Pro connects MCP clients to production KiCad EDA workflows. It exposes project setup, schematic analysis, PCB inspection, DRC/ERC validation, BOM/netlist generation, routing review, simulation, DFM, and manufacturing export tools. KiCad CLI must be installed for file-backed validation and export operations; live editing capabilities depend on the KiCad IPC runtime available in KiCad 9 and newer.",
+      "categories": [
+        "developer-tools",
+        "electronic-design-automation",
+        "manufacturing"
+      ],
+      "tags": [
+        "kicad",
+        "pcb",
+        "schematic",
+        "drc",
+        "erc",
+        "bom",
+        "netlist",
+        "gerber",
+        "manufacturing",
+        "eda",
+        "mcp"
+      ],
+      "screenshots": [
+        {
+          "src": "https://oaslananka.github.io/kicad-studio-kit/assets/screenshots/01-claude-desktop-quality-gate.png",
+          "caption": "Claude Desktop quality gate workflow"
+        },
+        {
+          "src": "https://oaslananka.github.io/kicad-studio-kit/assets/screenshots/02-cursor-schematic-build.png",
+          "caption": "Cursor schematic automation workflow"
+        },
+        {
+          "src": "https://oaslananka.github.io/kicad-studio-kit/assets/screenshots/03-vscode-pcb-inspection.png",
+          "caption": "VS Code PCB inspection workflow"
+        },
+        {
+          "src": "https://oaslananka.github.io/kicad-studio-kit/assets/screenshots/04-tools-reference.png",
+          "caption": "Generated MCP tools reference"
+        },
+        {
+          "src": "https://oaslananka.github.io/kicad-studio-kit/assets/screenshots/05-export-manufacturing.png",
+          "caption": "Manufacturing export automation"
+        }
+      ],
+      "toolCatalog": {
+        "summary": "EDA automation tools for KiCad project setup, schematic analysis, PCB inspection, DRC/ERC validation, BOM/netlist generation, routing review, simulation, DFM, and manufacturing export.",
+        "reference": "https://github.com/oaslananka/kicad-studio-kit/blob/main/packages/mcp-server/docs/tools-reference.generated.md"
+      },
+      "prerequisites": [
+        "KiCad CLI 8.x, 9.x, or 10.x available on PATH for file-backed DRC, ERC, and export tools."
+      ],
+      "supportedMcpProtocolVersions": [
+        "2025-11-25"
+      ],
+      "maintainer": {
+        "name": "Osman Aslan",
+        "url": "https://github.com/oaslananka"
+      },
+      "canonicalRepository": "https://github.com/oaslananka/kicad-studio-kit/tree/main/packages/mcp-server",
+      "license": "MIT",
+      "changelog": "https://github.com/oaslananka/kicad-studio-kit/blob/main/packages/mcp-server/CHANGELOG.md",
+      "releaseNotes": "https://github.com/oaslananka/kicad-studio-kit/blob/main/packages/mcp-server/CHANGELOG.md",
+      "serverInfo": {
+        "schemaVersion": "1.1.0",
+        "mcpProtocolVersion": "2025-11-25",
+        "toolSchemaVersion": "1.0.0",
+        "capabilities": [
+          "fileBackedDrc",
+          "fileBackedErc",
+          "fileBackedExports",
+          "livePcbRead",
+          "livePcbWrite",
+          "liveSchematicRead",
+          "liveSchematicWrite",
+          "chatgptConnectorCompatible",
+          "cliExports"
+        ]
+      }
+    }
+  }
 }

--- a/packages/mcp-server/tests/unit/test_mcp_manifest.py
+++ b/packages/mcp-server/tests/unit/test_mcp_manifest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_META_KEY = "io.github.oaslananka/kicad-mcp-pro"
 
 
 def _load_validator() -> object:
@@ -33,6 +34,127 @@ def test_checked_mcp_manifest_is_valid() -> None:
     ]
     assert all(package["version"] == manifest["version"] for package in manifest["packages"])
     assert manifest["packages"][2]["identifier"].endswith(f":{manifest['version']}")
+
+
+def test_checked_mcp_manifest_has_public_registry_listing_metadata() -> None:
+    module = _load_validator()
+    manifest = module.validate_manifest_file(ROOT / "mcp.json")
+    registry_meta = manifest["_meta"][REGISTRY_META_KEY]
+
+    assert len(manifest["description"]) <= 100
+    assert manifest["icons"] == [
+        {
+            "src": "https://oaslananka.github.io/kicad-studio-kit/assets/icon-512.png",
+            "mimeType": "image/png",
+            "sizes": ["512x512"],
+        },
+        {
+            "src": "https://oaslananka.github.io/kicad-studio-kit/assets/icon.svg",
+            "mimeType": "image/svg+xml",
+            "sizes": ["any"],
+        },
+    ]
+    assert registry_meta["categories"] == [
+        "developer-tools",
+        "electronic-design-automation",
+        "manufacturing",
+    ]
+    assert set(registry_meta["tags"]) >= {
+        "kicad",
+        "pcb",
+        "schematic",
+        "drc",
+        "erc",
+        "bom",
+        "gerber",
+        "mcp",
+    }
+    assert "KiCad CLI" in registry_meta["longDescription"]
+    assert len(registry_meta["screenshots"]) == 5
+    assert registry_meta["prerequisites"] == [
+        "KiCad CLI 8.x, 9.x, or 10.x available on PATH for file-backed DRC, ERC, and export tools."
+    ]
+    assert registry_meta["supportedMcpProtocolVersions"] == ["2025-11-25"]
+    assert registry_meta["license"] == "MIT"
+    assert registry_meta["canonicalRepository"] == (
+        "https://github.com/oaslananka/kicad-studio-kit/tree/main/packages/mcp-server"
+    )
+    assert registry_meta["changelog"] == (
+        "https://github.com/oaslananka/kicad-studio-kit/blob/main/packages/mcp-server/CHANGELOG.md"
+    )
+    assert registry_meta["releaseNotes"] == registry_meta["changelog"]
+    assert registry_meta["maintainer"] == {
+        "name": "Osman Aslan",
+        "url": "https://github.com/oaslananka",
+    }
+    assert registry_meta["serverInfo"] == {
+        "schemaVersion": "1.1.0",
+        "mcpProtocolVersion": "2025-11-25",
+        "toolSchemaVersion": "1.0.0",
+        "capabilities": [
+            "fileBackedDrc",
+            "fileBackedErc",
+            "fileBackedExports",
+            "livePcbRead",
+            "livePcbWrite",
+            "liveSchematicRead",
+            "liveSchematicWrite",
+            "chatgptConnectorCompatible",
+            "cliExports",
+        ],
+    }
+    assert registry_meta["toolCatalog"] == {
+        "summary": (
+            "EDA automation tools for KiCad project setup, schematic analysis, PCB "
+            "inspection, DRC/ERC validation, BOM/netlist generation, routing review, "
+            "simulation, DFM, and manufacturing export."
+        ),
+        "reference": (
+            "https://github.com/oaslananka/kicad-studio-kit/blob/main/"
+            "packages/mcp-server/docs/tools-reference.generated.md"
+        ),
+    }
+
+
+def test_validator_rejects_missing_public_registry_metadata(tmp_path: Path) -> None:
+    module = _load_validator()
+    manifest = json.loads((ROOT / "mcp.json").read_text(encoding="utf-8"))
+    manifest.pop("_meta", None)
+    manifest.pop("icons", None)
+    path = tmp_path / "mcp.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    errors = module.validate_manifest(module.load_manifest(path))
+
+    assert "icons must include at least one public registry icon." in errors
+    assert f"_meta.{REGISTRY_META_KEY} is required for public registry listing metadata." in errors
+
+
+def test_validator_lints_against_official_schema() -> None:
+    module = _load_validator()
+    manifest = json.loads((ROOT / "mcp.json").read_text(encoding="utf-8"))
+    manifest["icons"][0]["mimeType"] = "text/plain"
+
+    errors = module.validate_manifest(manifest)
+
+    assert any(
+        error.startswith("official MCP Registry schema icons.0.mimeType:") and "text/plain" in error
+        for error in errors
+    )
+
+
+def test_validator_rejects_invalid_license_and_broken_metadata_link() -> None:
+    module = _load_validator()
+    manifest = json.loads((ROOT / "mcp.json").read_text(encoding="utf-8"))
+    manifest["license"] = "MIT License"
+    manifest["_meta"][REGISTRY_META_KEY]["changelog"] = (
+        "https://github.com/oaslananka/kicad-studio-kit/blob/main/packages/mcp-server/MISSING.md"
+    )
+
+    errors = module.validate_manifest(manifest)
+
+    assert "license must be a valid SPDX license identifier." in errors
+    assert any("broken repository link" in error and "MISSING.md" in error for error in errors)
 
 
 def test_validator_rejects_missing_command(tmp_path: Path) -> None:

--- a/packages/mcp-server/tests/unit/test_mcp_registry_publish.py
+++ b/packages/mcp-server/tests/unit/test_mcp_registry_publish.py
@@ -28,6 +28,12 @@ def _load_publisher() -> object:
     return module
 
 
+def test_publish_adapter_defaults_to_official_server_manifest() -> None:
+    module = _load_publisher()
+
+    assert module.DEFAULT_MANIFEST == ROOT / "server.json"
+
+
 def test_publish_adapter_dry_run_success(monkeypatch) -> None:
     module = _load_publisher()
     monkeypatch.setenv("MCP_REGISTRY_TARGET", "generic")

--- a/packages/mcp-server/tests/unit/test_release_hardening.py
+++ b/packages/mcp-server/tests/unit/test_release_hardening.py
@@ -632,6 +632,11 @@ def test_release_and_publish_workflows_are_monorepo_ready() -> None:
     assert "mcp-publisher login github-oidc" in publish_mcp
     assert "MCP_PUBLISHER_VERSION: v1.7.9" in publish_mcp
     assert "releases/latest" not in publish_mcp
+    assert "pull_request:" in publish_mcp
+    assert "apps/kicad-mcp-pro/**" in publish_mcp
+    assert "packages/mcp-server/**" in publish_mcp
+    assert "corepack pnpm --dir packages/mcp-server run publish:mcp:dry-run" in publish_mcp
+    assert "if: github.event_name == 'release' ||" in publish_mcp
 
 
 def test_security_and_publish_workflows_emit_supply_chain_evidence() -> None:

--- a/packages/mcp-server/tests/unit/test_release_metadata.py
+++ b/packages/mcp-server/tests/unit/test_release_metadata.py
@@ -83,6 +83,11 @@ def test_release_metadata_is_synchronised() -> None:
 
     assert server_json["$schema"] == REGISTRY_SCHEMA
     assert server_json["version"] == version
+    assert server_json["icons"][0]["src"].endswith("/assets/icon-512.png")
+    assert server_json["_meta"]["io.github.oaslananka/kicad-mcp-pro"]["license"] == "MIT"
+    assert server_json["_meta"]["io.github.oaslananka/kicad-mcp-pro"]["toolCatalog"][
+        "reference"
+    ].endswith("/packages/mcp-server/docs/tools-reference.generated.md")
     assert server_json["packages"][0]["version"] == version
     server_oci = next(
         package for package in server_json["packages"] if package["registryType"] == "oci"


### PR DESCRIPTION
## Linear

OASLANA-105: https://linear.app/oaslananka/issue/OASLANA-105/polish-mcp-registry-metadata-and-add-validation-in-ci

## Summary

- Enrich `io.github.oaslananka/kicad-mcp-pro` registry metadata with icons, screenshots, categories, tags, long description, prerequisites, supported MCP protocol version, maintainer, canonical repo, changelog/release notes, tool catalog, SPDX license, and server-info capability metadata.
- Validate `server.json` and `mcp.json` against the official MCP Registry schema plus local public-listing rules for required fields, broken repository/site links, and license identifiers.
- Add `publish-mcp-registry.yml` PR dry-run validation for MCP registry-relevant paths while keeping real publishing release/manual-only behind OIDC and the `mcp-registry` environment.

## CI Follow-Up

- The first PR CI run failed because the current official schema includes a non-validating example URL that matches this repository's forbidden-reference policy.
- The local schema copy keeps the same validation rules and only replaces that example value with the existing GitHub example so `check:forbidden-refs` remains clean.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist` (known repo gap: missing root script)
- `cd packages/mcp-server && uv sync && uv run pytest` (known repo command mismatch: default sync removes extras required by tests)
- `cd packages/mcp-server && uv sync --all-extras --frozen && uv run --all-extras pytest`
- `corepack pnpm run check:forbidden-refs`
- `corepack pnpm --dir packages/mcp-server run metadata:check`
- `corepack pnpm --dir packages/mcp-server run mcp:manifest:check`
- `corepack pnpm --dir packages/mcp-server run publish:mcp:dry-run`
- `corepack pnpm --dir packages/mcp-server run submission:check`
- `corepack pnpm --dir packages/mcp-server run workflows:lint`
- `corepack pnpm --dir packages/mcp-server run workflows:security`
- `corepack pnpm --dir packages/mcp-server run security`
- `corepack pnpm audit --audit-level high`
- `docker run --rm -v "$PWD:/repo" ghcr.io/gitleaks/gitleaks:v8.30.1 detect --source /repo --redact --verbose`
- `uvx pre-commit run --all-files`

## Freshness / Deprecation

- Official MCP Registry schema `2025-12-11` fetched and checked; the local copy intentionally differs only in one non-validating example value required by repository forbidden-reference policy.
- `mcp-publisher` `v1.7.9` verified as latest release in `modelcontextprotocol/registry`.
- `actions/checkout`, `actions/setup-node`, and `astral-sh/setup-uv` pinned action metadata checked: all use Node24.
- Workflow deprecation grep checked: no `::set-output`, `::save-state`, insecure Node override, `node12`, `node16`, or `node20` hits.
