### PR TITLE
test(kicad-studio): expand accessibility keyboard coverage

### DIFF
--- a/apps/vscode-extension/media/styles/bom.css
+++ b/apps/vscode-extension/media/styles/bom.css
@@ -1,13 +1,22 @@
 :root {
   --bg: var(--vscode-editor-background);
-  --panel: var(--vscode-editorWidget-background, var(--vscode-editor-background));
-  --panel-alt: var(--vscode-sideBar-background, var(--vscode-editor-background));
+  --panel: var(
+    --vscode-editorWidget-background,
+    var(--vscode-editor-background)
+  );
+  --panel-alt: var(
+    --vscode-sideBar-background,
+    var(--vscode-editor-background)
+  );
   --text: var(--vscode-foreground);
   --muted: var(--vscode-descriptionForeground);
   --accent: var(--vscode-focusBorder);
   --success: var(--vscode-testing-iconPassed, #22c55e);
   --warning: var(--vscode-editorWarning-foreground, #f59e0b);
-  --border: var(--vscode-panel-border, var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.35)));
+  --border: var(
+    --vscode-panel-border,
+    var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.35))
+  );
 }
 
 *,
@@ -20,7 +29,10 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--text);
-  font: 13px/1.5 "Segoe UI", system-ui, sans-serif;
+  font:
+    13px/1.5 'Segoe UI',
+    system-ui,
+    sans-serif;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -71,7 +83,7 @@ body {
   user-select: none;
 }
 
-#topbar label input[type="checkbox"] {
+#topbar label input[type='checkbox'] {
   width: auto;
   margin: 0;
   accent-color: var(--accent);
@@ -91,7 +103,10 @@ button {
 }
 
 button:hover {
-  background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
+  background: var(
+    --vscode-button-hoverBackground,
+    var(--vscode-button-background)
+  );
 }
 
 button:active {
@@ -101,6 +116,30 @@ button:active {
 button:disabled {
   cursor: not-allowed;
   opacity: 0.55;
+}
+
+:where(
+  button,
+  [href],
+  input,
+  select,
+  textarea,
+  [tabindex]:not([tabindex='-1'])
+):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* ── Statsbar ── */
@@ -163,25 +202,80 @@ th::after {
   opacity: 0.5;
 }
 
-th[data-sort="asc"]::after  { content: '↑'; }
-th[data-sort="desc"]::after { content: '↓'; }
+th[data-sort='asc']::after {
+  content: '↑';
+}
+th[data-sort='desc']::after {
+  content: '↓';
+}
 
 /* Column widths (table-layout: fixed) */
-th:nth-child(1), td:nth-child(1) { width: 80px; }   /* Reference */
-th:nth-child(2), td:nth-child(2) { width: 36px; }   /* Qty */
-th:nth-child(3), td:nth-child(3) { width: 70px; }   /* Value */
-th:nth-child(4), td:nth-child(4) { width: 120px; }  /* Footprint */
-th:nth-child(5), td:nth-child(5) { width: 90px; }   /* MPN */
-th:nth-child(6), td:nth-child(6) { width: 100px; }  /* Manufacturer */
-th:nth-child(7), td:nth-child(7) { width: 60px; }   /* LCSC */
-th:nth-child(8), td:nth-child(8) { width: auto; }   /* Description */
+th:nth-child(1),
+td:nth-child(1) {
+  width: 80px;
+} /* Reference */
+th:nth-child(2),
+td:nth-child(2) {
+  width: 36px;
+} /* Qty */
+th:nth-child(3),
+td:nth-child(3) {
+  width: 70px;
+} /* Value */
+th:nth-child(4),
+td:nth-child(4) {
+  width: 120px;
+} /* Footprint */
+th:nth-child(5),
+td:nth-child(5) {
+  width: 90px;
+} /* MPN */
+th:nth-child(6),
+td:nth-child(6) {
+  width: 100px;
+} /* Manufacturer */
+th:nth-child(7),
+td:nth-child(7) {
+  width: 60px;
+} /* LCSC */
+th:nth-child(8),
+td:nth-child(8) {
+  width: auto;
+} /* Description */
 
 tbody tr:hover {
   background: var(--vscode-list-hoverBackground, rgba(128, 128, 128, 0.08));
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (forced-colors: active) {
+  :where(
+    button,
+    [href],
+    input,
+    select,
+    textarea,
+    [tabindex]:not([tabindex='-1'])
+  ):focus-visible {
+    outline: 2px solid CanvasText;
+  }
+}
+
 tbody tr.selected {
-  background: var(--vscode-list-activeSelectionBackground, color-mix(in srgb, var(--accent) 18%, transparent));
+  background: var(
+    --vscode-list-activeSelectionBackground,
+    color-mix(in srgb, var(--accent) 18%, transparent)
+  );
   color: var(--vscode-list-activeSelectionForeground, var(--text));
 }
 

--- a/apps/vscode-extension/media/styles/viewer.css
+++ b/apps/vscode-extension/media/styles/viewer.css
@@ -1,10 +1,19 @@
 :root {
   --bg: var(--vscode-editor-background);
-  --panel: var(--vscode-editorWidget-background, var(--vscode-editor-background));
-  --panel-alt: var(--vscode-sideBar-background, var(--vscode-editor-background));
+  --panel: var(
+    --vscode-editorWidget-background,
+    var(--vscode-editor-background)
+  );
+  --panel-alt: var(
+    --vscode-sideBar-background,
+    var(--vscode-editor-background)
+  );
   --text: var(--vscode-foreground);
   --muted: var(--vscode-descriptionForeground);
-  --border: var(--vscode-panel-border, var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.35)));
+  --border: var(
+    --vscode-panel-border,
+    var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.35))
+  );
   --accent: var(--vscode-focusBorder);
 }
 
@@ -12,7 +21,10 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--text);
-  font: 13px/1.5 "Segoe UI", system-ui, sans-serif;
+  font:
+    13px/1.5 'Segoe UI',
+    system-ui,
+    sans-serif;
 }
 
 #viewer-shell {
@@ -43,7 +55,10 @@ button {
   border-radius: 6px;
   padding: 5px 9px;
   cursor: pointer;
-  font: 12px/1.4 "Segoe UI", system-ui, sans-serif;
+  font:
+    12px/1.4 'Segoe UI',
+    system-ui,
+    sans-serif;
   white-space: nowrap;
   transition: background 0.1s;
 }
@@ -54,6 +69,18 @@ button:hover {
 
 button:active {
   opacity: 0.8;
+}
+
+:where(
+  button,
+  [href],
+  input,
+  select,
+  textarea,
+  [tabindex]:not([tabindex='-1'])
+):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .separator {
@@ -282,7 +309,10 @@ kicanvas-embed {
   gap: 6px;
   padding: 3px 8px;
   border-radius: 999px;
-  background: var(--vscode-badge-background, color-mix(in srgb, var(--accent) 15%, transparent));
+  background: var(
+    --vscode-badge-background,
+    color-mix(in srgb, var(--accent) 15%, transparent)
+  );
   color: var(--vscode-badge-foreground, var(--text));
 }
 
@@ -292,5 +322,33 @@ kicanvas-embed {
   }
   to {
     transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .spinner {
+    animation: none;
+  }
+}
+
+@media (forced-colors: active) {
+  :where(
+    button,
+    [href],
+    input,
+    select,
+    textarea,
+    [tabindex]:not([tabindex='-1'])
+  ):focus-visible {
+    outline: 2px solid CanvasText;
   }
 }

--- a/apps/vscode-extension/media/viewer/bom.html
+++ b/apps/vscode-extension/media/viewer/bom.html
@@ -1,76 +1,110 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
     default-src 'none';
     script-src 'nonce-{{scriptNonce}}' {{cspSource}};
     style-src {{cspSource}};
     font-src {{cspSource}};
     img-src {{cspSource}} data:;
-  ">
-  <title>KiCad BOM</title>
-  <link rel="stylesheet" href="{{bomCssUri}}">
-  <style>
-    #loading-row {
-      display: none;
-      padding: 24px;
-      text-align: center;
-      color: var(--muted);
-      gap: 10px;
-      align-items: center;
-      justify-content: center;
-    }
-    #loading-row.visible { display: flex; }
-    #loading-row .spinner {
-      width: 16px;
-      height: 16px;
-      border-radius: 50%;
-      border: 2px solid var(--border);
-      border-top-color: var(--accent);
-      animation: spin 0.8s linear infinite;
-      flex-shrink: 0;
-    }
-    @keyframes spin { to { transform: rotate(360deg); } }
-  </style>
-</head>
-<body>
-  <div id="bom-app">
-    <div id="topbar">
-      <input id="search" aria-label="Search BOM" placeholder="Search reference, value, footprint…">
-      <label title="Exclude Do Not Populate parts"><input id="toggle-dnp" type="checkbox"> Hide DNP</label>
-      <button id="btn-export-csv" aria-label="Export BOM as CSV" disabled>CSV</button>
-      <button id="btn-export-xlsx" aria-label="Export BOM as XLSX" disabled>XLSX</button>
+  "
+    />
+    <title>KiCad BOM</title>
+    <link rel="stylesheet" href="{{bomCssUri}}" />
+    <style>
+      #loading-row {
+        display: none;
+        padding: 24px;
+        text-align: center;
+        color: var(--muted);
+        gap: 10px;
+        align-items: center;
+        justify-content: center;
+      }
+      #loading-row.visible {
+        display: flex;
+      }
+      #loading-row .spinner {
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        border: 2px solid var(--border);
+        border-top-color: var(--accent);
+        animation: spin 0.8s linear infinite;
+        flex-shrink: 0;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="bom-app">
+      <div id="topbar">
+        <input
+          id="search"
+          aria-label="Search BOM"
+          placeholder="Search reference, value, footprint…"
+        />
+        <label title="Exclude Do Not Populate parts"
+          ><input id="toggle-dnp" type="checkbox" /> Hide DNP</label
+        >
+        <button
+          id="btn-export-csv"
+          aria-label="Export BOM as CSV"
+          aria-describedby="bom-export-disabled-reason"
+          title="BOM export is disabled until entries are loaded."
+          disabled
+        >
+          CSV
+        </button>
+        <button
+          id="btn-export-xlsx"
+          aria-label="Export BOM as XLSX"
+          aria-describedby="bom-export-disabled-reason"
+          title="BOM export is disabled until entries are loaded."
+          disabled
+        >
+          XLSX
+        </button>
+        <span id="bom-export-disabled-reason" class="sr-only"
+          >BOM export is disabled until entries are loaded.</span
+        >
+      </div>
+      <div id="statsbar">
+        <span id="summary-text" class="muted">Loading...</span>
+      </div>
+      <div id="loading-row" role="status" aria-live="polite">
+        <div class="spinner" aria-hidden="true"></div>
+        <span>Loading BOM...</span>
+      </div>
+      <div id="bom-empty" role="status" aria-live="polite">
+        Open a schematic to load the Bill of Materials.
+      </div>
+      <div id="table-wrapper" tabindex="0" aria-label="BOM table">
+        <table>
+          <thead>
+            <tr>
+              <th data-key="references">Reference</th>
+              <th data-key="quantity">Qty</th>
+              <th data-key="value">Value</th>
+              <th data-key="footprint">Footprint</th>
+              <th data-key="mpn">MPN</th>
+              <th data-key="manufacturer">Manufacturer</th>
+              <th data-key="lcsc">LCSC</th>
+              <th data-key="description">Description</th>
+            </tr>
+          </thead>
+          <tbody id="bom-rows"></tbody>
+        </table>
+      </div>
     </div>
