### PR TITLE
docs(repo): add protocol change PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,13 @@ Closes #
 
 ## Protocol / MCP impact
 
+Complete this section when the PR changes MCP tool names, tool schemas,
+capability metadata, transport behavior, server-info payloads, compatibility
+metadata, or extension adapter behavior. For non-protocol PRs, mark it not
+applicable and state why.
+
+Checklist reference: `docs/architecture/protocol-change-checklist.md`
+
 - [ ] Not applicable; reason:
 - [ ] Protocol schema updated
 - [ ] MCP server implementation updated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,14 @@ corepack pnpm run test:contract
 corepack pnpm run test:fixtures
 ```
 
+Protocol-impacting pull requests must complete the protocol section in
+`.github/PULL_REQUEST_TEMPLATE.md`. This applies to MCP tool names, tool
+schemas, capability metadata, transport behavior, server-info payloads,
+compatibility metadata, and extension MCP adapter behavior. Mark the section not
+applicable with a reason when none of those surfaces are touched. The checklist
+policy is documented in
+[docs/architecture/protocol-change-checklist.md](docs/architecture/protocol-change-checklist.md).
+
 Report KiCad, VS Code, MCP protocol, dependency, or release-tool compatibility failures with the compatibility regression issue form. Include old and new versions, the failing command or workflow, and any canary run link.
 
 Runtime support changes must also follow [docs/support-matrix.md](docs/support-matrix.md).

--- a/docs/architecture/definition-of-done.md
+++ b/docs/architecture/definition-of-done.md
@@ -40,7 +40,9 @@ Architecture changes must include:
 
 ## MCP protocol or capability changes
 
-Protocol-impacting changes must include:
+Protocol-impacting changes must complete the
+[protocol change checklist](protocol-change-checklist.md) in the pull request
+template and include:
 
 - Updated protocol schemas.
 - Updated MCP server implementation.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -10,6 +10,7 @@ the Python MCP server, the npm launcher, shared protocol schemas, examples, and 
 - [Release model](release-model.md)
 - [Branch protection](branch-protection.md)
 - [Definition of done](definition-of-done.md)
+- [Protocol change checklist](protocol-change-checklist.md)
 - [Governance board model](governance-board.md)
 - [M0 completion audit](m0-completion-audit.md)
 - [Testing strategy](testing-strategy.md)

--- a/docs/architecture/product-boundaries.md
+++ b/docs/architecture/product-boundaries.md
@@ -31,6 +31,9 @@ The products integrate through MCP protocol and metadata:
 - contract and compatibility checks
 
 Protocol changes must update both product surfaces and the compatibility validation scripts.
+Use the [protocol change checklist](protocol-change-checklist.md) when changing
+tool names, schemas, capability metadata, transport behavior, server-info
+payloads, or extension adapter behavior.
 
 ## Enforcement
 

--- a/docs/architecture/protocol-change-checklist.md
+++ b/docs/architecture/protocol-change-checklist.md
@@ -1,0 +1,78 @@
+# Protocol Change Checklist
+
+OASLANA-76 defines the required pull request evidence for changes that affect
+the MCP protocol boundary between the VS Code extension, `kicad-mcp-pro`, the
+npm launcher, and shared compatibility metadata.
+
+The pull request template contains the review checklist. This document explains
+when the checklist applies and what each checked item means.
+
+## When It Applies
+
+Complete the protocol section in `.github/PULL_REQUEST_TEMPLATE.md` when a pull
+request changes any of these surfaces:
+
+- MCP tool names.
+- MCP tool input or output schemas.
+- Capability metadata.
+- Streamable HTTP or session transport behavior.
+- Server-info payload fields, versions, or compatibility ranges.
+- Extension MCP adapter behavior.
+- Compatibility metadata in `compatibility.yaml`, extension compatibility
+  code, MCP server compatibility code, `mcp.json`, or `server.json`.
+
+If none of those surfaces are touched, check `Not applicable` in the pull
+request template and include the reason.
+
+## Required Evidence
+
+Protocol-impacting pull requests must account for each item below:
+
+- Protocol schema updated.
+- MCP server implementation updated.
+- Extension MCP adapter updated.
+- Contract tests updated.
+- Compatibility matrix updated.
+- Server-info/capabilities payload updated.
+- Docs updated.
+- Release notes considered for both products.
+- Backward compatibility impact documented.
+
+Use `Not applicable` only when the item is genuinely outside the changed
+surface. For example, a docs-only clarification may not require server code
+changes, but a tool schema change must update schemas, server behavior, adapter
+expectations, and contract coverage together.
+
+## CI And Review Visibility
+
+The root check runs `check:protocol-pr-template` to keep the pull request
+template, this architecture document, and the related contributor guidance in
+sync. That check is intentionally lightweight: it verifies that protocol-impact
+PRs remain visible in review without trying to infer protocol semantics from a
+diff.
+
+Run the narrow policy check directly with:
+
+```bash
+corepack pnpm run check:protocol-pr-template
+```
+
+Protocol-impacting changes still need the contract gate:
+
+```bash
+corepack pnpm run test:contract
+```
+
+When compatibility metadata or KiCad fixtures are touched, also run:
+
+```bash
+corepack pnpm run check:compatibility
+corepack pnpm run test:fixtures
+```
+
+## Related Policy
+
+- [Definition of done](definition-of-done.md)
+- [Product boundaries](product-boundaries.md)
+- [Release model](release-model.md)
+- [Testing strategy](../testing-strategy.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,6 +23,16 @@ corepack pnpm run check:mcp-npm
 corepack pnpm run test:contract
 ```
 
