### PR TITLE
test(repo): add KiCad GUI smoke coverage

### DIFF
--- a/.github/workflows/kicad-gui-smoke.yml
+++ b/.github/workflows/kicad-gui-smoke.yml
@@ -1,0 +1,101 @@
+name: KiCad GUI Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 3 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kicad-gui-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-primary:
+    name: Windows primary KiCad GUI smoke
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 60
+    env:
+      KICAD_MCP_ENABLE_GUI_SMOKE: "1"
+      KICAD_MCP_GUI_SMOKE_REQUIRED: "1"
+      KICAD_GUI_SMOKE_ARTIFACTS: artifacts/kicad-gui-smoke/windows-primary
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          version-file: packages/mcp-server/uv.toml
+      - name: Install KiCad GUI
+        shell: pwsh
+        run: |
+          choco install kicad --version=10.0.3 --yes --no-progress
+          $kicadBin = "C:\Program Files\KiCad\10.0\bin"
+          if (!(Test-Path $kicadBin)) {
+            throw "KiCad bin directory was not found: $kicadBin"
+          }
+          $kicadBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "KICAD_GUI_SMOKE_BIN_DIR=$kicadBin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - run: corepack enable
+      - run: corepack pnpm install --frozen-lockfile
+      - run: uv sync --all-extras --frozen --project packages/mcp-server
+      - name: Run KiCad GUI smoke suite
+        run: corepack pnpm run test:kicad-gui-smoke
+      - name: Upload KiCad GUI smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: kicad-gui-smoke-windows-primary
+          path: artifacts/kicad-gui-smoke/windows-primary
+          if-no-files-found: warn
+          retention-days: 14
+
+  linux-xvfb:
+    name: Linux Xvfb KiCad GUI smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      KICAD_MCP_ENABLE_GUI_SMOKE: "1"
+      KICAD_MCP_GUI_SMOKE_REQUIRED: "1"
+      KICAD_GUI_SMOKE_ARTIFACTS: artifacts/kicad-gui-smoke/linux-xvfb
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          version-file: packages/mcp-server/uv.toml
+      - name: Install KiCad GUI and Xvfb
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes software-properties-common xvfb xauth dbus-x11 imagemagick
+          sudo add-apt-repository --yes ppa:kicad/kicad-10.0-releases
+          sudo apt-get update
+          sudo apt-get install --yes kicad
+      - run: corepack enable
+      - run: corepack pnpm install --frozen-lockfile
+      - run: uv sync --all-extras --frozen --project packages/mcp-server
+      - name: Run KiCad GUI smoke suite
+        run: |
+          xvfb-run -a --server-args="-screen 0 1920x1080x24" \
+            dbus-run-session -- corepack pnpm run test:kicad-gui-smoke
+      - name: Upload KiCad GUI smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: kicad-gui-smoke-linux-xvfb
+          path: artifacts/kicad-gui-smoke/linux-xvfb
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -18,8 +18,10 @@ notes can add detail, but they should not weaken these gates.
 | Accessibility gate   | Extension-owned UI and webview changes                               | Prove WCAG 2.1 AA automated checks remain clean for in-scope extension surfaces.                | `corepack pnpm --filter kicadstudio run test:a11y` |
 | Contract gate        | Protocol, compatibility, or cross-product changes                    | Prove extension and MCP assumptions remain aligned.                                             | `corepack pnpm run test:contract`                  |
 | Protocol PR gate     | Protocol, compatibility, or cross-product review changes             | Keep protocol-impact PRs visible through the PR template and architecture guidance.             | `corepack pnpm run check:protocol-pr-template`     |
+| GUI smoke policy     | Real KiCad GUI smoke workflow/test wiring changes                    | Keep live-editor IPC smoke coverage wired without adding GUI work to the PR path.               | `corepack pnpm run check:kicad-gui-smoke`          |
 | Fixture gate         | Parser, diagnostics, command-builder, or KiCad file behavior changes | Prove deterministic KiCad corpus behavior stays stable.                                         | `corepack pnpm run test:fixtures`                  |
 | Nightly quality gate | Scheduled and manual workflow                                        | Re-run the repository gate plus contract and fixture gates outside the fast PR path.            | `.github/workflows/nightly-quality-gates.yml`      |
+| KiCad GUI smoke      | Scheduled and manual workflow                                        | Launch real KiCad editors on Windows primary plus Linux Xvfb and verify MCP live PCB context.   | `.github/workflows/kicad-gui-smoke.yml`            |
 | VS Code canary       | Scheduled and manual workflow                                        | Check supported VS Code host lanes before runtime/API changes reach users.                      | `.github/workflows/vscode-canary.yml`              |
 | KiCad canary         | Scheduled and manual workflow                                        | Check supported KiCad CLI lanes against real fixture exports without publishing packages.       | `.github/workflows/kicad-canary.yml`               |
 | Manual smoke         | Release candidate only                                               | Final human inspection where automation is not practical.                                       | PR notes must name the exact manual check          |