-    <div id="statsbar">
-      <span id="summary-text" class="muted">Loading...</span>
-    </div>
-    <div id="loading-row" role="status" aria-live="polite">
-      <div class="spinner" aria-hidden="true"></div>
-      <span>Loading BOM...</span>
-    </div>
-    <div id="bom-empty" role="status" aria-live="polite">
-      Open a schematic to load the Bill of Materials.
-    </div>
-    <div id="table-wrapper">
-      <table>
-        <thead>
-          <tr>
-            <th data-key="references">Reference</th>
-            <th data-key="quantity">Qty</th>
-            <th data-key="value">Value</th>
-            <th data-key="footprint">Footprint</th>
-            <th data-key="mpn">MPN</th>
-            <th data-key="manufacturer">Manufacturer</th>
-            <th data-key="lcsc">LCSC</th>
-            <th data-key="description">Description</th>
-          </tr>
-        </thead>
-        <tbody id="bom-rows"></tbody>
-      </table>
-    </div>
-  </div>
-  <script nonce="{{scriptNonce}}" src="{{scriptUri}}"></script>
-</body>
+    <script nonce="{{scriptNonce}}" src="{{scriptUri}}"></script>
+  </body>
 </html>

--- a/apps/vscode-extension/media/viewer/bom.js
+++ b/apps/vscode-extension/media/viewer/bom.js
@@ -28,14 +28,19 @@
 
   function syncExportState(loading = isLoading) {
     const disabled = loading || entries.length === 0;
-    exportCsv.disabled = disabled;
-    exportXlsx.disabled = disabled;
-    exportCsv.title = disabled
-      ? 'Export is available after BOM rows are loaded.'
-      : 'Export BOM as CSV';
-    exportXlsx.title = disabled
-      ? 'Export is available after BOM rows are loaded.'
-      : 'Export BOM as XLSX';
+    syncExportButton(exportCsv, disabled, 'Export BOM as CSV');
+    syncExportButton(exportXlsx, disabled, 'Export BOM as XLSX');
+  }
+
+  function syncExportButton(button, disabled, enabledTitle) {
+    button.disabled = disabled;
+    if (disabled) {
+      button.title = 'Export is available after BOM rows are loaded.';
+      button.setAttribute('aria-describedby', 'bom-export-disabled-reason');
+    } else {
+      button.title = enabledTitle;
+      button.removeAttribute('aria-describedby');
+    }
   }
 
   function showEmpty(message) {

--- a/apps/vscode-extension/media/viewer/netlist.html
+++ b/apps/vscode-extension/media/viewer/netlist.html
@@ -1,55 +1,73 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
     default-src 'none';
     script-src 'nonce-{{scriptNonce}}' {{cspSource}};
     style-src {{cspSource}};
-  ">
-  <title>KiCad Netlist</title>
-  <link rel="stylesheet" href="{{bomCssUri}}">
-  <style>
-    #error-card {
-      display: none;
-      margin: 10px;
-      padding: 10px 12px;
-      border-radius: 6px;
-      border: 1px solid var(--vscode-inputValidation-errorBorder, rgba(200, 50, 50, 0.5));
-      background: var(--vscode-inputValidation-errorBackground, rgba(200, 50, 50, 0.08));
-      color: var(--vscode-errorForeground, inherit);
-      font-size: 12px;
-    }
-    #error-card.visible { display: block; }
-    #error-card strong { display: block; margin-bottom: 4px; }
+  "
+    />
+    <title>KiCad Netlist</title>
+    <link rel="stylesheet" href="{{bomCssUri}}" />
+    <style>
+      #error-card {
+        display: none;
+        margin: 10px;
+        padding: 10px 12px;
+        border-radius: 6px;
+        border: 1px solid
+          var(--vscode-inputValidation-errorBorder, rgba(200, 50, 50, 0.5));
+        background: var(
+          --vscode-inputValidation-errorBackground,
+          rgba(200, 50, 50, 0.08)
+        );
+        color: var(--vscode-errorForeground, inherit);
+        font-size: 12px;
+      }
+      #error-card.visible {
+        display: block;
+      }
+      #error-card strong {
+        display: block;
+        margin-bottom: 4px;
+      }
 