+## Protocol Changes
+
+Protocol-impacting pull requests must complete the protocol section in
+`.github/PULL_REQUEST_TEMPLATE.md`. This applies to MCP tool names, tool
+schemas, capability metadata, transport behavior, server-info payloads,
+compatibility metadata, and extension MCP adapter behavior. Mark the section not
+applicable with a reason when none of those surfaces are touched.
+
+Checklist policy: [protocol change checklist](architecture/protocol-change-checklist.md).
+
 ## Issue Order
 
 Work follows the governance phases documented in

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -17,6 +17,7 @@ notes can add detail, but they should not weaken these gates.
 | Product gate         | Product-scoped changes                                               | Prove the touched product still builds, tests, and packages independently.                      | Product commands below                             |
 | Accessibility gate   | Extension-owned UI and webview changes                               | Prove WCAG 2.1 AA automated checks remain clean for in-scope extension surfaces.                | `corepack pnpm --filter kicadstudio run test:a11y` |
 | Contract gate        | Protocol, compatibility, or cross-product changes                    | Prove extension and MCP assumptions remain aligned.                                             | `corepack pnpm run test:contract`                  |
+| Protocol PR gate     | Protocol, compatibility, or cross-product review changes             | Keep protocol-impact PRs visible through the PR template and architecture guidance.             | `corepack pnpm run check:protocol-pr-template`     |
 | Fixture gate         | Parser, diagnostics, command-builder, or KiCad file behavior changes | Prove deterministic KiCad corpus behavior stays stable.                                         | `corepack pnpm run test:fixtures`                  |
 | Nightly quality gate | Scheduled and manual workflow                                        | Re-run the repository gate plus contract and fixture gates outside the fast PR path.            | `.github/workflows/nightly-quality-gates.yml`      |
 | VS Code canary       | Scheduled and manual workflow                                        | Check supported VS Code host lanes before runtime/API changes reach users.                      | `.github/workflows/vscode-canary.yml`              |
@@ -182,6 +183,7 @@ or artifact.
 | OASLANA-56  | Extension code bypassing the MCP adapter boundary.                              | Adapter unit tests plus integration tests for UI and command calls         |
 | OASLANA-57  | MCP server-info or capability metadata drift.                                   | Server-info and compatibility contract tests                               |
 | OASLANA-75  | Extension and MCP server passing independently but failing as a pair.           | Real-pair E2E tests                                                        |
+| OASLANA-76  | Protocol-impact pull requests missing schema, adapter, contract, or compatibility evidence. | PR template protocol checklist plus `corepack pnpm run check:protocol-pr-template` |
 | OASLANA-16  | Schematic viewer rendering as a tiny low-resolution thumbnail.                  | Playwright viewer fit tests plus visual regression snapshots               |
 | OASLANA-20  | Project tree duplicate rows or unclear file state indicators.                   | Extension integration tests for project tree model and labels              |
 | OASLANA-68  | Stale state across project, diagnostics, viewer, MCP, and export surfaces.      | State-store unit tests plus integration checks for derived UI state        |