@@ -41,7 +43,7 @@ notes can add detail, but they should not weaken these gates.
 | KiCad CLI contract tests              | KiCad 10 primary behavior plus supported 9.x and deprecated 8.x compatibility where supported.                                       | Shared fixtures and MCP integration tests                                | `kicad-cli`                                                    | Nightly/canary gate                                    |
 | MCP transport contract tests          | Streamable HTTP initialize flow, session handling, stateless behavior, `MCP-Protocol-Version`, tool discovery, errors, and timeouts. | MCP tests and future shared contract package                             | pytest/http client                                             | Contract gate                                          |
 | Real-pair tests                       | Built VS Code extension connected to built MCP server against fixture workspaces.                                                    | Future shared harness                                                    | VS Code test host plus local MCP server                        | Nightly gate                                           |
-| Real KiCad GUI IPC smoke              | KiCad application IPC behavior that cannot be proven headlessly.                                                                     | Dedicated smoke harness                                                  | KiCad GUI plus fixture workspace                               | Nightly only                                           |
+| Real KiCad GUI IPC smoke              | KiCad application IPC behavior that cannot be proven by file-backed CLI tests.                                                       | `packages/mcp-server/tests/gui/`                                         | KiCad GUI, Xvfb, fixture workspace, MCP server tools            | Nightly/manual only                                    |
 | Release candidate manual smoke        | Marketplace/package artifact sanity only.                                                                                            | PR/release notes                                                         | Human confirmation                                             | Release candidate only                                 |
 
 ## Fast PR Gates