-    /* Netlist-specific column widths */
-    th:nth-child(1), td:nth-child(1) { width: 40%; }
-    th:nth-child(2), td:nth-child(2) { width: 60%; }
-  </style>
-</head>
-<body>
-  <div id="bom-app">
-    <div id="statsbar">
-      <span id="summary-text" class="muted">No schematic opened.</span>
+      /* Netlist-specific column widths */
+      th:nth-child(1),
+      td:nth-child(1) {
+        width: 40%;
+      }
+      th:nth-child(2),
+      td:nth-child(2) {
+        width: 60%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="bom-app">
+      <div id="statsbar">
+        <span id="summary-text" class="muted">No schematic opened.</span>
+      </div>
+      <div id="error-card" role="alert" aria-live="polite">
+        <strong>Could not load netlist</strong>
+        <span id="error-message"></span>
+      </div>
+      <div id="table-wrapper" tabindex="0" aria-label="Netlist table">
+        <table>
+          <thead>
+            <tr>
+              <th>Net</th>
+              <th>Nodes</th>
+            </tr>
+          </thead>
+          <tbody id="netlist-rows"></tbody>
+        </table>
+      </div>
     </div>
-    <div id="error-card" role="alert" aria-live="polite">
-      <strong>Could not load netlist</strong>
-      <span id="error-message"></span>
-    </div>
-    <div id="table-wrapper">
-      <table>
-        <thead>
-          <tr>
-            <th>Net</th>
-            <th>Nodes</th>
-          </tr>
-        </thead>
-        <tbody id="netlist-rows"></tbody>
-      </table>
-    </div>
-  </div>
-  <script nonce="{{scriptNonce}}" src="{{scriptUri}}"></script>
-</body>
+    <script nonce="{{scriptNonce}}" src="{{scriptUri}}"></script>
+  </body>
 </html>

--- a/apps/vscode-extension/media/viewer/pcb.html
+++ b/apps/vscode-extension/media/viewer/pcb.html
@@ -136,9 +136,13 @@
             <div class="spinner" aria-hidden="true"></div>
             <span>Loading board…</span>
           </div>
-          <div id="error-overlay" hidden>
+          <div id="error-overlay" role="alert" aria-live="polite" hidden>
             <span id="error-message"></span>
-            <pre id="error-details"></pre>
+            <pre
+              id="error-details"
+              tabindex="0"
+              aria-label="Error details"
+            ></pre>
           </div>
         </div>
         <aside id="info-panel">

--- a/apps/vscode-extension/media/viewer/pcb.html
+++ b/apps/vscode-extension/media/viewer/pcb.html
@@ -1,95 +1,178 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
     default-src 'none';
     script-src 'nonce-{{scriptNonce}}' {{cspSource}};
     style-src 'nonce-{{scriptNonce}}' {{cspSource}};
     font-src {{cspSource}};
     img-src {{cspSource}} data:;
-  ">
-  <title>KiCad PCB Viewer</title>
-  <link rel="stylesheet" href="{{viewerCssUri}}">
-  <style nonce="{{scriptNonce}}">
-    body { margin: 0; background: #0f172a; color: #e2e8f0; font: 13px/1.5 "Segoe UI", sans-serif; }
-    #viewer-shell { min-height: 100vh; }
-    #toolbar, #footer-toolbar { display: flex; align-items: center; gap: 8px; padding: 10px 14px; }
-    button { color: #e2e8f0; background: #1e293b; border: 1px solid rgba(148,163,184,.25); border-radius: 8px; padding: 6px 10px; }
-    #loading-overlay, #error-overlay { color: #e2e8f0; text-align: center; }
-    #error-message { display: block; font-weight: 600; margin-bottom: 8px; }
-    #error-details {
-      max-width: min(900px, calc(100vw - 64px));
-      max-height: 45vh;
-      overflow: auto;
-      margin: 0;
-      padding: 12px;
-      border-radius: 10px;
-      text-align: left;
-      background: rgba(15, 23, 42, 0.92);
-      border: 1px solid rgba(148,163,184,.25);
-      color: #cbd5e1;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-    #diagnostic-banner {
-      display: block;
-      padding: 8px 14px;
-      background: rgba(56, 189, 248, 0.12);
-      color: #bae6fd;
-      border-bottom: 1px solid rgba(148,163,184,.18);
-    }
-  </style>
-</head>
-<body>
-  <div id="viewer-shell">
-    <div id="diagnostic-banner">Interactive KiCanvas mode is active.</div>
-    <div id="toolbar">
-      <button id="btn-zoom-fit" aria-label="Fit to screen" title="Fit to Screen">⊡</button>
-      <button id="btn-zoom-in" aria-label="Zoom in" title="Zoom In">+</button>
-      <button id="btn-zoom-out" aria-label="Zoom out" title="Zoom Out">−</button>
-      <button id="btn-grid" aria-label="Toggle grid" title="Toggle Grid">#</button>
-      <span class="separator"></span>
-      <button id="btn-theme" aria-label="Toggle theme" title="Toggle Theme">◑</button>
-      <button id="btn-open-kicad" aria-label="Open in KiCad" title="Open in KiCad">↗</button>
-      <span id="status-text" class="status">Waiting for PCB…</span>
-    </div>
-    <div id="viewer-layout">
-      <aside id="side-panel">
-        <h3>Layers</h3>
-        <div id="layer-list" class="layer-list"></div>
-      </aside>
-      <div id="viewer-container">
-        <kicanvas-embed id="viewer" controls="full" controlslist="zoom pan select"></kicanvas-embed>
-        <div id="loading-overlay" hidden>
-          <div class="spinner" aria-hidden="true"></div>
-          <span>Loading board…</span>
-        </div>
-        <div id="error-overlay" hidden>
-          <span id="error-message"></span>
-          <pre id="error-details"></pre>
-        </div>
+  "
+    />
+    <title>KiCad PCB Viewer</title>
+    <link rel="stylesheet" href="{{viewerCssUri}}" />
+    <style nonce="{{scriptNonce}}">
+      :root {
+        --bg: var(--vscode-editor-background, #0f172a);
+        --panel: var(
+          --vscode-editorWidget-background,
+          var(--vscode-editor-background, #1e293b)
+        );
+        --text: var(--vscode-foreground, #e2e8f0);
+        --muted: var(--vscode-descriptionForeground, #94a3b8);
+        --border: var(
+          --vscode-panel-border,
+          var(--vscode-editorWidget-border, rgba(148, 163, 184, 0.25))
+        );
+        --accent: var(--vscode-focusBorder, #38bdf8);
+        --btn-bg: var(--vscode-button-secondaryBackground, #1e293b);
+        --btn-fg: var(--vscode-button-secondaryForeground, #e2e8f0);
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font:
+          13px/1.5 'Segoe UI',
+          sans-serif;
+      }
+      #viewer-shell {
+        min-height: 100vh;
+      }
+      #toolbar,
+      #footer-toolbar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 14px;
+      }
+      button {
+        color: var(--btn-fg);
+        background: var(--btn-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 6px 10px;
+      }
+      #loading-overlay,
+      #error-overlay {
+        color: var(--text);
+        text-align: center;
+      }
+      #error-message {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 8px;
+      }
+      #error-details {
+        max-width: min(900px, calc(100vw - 64px));
+        max-height: 45vh;
+        overflow: auto;
+        margin: 0;
+        padding: 12px;
+        border-radius: 10px;
+        text-align: left;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        color: var(--muted);
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      #diagnostic-banner {
+        display: block;
+        padding: 8px 14px;
+        background: color-mix(in srgb, var(--accent) 10%, transparent);
+        color: var(--muted);
+        border-bottom: 1px solid var(--border);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="viewer-shell">
+      <div id="diagnostic-banner">Interactive KiCanvas mode is active.</div>
+      <div id="toolbar">
+        <button
+          id="btn-zoom-fit"
+          aria-label="Fit to screen"
+          title="Fit to Screen"
+        >
+          ⊡
+        </button>
+        <button id="btn-zoom-in" aria-label="Zoom in" title="Zoom In">+</button>
+        <button id="btn-zoom-out" aria-label="Zoom out" title="Zoom Out">
+          −
+        </button>
+        <button id="btn-grid" aria-label="Toggle grid" title="Toggle Grid">
+          #
+        </button>
+        <span class="separator"></span>
+        <button id="btn-theme" aria-label="Toggle theme" title="Toggle Theme">
+          ◑
+        </button>
+        <button
+          id="btn-open-kicad"
+          aria-label="Open in KiCad"
+          title="Open in KiCad"
+        >
+          ↗
+        </button>
+        <span id="status-text" class="status">Waiting for PCB…</span>
       </div>
-      <aside id="info-panel">
-        <h3>Inspector</h3>
-        <div id="component-info" class="property-list">
-          No item selected
+      <div id="viewer-layout">
+        <aside id="side-panel">
+          <h3>Layers</h3>
+          <div id="layer-list" class="layer-list"></div>
+        </aside>
+        <div id="viewer-container">
+          <kicanvas-embed
+            id="viewer"
+            controls="full"
+            controlslist="zoom pan select"
+          ></kicanvas-embed>
+          <div id="loading-overlay" hidden>
+            <div class="spinner" aria-hidden="true"></div>
+            <span>Loading board…</span>
+          </div>
+          <div id="error-overlay" hidden>
+            <span id="error-message"></span>
+            <pre id="error-details"></pre>
+          </div>
         </div>
-      </aside>
+        <aside id="info-panel">
+          <h3>Inspector</h3>
+          <div id="component-info" class="property-list">No item selected</div>
+        </aside>
+      </div>
+      <div id="footer-toolbar">
+        <button data-preset="All Cu" aria-label="Show All Cu layers">
+          All Cu
+        </button>
+        <button data-preset="Front" aria-label="Show Front layers">
+          Front
+        </button>
+        <button data-preset="Back" aria-label="Show Back layers">Back</button>
+        <button data-preset="Fab" aria-label="Show Fab layers">Fab</button>
+        <button data-preset="Assembly" aria-label="Show Assembly layers">
+          Assembly
+        </button>
+        <button data-preset="User" aria-label="Show User layers">User</button>
+        <span class="status" id="layer-status"
+          >Layer toggles are read-only unless supported by the bundled KiCanvas
+          build.</span
+        >
+      </div>
     </div>
-    <div id="footer-toolbar">
-      <button data-preset="All Cu" aria-label="Show all copper layers">All Cu</button>
-      <button data-preset="Front" aria-label="Show front layers">Front</button>
-      <button data-preset="Back" aria-label="Show back layers">Back</button>
-      <button data-preset="Fab" aria-label="Show fabrication layers">Fab</button>
-      <button data-preset="Assembly" aria-label="Show assembly layers">Assembly</button>
-      <button data-preset="User" aria-label="Show user layers">User</button>
-      <span class="status" id="layer-status">Layer toggles are read-only unless supported by the bundled KiCanvas build.</span>
-    </div>
-  </div>
-  <script id="initial-payload" nonce="{{scriptNonce}}" type="application/json">{{initialPayload}}</script>
-  <script nonce="{{scriptNonce}}" src="{{kicanvasUri}}"></script>
-  <script nonce="{{scriptNonce}}" src="{{viewerScriptUri}}"></script>
-</body>
+    <script
+      id="initial-payload"
+      nonce="{{scriptNonce}}"
+      type="application/json"
+    >
+      {{initialPayload}}
+    </script>
+    <script nonce="{{scriptNonce}}" src="{{kicanvasUri}}"></script>
+    <script nonce="{{scriptNonce}}" src="{{viewerScriptUri}}"></script>
+  </body>
 </html>

--- a/apps/vscode-extension/src/ai/chatHtml.ts
+++ b/apps/vscode-extension/src/ai/chatHtml.ts
@@ -74,6 +74,10 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
     select:focus, input:focus, textarea:focus {
       border-color: var(--accent);
     }
+    :where(button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])):focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
     header {
       display: grid;
       grid-template-columns: minmax(140px, 1fr) auto;
@@ -284,9 +288,31 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       vertical-align: text-bottom;
       animation: blink 0.9s step-end infinite;
     }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
     @keyframes blink {
       0%, 100% { opacity: 1; }
       50% { opacity: 0; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *,
+      *::before,
+      *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+      }
+      .typing-indicator::after { animation: none; }
     }
     @media (max-width: 680px) {
       header { grid-template-columns: 1fr; }
@@ -319,7 +345,8 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       <button id="settings" class="icon" type="button" title="Open KiCad Studio settings" aria-label="Open settings">&#9881;</button>
       <button id="export" class="icon" type="button" title="Export chat transcript" aria-label="Export chat">&#8681;</button>
       <button id="clear" class="icon" type="button" title="Clear chat" aria-label="Clear chat">Clear</button>
-      <button id="cancel" class="danger" type="button" disabled>Cancel</button>
+      <button id="cancel" class="danger" type="button" aria-describedby="cancel-disabled-reason" disabled>Cancel</button>
+      <span id="cancel-disabled-reason" class="sr-only">Cancel is disabled until a response is streaming.</span>
     </div>
   </header>
   <main id="messages" aria-live="polite">
@@ -388,6 +415,11 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       state.busy = !!busy;
       nodes.send.disabled = state.busy;
       nodes.cancel.disabled = !state.busy;
+      if (state.busy) {
+        nodes.cancel.removeAttribute('aria-describedby');
+      } else {
+        nodes.cancel.setAttribute('aria-describedby', 'cancel-disabled-reason');
+      }
       nodes.send.textContent = state.busy ? '…' : l10n.t('Send');
     }
     function clearMessages() {

--- a/apps/vscode-extension/src/components/componentSearch.ts
+++ b/apps/vscode-extension/src/components/componentSearch.ts
@@ -144,53 +144,10 @@ export class ComponentSearchService {
     this.detailsPanel.title = `Part: ${result.mpn || result.lcscPartNumber || 'Details'}`;
     const nonce = createNonce();
     const cspSource = this.detailsPanel.webview.cspSource;
-    this.detailsPanel.webview.html = injectWebviewLocalization(
-      `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} data:; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
-  <style nonce="${nonce}">
-    body {
-      font-family: "Segoe UI", system-ui, sans-serif;
-      background: var(--vscode-editor-background);
-      color: var(--vscode-foreground);
-      padding: 16px;
-    }
-    button {
-      margin-right: 8px;
-      background: var(--vscode-button-background);
-      color: var(--vscode-button-foreground);
-      border: none;
-      border-radius: 4px;
-      padding: 6px 12px;
-      cursor: pointer;
-      font: inherit;
-    }
-    button:hover { background: var(--vscode-button-hoverBackground, var(--vscode-button-background)); }
-    pre { white-space: pre-wrap; }
-  </style>
-</head>
-<body>
-  <h1>${escapeHtml(result.mpn || result.lcscPartNumber || 'Part')}</h1>
-  <p>${escapeHtml(result.description)}</p>
-  <p><strong>Manufacturer:</strong> ${escapeHtml(result.manufacturer || 'Unknown')}</p>
-  <p><strong>Source:</strong> ${escapeHtml(result.source)}</p>
-  <button id="datasheet">Open Datasheet</button>
-  <button id="copy">Copy MPN</button>
-  ${result.pcmPackageId ? '<button id="pcm-install">Install PCM Library</button>' : ''}
-  <h2>Offers</h2>
-  <pre>${escapeHtml(JSON.stringify(result.offers, null, 2))}</pre>
-  <script nonce="${nonce}">
-    const vscode = acquireVsCodeApi();
-    document.getElementById('datasheet').addEventListener('click', () => vscode.postMessage({ type: 'datasheet', url: ${JSON.stringify(result.datasheetUrl ?? '')} }));
-    document.getElementById('copy').addEventListener('click', () => vscode.postMessage({ type: 'copy-mpn', mpn: ${JSON.stringify(result.mpn)} }));
-    document.getElementById('pcm-install')?.addEventListener('click', () => vscode.postMessage({ type: 'pcm-install' }));
-  </script>
-</body>
-    </html>`,
-      nonce
-    );
+    this.detailsPanel.webview.html = buildComponentDetailsHtml(result, {
+      nonce,
+      cspSource
+    });
   }
 
   private async searchWithCache(
@@ -321,7 +278,10 @@ export class ComponentSearchService {
       'Install PCM Library'
     );
     if (action === 'Install PCM Library') {
-      await vscode.commands.executeCommand(COMMANDS.installPcmPackage, candidate);
+      await vscode.commands.executeCommand(
+        COMMANDS.installPcmPackage,
+        candidate
+      );
     }
   }
 
@@ -336,6 +296,64 @@ export class ComponentSearchService {
       result.pcmPackageId
     );
   }
+}
+
+export function buildComponentDetailsHtml(
+  result: ComponentSearchResult,
+  options: { nonce: string; cspSource: string }
+): string {
+  return injectWebviewLocalization(
+    `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${options.cspSource} data:; style-src 'nonce-${options.nonce}'; script-src 'nonce-${options.nonce}';">
+  <title>KiCad Component Details</title>
+  <style nonce="${options.nonce}">
+    body {
+      font-family: "Segoe UI", system-ui, sans-serif;
+      background: var(--vscode-editor-background);
+      color: var(--vscode-foreground);
+      padding: 16px;
+    }
+    button {
+      margin-right: 8px;
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+      border: none;
+      border-radius: 4px;
+      padding: 6px 12px;
+      cursor: pointer;
+      font: inherit;
+    }
+    button:hover { background: var(--vscode-button-hoverBackground, var(--vscode-button-background)); }
+    button:focus-visible {
+      outline: 2px solid var(--vscode-focusBorder, #007acc);
+      outline-offset: 2px;
+    }
+    pre { white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <h1>${escapeHtml(result.mpn || result.lcscPartNumber || 'Part')}</h1>
+  <p>${escapeHtml(result.description)}</p>
+  <p><strong>Manufacturer:</strong> ${escapeHtml(result.manufacturer || 'Unknown')}</p>
+  <p><strong>Source:</strong> ${escapeHtml(result.source)}</p>
+  <button id="datasheet">Open Datasheet</button>
+  <button id="copy">Copy MPN</button>
+  ${result.pcmPackageId ? '<button id="pcm-install">Install PCM Library</button>' : ''}
+  <h2>Offers</h2>
+  <pre>${escapeHtml(JSON.stringify(result.offers, null, 2))}</pre>
+  <script nonce="${options.nonce}">
+    const vscode = acquireVsCodeApi();
+    document.getElementById('datasheet').addEventListener('click', () => vscode.postMessage({ type: 'datasheet', url: ${JSON.stringify(result.datasheetUrl ?? '')} }));
+    document.getElementById('copy').addEventListener('click', () => vscode.postMessage({ type: 'copy-mpn', mpn: ${JSON.stringify(result.mpn)} }));
+    document.getElementById('pcm-install')?.addEventListener('click', () => vscode.postMessage({ type: 'pcm-install' }));
+  </script>
+</body>
+</html>`,
+    options.nonce
+  );
 }
 
 function escapeHtml(value: string): string {

--- a/apps/vscode-extension/src/drc/drcRuleEditorPanel.ts
+++ b/apps/vscode-extension/src/drc/drcRuleEditorPanel.ts
@@ -126,6 +126,10 @@ export function buildDrcRuleEditorHtml(): string {
     .actions { display: flex; gap: 8px; }
     button { color: var(--vscode-button-foreground); background: var(--vscode-button-background); border: 0; padding: 8px 12px; font: inherit; cursor: pointer; }
     button.secondary { color: var(--vscode-button-secondaryForeground); background: var(--vscode-button-secondaryBackground); }
+    :where(button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])):focus-visible {
+      outline: 2px solid var(--vscode-focusBorder, #007acc);
+      outline-offset: 2px;
+    }
   </style>
 </head>
 <body>

--- a/apps/vscode-extension/src/providers/viewerHtml.ts
+++ b/apps/vscode-extension/src/providers/viewerHtml.ts
@@ -142,7 +142,7 @@ export function createKiCanvasViewerHtml(
           ${
             hasLayerControls
               ? `<button class="btn" id="all-layers-btn" type="button" aria-label="Show All layers">All</button>
-          <button class="btn" id="none-layers-btn" type="button" aria-label="Hide None layers">None</button>
+          <button class="btn" id="none-layers-btn" type="button" aria-label="None - hide all layers">None</button>
           <button class="btn" id="copper-layers-btn" type="button" aria-label="Show Copper Only layers">Copper Only</button>`
               : ''
           }

--- a/apps/vscode-extension/src/providers/viewerHtml.ts
+++ b/apps/vscode-extension/src/providers/viewerHtml.ts
@@ -136,14 +136,14 @@ export function createKiCanvasViewerHtml(
       <div class="side-section">
         <h2>Viewer Tools</h2>
         <div class="side-actions">
-          <button class="btn" id="fit-btn" type="button">Fit</button>
-          <button class="btn" id="zoom-in-btn" type="button">+</button>
-          <button class="btn" id="zoom-out-btn" type="button">-</button>
+          <button class="btn" id="fit-btn" type="button" aria-label="Fit viewer">Fit</button>
+          <button class="btn" id="zoom-in-btn" type="button" aria-label="Zoom in viewer">+</button>
+          <button class="btn" id="zoom-out-btn" type="button" aria-label="Zoom out viewer">-</button>
           ${
             hasLayerControls
-              ? `<button class="btn" id="all-layers-btn" type="button">All</button>
-          <button class="btn" id="none-layers-btn" type="button">None</button>
-          <button class="btn" id="copper-layers-btn" type="button">Copper Only</button>`
+              ? `<button class="btn" id="all-layers-btn" type="button" aria-label="Show All layers">All</button>
+          <button class="btn" id="none-layers-btn" type="button" aria-label="Hide None layers">None</button>
+          <button class="btn" id="copper-layers-btn" type="button" aria-label="Show Copper Only layers">Copper Only</button>`
               : ''
           }
         </div>

--- a/apps/vscode-extension/src/settings/settingsHtml.ts
+++ b/apps/vscode-extension/src/settings/settingsHtml.ts
@@ -72,6 +72,10 @@ export function buildSettingsHtml(options: SettingsHtmlOptions): string {
       outline: none;
     }
     input:focus, select:focus { border-color: var(--accent); }
+    :where(button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])):focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
     header {
       position: sticky;
       top: 0;

--- a/apps/vscode-extension/test/a11y/accessibilityConformance.test.ts
+++ b/apps/vscode-extension/test/a11y/accessibilityConformance.test.ts
@@ -134,11 +134,12 @@ describe('native VS Code surface accessibility gate', () => {
   });
 
   it('labels MCP Tools, Quality Gates, and AI Fix Queue tree rows', async () => {
-    const issues = [
-      ...collectMcpToolsTreeIssues(),
-      ...collectQualityGateTreeIssues(),
-      ...(await collectFixQueueTreeIssues())
-    ];
+    const [mcpIssues, qualityGateIssues, fixQueueIssues] = await Promise.all([
+      collectMcpToolsTreeIssues(),
+      collectQualityGateTreeIssues(),
+      collectFixQueueTreeIssues()
+    ]);
+    const issues = [...mcpIssues, ...qualityGateIssues, ...fixQueueIssues];
 
     expect(issues).toEqual([]);
   });
@@ -824,7 +825,7 @@ function createComponentSearchDetailsHtml(): string {
   });
 }
 
-function collectMcpToolsTreeIssues(): string[] {
+async function collectMcpToolsTreeIssues(): Promise<string[]> {
   const capabilities: McpCapabilityCard = {
     tools: ['pcb_validate'],
     resources: ['project://active'],
@@ -848,7 +849,7 @@ function collectMcpToolsTreeIssues(): string[] {
   return collectTreeProviderIssues('MCP Tools', provider);
 }
 
-function collectQualityGateTreeIssues(): string[] {
+async function collectQualityGateTreeIssues(): Promise<string[]> {
   const context = createExtensionContextMock();
   const provider = new QualityGateProvider(context as never, {} as never);
   return collectTreeProviderIssues('Quality Gates', provider);
@@ -871,37 +872,40 @@ async function collectFixQueueTreeIssues(): Promise<string[]> {
   return collectTreeProviderIssues('AI Fix Queue', provider);
 }
 
-function collectTreeProviderIssues(
+async function collectTreeProviderIssues(
   surfaceName: string,
   provider: vscode.TreeDataProvider<unknown>
-): string[] {
-  return walkTreeProvider(surfaceName, provider).flatMap(
+): Promise<string[]> {
+  return (await walkTreeProvider(surfaceName, provider)).flatMap(
     ({ path: itemPath, item }) => collectTreeItemIssues(itemPath, item)
   );
 }
 
-function walkTreeProvider(
+async function walkTreeProvider(
   surfaceName: string,
   provider: vscode.TreeDataProvider<unknown>,
   element?: unknown,
   parentPath = surfaceName
-): Array<{ path: string; item: vscode.TreeItem }> {
-  const children = provider.getChildren(element) as unknown[];
-  return children.flatMap((child) => {
-    const item = provider.getTreeItem(child) as vscode.TreeItem;
-    const label =
-      typeof item.label === 'string'
-        ? item.label
-        : item.label
-          ? String(item.label)
-          : 'unlabeled';
-    const itemPath = `${parentPath} > ${label}`;
-    const descendants =
-      item.collapsibleState !== vscode.TreeItemCollapsibleState.None
-        ? walkTreeProvider(itemPath, provider, child, itemPath)
-        : [];
-    return [{ path: itemPath, item }, ...descendants];
-  });
+): Promise<Array<{ path: string; item: vscode.TreeItem }>> {
+  const children = ((await provider.getChildren(element)) ?? []) as unknown[];
+  const items = await Promise.all(
+    children.map(async (child) => {
+      const item = (await provider.getTreeItem(child)) as vscode.TreeItem;
+      const label =
+        typeof item.label === 'string'
+          ? item.label
+          : item.label
+            ? String(item.label)
+            : 'unlabeled';
+      const itemPath = `${parentPath} > ${label}`;
+      const descendants =
+        item.collapsibleState !== vscode.TreeItemCollapsibleState.None
+          ? await walkTreeProvider(surfaceName, provider, child, itemPath)
+          : [];
+      return [{ path: itemPath, item }, ...descendants];
+    })
+  );
+  return items.flat();
 }
 
 function collectTreeItemIssues(
@@ -937,9 +941,12 @@ function collectStatusBarItemIssues(
     return [];
   }
   const strippedText = item.text.replace(/\$\([^)]+\)/gu, '').trim();
+  const accessibilityLabel = item.accessibilityInformation?.label?.trim() ?? '';
   const tooltip = String(item.tooltip ?? '').trim();
   return [
-    !strippedText ? `status bar item ${index} has only an icon label` : '',
+    !strippedText && !accessibilityLabel
+      ? `status bar item ${index} has only an icon label`
+      : '',
     !tooltip ? `status bar item ${index} is missing a tooltip` : ''
   ].filter(Boolean);
 }

--- a/apps/vscode-extension/test/a11y/accessibilityConformance.test.ts
+++ b/apps/vscode-extension/test/a11y/accessibilityConformance.test.ts
@@ -4,16 +4,42 @@ import { chromium, type Browser, type Page } from '@playwright/test';
 import axe, { type Result, type RunOptions } from 'axe-core';
 import * as vscode from 'vscode';
 import { buildChatHtml } from '../../src/ai/chatHtml';
+import { buildComponentDetailsHtml } from '../../src/components/componentSearch';
 import { buildDrcRuleEditorHtml } from '../../src/drc/drcRuleEditorPanel';
+import { FixQueueProvider } from '../../src/mcp/fixQueueProvider';
+import { McpToolsProvider } from '../../src/mcp/mcpToolsProvider';
+import { QualityGateProvider } from '../../src/providers/qualityGateProvider';
 import {
   createKiCanvasViewerHtml,
   createViewerErrorHtml
 } from '../../src/providers/viewerHtml';
 import { buildSettingsHtml } from '../../src/settings/settingsHtml';
+import { KiCadStatusBar } from '../../src/statusbar/kicadStatusBar';
+import type {
+  ComponentSearchResult,
+  FixItem,
+  McpCapabilityCard
+} from '../../src/types';
+import {
+  __setConfiguration,
+  createExtensionContextMock,
+  window as vscodeWindow
+} from '../unit/vscodeMock';
 
 jest.setTimeout(60_000);
 
 const extensionRoot = path.resolve(__dirname, '../..');
+type MediaOptions = Parameters<Page['emulateMedia']>[0];
+type WebviewSurface = {
+  name: string;
+  html: string;
+  expectedFocusOrder?: string[];
+};
+type ThemeFixture = {
+  name: string;
+  media: MediaOptions;
+  css: string;
+};
 
 const axeOptions: RunOptions = {
   runOnly: {
@@ -38,10 +64,11 @@ describe('WCAG 2.1 AA webview conformance gate', () => {
     await browser?.close();
   });
 
-  it.each(webviewSurfaces())(
-    'has no automated axe-core A/AA violations in %s',
-    async (_name, html) => {
-      await page.setContent(prepareForAxe(html), {
+  it.each(themeSurfaceCases())(
+    'has no automated axe-core A/AA violations in %s under %s',
+    async (_surfaceName, _themeName, surface, theme) => {
+      await page.emulateMedia(theme.media);
+      await page.setContent(prepareForAxe(surface.html, theme.css), {
         waitUntil: 'domcontentloaded'
       });
       await page.addScriptTag({ content: axe.source });
@@ -53,14 +80,128 @@ describe('WCAG 2.1 AA webview conformance gate', () => {
       expect(formatViolations(results.violations)).toEqual([]);
     }
   );
+
+  it.each(webviewSurfaces().map((surface) => [surface.name, surface] as const))(
+    'exposes accessible names and disabled reasons in %s',
+    async (_name, surface) => {
+      await page.emulateMedia({});
+      await page.setContent(prepareForAxe(surface.html), {
+        waitUntil: 'domcontentloaded'
+      });
+
+      expect(await collectInteractiveControlIssues(page)).toEqual([]);
+    }
+  );
+
+  it.each(
+    webviewSurfaces()
+      .filter((surface) => surface.expectedFocusOrder?.length)
+      .map((surface) => [surface.name, surface] as const)
+  )(
+    'keeps deterministic keyboard tab order and no focus trap in %s',
+    async (_name, surface) => {
+      await page.emulateMedia({});
+      await page.setContent(prepareForAxe(surface.html), {
+        waitUntil: 'domcontentloaded'
+      });
+
+      expect(
+        await collectTabSequence(page, surface.expectedFocusOrder!.length)
+      ).toEqual(surface.expectedFocusOrder);
+    }
+  );
+
+  it.each(webviewSurfaces().map((surface) => [surface.name, surface] as const))(
+    'ships focus-visible and reduced-motion affordances in %s',
+    async (_name, surface) => {
+      await page.emulateMedia({ reducedMotion: 'reduce' });
+      await page.setContent(prepareForAxe(surface.html), {
+        waitUntil: 'domcontentloaded'
+      });
+
+      expect(await collectMotionAndFocusCssIssues(page)).toEqual([]);
+    }
+  );
 });
 
-function webviewSurfaces(): Array<[string, string]> {
+describe('native VS Code surface accessibility gate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __setConfiguration({
+      'kicadstudio.mcp.endpoint': 'http://127.0.0.1:27185',
+      'kicadstudio.mcp.profile': 'full'
+    });
+  });
+
+  it('labels MCP Tools, Quality Gates, and AI Fix Queue tree rows', async () => {
+    const issues = [
+      ...collectMcpToolsTreeIssues(),
+      ...collectQualityGateTreeIssues(),
+      ...(await collectFixQueueTreeIssues())
+    ];
+
+    expect(issues).toEqual([]);
+  });
+
+  it('keeps status bar icon rows named, described, and actionable', () => {
+    const statusBar = new KiCadStatusBar({} as never);
+    statusBar.update({
+      activeProjectName: 'demo-board',
+      cli: {
+        path: '/usr/bin/kicad-cli',
+        version: '10.0.3',
+        versionLabel: 'KiCad 10.0.3',
+        source: 'path'
+      },
+      drc: {
+        file: 'board.kicad_pcb',
+        errors: 1,
+        warnings: 0,
+        infos: 0,
+        source: 'drc'
+      },
+      erc: {
+        file: 'demo.kicad_sch',
+        errors: 0,
+        warnings: 1,
+        infos: 0,
+        source: 'erc'
+      },
+      aiConfigured: true,
+      aiHealthy: false,
+      mcpState: {
+        kind: 'Connected',
+        available: true,
+        connected: true,
+        server: {
+          version: '1.0.0',
+          compat: 'ok',
+          capturedAt: new Date().toISOString(),
+          capabilities: { tools: [], resources: [], prompts: [] }
+        }
+      },
+      mcpProfile: 'full',
+      activeVariant: 'prototype'
+    });
+
+    const statusItems = (
+      vscodeWindow.createStatusBarItem as jest.Mock
+    ).mock.results.map((result) => result.value as vscode.StatusBarItem);
+    const issues = statusItems.flatMap((item, index) =>
+      collectStatusBarItemIssues(index, item)
+    );
+
+    statusBar.dispose();
+    expect(issues).toEqual([]);
+  });
+});
+
+function webviewSurfaces(): WebviewSurface[] {
   const webview = createWebviewMock();
   return [
-    [
-      'KiCad Studio Settings',
-      buildSettingsHtml({
+    {
+      name: 'KiCad Studio Settings',
+      html: buildSettingsHtml({
         webview,
         state: {
           aiKeyStored: true,
@@ -77,23 +218,34 @@ function webviewSurfaces(): Array<[string, string]> {
           }
         }
       })
-    ],
-    [
-      'KiCad AI Chat',
-      buildChatHtml({
+    },
+    {
+      name: 'KiCad AI Chat',
+      html: buildChatHtml({
         webview,
         extensionUri: vscode.Uri.file(extensionRoot)
-      })
-    ],
-    [
-      'KiCad schematic viewer',
-      createKiCanvasViewerHtml({
+      }),
+      expectedFocusOrder: [
+        '#provider',
+        '#model',
+        '#settings',
+        '#export',
+        '#clear',
+        '#toggle-context',
+        '#prompt',
+        '#send'
+      ]
+    },
+    {
+      name: 'KiCad schematic viewer',
+      html: createKiCanvasViewerHtml({
         title: 'KiCad Studio Schematic Viewer',
         fileName: 'demo.kicad_sch',
         fileType: 'schematic',
         status: 'Opening interactive renderer...',
         cspSource: webview.cspSource,
         kicanvasUri: `${webview.cspSource}/media/kicanvas/kicanvas.js`,
+        viewerCssUri: 'vscode-resource:/media/styles/viewer.css',
         base64: Buffer.from('(kicad_sch)').toString('base64'),
         disabledReason: '',
         metadata: {
@@ -101,17 +253,27 @@ function webviewSurfaces(): Array<[string, string]> {
             'Schematic metadata is available outside the KiCanvas canvas.'
           ]
         }
-      })
-    ],
-    [
-      'KiCad PCB viewer',
-      createKiCanvasViewerHtml({
+      }),
+      expectedFocusOrder: [
+        '#reload-btn',
+        '#open-kicad-btn',
+        '#export-png-btn',
+        '#export-svg-btn',
+        '#fit-btn',
+        '#zoom-in-btn',
+        '#zoom-out-btn'
+      ]
+    },
+    {
+      name: 'KiCad PCB viewer',
+      html: createKiCanvasViewerHtml({
         title: 'KiCad Studio PCB Viewer',
         fileName: 'demo.kicad_pcb',
         fileType: 'board',
         status: 'Opening interactive renderer...',
         cspSource: webview.cspSource,
         kicanvasUri: `${webview.cspSource}/media/kicanvas/kicanvas.js`,
+        viewerCssUri: 'vscode-resource:/media/styles/viewer.css',
         base64: Buffer.from('(kicad_pcb)').toString('base64'),
         disabledReason: '',
         metadata: {
@@ -124,21 +286,229 @@ function webviewSurfaces(): Array<[string, string]> {
           ],
           tuningProfiles: [{ name: 'USB differential pair', layer: 'F.Cu' }]
         }
-      })
-    ],
-    [
-      'KiCad viewer error state',
-      createViewerErrorHtml(
+      }),
+      expectedFocusOrder: [
+        '#reload-btn',
+        '#open-kicad-btn',
+        '#export-png-btn',
+        '#export-svg-btn',
+        '#fit-btn',
+        '#zoom-in-btn',
+        '#zoom-out-btn',
+        '#all-layers-btn',
+        '#none-layers-btn',
+        '#copper-layers-btn'
+      ]
+    },
+    {
+      name: 'KiCad viewer error state',
+      html: createViewerErrorHtml(
         'demo.kicad_sch',
         new Error('Fixture failure for accessibility audit'),
         webview.cspSource
       )
-    ],
-    ['Bill of Materials view', loadTemplate('bom.html')],
-    ['Netlist view', loadTemplate('netlist.html')],
-    ['Visual diff view', loadTemplate('diff.html')],
-    ['DRC rule editor', buildDrcRuleEditorHtml()]
+    },
+    {
+      name: 'Legacy PCB viewer template',
+      html: loadTemplate('pcb.html'),
+      expectedFocusOrder: [
+        '#btn-zoom-fit',
+        '#btn-zoom-in',
+        '#btn-zoom-out',
+        '#btn-grid',
+        '#btn-theme',
+        '#btn-open-kicad',
+        '[data-preset="All Cu"]',
+        '[data-preset="Front"]',
+        '[data-preset="Back"]',
+        '[data-preset="Fab"]',
+        '[data-preset="Assembly"]',
+        '[data-preset="User"]'
+      ]
+    },
+    {
+      name: 'Legacy schematic viewer template',
+      html: loadTemplate('schematic.html'),
+      expectedFocusOrder: [
+        '#btn-zoom-fit',
+        '#btn-zoom-in',
+        '#btn-zoom-out',
+        '#btn-grid',
+        '#btn-theme',
+        '#btn-open-kicad'
+      ]
+    },
+    {
+      name: 'Bill of Materials view',
+      html: loadTemplate('bom.html'),
+      expectedFocusOrder: ['#search', '#toggle-dnp', '#table-wrapper']
+    },
+    {
+      name: 'Netlist view',
+      html: loadTemplate('netlist.html'),
+      expectedFocusOrder: ['#table-wrapper']
+    },
+    { name: 'Visual diff view', html: loadTemplate('diff.html') },
+    {
+      name: 'Component Search details',
+      html: createComponentSearchDetailsHtml(),
+      expectedFocusOrder: ['#datasheet', '#copy', '#pcm-install']
+    },
+    {
+      name: 'DRC rule editor',
+      html: buildDrcRuleEditorHtml(),
+      expectedFocusOrder: [
+        '#name',
+        '#condition',
+        '#constraint',
+        'Save Rule',
+        '#delete-rule'
+      ]
+    }
   ];
+}
+
+function themeSurfaceCases(): Array<
+  [
+    surfaceName: string,
+    themeName: string,
+    surface: WebviewSurface,
+    theme: ThemeFixture
+  ]
+> {
+  return webviewSurfaces().flatMap((surface) =>
+    themeFixtures().map(
+      (theme): [string, string, WebviewSurface, ThemeFixture] => [
+        surface.name,
+        theme.name,
+        surface,
+        theme
+      ]
+    )
+  );
+}
+
+function themeFixtures(): ThemeFixture[] {
+  return [
+    {
+      name: 'dark',
+      media: {
+        colorScheme: 'dark',
+        forcedColors: 'none',
+        reducedMotion: 'no-preference'
+      },
+      css: vscodeThemeCss({
+        background: '#1e1e1e',
+        panel: '#252526',
+        side: '#252526',
+        text: '#f2f2f2',
+        muted: '#cccccc',
+        border: '#8a8a8a',
+        focus: '#80bdff',
+        danger: '#ff9b9b',
+        input: '#111827',
+        button: '#0e639c',
+        buttonText: '#ffffff',
+        buttonSecondary: '#3a3d41'
+      })
+    },
+    {
+      name: 'light',
+      media: {
+        colorScheme: 'light',
+        forcedColors: 'none',
+        reducedMotion: 'no-preference'
+      },
+      css: vscodeThemeCss({
+        background: '#ffffff',
+        panel: '#f3f3f3',
+        side: '#f8f8f8',
+        text: '#1f2328',
+        muted: '#4b5563',
+        border: '#6b7280',
+        focus: '#005fb8',
+        danger: '#b42318',
+        input: '#ffffff',
+        button: '#005fb8',
+        buttonText: '#ffffff',
+        buttonSecondary: '#e5e7eb'
+      })
+    },
+    {
+      name: 'high contrast',
+      media: {
+        colorScheme: 'dark',
+        forcedColors: 'active',
+        reducedMotion: 'reduce'
+      },
+      css: vscodeThemeCss({
+        background: '#000000',
+        panel: '#000000',
+        side: '#000000',
+        text: '#ffffff',
+        muted: '#ffffff',
+        border: '#ffffff',
+        focus: '#ffff00',
+        danger: '#ff6b6b',
+        input: '#000000',
+        button: '#000000',
+        buttonText: '#ffffff',
+        buttonSecondary: '#000000'
+      })
+    }
+  ];
+}
+
+function vscodeThemeCss(theme: {
+  background: string;
+  panel: string;
+  side: string;
+  text: string;
+  muted: string;
+  border: string;
+  focus: string;
+  danger: string;
+  input: string;
+  button: string;
+  buttonText: string;
+  buttonSecondary: string;
+}): string {
+  return `
+    :root {
+      --vscode-editor-background: ${theme.background};
+      --vscode-editorWidget-background: ${theme.panel};
+      --vscode-sideBar-background: ${theme.side};
+      --vscode-panel-border: ${theme.border};
+      --vscode-editorWidget-border: ${theme.border};
+      --vscode-foreground: ${theme.text};
+      --vscode-descriptionForeground: ${theme.muted};
+      --vscode-focusBorder: ${theme.focus};
+      --vscode-errorForeground: ${theme.danger};
+      --vscode-input-background: ${theme.input};
+      --vscode-input-foreground: ${theme.text};
+      --vscode-input-border: ${theme.border};
+      --vscode-button-background: ${theme.button};
+      --vscode-button-foreground: ${theme.buttonText};
+      --vscode-button-hoverBackground: ${theme.button};
+      --vscode-button-secondaryBackground: ${theme.buttonSecondary};
+      --vscode-button-secondaryForeground: ${theme.text};
+      --vscode-button-secondaryHoverBackground: ${theme.buttonSecondary};
+      --vscode-badge-background: ${theme.buttonSecondary};
+      --vscode-badge-foreground: ${theme.text};
+      --vscode-font-family: "Segoe UI", sans-serif;
+      --vscode-editor-font-family: Consolas, monospace;
+      --bg: ${theme.background};
+      --panel: ${theme.panel};
+      --panel2: ${theme.panel};
+      --side: ${theme.side};
+      --border: ${theme.border};
+      --text: ${theme.text};
+      --muted: ${theme.muted};
+      --accent: ${theme.focus};
+      --danger: ${theme.danger};
+      --input: ${theme.input};
+    }
+  `;
 }
 
 function createWebviewMock(): vscode.Webview {
@@ -150,21 +520,41 @@ function createWebviewMock(): vscode.Webview {
 }
 
 function loadTemplate(fileName: string): string {
-  return fs
-    .readFileSync(path.join(extensionRoot, 'media', 'viewer', fileName), 'utf8')
-    .replaceAll('{{cspSource}}', 'vscode-resource:')
-    .replaceAll('{{scriptNonce}}', 'test-nonce')
-    .replaceAll('{{bomCssUri}}', 'vscode-resource:/media/styles/bom.css')
-    .replaceAll('{{viewerCssUri}}', 'vscode-resource:/media/styles/viewer.css')
-    .replaceAll(
-      '{{kicanvasUri}}',
-      'vscode-resource:/media/kicanvas/kicanvas.js'
-    )
-    .replaceAll('{{scriptUri}}', 'vscode-resource:/media/viewer/test.js');
+  return inlineLocalStylesheets(
+    fs
+      .readFileSync(
+        path.join(extensionRoot, 'media', 'viewer', fileName),
+        'utf8'
+      )
+      .replaceAll('{{cspSource}}', 'vscode-resource:')
+      .replaceAll('{{scriptNonce}}', 'test-nonce')
+      .replaceAll('{{bomCssUri}}', 'vscode-resource:/media/styles/bom.css')
+      .replaceAll(
+        '{{viewerCssUri}}',
+        'vscode-resource:/media/styles/viewer.css'
+      )
+      .replaceAll(
+        '{{kicanvasUri}}',
+        'vscode-resource:/media/kicanvas/kicanvas.js'
+      )
+      .replaceAll('{{scriptUri}}', 'vscode-resource:/media/viewer/test.js')
+      .replaceAll(
+        '{{viewerScriptUri}}',
+        'vscode-resource:/media/viewer/test-viewer.js'
+      )
+      .replaceAll(
+        '{{initialPayload}}',
+        JSON.stringify({ fileName: 'demo.kicad_pcb', kind: 'test' })
+      )
+  );
 }
 
-function prepareForAxe(html: string): string {
-  const withoutCsp = html.replace(
+function prepareForAxe(
+  html: string,
+  themeCss = themeFixtures()[0]!.css
+): string {
+  const withInlinedStyles = inlineLocalStylesheets(html);
+  const withoutCsp = withInlinedStyles.replace(
     /<meta\s+http-equiv=["']Content-Security-Policy["'][\s\S]*?>/giu,
     ''
   );
@@ -178,38 +568,380 @@ function prepareForAxe(html: string): string {
     /<head>/iu,
     `<head>
   <style>
-    :root {
-      --vscode-editor-background: #1e1e1e;
-      --vscode-editorWidget-background: #252526;
-      --vscode-sideBar-background: #252526;
-      --vscode-panel-border: #6f6f6f;
-      --vscode-foreground: #f2f2f2;
-      --vscode-descriptionForeground: #cccccc;
-      --vscode-focusBorder: #80bdff;
-      --vscode-errorForeground: #ff9b9b;
-      --vscode-input-background: #111827;
-      --vscode-input-foreground: #f2f2f2;
-      --vscode-input-border: #8a8a8a;
-      --vscode-button-background: #0e639c;
-      --vscode-button-foreground: #ffffff;
-      --vscode-button-hoverBackground: #1177bb;
-      --vscode-button-secondaryBackground: #3a3d41;
-      --vscode-button-secondaryForeground: #ffffff;
-      --vscode-font-family: "Segoe UI", sans-serif;
-      --vscode-editor-font-family: Consolas, monospace;
-      --bg: #1e1e1e;
-      --panel: #252526;
-      --panel2: #252526;
-      --side: #252526;
-      --border: #8a8a8a;
-      --text: #f2f2f2;
-      --muted: #cccccc;
-      --accent: #80bdff;
-      --danger: #ff9b9b;
-      --input: #111827;
-    }
+    ${themeCss}
   </style>`
   );
+}
+
+function inlineLocalStylesheets(html: string): string {
+  return html.replace(
+    /<link\b(?=[^>]*rel=["']stylesheet["'])(?=[^>]*href=["']vscode-resource:\/media\/styles\/([^"']+)["'])[^>]*>/giu,
+    (_match, fileName: string) =>
+      `<style>${loadStylesheet(path.basename(fileName))}</style>`
+  );
+}
+
+function loadStylesheet(fileName: string): string {
+  return fs.readFileSync(
+    path.join(extensionRoot, 'media', 'styles', fileName),
+    'utf8'
+  );
+}
+
+async function collectInteractiveControlIssues(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const selector = [
+      'a[href]',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      '[role="button"]',
+      '[role="link"]',
+      '[role="menuitem"]',
+      '[tabindex]:not([tabindex="-1"])'
+    ].join(',');
+    return Array.from(document.querySelectorAll<HTMLElement>(selector))
+      .filter(isVisibleElement)
+      .flatMap((element) => {
+        const issues: string[] = [];
+        const name = accessibleName(element);
+        const visibleText = normalizedText(element.textContent ?? '');
+        if (!name) {
+          issues.push(
+            `${controlSignature(element)} is missing an accessible name`
+          );
+        }
+        if (
+          name &&
+          visibleText &&
+          /[a-z0-9]/iu.test(visibleText) &&
+          !(element instanceof HTMLInputElement) &&
+          !(element instanceof HTMLTextAreaElement) &&
+          !(element instanceof HTMLSelectElement) &&
+          isActionControl(element) &&
+          element.hasAttribute('aria-label') &&
+          !normalizedText(name)
+            .toLocaleLowerCase()
+            .includes(visibleText.toLocaleLowerCase())
+        ) {
+          issues.push(
+            `${controlSignature(element)} accessible name "${name}" does not include visible label "${visibleText}"`
+          );
+        }
+        if (isDisabledControl(element) && !disabledReason(element)) {
+          issues.push(
+            `${controlSignature(element)} is disabled without aria-describedby, title, or reason text`
+          );
+        }
+        return issues;
+      });
+
+    function isVisibleElement(element: HTMLElement): boolean {
+      if (element.hidden || element.closest('[hidden]')) {
+        return false;
+      }
+      const style = getComputedStyle(element);
+      return style.display !== 'none' && style.visibility !== 'hidden';
+    }
+
+    function accessibleName(element: HTMLElement): string {
+      const labelledBy = element.getAttribute('aria-labelledby');
+      if (labelledBy) {
+        const label = labelledBy
+          .split(/\s+/u)
+          .map((id) => document.getElementById(id)?.textContent ?? '')
+          .join(' ');
+        if (normalizedText(label)) {
+          return normalizedText(label);
+        }
+      }
+      const ariaLabel = element.getAttribute('aria-label');
+      if (ariaLabel) {
+        return normalizedText(ariaLabel);
+      }
+      if (
+        element instanceof HTMLInputElement ||
+        element instanceof HTMLTextAreaElement ||
+        element instanceof HTMLSelectElement
+      ) {
+        const label = Array.from(element.labels ?? [])
+          .map((item) => item.textContent ?? '')
+          .join(' ');
+        if (normalizedText(label)) {
+          return normalizedText(label);
+        }
+      }
+      return normalizedText(
+        element.getAttribute('alt') ??
+          element.getAttribute('title') ??
+          element.getAttribute('placeholder') ??
+          element.textContent ??
+          ''
+      );
+    }
+
+    function disabledReason(element: HTMLElement): string {
+      const describedBy = element.getAttribute('aria-describedby');
+      const description = describedBy
+        ? describedBy
+            .split(/\s+/u)
+            .map((id) => document.getElementById(id)?.textContent ?? '')
+            .join(' ')
+        : '';
+      const explicit =
+        description ||
+        element.getAttribute('title') ||
+        element.getAttribute('aria-label') ||
+        '';
+      return /disabled|unavailable|requires|loading|empty|no |not |until|while/iu.test(
+        explicit
+      )
+        ? normalizedText(explicit)
+        : '';
+    }
+
+    function isDisabledControl(element: HTMLElement): boolean {
+      return (
+        ('disabled' in element &&
+          Boolean(
+            (element as HTMLButtonElement | HTMLInputElement).disabled
+          )) ||
+        element.getAttribute('aria-disabled') === 'true'
+      );
+    }
+
+    function isActionControl(element: HTMLElement): boolean {
+      const tag = element.tagName.toLowerCase();
+      const role = element.getAttribute('role');
+      return (
+        tag === 'button' ||
+        tag === 'a' ||
+        role === 'button' ||
+        role === 'link' ||
+        role === 'menuitem'
+      );
+    }
+
+    function controlSignature(element: HTMLElement): string {
+      if (element.id) {
+        return `#${element.id}`;
+      }
+      const preset = element.getAttribute('data-preset');
+      if (preset) {
+        return `[data-preset="${preset}"]`;
+      }
+      const label = element.getAttribute('aria-label');
+      if (label) {
+        return `[aria-label="${label}"]`;
+      }
+      return normalizedText(
+        element.textContent ?? element.tagName.toLowerCase()
+      );
+    }
+
+    function normalizedText(value: string): string {
+      return value.replace(/\s+/gu, ' ').trim();
+    }
+  });
+}
+
+async function collectTabSequence(
+  page: Page,
+  count: number
+): Promise<string[]> {
+  const sequence: string[] = [];
+  await page.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+  });
+  for (let index = 0; index < count; index += 1) {
+    await page.keyboard.press('Tab');
+    sequence.push(await activeElementSignature(page));
+  }
+  expect(new Set(sequence).size).toBe(sequence.length);
+  return sequence;
+}
+
+async function activeElementSignature(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const element = document.activeElement;
+    if (!(element instanceof HTMLElement)) {
+      return 'none';
+    }
+    if (element.id) {
+      return `#${element.id}`;
+    }
+    const preset = element.getAttribute('data-preset');
+    if (preset) {
+      return `[data-preset="${preset}"]`;
+    }
+    const label = element.getAttribute('aria-label');
+    if (label) {
+      return `[aria-label="${label}"]`;
+    }
+    return (element.textContent ?? element.tagName.toLowerCase())
+      .replace(/\s+/gu, ' ')
+      .trim();
+  });
+}
+
+async function collectMotionAndFocusCssIssues(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const css = Array.from(document.querySelectorAll('style'))
+      .map((style) => style.textContent ?? '')
+      .join('\n');
+    const focusable = document.querySelector(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    const hasMotion = /animation\s*:|transition\s*:|@keyframes/iu.test(css);
+    const issues: string[] = [];
+    if (focusable && !/focus-visible/iu.test(css)) {
+      issues.push('interactive surface is missing :focus-visible styling');
+    }
+    if (hasMotion && !/prefers-reduced-motion/iu.test(css)) {
+      issues.push('animated surface is missing prefers-reduced-motion styling');
+    }
+    return issues;
+  });
+}
+
+function createComponentSearchDetailsHtml(): string {
+  const result: ComponentSearchResult = {
+    source: 'octopart',
+    mpn: 'STM32F411',
+    manufacturer: 'STMicroelectronics',
+    description: 'ARM Cortex-M4 MCU',
+    datasheetUrl: 'https://example.com/stm32f411.pdf',
+    offers: [],
+    specs: [],
+    pcmPackageId: 'stm32-library'
+  };
+  return buildComponentDetailsHtml(result, {
+    nonce: 'test-nonce',
+    cspSource: 'vscode-resource:'
+  });
+}
+
+function collectMcpToolsTreeIssues(): string[] {
+  const capabilities: McpCapabilityCard = {
+    tools: ['pcb_validate'],
+    resources: ['project://active'],
+    prompts: ['manufacturing-review'],
+    diagnostics: ['Live KiCad PCB context is unavailable.']
+  };
+  const provider = new McpToolsProvider({
+    getState: () => ({
+      kind: 'Connected',
+      available: true,
+      connected: true,
+      install: { found: true, command: 'uvx', source: 'uvx', version: '1.0.0' },
+      server: {
+        version: '1.0.0',
+        compat: 'ok',
+        capturedAt: '2026-05-24T00:00:00.000Z',
+        capabilities
+      }
+    })
+  } as never);
+  return collectTreeProviderIssues('MCP Tools', provider);
+}
+
+function collectQualityGateTreeIssues(): string[] {
+  const context = createExtensionContextMock();
+  const provider = new QualityGateProvider(context as never, {} as never);
+  return collectTreeProviderIssues('Quality Gates', provider);
+}
+
+async function collectFixQueueTreeIssues(): Promise<string[]> {
+  const item: FixItem = {
+    id: 'fix-1',
+    description: 'Move decoupling capacitor closer to U1',
+    severity: 'warning',
+    tool: 'pcb_move_component',
+    args: {},
+    status: 'pending',
+    preview: 'diff --git a/board.kicad_pcb b/board.kicad_pcb'
+  };
+  const provider = new FixQueueProvider({
+    fetchFixQueue: jest.fn().mockResolvedValue([item])
+  } as never);
+  await provider.refresh();
+  return collectTreeProviderIssues('AI Fix Queue', provider);
+}
+
+function collectTreeProviderIssues(
+  surfaceName: string,
+  provider: vscode.TreeDataProvider<unknown>
+): string[] {
+  return walkTreeProvider(surfaceName, provider).flatMap(
+    ({ path: itemPath, item }) => collectTreeItemIssues(itemPath, item)
+  );
+}
+
+function walkTreeProvider(
+  surfaceName: string,
+  provider: vscode.TreeDataProvider<unknown>,
+  element?: unknown,
+  parentPath = surfaceName
+): Array<{ path: string; item: vscode.TreeItem }> {
+  const children = provider.getChildren(element) as unknown[];
+  return children.flatMap((child) => {
+    const item = provider.getTreeItem(child) as vscode.TreeItem;
+    const label =
+      typeof item.label === 'string'
+        ? item.label
+        : item.label
+          ? String(item.label)
+          : 'unlabeled';
+    const itemPath = `${parentPath} > ${label}`;
+    const descendants =
+      item.collapsibleState !== vscode.TreeItemCollapsibleState.None
+        ? walkTreeProvider(itemPath, provider, child, itemPath)
+        : [];
+    return [{ path: itemPath, item }, ...descendants];
+  });
+}
+
+function collectTreeItemIssues(
+  pathName: string,
+  item: vscode.TreeItem
+): string[] {
+  const issues: string[] = [];
+  const label = typeof item.label === 'string' ? item.label.trim() : '';
+  const tooltip =
+    typeof item.tooltip === 'string'
+      ? item.tooltip.trim()
+      : item.tooltip
+        ? String(item.tooltip).trim()
+        : '';
+  const command = item.command as vscode.Command | undefined;
+  if (!label) {
+    issues.push(`${pathName} is missing a label`);
+  }
+  if (item.iconPath && !tooltip && !item.description) {
+    issues.push(`${pathName} has an icon without tooltip or description`);
+  }
+  if (command && !command.title?.trim()) {
+    issues.push(`${pathName} command is missing a title`);
+  }
+  return issues;
+}
+
+function collectStatusBarItemIssues(
+  index: number,
+  item: vscode.StatusBarItem
+): string[] {
+  if (!item.command) {
+    return [];
+  }
+  const strippedText = item.text.replace(/\$\([^)]+\)/gu, '').trim();
+  const tooltip = String(item.tooltip ?? '').trim();
+  return [
+    !strippedText ? `status bar item ${index} has only an icon label` : '',
+    !tooltip ? `status bar item ${index} is missing a tooltip` : ''
+  ].filter(Boolean);
 }
 
 function removePairedElements(html: string, tagName: string): string {

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -42,7 +42,10 @@ corepack pnpm --filter kicadstudio run test:a11y
 
 The gate renders representative extension-owned webview HTML in Chromium and
 runs axe-core with WCAG 2.0 A, WCAG 2.0 AA, WCAG 2.1 A, and WCAG 2.1 AA rule
-tags. It is part of the extension `check` and `check:ci` scripts and runs in
+tags. It also exercises dark, light, and high-contrast theme fixtures,
+keyboard tab order, accessible names, disabled-control reason text,
+focus-visible CSS, reduced-motion CSS, native tree rows, and status bar item
+labels. It is part of the extension `check` and `check:ci` scripts and runs in
 the GitHub Actions `vscode-extension` CI job.
 
 Manual release gate:
@@ -93,19 +96,19 @@ Status key:
 | 1.4.11 Non-text Contrast                        | AA    | Automated + Manual | Focus borders, input borders, status indicators, and interactive component boundaries must meet 3:1 against adjacent colors.                                                                                  |
 | 1.4.12 Text Spacing                             | AA    | Manual             | Text spacing changes must not clip or overlap labels, buttons, tables, cards, or status messages.                                                                                                             |
 | 1.4.13 Content on Hover or Focus                | AA    | Manual             | Tooltips/popovers must be dismissible, hoverable where applicable, and not obscure their trigger unless unavoidable in VS Code native UI.                                                                     |
-| 2.1.1 Keyboard                                  | A     | Manual             | All extension commands and in-scope webview actions must be reachable and operable by keyboard.                                                                                                               |
-| 2.1.2 No Keyboard Trap                          | A     | Manual             | No webview, custom editor, or tree view may trap keyboard focus.                                                                                                                                              |
+| 2.1.1 Keyboard                                  | A     | Automated + Manual | All extension commands and in-scope webview actions must be reachable and operable by keyboard. Representative webviews are checked for deterministic tab traversal.                                          |
+| 2.1.2 No Keyboard Trap                          | A     | Automated + Manual | No webview, custom editor, or tree view may trap keyboard focus. Representative tab-order tests catch focus loops in webview chrome.                                                                          |
 | 2.1.4 Character Key Shortcuts                   | A     | Manual             | Single-character shortcuts must be avoidable, remappable, or active only while focus is in the relevant control.                                                                                              |
 | 2.2.1 Timing Adjustable                         | A     | Manual             | Long-running operations use progress/status and cancellation where possible; no essential UI expires without user control.                                                                                    |
-| 2.2.2 Pause, Stop, Hide                         | A     | Manual             | Spinners, animations, and live updates must be tied to active work and stop when work completes.                                                                                                              |
+| 2.2.2 Pause, Stop, Hide                         | A     | Automated + Manual | Spinners, animations, and live updates must be tied to active work, stop when work completes, and include `prefers-reduced-motion` CSS when animation is present.                                             |
 | 2.3.1 Three Flashes or Below Threshold          | A     | Manual             | No extension-owned animation may flash more than three times per second.                                                                                                                                      |
 | 2.4.1 Bypass Blocks                             | A     | Manual             | Webviews with repeated chrome should keep primary controls early in the tab order; native VS Code navigation handles workbench-level bypass.                                                                  |
 | 2.4.2 Page Titled                               | A     | Automated          | Webview documents must include a meaningful title.                                                                                                                                                            |
-| 2.4.3 Focus Order                               | A     | Manual             | Focus order must follow logical task order in settings, chat, BOM, netlist, DRC editing, and viewer toolbars.                                                                                                 |
+| 2.4.3 Focus Order                               | A     | Automated + Manual | Focus order must follow logical task order in settings, chat, BOM, netlist, DRC editing, Component Search details, and viewer toolbars.                                                                       |
 | 2.4.4 Link Purpose (In Context)                 | A     | Automated + Manual | Links and buttons must identify their purpose through visible text, `aria-label`, title, or surrounding context.                                                                                              |
 | 2.4.5 Multiple Ways                             | AA    | Not applicable     | The extension is not a website with multiple pages; commands are available through VS Code navigation surfaces.                                                                                               |
 | 2.4.6 Headings and Labels                       | AA    | Automated + Manual | Section headings and form labels must describe their topic or purpose.                                                                                                                                        |
-| 2.4.7 Focus Visible                             | AA    | Manual             | Keyboard focus must be visible in native VS Code controls and extension-owned webviews.                                                                                                                       |
+| 2.4.7 Focus Visible                             | AA    | Automated + Manual | Keyboard focus must be visible in native VS Code controls and extension-owned webviews. Webview CSS must include `:focus-visible` styling for interactive controls.                                           |
 | 2.5.1 Pointer Gestures                          | A     | Manual             | Pointer gestures in viewer fallbacks must have keyboard or button alternatives where the function is extension-owned.                                                                                         |
 | 2.5.2 Pointer Cancellation                      | A     | Manual             | Click/drag actions should complete on release and avoid destructive down-event behavior.                                                                                                                      |
 | 2.5.3 Label in Name                             | A     | Automated + Manual | Accessible names for buttons and inputs must include their visible label text.                                                                                                                                |
@@ -137,11 +140,43 @@ Status key:
   `apps/vscode-extension/test/a11y/accessibilityConformance.test.ts` before they
   are considered release-ready.
 
+## Contributor Requirements
+
+New extension UI is not release-ready until the accessibility gate represents
+the changed surface. The requirement applies to webviews, custom editor chrome,
+tree views, status bar items, command flows, and generated HTML templates.
+
+- Add or update `apps/vscode-extension/test/a11y/accessibilityConformance.test.ts`
+  for every new or materially changed webview, toolbar, side panel, tree view,
+  status item, dialog-like flow, search box, or overlay.
+- Keep keyboard tab order deterministic. Focus must follow the visible workflow
+  order and must not loop inside a webview.
+- Give every icon-only, status-like, and symbolic action a stable accessible
+  name through visible text, `aria-label`, title, tooltip, or the native VS Code
+  API label/tooltip fields.
+- Disabled buttons should expose why the action is unavailable through
+  `aria-describedby`, title text, or adjacent reason text when the reason is
+  knowable.
+- Production CSS for interactive webviews must include `:focus-visible` styling
+  and keep that indicator visible in VS Code Dark, Light, and High Contrast
+  themes.
+- Production CSS with animation or transition effects must include a
+  `prefers-reduced-motion: reduce` rule that removes unnecessary motion without
+  hiding status text.
+- Prefer VS Code theme variables for foreground, background, border, and focus
+  colors. Avoid fixed colors that only work in one theme.
+- Keep visually hidden helper text available to assistive technology using the
+  local `.sr-only` pattern; do not hide required accessible names with
+  `display: none`.
+
 ## Source Verification
 
 Primary sources checked for this policy:
 
 - W3C WCAG 2.1 Recommendation: https://www.w3.org/TR/WCAG21/
-- VS Code Webviews UX guidance from the official VS Code API docs, checked
-  during implementation.
+- VS Code Webviews UX guidance and UX overview from the official VS Code API
+  docs, checked during implementation and rechecked on 2026-05-24.
 - Deque axe-core README and API documentation: https://github.com/dequelabs/axe-core
+- Playwright media emulation documentation for color scheme, forced colors, and
+  reduced motion, checked on 2026-05-24:
+  https://playwright.dev/docs/api/class-page#page-emulate-media

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,8 +40,6 @@ Bug fixes should include automated regression coverage when practical. Use unit 
 integration tests, fixture checks, contract tests, or visual/accessibility checks based on the
 changed surface.
 
-Runtime support changes must follow the [support matrix](support-matrix.md).
-
 ## Accessibility Coverage
 
 New or changed KiCad Studio UI must keep the accessibility gate current before a
@@ -68,3 +66,5 @@ Contributor requirements:
   transitions.
 
 See [accessibility conformance target](accessibility.md) for the full policy.
+
+Runtime support changes must follow the [support matrix](support-matrix.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -41,3 +41,30 @@ integration tests, fixture checks, contract tests, or visual/accessibility check
 changed surface.
 
 Runtime support changes must follow the [support matrix](support-matrix.md).
+
+## Accessibility Coverage
+
+New or changed KiCad Studio UI must keep the accessibility gate current before a
+pull request is ready for review:
+
+```bash
+corepack pnpm --filter kicadstudio run test:a11y
+```
+
+Update `apps/vscode-extension/test/a11y/accessibilityConformance.test.ts` when a
+change adds or materially changes a webview, custom editor toolbar, side panel,
+BOM/Netlist/Component Search surface, MCP Tools tree, Quality Gates tree, AI Fix
+Queue tree, status bar item, dialog-like flow, search box, or overlay.
+
+Contributor requirements:
+
+- Keep keyboard order deterministic and free of focus traps.
+- Provide accessible names for icon-only, symbolic, status, and toolbar actions.
+- Give disabled buttons reason text with `aria-describedby`, title text, or
+  adjacent assistive text when the reason is knowable.
+- Use VS Code theme tokens and verify dark, light, and high-contrast behavior.
+- Include `:focus-visible` styling for production webview controls.
+- Include `prefers-reduced-motion: reduce` CSS when a surface uses animation or
+  transitions.
+
+See [accessibility conformance target](accessibility.md) for the full policy.

--- a/docs/superpowers/plans/2026-05-24-oaslana-42-accessibility-keyboard-tests.md
+++ b/docs/superpowers/plans/2026-05-24-oaslana-42-accessibility-keyboard-tests.md
@@ -1,0 +1,151 @@
+# OASLANA-42 Accessibility Keyboard Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand the KiCad Studio accessibility gate so CI catches missing accessible names, keyboard traps, high-contrast regressions, and unlabeled icon/status controls across webviews and native VS Code surfaces.
+
+**Architecture:** Keep the existing `test:a11y` entry point and extend its Playwright/Jest coverage instead of adding a new runner. Fix only production UI gaps exposed by the stricter tests, then document the gate for future contributors.
+
+**Tech Stack:** TypeScript, Jest, Playwright Chromium, axe-core, VS Code extension APIs, Markdown docs.
+
+---
+
+### Task 1: Webview A11y Gate Expansion
+
+**Files:**
+
+- Modify: `apps/vscode-extension/test/a11y/accessibilityConformance.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add tests that render each webview under dark, light, and high-contrast fixtures, verify interactive controls have accessible names, verify disabled buttons expose a reason, check deterministic tab traversal, and require production CSS to include focus-visible/reduced-motion affordances.
+
+```ts
+it.each(themeSurfaceCases())(
+  "has no axe-core A/AA violations in %s under %s",
+  async (surfaceName, themeName, html, theme) => {
+    await page.emulateMedia(theme.media);
+    await page.setContent(prepareForAxe(html, theme.css), {
+      waitUntil: "domcontentloaded",
+    });
+    await page.addScriptTag({ content: axe.source });
+    const results = await page.evaluate(
+      async (options) => window.axe.run(document, options),
+      axeOptions,
+    );
+    expect(formatViolations(results.violations)).toEqual([]);
+  },
+);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+corepack pnpm --filter kicadstudio run test:a11y
+```
+
+Expected: FAIL on the newly enforced gaps before production fixes.
+
+- [ ] **Step 3: Keep the test focused**
+
+The test must remain limited to OASLANA-42 surfaces: Settings, AI Chat, KiCanvas viewer/error, BOM, Netlist, Visual Diff, DRC Rule Editor, Component Search details, MCP Tools, Quality Gates, AI Fix Queue, and status bar items.
+
+### Task 2: Production UI Fixes
+
+**Files:**
+
+- Modify: `apps/vscode-extension/src/providers/viewerHtml.ts`
+- Modify: `apps/vscode-extension/src/components/componentSearch.ts`
+- Modify: `apps/vscode-extension/src/ai/chatHtml.ts`
+- Modify: `apps/vscode-extension/src/settings/settingsHtml.ts`
+- Modify: `apps/vscode-extension/src/drc/drcRuleEditorPanel.ts`
+- Modify: `apps/vscode-extension/media/styles/viewer.css`
+- Modify: `apps/vscode-extension/media/styles/bom.css`
+- Modify: `apps/vscode-extension/media/viewer/bom.html`
+- Modify: `apps/vscode-extension/media/viewer/netlist.html`
+- Modify only if tests require it: `apps/vscode-extension/media/viewer/pcb.html`, `apps/vscode-extension/media/viewer/schematic.html`, `apps/vscode-extension/media/viewer/diff.html`
+
+- [ ] **Step 1: Implement minimal fixes**
+
+Add accessible labels to symbol-only controls, add `aria-describedby` reason text for disabled buttons, add focus-visible CSS, add reduced-motion CSS for spinners/typing indicators, and extract a reusable Component Search details HTML builder for test coverage.
+
+```ts
+export function buildComponentDetailsHtml(
+  result: ComponentSearchResult,
+  options: { nonce: string; cspSource: string },
+): string {
+  return injectWebviewLocalization(
+    componentDetailsHtml(result, options),
+    options.nonce,
+  );
+}
+```
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+corepack pnpm --filter kicadstudio run test:a11y
+corepack pnpm --filter kicadstudio exec jest --config jest.config.js --runInBand --coverage=false test/unit/componentSearch.test.ts
+```
+
+Expected: PASS with no deprecation warnings introduced by the change.
+
+### Task 3: Documentation
+
+**Files:**
+
+- Modify: `docs/accessibility.md`
+- Modify: `docs/contributing.md`
+
+- [ ] **Step 1: Document contributor requirements**
+
+Update docs to require new UI surfaces to be represented in `test:a11y`, to keep focus-visible/reduced-motion/high-contrast behavior in production CSS, and to expose labels/tooltips/reason text for icon, status, and disabled controls.
+
+```md
+New webviews, tree views, status bar items, and command flows must update the
+accessibility gate before they are release-ready.
+```
+
+- [ ] **Step 2: Run docs checks as part of full validation**
+
+Run the repository-required command sequence after the code is green.
+
+### Task 4: Full Validation And PR
+
+**Files:**
+
+- No additional file changes unless validation exposes scoped failures.
+
+- [ ] **Step 1: Run required validation**
+
+Run:
+
+```bash
+corepack pnpm install --frozen-lockfile
+corepack pnpm run lint
+corepack pnpm run typecheck
+corepack pnpm run test
+corepack pnpm run build
+corepack pnpm run verify:dist
+```
+
+Expected: all PASS. Do not run `uv sync && uv run pytest` unless Python/MCP code was touched.
+
+- [ ] **Step 2: Commit, push, PR, Linear, CI**
+
+Run:
+
+```bash
+git status --short
+git add apps/vscode-extension/test/a11y/accessibilityConformance.test.ts apps/vscode-extension/src apps/vscode-extension/media docs
+git commit -m "test: expand accessibility keyboard coverage"
+git push -u origin codex/OASLANA-42-accessibility-keyboard-tests
+gh pr create --base main --head codex/OASLANA-42-accessibility-keyboard-tests --title "test: expand accessibility keyboard coverage" --body-file /tmp/oaslana-42-pr.md
+gh pr checks --watch --fail-fast
+```
+
+Expected: PR linked to GitHub issue #43 and Linear OASLANA-42, CI reaches terminal success or a real external blocker is recorded in Linear.

--- a/scripts/generate-docs-site.mjs
+++ b/scripts/generate-docs-site.mjs
@@ -419,6 +419,33 @@ Bug fixes should include automated regression coverage when practical. Use unit 
 integration tests, fixture checks, contract tests, or visual/accessibility checks based on the
 changed surface.
 
+## Accessibility Coverage
+
+New or changed KiCad Studio UI must keep the accessibility gate current before a
+pull request is ready for review:
+
+\`\`\`bash
+corepack pnpm --filter kicadstudio run test:a11y
+\`\`\`
+
+Update \`apps/vscode-extension/test/a11y/accessibilityConformance.test.ts\` when a
+change adds or materially changes a webview, custom editor toolbar, side panel,
+BOM/Netlist/Component Search surface, MCP Tools tree, Quality Gates tree, AI Fix
+Queue tree, status bar item, dialog-like flow, search box, or overlay.
+
+Contributor requirements:
+
+- Keep keyboard order deterministic and free of focus traps.
+- Provide accessible names for icon-only, symbolic, status, and toolbar actions.
+- Give disabled buttons reason text with \`aria-describedby\`, title text, or
+  adjacent assistive text when the reason is knowable.
+- Use VS Code theme tokens and verify dark, light, and high-contrast behavior.
+- Include \`:focus-visible\` styling for production webview controls.
+- Include \`prefers-reduced-motion: reduce\` CSS when a surface uses animation or
+  transitions.
+
+See [accessibility conformance target](accessibility.md) for the full policy.
+
 Runtime support changes must follow the [support matrix](support-matrix.md).
 `;
 }


### PR DESCRIPTION
## Summary
- Expands the accessibility conformance gate across extension webviews, native tree rows, and status bar items.
- Adds dark, light, and high-contrast axe coverage plus deterministic keyboard tab-order checks.
- Adds accessible names, disabled-reason text, focus-visible CSS, reduced-motion CSS, and theme-token fixes for touched UI surfaces.
- Documents contributor requirements for future accessibility coverage.

## Linked Work
- Linear: https://linear.app/oaslananka/issue/OASLANA-42/add-accessibility-and-keyboard-navigation-tests-for-all-kicad-studio
- Closes #43

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter kicadstudio run test:a11y`
- `corepack pnpm --filter kicadstudio exec jest --config jest.config.js --runInBand --coverage=false test/unit/componentSearch.test.ts`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist`
- `uvx pre-commit run --all-files`
- `gitleaks detect --source . --redact --verbose`
- Workflow deprecation scan for deprecated Actions commands and Node runtimes

## Source Verification
- VS Code Webviews UX guidance, rechecked 2026-05-24.
- axe-core API/WCAG tag behavior via current docs for installed `axe-core` 4.11.4.
- Playwright media emulation behavior via current docs for installed `@playwright/test` 1.59.1.

## Notes
- Direct `pre-commit` binary is not installed locally; `uvx pre-commit run --all-files` was used successfully.
- `gitleaks detect --source . --no-git --redact --exit-code 1` reports existing generated/cache working-tree findings outside the staged OASLANA-42 diff; the CI-equivalent git-history scan passed.