@@ -208,6 +210,7 @@ before pushing.
 | MCP unit behavior              | `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/<test_file>.py -q` | `corepack pnpm run check:kicad-mcp-pro`        |
 | MCP full behavior              | `corepack pnpm --dir packages/mcp-server run test`                                                          | `corepack pnpm run check:kicad-mcp-pro`        |
 | Protocol or compatibility      | `corepack pnpm run test:contract`                                                                           | `corepack pnpm run check`                      |
+| Protocol PR checklist          | `corepack pnpm run check:protocol-pr-template`                                                              | `corepack pnpm run check`                      |
 | Fixtures                       | `corepack pnpm run test:fixtures`                                                                           | `corepack pnpm run check`                      |
 
 ## KiCad Fixture Corpus

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "check:repo-governance": "node scripts/check-repo-governance.mjs",
     "check:governance": "node scripts/sync-governance-project-items.mjs --self-test && pnpm run check:repo-governance",
     "check:testing-strategy": "node scripts/check-testing-strategy.mjs",
+    "check:protocol-pr-template": "node scripts/check-protocol-pr-template.mjs",
     "check:performance-budgets": "node scripts/check-performance-budgets.mjs && node --test scripts/check-performance-budgets.test.mjs",
     "test:beta-program": "node --test scripts/check-beta-program.test.mjs",
     "check:beta-program": "node scripts/check-beta-program.mjs && pnpm run test:beta-program",
@@ -64,7 +65,7 @@
     "check:docs-site": "pnpm --dir packages/mcp-server run docs:tools:check && pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "check:publish": "node scripts/check-publish-preflight.mjs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run check:protocol-pr-template && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.0",