@@ -125,6 +127,16 @@ corepack pnpm run test:contract
 corepack pnpm run test:fixtures
 ```
 
+The real KiCad GUI smoke suite is isolated in
+`.github/workflows/kicad-gui-smoke.yml` because it starts desktop applications
+and requires a display server. The workflow is scheduled and manually
+dispatched only; it is not a PR or push trigger. Its Windows primary lane
+installs pinned KiCad 10.0.3, adds the KiCad binary directory to discovery, and
+captures process logs plus screenshots as artifacts. The Linux lane keeps a
+second Xvfb/dbus signal using the repository's existing KiCad canary PPA policy.
+The pytest suite is skipped unless `KICAD_MCP_ENABLE_GUI_SMOKE=1` is set, so
+local and PR test runs do not try to launch a desktop session by accident.
+
 As the M1-M4 roadmap lands, extend this workflow in focused PRs:
 
 | Future gate                | Tracking issue | Required behavior                                                                                                              |
@@ -132,6 +144,7 @@ As the M1-M4 roadmap lands, extend this workflow in focused PRs:
 | Shared fixture corpus      | OASLANA-36     | Maintain `apps/vscode-extension/test/fixtures/kicad/` with semantic fixture IDs and golden expected outputs.                   |
 | Unit test expansion        | OASLANA-37     | Cover project discovery, command builders, diagnostics, state machines, and MCP client behavior.                               |
 | MCP protocol contracts     | OASLANA-43     | Cover Streamable HTTP, session headers, stateless mode, tool discovery, errors, timeouts, and ChatGPT connector compatibility. |
+| KiCad GUI IPC smoke        | OASLANA-44     | Cover live PCB context, GUI-closed fallback diagnostics, multi-window behavior, and project switch isolation.                  |
 | MCP adapter layer tests    | OASLANA-56     | Verify extension UI and commands use the adapter boundary instead of direct MCP calls.                                         |
 | Server-info contract tests | OASLANA-57     | Verify advertised server-info, capability metadata, and compatibility ranges.                                                  |
 | Real-pair E2E              | OASLANA-75     | Build both products, start the server, launch the extension host, connect them, and validate capability handshakes.            |
@@ -168,6 +181,25 @@ artifacts. A failing lane opens or updates a compatibility issue. Stable-lane
 failures add the `release-blocker` label because the release gate lists VS Code
 stable compatibility as required.
 
+## KiCad GUI Smoke
+
+`.github/workflows/kicad-gui-smoke.yml` runs the OASLANA-44 live-editor smoke
+suite daily and on manual dispatch. Windows is the primary lane because KiCad
+process discovery and IPC endpoint behavior differ there; Linux Xvfb remains a
+secondary lane for the repository's existing headless CI environment. The
+workflow is intentionally separate from the normal nightly quality gate so GUI
+failures can be triaged as environment, window-manager, or IPC regressions
+without hiding deterministic unit, integration, and CLI-contract failures.
+
+The suite launches a fixture project, opens the schematic and PCB editors where
+the installed KiCad build exposes those entry points, then verifies
+`pcb_get_board_summary`, `pcb_get_tracks`, `pcb_get_footprints`, and
+`pcb_get_nets` report `live-gui` while the PCB Editor is open. It also verifies
+the closed/unavailable GUI path reports structured file-backed fallback
+diagnostics and that switching projects does not leak the old live board
+context. Failures upload process stdout/stderr, tool-output JSON, discovery
+metadata, and a screenshot when the runner can capture one.
+
 ## Regression Coverage Map
 
 Every bug fix should add an automated regression when practical. If automation
@@ -180,6 +212,7 @@ or artifact.
 | OASLANA-36  | KiCad file parser or quality-gate regressions that lack deterministic fixtures. | Shared KiCad fixture corpus and golden expected outputs                    |
 | OASLANA-37  | Extension helpers regressing without unit coverage.                             | Jest unit suites under `apps/vscode-extension/test/unit/`                  |
 | OASLANA-43  | MCP transport/session compatibility regressions.                                | MCP contract tests for Streamable HTTP and `MCP-Protocol-Version` behavior |
+| OASLANA-44  | Live KiCad PCB context regressing while file-backed CLI checks still pass.       | Scheduled GUI smoke suite for live context, fallback diagnostics, and project switching |
 | OASLANA-56  | Extension code bypassing the MCP adapter boundary.                              | Adapter unit tests plus integration tests for UI and command calls         |
 | OASLANA-57  | MCP server-info or capability metadata drift.                                   | Server-info and compatibility contract tests                               |
 | OASLANA-75  | Extension and MCP server passing independently but failing as a pair.           | Real-pair E2E tests                                                        |
@@ -211,6 +244,8 @@ before pushing.
 | MCP full behavior              | `corepack pnpm --dir packages/mcp-server run test`                                                          | `corepack pnpm run check:kicad-mcp-pro`        |
 | Protocol or compatibility      | `corepack pnpm run test:contract`                                                                           | `corepack pnpm run check`                      |
 | Protocol PR checklist          | `corepack pnpm run check:protocol-pr-template`                                                              | `corepack pnpm run check`                      |
+| KiCad GUI smoke wiring         | `corepack pnpm run check:kicad-gui-smoke`                                                                   | `corepack pnpm run check`                      |
+| Real KiCad GUI smoke           | `KICAD_MCP_ENABLE_GUI_SMOKE=1 corepack pnpm run test:kicad-gui-smoke`                                       | `.github/workflows/kicad-gui-smoke.yml`       |
 | Fixtures                       | `corepack pnpm run test:fixtures`                                                                           | `corepack pnpm run check`                      |
 
 ## KiCad Fixture Corpus
@@ -243,6 +278,9 @@ CI ownership follows product boundaries:
   `.github/workflows/codeql.yml` own security and static analysis lanes.
 - `.github/workflows/nightly-quality-gates.yml` owns the non-release scheduled
   quality gate.
+- `.github/workflows/kicad-gui-smoke.yml` owns scheduled/manual real KiCad GUI
+  live-context smoke coverage on Windows primary plus Linux Xvfb, and uploads
+  debugging artifacts on failure.
 - `.github/workflows/vscode-canary.yml` owns scheduled/manual VS Code
   compatibility lanes sourced from `compatibility.yaml`.
 - `.github/workflows/kicad-canary.yml` owns scheduled/manual real KiCad CLI
@@ -266,6 +304,14 @@ This strategy was checked against current primary sources:
   and snapshot update flow.
 - KiCad 10 command-line documentation for `kicad-cli` driven ERC, DRC, export,
   and version checks.
+- KiCad PCB Editor documentation for action-plugin/GUI scripting boundaries and
+  KiCad IPC API developer documentation for live-editor automation scope.
+- KiCad Windows Downloads for supported Windows versions and current stable
+  10.0.3 installer availability.
+- Chocolatey KiCad package metadata for the pinned Windows CI install command
+  and checksum-backed official KiCad installer URL.
+- GitHub Actions artifact documentation and `actions/upload-artifact` metadata
+  for scheduled failure log and screenshot uploads.
 - Model Context Protocol 2025-06-18 transport docs for Streamable HTTP,
   session handling, and `MCP-Protocol-Version`.
 - GitHub Actions workflow syntax docs for scheduled and manually dispatched

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:kicad-mcp-pro": "pnpm --dir packages/mcp-server run test:unit",
     "test:contract": "pnpm run check:compatibility && pnpm --dir packages/mcp-server run mcp:manifest:check",
     "test:perf": "pnpm --filter kicadstudio run test:perf && uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_benchmark_latency.py",
+    "test:kicad-gui-smoke": "pnpm --dir packages/mcp-server run test:gui-smoke",
     "fixtures:kicad:generate": "node scripts/generate-kicad-fixture-corpus.mjs --write",
     "check:fixtures": "node scripts/generate-kicad-fixture-corpus.mjs --check",
     "test:fixtures": "pnpm run check:fixtures",
@@ -53,6 +54,7 @@
     "check:governance": "node scripts/sync-governance-project-items.mjs --self-test && pnpm run check:repo-governance",
     "check:testing-strategy": "node scripts/check-testing-strategy.mjs",
     "check:protocol-pr-template": "node scripts/check-protocol-pr-template.mjs",
+    "check:kicad-gui-smoke": "node scripts/check-kicad-gui-smoke.mjs",
     "check:performance-budgets": "node scripts/check-performance-budgets.mjs && node --test scripts/check-performance-budgets.test.mjs",
     "test:beta-program": "node --test scripts/check-beta-program.test.mjs",
     "check:beta-program": "node scripts/check-beta-program.mjs && pnpm run test:beta-program",
@@ -65,7 +67,7 @@
     "check:docs-site": "pnpm --dir packages/mcp-server run docs:tools:check && pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "check:publish": "node scripts/check-publish-preflight.mjs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run check:protocol-pr-template && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.0",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -23,6 +23,7 @@
     "typecheck": "uv run --all-extras python -m mypy src/kicad_mcp/",
     "test": "uv run --all-extras python scripts/run_pytest.py full",
     "test:unit": "uv run --all-extras python scripts/run_pytest.py unit",
+    "test:gui-smoke": "uv run --all-extras python scripts/run_pytest.py gui",
     "build": "uv build",
     "package:check": "uv build && uv run --all-extras python scripts/check_package_metadata.py",
     "workflows:lint": "uv run --all-extras python scripts/check_workflows.py --actionlint",

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -128,6 +128,7 @@ testpaths = ["tests"]
 addopts = "-q"
 markers = [
   "benchmark: lightweight performance regression checks with committed baselines",
+  "gui: real KiCad GUI smoke tests for scheduled/manual environments",
   "slow: tests that are useful for scheduled/full validation but skipped by fast loops",
 ]
 

--- a/packages/mcp-server/scripts/run_pytest.py
+++ b/packages/mcp-server/scripts/run_pytest.py
@@ -10,6 +10,7 @@ import pytest
 
 SUITES = {
     "unit": ["tests/unit/", "-q"],
+    "gui": ["tests/gui/", "-q"],
     "full": [
         "tests/unit/",
         "tests/integration/",

--- a/packages/mcp-server/tests/gui/test_kicad_gui_live_context.py
+++ b/packages/mcp-server/tests/gui/test_kicad_gui_live_context.py
@@ -1,0 +1,457 @@
+"""OASLANA-44 real KiCad GUI smoke coverage for GitHub issue #35.
+
+The suite is skipped unless ``KICAD_MCP_ENABLE_GUI_SMOKE=1`` is set. It is
+intended for scheduled/manual CI where a real KiCad GUI can be launched, not for
+the normal PR path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import platform
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.connection import reset_connection
+from kicad_mcp.server import build_server
+from tests.conftest import call_tool_text
+
+pytestmark = [pytest.mark.anyio, pytest.mark.gui, pytest.mark.slow]
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FIXTURE_ROOT = (
+    REPO_ROOT / "apps" / "vscode-extension" / "test" / "fixtures" / "kicad" / "clean-led-kicad10"
+)
+SMOKE_TOOLS = (
+    "pcb_get_board_summary",
+    "pcb_get_tracks",
+    "pcb_get_footprints",
+    "pcb_get_nets",
+)
+LIVE_TIMEOUT_SECONDS = 150
+
+
+@dataclass(frozen=True)
+class KiCadExecutables:
+    """Discovered KiCad GUI executables used by the smoke suite."""
+
+    project_manager: Path | None
+    pcb_editor: Path | None
+    schematic_editor: Path | None
+    searched: tuple[str, ...]
+
+
+@dataclass
+class ManagedProcess:
+    """A spawned KiCad GUI process plus its captured output."""
+
+    name: str
+    process: subprocess.Popen[str]
+    log_dir: Path
+
+
+def _require_enabled() -> None:
+    if os.environ.get("KICAD_MCP_ENABLE_GUI_SMOKE") != "1":
+        pytest.skip("Set KICAD_MCP_ENABLE_GUI_SMOKE=1 to run real KiCad GUI smoke tests.")
+
+
+def _required() -> bool:
+    return os.environ.get("KICAD_MCP_GUI_SMOKE_REQUIRED") == "1"
+
+
+def _artifact_root(tmp_path: Path) -> Path:
+    raw_path = os.environ.get("KICAD_GUI_SMOKE_ARTIFACTS")
+    root = Path(raw_path).expanduser() if raw_path else tmp_path / "kicad-gui-smoke-artifacts"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _executables_payload(executables: KiCadExecutables) -> dict[str, object]:
+    return {
+        "project_manager": str(executables.project_manager)
+        if executables.project_manager is not None
+        else None,
+        "pcb_editor": str(executables.pcb_editor) if executables.pcb_editor is not None else None,
+        "schematic_editor": str(executables.schematic_editor)
+        if executables.schematic_editor is not None
+        else None,
+        "searched": list(executables.searched),
+    }
+
+
+def _copy_fixture(tmp_path: Path, name: str) -> Path:
+    destination = tmp_path / name
+    shutil.copytree(FIXTURE_ROOT, destination)
+    return destination
+
+
+def _configure_project(monkeypatch: pytest.MonkeyPatch, project_dir: Path) -> dict[str, str]:
+    stem = "clean-led-kicad10"
+    env = {
+        "KICAD_MCP_PROJECT_DIR": str(project_dir),
+        "KICAD_MCP_PROJECT_FILE": str(project_dir / f"{stem}.kicad_pro"),
+        "KICAD_MCP_PCB_FILE": str(project_dir / f"{stem}.kicad_pcb"),
+        "KICAD_MCP_SCH_FILE": str(project_dir / f"{stem}.kicad_sch"),
+        "KICAD_MCP_OUTPUT_DIR": str(project_dir / "mcp-output"),
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return env
+
+
+def _candidate_names(names: tuple[str, ...]) -> tuple[str, ...]:
+    if platform.system() != "Windows":
+        return names
+    expanded: list[str] = []
+    for name in names:
+        expanded.append(name)
+        if not name.lower().endswith(".exe"):
+            expanded.append(f"{name}.exe")
+    return tuple(expanded)
+
+
+def _existing_file(path: Path) -> Path | None:
+    expanded = path.expanduser()
+    if expanded.exists() and expanded.is_file():
+        return expanded
+    return None
+
+
+def _discover_one(
+    env_names: tuple[str, ...],
+    binary_names: tuple[str, ...],
+    bin_dirs: tuple[Path, ...],
+    searched: list[str],
+) -> Path | None:
+    for env_name in env_names:
+        raw = os.environ.get(env_name, "").strip()
+        if raw:
+            searched.append(f"{env_name}={raw}")
+            candidate = _existing_file(Path(raw))
+            if candidate is not None:
+                return candidate
+
+    for bin_dir in bin_dirs:
+        for binary_name in _candidate_names(binary_names):
+            candidate_path = bin_dir / binary_name
+            searched.append(str(candidate_path))
+            candidate = _existing_file(candidate_path)
+            if candidate is not None:
+                return candidate
+
+    for binary_name in _candidate_names(binary_names):
+        discovered = shutil.which(binary_name)
+        searched.append(f"PATH:{binary_name}")
+        if discovered:
+            return Path(discovered)
+    return None
+
+
+def _discover_executables() -> KiCadExecutables:
+    searched: list[str] = []
+    bin_dirs: list[Path] = []
+    for env_name in ("KICAD_GUI_SMOKE_BIN_DIR", "KICAD_INSTALL_BIN_DIR"):
+        raw = os.environ.get(env_name, "").strip()
+        if raw:
+            bin_dirs.append(Path(raw).expanduser())
+            searched.append(f"{env_name}={raw}")
+
+    for env_name in ("KICAD_GUI_SMOKE_KICAD_CLI", "KICAD_MCP_KICAD_CLI", "KICAD_CLI_PATH"):
+        raw = os.environ.get(env_name, "").strip()
+        if raw:
+            bin_dirs.append(Path(raw).expanduser().parent)
+            searched.append(f"{env_name}={raw}")
+
+    project_manager = _discover_one(
+        ("KICAD_GUI_PATH", "KICAD_PROJECT_MANAGER_PATH"),
+        ("kicad",),
+        tuple(bin_dirs),
+        searched,
+    )
+    pcb_editor = _discover_one(
+        ("KICAD_PCBNEW_PATH", "KICAD_PCB_EDITOR_PATH"),
+        ("pcbnew",),
+        tuple(bin_dirs),
+        searched,
+    )
+    schematic_editor = _discover_one(
+        ("KICAD_EESCHEMA_PATH", "KICAD_SCHEMATIC_EDITOR_PATH"),
+        ("eeschema",),
+        tuple(bin_dirs),
+        searched,
+    )
+    return KiCadExecutables(
+        project_manager=project_manager,
+        pcb_editor=pcb_editor,
+        schematic_editor=schematic_editor,
+        searched=tuple(searched),
+    )
+
+
+def _launch_process(
+    name: str,
+    executable: Path,
+    target: Path,
+    log_dir: Path,
+) -> ManagedProcess:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    process = subprocess.Popen(
+        [str(executable), str(target)],
+        cwd=target.parent,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    (log_dir / f"{name}-pid.txt").write_text(str(process.pid), encoding="utf-8")
+    return ManagedProcess(name=name, process=process, log_dir=log_dir)
+
+
+def _stop_processes(processes: list[ManagedProcess]) -> None:
+    for managed in reversed(processes):
+        _stop_process(managed)
+
+
+def _stop_process(managed: ManagedProcess) -> None:
+    process = managed.process
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+    try:
+        stdout, stderr = process.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        stdout, stderr = process.communicate(timeout=5)
+    (managed.log_dir / f"{managed.name}-stdout.log").write_text(stdout or "", encoding="utf-8")
+    (managed.log_dir / f"{managed.name}-stderr.log").write_text(stderr or "", encoding="utf-8")
+    (managed.log_dir / f"{managed.name}-returncode.txt").write_text(
+        str(process.returncode),
+        encoding="utf-8",
+    )
+
+
+def _classify_tool_output(text: str) -> str:
+    if "- Source: live-gui" in text:
+        return "live-gui"
+    if "file-backed fallback" in text or "- Source: file-backed" in text:
+        return "file-backed"
+    if "Error executing tool" in text:
+        return "error"
+    return "other"
+
+
+def _capture_screenshot(destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    system = platform.system()
+    if system == "Windows":
+        powershell = shutil.which("pwsh") or shutil.which("powershell")
+        if powershell is None:
+            destination.with_suffix(".txt").write_text(
+                "Screenshot unavailable: PowerShell was not found.",
+                encoding="utf-8",
+            )
+            return
+        script = f"""
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+$bitmap = New-Object System.Drawing.Bitmap $bounds.Width, $bounds.Height
+$graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+$graphics.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
+$bitmap.Save('{destination}', [System.Drawing.Imaging.ImageFormat]::Png)
+$graphics.Dispose()
+$bitmap.Dispose()
+"""
+        result = subprocess.run(
+            [powershell, "-NoProfile", "-Command", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    else:
+        import_binary = shutil.which("import")
+        if import_binary is None:
+            destination.with_suffix(".txt").write_text(
+                "Screenshot unavailable: ImageMagick import was not found.",
+                encoding="utf-8",
+            )
+            return
+        result = subprocess.run(
+            [import_binary, "-window", "root", str(destination)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+    if result.returncode != 0:
+        destination.with_suffix(".txt").write_text(
+            f"Screenshot command failed.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            encoding="utf-8",
+        )
+
+
+async def _call_smoke_tools(server: object) -> dict[str, dict[str, str]]:
+    outputs: dict[str, dict[str, str]] = {}
+    for tool_name in SMOKE_TOOLS:
+        text = await call_tool_text(server, tool_name, {})
+        outputs[tool_name] = {
+            "classification": _classify_tool_output(text),
+            "text": text,
+        }
+    return outputs
+
+
+async def _wait_for_live_context(server: object, artifacts: Path) -> dict[str, dict[str, str]]:
+    deadline = time.monotonic() + LIVE_TIMEOUT_SECONDS
+    last_outputs: dict[str, dict[str, str]] = {}
+    attempt = 0
+    while time.monotonic() < deadline:
+        attempt += 1
+        last_outputs = await _call_smoke_tools(server)
+        _write_json(
+            artifacts / "live-context-attempts" / f"attempt-{attempt:03d}.json",
+            last_outputs,
+        )
+        if all(value["classification"] == "live-gui" for value in last_outputs.values()):
+            return last_outputs
+        await asyncio.sleep(3)
+    _write_json(artifacts / "live-context-timeout.json", last_outputs)
+    raise AssertionError("Timed out waiting for every OASLANA-44 read tool to use live-gui.")
+
+
+async def test_gui_closed_reports_structured_file_backed_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GUI closed/unavailable must be distinguishable from valid file-backed fallback."""
+    _require_enabled()
+    project_dir = _copy_fixture(tmp_path, "gui-closed")
+    env = _configure_project(monkeypatch, project_dir)
+    monkeypatch.setenv("KICAD_API_SOCKET", str(tmp_path / "closed-gui.sock"))
+    artifacts = _artifact_root(tmp_path) / "gui-closed"
+    artifacts.mkdir(parents=True, exist_ok=True)
+
+    server = build_server("pcb")
+    await call_tool_text(server, "kicad_set_project", {"project_dir": str(project_dir)})
+    outputs = await _call_smoke_tools(server)
+    _write_json(
+        artifacts / "fallback-summary.json",
+        {"env": env, "outputs": outputs, "issue": "OASLANA-44 / GitHub issue #35"},
+    )
+
+    for tool_name, result in outputs.items():
+        assert result["classification"] == "file-backed", result["text"]
+        assert "Diagnostics:" in result["text"], tool_name
+        assert "IPC endpoint:" in result["text"], tool_name
+        assert "Fallback status: using file-backed .kicad_pcb parser" in result["text"], tool_name
+
+
+async def test_open_pcb_editor_uses_live_board_context_and_project_switches(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Launch real KiCad editors, verify live PCB tools, then guard project switching."""
+    _require_enabled()
+    artifacts = _artifact_root(tmp_path) / "open-editors"
+    processes: list[ManagedProcess] = []
+    executables = _discover_executables()
+    _write_json(artifacts / "discovery.json", _executables_payload(executables))
+
+    if executables.pcb_editor is None:
+        message = "KiCad PCB Editor executable was not found for OASLANA-44 live GUI smoke."
+        if _required():
+            pytest.fail(f"{message} Searched: {executables.searched}")
+        pytest.skip(message)
+
+    first_project = _copy_fixture(tmp_path, "first-project")
+    env = _configure_project(monkeypatch, first_project)
+    server = build_server("pcb")
+    await call_tool_text(server, "kicad_set_project", {"project_dir": str(first_project)})
+
+    try:
+        if executables.project_manager is not None:
+            processes.append(
+                _launch_process(
+                    "project-manager",
+                    executables.project_manager,
+                    Path(env["KICAD_MCP_PROJECT_FILE"]),
+                    artifacts / "processes",
+                )
+            )
+        if executables.schematic_editor is not None:
+            processes.append(
+                _launch_process(
+                    "schematic-editor",
+                    executables.schematic_editor,
+                    Path(env["KICAD_MCP_SCH_FILE"]),
+                    artifacts / "processes",
+                )
+            )
+        first_pcb = _launch_process(
+            "pcb-editor-first-project",
+            executables.pcb_editor,
+            Path(env["KICAD_MCP_PCB_FILE"]),
+            artifacts / "processes",
+        )
+        processes.append(first_pcb)
+
+        live_outputs = await _wait_for_live_context(server, artifacts)
+        _write_json(artifacts / "live-context-summary.json", live_outputs)
+
+        tracks = live_outputs["pcb_get_tracks"]["text"]
+        footprints = live_outputs["pcb_get_footprints"]["text"]
+        nets = live_outputs["pcb_get_nets"]["text"]
+        assert "Tracks (" in tracks and "LED_A" in tracks
+        assert "R1" in footprints and "LED1" in footprints
+        assert "LED_A" in nets and "GND" in nets
+
+        _stop_process(first_pcb)
+        processes.remove(first_pcb)
+        reset_connection()
+
+        second_project = _copy_fixture(tmp_path, "second-project")
+        second_board = second_project / "clean-led-kicad10.kicad_pcb"
+        second_board.write_text(
+            second_board.read_text(encoding="utf-8")
+            .replace("LED_A", "SWITCHED_PROJECT_NET")
+            .replace("GND", "SWITCHED_PROJECT_GND"),
+            encoding="utf-8",
+        )
+        second_env = _configure_project(monkeypatch, second_project)
+        await call_tool_text(server, "kicad_set_project", {"project_dir": str(second_project)})
+        processes.append(
+            _launch_process(
+                "pcb-editor-second-project",
+                executables.pcb_editor,
+                Path(second_env["KICAD_MCP_PCB_FILE"]),
+                artifacts / "processes",
+            )
+        )
+
+        switched_outputs = await _wait_for_live_context(server, artifacts / "project-switch")
+        switched_nets = switched_outputs["pcb_get_nets"]["text"]
+        _write_json(artifacts / "project-switch-summary.json", switched_outputs)
+
+        assert "SWITCHED_PROJECT_NET" in switched_nets
+        assert "SWITCHED_PROJECT_GND" in switched_nets
+    except Exception:
+        _capture_screenshot(artifacts / "failure-screenshot.png")
+        raise
+    finally:
+        _stop_processes(processes)

--- a/scripts/check-kicad-gui-smoke.mjs
+++ b/scripts/check-kicad-gui-smoke.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const workflowPath = path.join(root, ".github", "workflows", "kicad-gui-smoke.yml");
+const rootPackagePath = path.join(root, "package.json");
+const mcpPackagePath = path.join(root, "packages", "mcp-server", "package.json");
+const pytestPath = path.join(
+  root,
+  "packages",
+  "mcp-server",
+  "tests",
+  "gui",
+  "test_kicad_gui_live_context.py",
+);
+const runnerPath = path.join(root, "packages", "mcp-server", "scripts", "run_pytest.py");
+const pyprojectPath = path.join(root, "packages", "mcp-server", "pyproject.toml");
+const strategyPath = path.join(root, "docs", "testing-strategy.md");
+
+function readText(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    throw new Error(`Missing ${path.relative(root, filePath)}: ${error.message}`);
+  }
+}
+
+function readJson(filePath) {
+  return JSON.parse(readText(filePath));
+}
+
+function assertIncludes(haystack, needle, source) {
+  if (!haystack.includes(needle)) {
+    throw new Error(`${source} must include ${JSON.stringify(needle)}`);
+  }
+}
+
+function assertExcludes(haystack, needle, source) {
+  if (haystack.includes(needle)) {
+    throw new Error(`${source} must not include ${JSON.stringify(needle)}`);
+  }
+}
+
+const workflow = readText(workflowPath);
+const pytest = readText(pytestPath);
+const runner = readText(runnerPath);
+const pyproject = readText(pyprojectPath);
+const strategy = readText(strategyPath);
+const rootScripts = readJson(rootPackagePath).scripts ?? {};
+const mcpScripts = readJson(mcpPackagePath).scripts ?? {};
+
+for (const phrase of [
+  "name: KiCad GUI Smoke",
+  "workflow_dispatch:",
+  "schedule:",
+  "cron:",
+  "windows-primary:",
+  "Windows primary KiCad GUI smoke",
+  "windows-2025-vs2026",
+  "choco install kicad --version=10.0.3 --yes --no-progress",
+  "KICAD_GUI_SMOKE_BIN_DIR",
+  "kicad-gui-smoke-windows-primary",
+  "ubuntu-24.04",
+  "xvfb-run",
+  "dbus-run-session",
+  "ppa:kicad/kicad-10.0-releases",
+  "KICAD_MCP_ENABLE_GUI_SMOKE: \"1\"",
+  "KICAD_MCP_GUI_SMOKE_REQUIRED: \"1\"",
+  "corepack pnpm run test:kicad-gui-smoke",
+  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+  "if: always()",
+  "retention-days: 14",
+]) {
+  assertIncludes(workflow, phrase, ".github/workflows/kicad-gui-smoke.yml");
+}
+assertExcludes(workflow, "pull_request:", ".github/workflows/kicad-gui-smoke.yml");
+assertExcludes(workflow, "push:", ".github/workflows/kicad-gui-smoke.yml");
+
+for (const phrase of [
+  "OASLANA-44",
+  "GitHub issue #35",
+  "KICAD_MCP_ENABLE_GUI_SMOKE",
+  "pcb_get_board_summary",
+  "pcb_get_tracks",
+  "pcb_get_footprints",
+  "pcb_get_nets",
+  "live-gui",
+  "file-backed fallback",
+  "project-switch",
+  "failure-screenshot.png",
+]) {
+  assertIncludes(pytest, phrase, "GUI smoke pytest suite");
+}
+
+assertIncludes(runner, "\"gui\"", "packages/mcp-server/scripts/run_pytest.py");
+assertIncludes(runner, "tests/gui/", "packages/mcp-server/scripts/run_pytest.py");
+assertIncludes(pyproject, "\"gui:", "packages/mcp-server/pyproject.toml");
+
+if (
+  mcpScripts["test:gui-smoke"] !==
+  "uv run --all-extras python scripts/run_pytest.py gui"
+) {
+  throw new Error("packages/mcp-server/package.json must define test:gui-smoke");
+}
+if (rootScripts["test:kicad-gui-smoke"] !== "pnpm --dir packages/mcp-server run test:gui-smoke") {
+  throw new Error("package.json must define test:kicad-gui-smoke");
+}
+if (rootScripts["check:kicad-gui-smoke"] !== "node scripts/check-kicad-gui-smoke.mjs") {
+  throw new Error("package.json must define check:kicad-gui-smoke");
+}
+if (!rootScripts.check?.includes("pnpm run check:kicad-gui-smoke")) {
+  throw new Error("package.json check must run check:kicad-gui-smoke");
+}
+
+for (const phrase of [
+  "OASLANA-44",
+  ".github/workflows/kicad-gui-smoke.yml",
+  "corepack pnpm run check:kicad-gui-smoke",
+  "corepack pnpm run test:kicad-gui-smoke",
+  "KiCad IPC API",
+]) {
+  assertIncludes(strategy, phrase, "docs/testing-strategy.md");
+}

--- a/scripts/check-testing-strategy.mjs
+++ b/scripts/check-testing-strategy.mjs
@@ -40,6 +40,8 @@ const requiredPhrases = [
   "corepack pnpm run package:kicad-mcp-pro",
   "corepack pnpm run check:mcp-npm",
   "corepack pnpm run check:performance-budgets",
+  "corepack pnpm run check:kicad-gui-smoke",
+  "corepack pnpm run test:kicad-gui-smoke",
   "corepack pnpm run test:contract",
   "corepack pnpm run test:fixtures",
   "docs/performance-baselines.md",
@@ -52,6 +54,7 @@ const requiredPhrases = [
   "visual regression",
   "accessibility",
   "manual smoke",
+  ".github/workflows/kicad-gui-smoke.yml",
 ];
 
 const roadmapIssueIds = [
@@ -59,6 +62,7 @@ const roadmapIssueIds = [
   "OASLANA-36",
   "OASLANA-37",
   "OASLANA-43",
+  "OASLANA-44",
   "OASLANA-56",
   "OASLANA-57",
   "OASLANA-75",


### PR DESCRIPTION
## Summary

- Add scheduled/manual KiCad GUI smoke workflow for OASLANA-44 with Windows primary and Linux Xvfb lanes.
- Add skipped-by-default MCP pytest GUI smoke coverage for live PCB context, file-backed fallback diagnostics, multi-window editor launch, and project switch isolation.
- Add static repository gate wiring so GUI smoke coverage stays outside the PR path while remaining documented and checked.

Linear: OASLANA-44
Closes #45

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run format:check`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist`
- `corepack pnpm run check`
- `corepack pnpm run check:kicad-gui-smoke`
- `corepack pnpm run check:testing-strategy`
- `corepack pnpm run test:kicad-gui-smoke` (skipped locally unless `KICAD_MCP_ENABLE_GUI_SMOKE=1`)
- `corepack pnpm --dir packages/mcp-server run workflows:lint`
- `corepack pnpm --dir packages/mcp-server run workflows:security`
- `corepack pnpm audit --audit-level high`
- `uv sync --all-extras --frozen --project packages/mcp-server`
- `uv run --all-extras pytest` from `packages/mcp-server` (`679 passed, 2 skipped`)
- `uvx pre-commit run --all-files`
- `gitleaks detect --source . --redact --verbose`
- workflow deprecation scan for deprecated Actions commands/runtimes
- `git diff --check`

## Notes

- The new GUI workflow has no `pull_request` or `push` trigger.
- Windows primary installs pinned KiCad 10.0.3 for process-discovery coverage; Linux uses the existing KiCad 10 PPA policy under Xvfb/dbus.
- Failure artifacts include process logs, discovery/tool JSON, and screenshots when the runner can capture them.