--- a/scripts/check-protocol-pr-template.mjs
+++ b/scripts/check-protocol-pr-template.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const failures = [];
+
+function read(path) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+function readJson(path) {
+  return JSON.parse(read(path));
+}
+
+function requireIncludes(text, needle, source) {
+  if (!text.includes(needle)) {
+    failures.push(`${source} must include ${JSON.stringify(needle)}`);
+  }
+}
+
+const template = read(".github/PULL_REQUEST_TEMPLATE.md");
+const protocolDoc = read("docs/architecture/protocol-change-checklist.md");
+const definitionOfDone = read("docs/architecture/definition-of-done.md");
+const productBoundaries = read("docs/architecture/product-boundaries.md");
+const architectureIndex = read("docs/architecture/index.md");
+const rootContributing = read("CONTRIBUTING.md");
+const contributing = read("docs/contributing.md");
+const testingStrategy = read("docs/testing-strategy.md");
+const packageJson = readJson("package.json");
+
+const requiredTemplatePhrases = [
+  "## Protocol / MCP impact",
+  "Not applicable; reason:",
+  "Protocol schema updated",
+  "MCP server implementation updated",
+  "Extension MCP adapter updated",
+  "Contract tests updated",
+  "Compatibility matrix updated",
+  "Server-info/capabilities payload updated",
+  "Docs updated",
+  "Release notes considered for both products",
+  "Backward compatibility impact documented",
+  "tool names",
+  "tool schemas",
+  "capability metadata",
+  "transport behavior",
+  "server-info payloads",
+  "extension adapter behavior",
+  "docs/architecture/protocol-change-checklist.md",
+];
+
+for (const phrase of requiredTemplatePhrases) {
+  requireIncludes(
+    template,
+    phrase,
+    ".github/PULL_REQUEST_TEMPLATE.md",
+  );
+}
+
+const requiredDocPhrases = [
+  "# Protocol Change Checklist",
+  "OASLANA-76",
+  "When It Applies",
+  "Required Evidence",
+  "CI And Review Visibility",
+  "corepack pnpm run check:protocol-pr-template",
+  "corepack pnpm run test:contract",
+  "Definition of done",
+  "Product boundaries",
+  "Release model",
+  "Testing strategy",
+];
+
+for (const phrase of requiredDocPhrases) {
+  requireIncludes(protocolDoc, phrase, "docs/architecture/protocol-change-checklist.md");
+}
+
+requireIncludes(
+  definitionOfDone,
+  "protocol change checklist](protocol-change-checklist.md)",
+  "docs/architecture/definition-of-done.md",
+);
+requireIncludes(
+  productBoundaries,
+  "protocol change checklist](protocol-change-checklist.md)",
+  "docs/architecture/product-boundaries.md",
+);
+requireIncludes(
+  architectureIndex,
+  "Protocol change checklist](protocol-change-checklist.md)",
+  "docs/architecture/index.md",
+);
+requireIncludes(
+  rootContributing,
+  "docs/architecture/protocol-change-checklist.md",
+  "CONTRIBUTING.md",
+);
+requireIncludes(
+  contributing,
+  "protocol change checklist](architecture/protocol-change-checklist.md)",
+  "docs/contributing.md",
+);
+requireIncludes(
+  testingStrategy,
+  "OASLANA-76",
+  "docs/testing-strategy.md",
+);
+requireIncludes(
+  testingStrategy,
+  "corepack pnpm run check:protocol-pr-template",
+  "docs/testing-strategy.md",
+);
+
+const scripts = packageJson.scripts ?? {};
+if (
+  scripts["check:protocol-pr-template"] !==
+  "node scripts/check-protocol-pr-template.mjs"
+) {
+  failures.push("package.json must define check:protocol-pr-template");
+}
+
+if (!scripts.check?.includes("pnpm run check:protocol-pr-template")) {
+  failures.push("package.json check must run check:protocol-pr-template");
+}
+
+if (failures.length > 0) {
+  console.error("Protocol PR template check failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("Protocol PR template check passed.");

--- a/scripts/generate-docs-site.mjs
+++ b/scripts/generate-docs-site.mjs
@@ -402,6 +402,16 @@ corepack pnpm run check:mcp-npm
 corepack pnpm run test:contract
 \`\`\`
 
+## Protocol Changes
+
+Protocol-impacting pull requests must complete the protocol section in
+\`.github/PULL_REQUEST_TEMPLATE.md\`. This applies to MCP tool names, tool
+schemas, capability metadata, transport behavior, server-info payloads,
+compatibility metadata, and extension MCP adapter behavior. Mark the section not
+applicable with a reason when none of those surfaces are touched.
+
+Checklist policy: [protocol change checklist](architecture/protocol-change-checklist.md).
+
 ## Issue Order
 
 Work follows the governance phases documented in


### PR DESCRIPTION
## Summary
- Adds a protocol change checklist reference to the repository PR template with explicit trigger guidance and a not-applicable path.
- Adds `docs/architecture/protocol-change-checklist.md` and links it from architecture, contributing, definition-of-done, and testing strategy docs.
- Adds `check:protocol-pr-template` to keep the PR template and checklist guidance visible in the root `check` gate.

## Linked issue
Closes #77
Linear: OASLANA-76

## Type of change
- [ ] type:bug
- [ ] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence
- `corepack pnpm install --frozen-lockfile` — pass
- `corepack pnpm run format:check` — pass
- `corepack pnpm run lint` — pass
- `corepack pnpm run typecheck` — pass
- `corepack pnpm run test` — pass
- `corepack pnpm run build` — pass
- `corepack pnpm run verify:dist` — pass
- `corepack pnpm run check:protocol-pr-template` — pass
- `corepack pnpm run docs:check-generated` — pass
- `corepack pnpm run docs:lint` — pass
- `corepack pnpm run docs:links` — pass
- `corepack pnpm run check` — pass after moving generated contributing docs source into `scripts/generate-docs-site.mjs`
- `corepack pnpm audit --audit-level high` — pass
- `uvx pre-commit run --all-files` — pass
- `gitleaks detect --source . --redact --verbose` — pass
- workflow deprecation grep for `::set-output`, `::save-state`, insecure Node override, `node12`, `node16`, `node20` — pass
- `git diff --check` — pass

## Protocol / MCP impact

Complete this section when the PR changes MCP tool names, tool schemas,
capability metadata, transport behavior, server-info payloads, compatibility
metadata, or extension adapter behavior. For non-protocol PRs, mark it not
applicable and state why.

Checklist reference: `docs/architecture/protocol-change-checklist.md`

- [x] Not applicable; reason: this PR changes protocol review policy/docs/checks only; it does not change MCP schemas, tool behavior, transport behavior, server-info payloads, compatibility metadata, or adapter runtime behavior.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

## Automation evidence
- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist
- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
