### PR TITLE
feat(kicad-studio): add MCP compatibility dashboard

### DIFF
--- a/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
@@ -3,7 +3,8 @@ import { COMMANDS, SETTINGS } from '../constants';
 import type {
   McpCapabilityCard,
   McpConnectionState,
-  McpInstallStatus
+  McpInstallStatus,
+  McpServerInfoContract
 } from '../types';
 import type { McpConnectionAdapter } from './mcpToolAdapter';
 import { readConfiguredMcpProfile } from '../commands/mcpProfilePicker';
@@ -16,6 +17,60 @@ type McpToolsNode = {
   contextValue?: string | undefined;
   command?: vscode.Command | undefined;
   children?: McpToolsNode[] | undefined;
+};
+
+type DashboardStatus =
+  | 'compatible'
+  | 'degraded'
+  | 'incompatible'
+  | 'disconnected';
+
+type CompatibilityDashboard = {
+  status: DashboardStatus;
+  stateLabel: string;
+  serverName: string;
+  serverVersion: string;
+  endpoint: string;
+  transportMode: string;
+  profile: string;
+  protocolVersion: string;
+  toolSchemaVersion: string;
+  compatibility: string;
+  kicadCli: string;
+  liveGui: string;
+  livePcb: string;
+  liveSchematic: string;
+  toolCount: number | undefined;
+  resourceCount: number | undefined;
+  promptCount: number | undefined;
+  missingRequiredTools: string[];
+  missingOptionalCapabilities: string[];
+  lastHealthCheck: string;
+  lastError: string;
+  remediation: string;
+  diagnostics: string[];
+};
+
+const REQUIRED_EXTENSION_TOOLS = [
+  'kicad_get_version',
+  'run_drc',
+  'run_erc',
+  'project_get_design_intent',
+  'export_bom',
+  'export_netlist'
+] as const;
+
+const CLI_EXPORT_LABELS: Record<
+  keyof McpServerInfoContract['capabilities']['cliExports'],
+  string
+> = {
+  ipc2581: 'IPC-2581 export',
+  odb: 'ODB++ export',
+  svg: 'SVG export',
+  dxf: 'DXF export',
+  step: 'STEP export',
+  render: 'render export',
+  spiceNetlist: 'SPICE netlist export'
 };
 
 export class McpToolsProvider implements vscode.TreeDataProvider<McpToolsNode> {
@@ -54,8 +109,8 @@ export class McpToolsProvider implements vscode.TreeDataProvider<McpToolsNode> {
   }
 
   getChildren(element?: McpToolsNode): McpToolsNode[] {
-    if (element?.children) {
-      return element.children;
+    if (element) {
+      return element.children ?? [];
     }
     return buildMcpToolNodes(
       this.mcpAdapter.getState(),
@@ -68,60 +123,242 @@ function buildMcpToolNodes(
   state: McpConnectionState,
   profile: string | undefined
 ): McpToolsNode[] {
+  const dashboard = buildCompatibilityDashboard(state, profile);
   const nodes: McpToolsNode[] = [
-    stateNode(state),
-    transportNode(state),
-    profileNode(profile),
-    installNode(state.install),
-    {
-      label: 'Open MCP Log',
-      description: 'request and response trace',
-      icon: 'output',
-      command: {
-        command: COMMANDS.openMcpLog,
-        title: 'Open MCP Log'
-      }
-    }
+    stateNode(state, dashboard),
+    compatibilityDashboardNode(dashboard),
+    actionGroupNode(),
+    installNode(state.install)
   ];
 
   if (state.server) {
-    nodes.splice(
-      3,
-      0,
-      serverNode(state),
-      capabilityNode(state.server.capabilities)
-    );
+    nodes.push(capabilityNode(state.server.capabilities));
   }
-  if (state.message) {
-    nodes.splice(1, 0, {
-      label: 'Last diagnostic',
-      description: state.message,
-      tooltip: state.message,
-      icon: 'info'
-    });
-  }
+
   return nodes;
 }
 
-function stateNode(state: McpConnectionState): McpToolsNode {
-  if (state.kind === 'Degraded') {
+function buildCompatibilityDashboard(
+  state: McpConnectionState,
+  profile: string | undefined
+): CompatibilityDashboard {
+  const server = state.server;
+  const capabilities = server?.capabilities;
+  const serverInfo = capabilities?.serverInfo;
+  const diagnostics = [
+    ...(capabilities?.diagnostics ?? []),
+    ...(serverInfo?.diagnostics ?? [])
+  ].filter((value, index, values) => values.indexOf(value) === index);
+  const endpoint =
+    serverInfo?.transport.endpoint ??
+    vscode.workspace
+      .getConfiguration()
+      .get<string>(SETTINGS.mcpEndpoint, 'http://127.0.0.1:27185');
+  const missingRequiredTools = server
+    ? REQUIRED_EXTENSION_TOOLS.filter(
+        (tool) => !server.capabilities.tools.includes(tool)
+      )
+    : [];
+  const missingOptionalCapabilities = serverInfo
+    ? missingOptionalCapabilitiesFor(state, serverInfo)
+    : missingOptionalCapabilitiesWithoutServerInfo(state, Boolean(server));
+  const status = dashboardStatus(
+    state,
+    missingRequiredTools,
+    missingOptionalCapabilities,
+    diagnostics
+  );
+
+  return {
+    status,
+    stateLabel: dashboardStateLabel(state, status),
+    serverName: serverInfo?.server ?? 'kicad-mcp-pro',
+    serverVersion: server?.version ?? serverInfo?.version ?? 'unknown',
+    endpoint,
+    transportMode: transportDescription(state, serverInfo),
+    profile: profile ?? 'default',
+    protocolVersion: serverInfo?.mcpProtocolVersion ?? 'unknown',
+    toolSchemaVersion: serverInfo?.toolSchemaVersion ?? 'unknown',
+    compatibility: compatibilityDescription(state, status),
+    kicadCli: kicadCliDescription(serverInfo),
+    liveGui: availability(serverInfo?.kicad.ipcAvailable),
+    livePcb: availability(serverInfo?.kicad.livePcbContext),
+    liveSchematic: availability(serverInfo?.kicad.liveSchematicContext),
+    toolCount: capabilities?.tools.length,
+    resourceCount: capabilities?.resources.length,
+    promptCount: capabilities?.prompts.length,
+    missingRequiredTools,
+    missingOptionalCapabilities,
+    lastHealthCheck: server?.capturedAt ?? 'never',
+    lastError: state.message ?? 'none',
+    remediation: remediationHint(state, status),
+    diagnostics
+  };
+}
+
+function dashboardStatus(
+  state: McpConnectionState,
+  missingRequiredTools: string[],
+  missingOptionalCapabilities: string[],
+  diagnostics: string[]
+): DashboardStatus {
+  if (state.kind === 'Incompatible') {
+    return 'incompatible';
+  }
+  if (
+    !state.connected &&
+    state.kind !== 'VsCodeStdio' &&
+    state.kind !== 'Degraded'
+  ) {
+    return 'disconnected';
+  }
+  if (
+    state.kind === 'Degraded' ||
+    state.server?.compat === 'warn' ||
+    missingRequiredTools.length > 0 ||
+    missingOptionalCapabilities.length > 0 ||
+    diagnostics.length > 0
+  ) {
+    return 'degraded';
+  }
+  return 'compatible';
+}
+
+function dashboardStateLabel(
+  state: McpConnectionState,
+  status: DashboardStatus
+): string {
+  if (state.kind === 'NotInstalled') {
+    return 'No MCP installed';
+  }
+  if (state.kind === 'Connecting') {
+    return 'Connecting';
+  }
+  if (state.kind === 'Incompatible') {
+    return 'Connected but incompatible';
+  }
+  if (state.kind === 'Degraded' || status === 'degraded') {
+    return state.connected || state.kind === 'VsCodeStdio'
+      ? 'Connected but degraded'
+      : 'Installed but degraded';
+  }
+  if (state.connected || state.kind === 'VsCodeStdio') {
+    return 'Connected and compatible';
+  }
+  if (isRemoteEndpointBlocked(state.message)) {
+    return 'Remote endpoint blocked by settings';
+  }
+  if (isTimeout(state.message)) {
+    return 'Timeout';
+  }
+  if (isAuthOrProtocolFailure(state.message)) {
+    return 'Auth/protocol failure';
+  }
+  return state.available ? 'Installed but not running' : 'Disconnected';
+}
+
+function compatibilityDescription(
+  state: McpConnectionState,
+  status: DashboardStatus
+): string {
+  if (status === 'compatible') {
+    return state.server?.compat ?? 'ok';
+  }
+  if (status === 'degraded') {
+    return state.server?.compat === 'warn' ? 'warn' : 'degraded';
+  }
+  if (status === 'incompatible') {
+    return 'incompatible';
+  }
+  return 'disconnected';
+}
+
+function compatibilityDashboardNode(
+  dashboard: CompatibilityDashboard
+): McpToolsNode {
+  return {
+    label: 'Compatibility dashboard',
+    description: dashboard.status,
+    tooltip: [
+      `State: ${dashboard.stateLabel}`,
+      `Server: ${dashboard.serverName} ${dashboard.serverVersion}`,
+      `Transport: ${dashboard.transportMode}`,
+      `Missing required tools: ${dashboard.missingRequiredTools.length}`,
+      `Missing optional capabilities: ${dashboard.missingOptionalCapabilities.length}`,
+      `Last health check: ${dashboard.lastHealthCheck}`,
+      `Remediation: ${dashboard.remediation}`
+    ].join('\n'),
+    icon: dashboardIcon(dashboard.status),
+    children: [
+      dashboardField(
+        'Compatibility state',
+        dashboard.stateLabel,
+        dashboard.status,
+        dashboardIcon(dashboard.status)
+      ),
+      dashboardGroup('Server contract', [
+        dashboardField('Server', dashboard.serverName, dashboard.serverVersion),
+        dashboardField('Endpoint', dashboard.endpoint),
+        dashboardField('Transport mode', dashboard.transportMode),
+        dashboardField('Profile', dashboard.profile),
+        dashboardField('Protocol version', dashboard.protocolVersion),
+        dashboardField('Tool schema version', dashboard.toolSchemaVersion),
+        dashboardField('Compatibility', dashboard.compatibility)
+      ]),
+      dashboardGroup('KiCad runtime', [
+        dashboardField('KiCad CLI', dashboard.kicadCli),
+        dashboardField('Live GUI availability', dashboard.liveGui),
+        dashboardField('Live PCB context', dashboard.livePcb),
+        dashboardField('Live schematic context', dashboard.liveSchematic)
+      ]),
+      dashboardGroup('Advertised surface', [
+        dashboardField('Advertised tools', countText(dashboard.toolCount)),
+        dashboardField('Advertised resources', countText(dashboard.resourceCount)),
+        dashboardField('Advertised prompts', countText(dashboard.promptCount)),
+        missingGroup(
+          'Missing required tools',
+          dashboard.missingRequiredTools,
+          'All required extension tools are advertised.'
+        ),
+        missingGroup(
+          'Missing optional capabilities',
+          dashboard.missingOptionalCapabilities,
+          'All optional capabilities are available.'
+        )
+      ]),
+      dashboardGroup('Health and remediation', [
+        dashboardField('Last health check', dashboard.lastHealthCheck),
+        dashboardField('Last error', dashboard.lastError),
+        dashboardField('Remediation hint', dashboard.remediation),
+        diagnosticsGroup(dashboard.diagnostics)
+      ])
+    ]
+  };
+}
+
+function stateNode(
+  state: McpConnectionState,
+  dashboard: CompatibilityDashboard
+): McpToolsNode {
+  if (dashboard.status === 'degraded') {
     return {
-      label: 'MCP degraded',
-      description: state.server?.version ?? 'protocol contract failed',
-      tooltip:
-        state.message ??
-        'The MCP endpoint initialized but failed the Streamable HTTP contract check.',
+      label:
+        state.connected || state.kind === 'VsCodeStdio'
+          ? 'MCP connected with degraded capabilities'
+          : 'MCP degraded',
+      description: dashboard.serverVersion,
+      tooltip: dashboard.remediation,
       icon: 'warning',
       command: {
         command: COMMANDS.retryMcp,
-        title: 'Retry MCP Connection'
+        title: 'Refresh MCP Capabilities'
       }
     };
   }
   if (state.kind === 'Incompatible') {
     return {
       label: 'MCP incompatible',
-      description: state.server?.version ?? 'unknown server',
+      description: dashboard.serverVersion,
       tooltip:
         'The detected kicad-mcp-pro version is outside the extension compatibility range.',
       icon: 'warning',
@@ -154,8 +391,9 @@ function stateNode(state: McpConnectionState): McpToolsNode {
     };
   }
   return {
-    label: 'MCP disconnected',
+    label: dashboard.stateLabel,
     description: state.available ? 'detected, not connected' : 'not detected',
+    tooltip: dashboard.lastError === 'none' ? dashboard.remediation : dashboard.lastError,
     icon: state.available ? 'warning' : 'circle-slash',
     command: {
       command: state.available
@@ -166,46 +404,123 @@ function stateNode(state: McpConnectionState): McpToolsNode {
   };
 }
 
-function transportNode(state: McpConnectionState): McpToolsNode {
-  const endpoint = vscode.workspace
-    .getConfiguration()
-    .get<string>(SETTINGS.mcpEndpoint, 'http://127.0.0.1:27185');
-  const isStdio = state.kind === 'VsCodeStdio';
+function actionGroupNode(): McpToolsNode {
   return {
-    label: 'Transport',
-    description: isStdio ? 'VS Code stdio' : endpoint,
-    tooltip: isStdio
-      ? 'Configured by .vscode/mcp.json and managed by VS Code.'
-      : `HTTP endpoint: ${endpoint}`,
-    icon: isStdio ? 'terminal' : 'server',
+    label: 'Actions',
+    description: 'MCP operations',
+    tooltip: 'Run common MCP setup, recovery, diagnostics, and profile actions.',
+    icon: 'tools',
+    children: [
+      actionNode('Reconnect', COMMANDS.retryMcp, 'Reconnect MCP endpoint', 'sync'),
+      actionNode(
+        'Refresh capabilities',
+        COMMANDS.retryMcp,
+        'Refresh server-info and advertised tools',
+        'refresh'
+      ),
+      actionNode('Open MCP log', COMMANDS.openMcpLog, 'Open MCP log', 'output'),
+      actionNode(
+        'Save diagnostic bundle',
+        COMMANDS.saveMcpLog,
+        'Save MCP diagnostic bundle',
+        'save'
+      ),
+      actionNode(
+        'Pick profile',
+        COMMANDS.pickMcpProfile,
+        'Pick MCP profile',
+        'settings'
+      ),
+      actionNode(
+        'Switch endpoint',
+        COMMANDS.setupMcpIntegration,
+        'Switch MCP endpoint or transport',
+        'plug'
+      ),
+      actionNode(
+        'Launch local MCP server',
+        COMMANDS.launchMcpHttp,
+        'Launch local kicad-mcp-pro HTTP server',
+        'server-process'
+      ),
+      actionNode(
+        'Open compatibility docs',
+        COMMANDS.openMcpUpgradeGuide,
+        'Open MCP compatibility documentation',
+        'book'
+      )
+    ]
+  };
+}
+
+function actionNode(
+  label: string,
+  command: string,
+  title: string,
+  icon: string
+): McpToolsNode {
+  return {
+    label,
+    tooltip: title,
+    icon,
     command: {
-      command: isStdio ? COMMANDS.launchMcpHttp : COMMANDS.setupMcpIntegration,
-      title: isStdio ? 'Switch to HTTP Mode' : 'Setup MCP Integration'
+      command,
+      title
     }
   };
 }
 
-function profileNode(profile: string | undefined): McpToolsNode {
+function dashboardGroup(label: string, children: McpToolsNode[]): McpToolsNode {
   return {
-    label: 'Profile',
-    description: profile ?? 'default',
-    tooltip: 'Pick the kicad-mcp-pro tool profile for this workspace.',
-    icon: 'settings',
-    command: {
-      command: COMMANDS.pickMcpProfile,
-      title: 'Pick MCP Profile'
-    }
+    label,
+    description: `${children.length}`,
+    tooltip: label,
+    icon: 'list-tree',
+    children
   };
 }
 
-function serverNode(state: McpConnectionState): McpToolsNode {
+function dashboardField(
+  label: string,
+  description: string,
+  tooltip = description,
+  icon = 'info'
+): McpToolsNode {
   return {
-    label: 'Server version',
-    description: `${state.server?.version ?? 'unknown'} (${state.server?.compat ?? 'unknown'})`,
-    tooltip: state.server?.capturedAt
-      ? `Captured at ${state.server.capturedAt}`
-      : 'Server metadata has not been captured yet.',
-    icon: state.server?.compat === 'incompatible' ? 'warning' : 'verified'
+    label,
+    description,
+    tooltip,
+    icon
+  };
+}
+
+function missingGroup(
+  label: string,
+  values: string[],
+  emptyTooltip: string
+): McpToolsNode {
+  return {
+    label,
+    description: values.length ? `${values.length}` : 'none',
+    tooltip: values.length ? values.join('\n') : emptyTooltip,
+    icon: values.length ? 'warning' : 'pass',
+    children: values.map((value) => ({
+      label: value,
+      icon: 'warning'
+    }))
+  };
+}
+
+function diagnosticsGroup(values: string[]): McpToolsNode {
+  return {
+    label: 'Capability diagnostics',
+    description: values.length ? `${values.length}` : 'none',
+    tooltip: values.length ? values.join('\n') : 'No capability diagnostics.',
+    icon: values.length ? 'warning' : 'pass',
+    children: values.map((value) => ({
+      label: value,
+      icon: 'warning'
+    }))
   };
 }
 
@@ -218,15 +533,15 @@ function capabilityNode(capabilities: McpCapabilityCard): McpToolsNode {
   }`;
   const details = capabilities.serverInfo
     ? [
-        capabilityDiagnosticsGroup(diagnostics),
+        diagnosticsGroup(diagnostics),
         kicadRuntimeNode(capabilities.serverInfo),
         operationModesNode(capabilities.serverInfo)
       ]
     : diagnostics.length
-      ? [capabilityDiagnosticsGroup(diagnostics)]
+      ? [diagnosticsGroup(diagnostics)]
       : [];
   return {
-    label: 'Capabilities',
+    label: 'Raw advertised capabilities',
     description,
     tooltip: diagnostics.length
       ? diagnostics.join('\n')
@@ -238,19 +553,6 @@ function capabilityNode(capabilities: McpCapabilityCard): McpToolsNode {
       capabilityGroup('Resources', capabilities.resources),
       capabilityGroup('Prompts', capabilities.prompts)
     ]
-  };
-}
-
-function capabilityDiagnosticsGroup(values: string[]): McpToolsNode {
-  return {
-    label: 'Capability diagnostics',
-    description: values.length ? `${values.length}` : 'none',
-    tooltip: values.length ? values.join('\n') : 'No capability diagnostics.',
-    icon: values.length ? 'warning' : 'pass',
-    children: values.map((value) => ({
-      label: value,
-      icon: 'warning'
-    }))
   };
 }
 
@@ -358,4 +660,166 @@ function installNode(install: McpInstallStatus | undefined): McpToolsNode {
     tooltip: `Detected from ${install.source ?? 'unknown source'}.`,
     icon: 'check'
   };
+}
+
+function missingOptionalCapabilitiesFor(
+  state: McpConnectionState,
+  serverInfo: McpServerInfoContract
+): string[] {
+  const missing: string[] = [];
+  if (state.kind === 'VsCodeStdio') {
+    missing.push('HTTP-only Quality Gates and Fix Queue');
+  }
+  if (!serverInfo.transport.streamableHttp) {
+    missing.push('Streamable HTTP transport');
+  }
+  if (!serverInfo.transport.statelessHttp) {
+    missing.push('stateless Streamable HTTP transport');
+  }
+  if (serverInfo.transport.legacySse) {
+    missing.push('legacy SSE disabled by default');
+  }
+  if (!serverInfo.kicad.ipcAvailable) {
+    missing.push('live GUI IPC');
+  }
+  if (!serverInfo.kicad.livePcbContext) {
+    missing.push('live PCB context');
+  }
+  if (!serverInfo.kicad.liveSchematicContext) {
+    missing.push('live schematic context');
+  }
+  if (!serverInfo.capabilities.chatgptConnectorCompatible) {
+    missing.push('ChatGPT connector compatibility');
+  }
+  const unavailableEditingTools = Object.entries(
+    serverInfo.capabilities.liveEditingTools
+  )
+    .filter(([, value]) => !value.available)
+    .map(([name]) => name);
+  if (unavailableEditingTools.length > 0) {
+    missing.push(`${unavailableEditingTools.length} live editing tools`);
+  }
+  for (const [key, label] of Object.entries(CLI_EXPORT_LABELS) as Array<
+    [keyof McpServerInfoContract['capabilities']['cliExports'], string]
+  >) {
+    if (!serverInfo.capabilities.cliExports[key]) {
+      missing.push(label);
+    }
+  }
+  return missing;
+}
+
+function missingOptionalCapabilitiesWithoutServerInfo(
+  state: McpConnectionState,
+  hasServerCard: boolean
+): string[] {
+  const missing: string[] = [];
+  if (hasServerCard) {
+    missing.push('server-info capability contract');
+  }
+  if (state.kind === 'VsCodeStdio') {
+    missing.push(
+      'HTTP-only Quality Gates and Fix Queue',
+      'stateless Streamable HTTP transport',
+      'ChatGPT connector compatibility'
+    );
+  }
+  return missing;
+}
+
+function remediationHint(
+  state: McpConnectionState,
+  status: DashboardStatus
+): string {
+  if (state.kind === 'NotInstalled') {
+    return 'Install kicad-mcp-pro, then rerun setup.';
+  }
+  if (isRemoteEndpointBlocked(state.message)) {
+    return `Use a loopback endpoint or enable ${SETTINGS.mcpAllowRemoteEndpoint} intentionally.`;
+  }
+  if (isTimeout(state.message)) {
+    return 'Retry the health check or increase the MCP timeout setting.';
+  }
+  if (isAuthOrProtocolFailure(state.message)) {
+    return 'Check endpoint authentication, protocol version, and Streamable HTTP headers.';
+  }
+  if (status === 'incompatible') {
+    return 'Install a kicad-mcp-pro version inside the supported compatibility range.';
+  }
+  if (status === 'degraded') {
+    return 'Refresh capabilities, launch the local HTTP server, or open KiCad with the target project.';
+  }
+  if (status === 'disconnected') {
+    return state.available
+      ? 'Reconnect to the detected MCP server.'
+      : 'Set up or launch kicad-mcp-pro.';
+  }
+  return 'No action required.';
+}
+
+function transportDescription(
+  state: McpConnectionState,
+  serverInfo: McpServerInfoContract | undefined
+): string {
+  if (state.kind === 'VsCodeStdio') {
+    return 'VS Code stdio';
+  }
+  if (!serverInfo) {
+    return 'HTTP endpoint not verified';
+  }
+  const statefulness = serverInfo.transport.statelessHttp
+    ? 'stateless'
+    : 'stateful';
+  const legacy = serverInfo.transport.legacySse ? ', legacy SSE enabled' : '';
+  return `${serverInfo.transport.type}, ${statefulness}${legacy}`;
+}
+
+function kicadCliDescription(
+  serverInfo: McpServerInfoContract | undefined
+): string {
+  if (!serverInfo) {
+    return 'unknown';
+  }
+  if (!serverInfo.kicad.cliFound) {
+    return 'not found';
+  }
+  return serverInfo.kicad.cliVersion
+    ? `${serverInfo.kicad.cliVersion} (${serverInfo.kicad.cliPath})`
+    : serverInfo.kicad.cliPath;
+}
+
+function availability(value: boolean | undefined): string {
+  if (value === undefined) {
+    return 'unknown';
+  }
+  return value ? 'available' : 'unavailable';
+}
+
+function countText(value: number | undefined): string {
+  return value === undefined ? 'not checked' : `${value}`;
+}
+
+function dashboardIcon(status: DashboardStatus): string {
+  if (status === 'compatible') {
+    return 'pass';
+  }
+  if (status === 'degraded') {
+    return 'warning';
+  }
+  if (status === 'incompatible') {
+    return 'error';
+  }
+  return 'circle-slash';
+}
+
+function isRemoteEndpointBlocked(message: string | undefined): boolean {
+  return /Refusing remote MCP endpoint/iu.test(message ?? '');
+}
+
+function isTimeout(message: string | undefined): boolean {
+  return /timed out|timeout|AbortError/iu.test(message ?? '');
+}
+
+function isAuthOrProtocolFailure(message: string | undefined): boolean {
+  return /auth|401|403|protocol|header|version/iu.test(message ?? '');
 }

--- a/apps/vscode-extension/test/integration/canaryCompatibility.test.ts
+++ b/apps/vscode-extension/test/integration/canaryCompatibility.test.ts
@@ -40,7 +40,13 @@ suite('VS Code Canary Compatibility', () => {
       'kicadstudio.openPCB',
       'kicadstudio.runDRC',
       'kicadstudio.runERC',
-      'kicadstudio.mcp.retry'
+      'kicadstudio.setupMcpIntegration',
+      'kicadstudio.mcp.retry',
+      'kicadstudio.mcp.launchHttp',
+      'kicadstudio.mcp.openUpgradeGuide',
+      'kicadstudio.mcp.pickProfile',
+      'kicadstudio.mcp.openLog',
+      'kicadstudio.mcp.saveLog'
     ]) {
       assert.ok(commands.includes(command), `Missing command ${command}`);
     }

--- a/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
@@ -1,9 +1,15 @@
 import { McpToolsProvider } from '../../src/mcp/mcpToolsProvider';
+import type {
+  McpConnectionState,
+  McpServerInfoContract
+} from '../../src/types';
 import { __setConfiguration } from './vscodeMock';
 
 jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
   virtual: true
 });
+
+type ProviderNode = ReturnType<McpToolsProvider['getChildren']>[number];
 
 describe('McpToolsProvider', () => {
   beforeEach(() => {
@@ -14,228 +20,447 @@ describe('McpToolsProvider', () => {
     });
   });
 
-  it('shows transport, server metadata, capability counts, and install source', () => {
-    const provider = new McpToolsProvider({
-      getState: () => ({
-        kind: 'Connected',
+  it('renders a compatibility dashboard with required fields, actions, and raw capabilities', () => {
+    const provider = providerForState(
+      connectedState({
+        tools: ['pcb_validate', 'sch_validate']
+      })
+    );
+
+    const children = provider.getChildren();
+
+    expect(children.map((item) => item.label)).toEqual([
+      'MCP connected with degraded capabilities',
+      'Compatibility dashboard',
+      'Actions',
+      'Install',
+      'Raw advertised capabilities'
+    ]);
+    expect(treeDescription(provider, children, 'Compatibility dashboard')).toBe(
+      'degraded'
+    );
+
+    const dashboard = child(children, 'Compatibility dashboard');
+    expect(labels(provider.getChildren(dashboard))).toEqual([
+      'Compatibility state',
+      'Server contract',
+      'KiCad runtime',
+      'Advertised surface',
+      'Health and remediation'
+    ]);
+    expect(
+      labels(provider.getChildren(child(provider.getChildren(dashboard), 'Server contract')))
+    ).toEqual([
+      'Server',
+      'Endpoint',
+      'Transport mode',
+      'Profile',
+      'Protocol version',
+      'Tool schema version',
+      'Compatibility'
+    ]);
+
+    const advertisedSurface = child(
+      provider.getChildren(dashboard),
+      'Advertised surface'
+    );
+    expect(
+      treeDescription(
+        provider,
+        provider.getChildren(advertisedSurface),
+        'Missing required tools'
+      )
+    ).toBe('6');
+    expect(
+      treeDescription(
+        provider,
+        provider.getChildren(advertisedSurface),
+        'Missing optional capabilities'
+      )
+    ).toBe('none');
+
+    expect(labels(provider.getChildren(child(children, 'Actions')))).toEqual([
+      'Reconnect',
+      'Refresh capabilities',
+      'Open MCP log',
+      'Save diagnostic bundle',
+      'Pick profile',
+      'Switch endpoint',
+      'Launch local MCP server',
+      'Open compatibility docs'
+    ]);
+    expect(treeDescription(provider, children, 'Raw advertised capabilities')).toBe(
+      '2 tools, 1 resources, 1 prompts'
+    );
+  });
+
+  it('does not report connected-only status when live PCB context is unavailable', () => {
+    const provider = providerForState(
+      connectedState({
+        tools: [
+          'kicad_get_version',
+          'run_drc',
+          'run_erc',
+          'project_get_design_intent',
+          'export_bom',
+          'export_netlist'
+        ],
+        serverInfo: serverInfoFixture({
+          kicad: {
+            livePcbContext: false,
+            liveSchematicContext: true,
+            ipcAvailable: true
+          },
+          capabilities: {
+            chatgptConnectorCompatible: true
+          }
+        }),
+        diagnostics: ['Live KiCad PCB context is unavailable: No PCB is open.']
+      })
+    );
+
+    const children = provider.getChildren();
+    const dashboard = child(children, 'Compatibility dashboard');
+    const runtime = child(provider.getChildren(dashboard), 'KiCad runtime');
+
+    expect(child(children, 'MCP connected with degraded capabilities')).toBeDefined();
+    expect(treeDescription(provider, provider.getChildren(dashboard), 'Compatibility state')).toBe(
+      'Connected but degraded'
+    );
+    expect(treeDescription(provider, provider.getChildren(runtime), 'Live PCB context')).toBe(
+      'unavailable'
+    );
+
+    const stdioProvider = providerForState({
+      kind: 'VsCodeStdio',
+      available: true,
+      connected: true,
+      install: {
+        found: true,
+        command: 'uvx',
+        source: 'uvx',
+        version: '1.0.0'
+      }
+    });
+    const stdioChildren = stdioProvider.getChildren();
+    const stdioDashboard = child(stdioChildren, 'Compatibility dashboard');
+    const stdioSurface = child(
+      stdioProvider.getChildren(stdioDashboard),
+      'Advertised surface'
+    );
+
+    expect(
+      child(stdioChildren, 'MCP connected with degraded capabilities')
+    ).toBeDefined();
+    expect(
+      treeDescription(
+        stdioProvider,
+        stdioProvider.getChildren(stdioDashboard),
+        'Compatibility state'
+      )
+    ).toBe('Connected but degraded');
+    expect(
+      treeDescription(
+        stdioProvider,
+        stdioProvider.getChildren(stdioSurface),
+        'Missing optional capabilities'
+      )
+    ).toBe('3');
+  });
+
+  it('renders disconnected, remote-blocked, timeout, and protocol failure dashboard states', () => {
+    expect(
+      stateLabelFor({
+        kind: 'Disconnected',
         available: true,
-        connected: true,
-        install: {
-          found: true,
-          command: 'uvx',
-          source: 'uvx',
-          version: '1.0.0'
-        },
+        connected: false
+      })
+    ).toBe('Installed but not running');
+    expect(
+      stateLabelFor({
+        kind: 'Disconnected',
+        available: true,
+        connected: false,
+        message:
+          'Refusing remote MCP endpoint https://example.com. Use a loopback endpoint.'
+      })
+    ).toBe('Remote endpoint blocked by settings');
+    expect(
+      stateLabelFor({
+        kind: 'Disconnected',
+        available: true,
+        connected: false,
+        message: 'MCP request timed out after 15000ms.'
+      })
+    ).toBe('Timeout');
+    expect(
+      stateLabelFor({
+        kind: 'Degraded',
+        available: true,
+        connected: false,
+        message: 'MCP protocol contract failed: unsupported protocol version'
+      })
+    ).toBe('Installed but degraded');
+    expect(
+      stateLabelFor({
+        kind: 'Disconnected',
+        available: false,
+        connected: false,
+        message: 'Using cached MCP server metadata while reconnecting.',
         server: {
           version: '1.0.0',
           compat: 'ok',
           capturedAt: '2026-05-20T12:00:00.000Z',
           capabilities: {
-            tools: ['pcb_validate', 'sch_validate'],
+            tools: [
+              'kicad_get_version',
+              'run_drc',
+              'run_erc',
+              'project_get_design_intent',
+              'export_bom',
+              'export_netlist'
+            ],
             resources: ['project://active'],
             prompts: ['manufacturing-review'],
-            serverInfo: {
-              schemaVersion: '1.1.0',
-              server: 'kicad-mcp-pro',
-              version: '1.0.0',
-              mcpProtocolVersion: '2025-11-25',
-              toolSchemaVersion: '1.0.0',
-              compatibilityRange: {
-                kicadStudio: {
-                  required: '>=1.0.0 <2.0.0',
-                  recommended: '>=1.0.0 <2.0.0',
-                  testedAgainst: '1.0.0'
-                },
-                kicadMcpPro: {
-                  required: '>=1.0.0 <2.0.0',
-                  testedAgainst: '1.0.0'
-                }
-              },
-              transport: {
-                type: 'streamable-http',
-                streamableHttp: true,
-                statelessHttp: true,
-                legacySse: false,
-                authRequired: false,
-                endpoint: 'http://127.0.0.1:27185/mcp'
-              },
-              kicad: {
-                cliFound: true,
-                cliPath: '/usr/bin/kicad-cli',
-                cliVersion: 'KiCad 10.0.3',
-                ipcAvailable: false,
-                ipcVersion: null,
-                ipcApiVersion: null,
-                ipcMajorVersion: null,
-                ipcEndpointSource: 'default',
-                livePcbContext: false,
-                liveSchematicContext: false
-              },
-              capabilities: {
-                fileBackedDrc: true,
-                fileBackedErc: true,
-                fileBackedExports: true,
-                livePcbRead: false,
-                livePcbWrite: false,
-                liveSchematicRead: false,
-                liveSchematicWrite: false,
-                liveEditingTools: {
-                  pcb_place_component: {
-                    available: false,
-                    backend: 'kicad-ipc',
-                    reason: 'KiCad IPC is unavailable.',
-                    minimumKiCadMajor: 9
-                  },
-                  pcb_route_trace: {
-                    available: false,
-                    backend: 'kicad-ipc',
-                    reason: 'KiCad IPC is unavailable.',
-                    minimumKiCadMajor: 9
-                  },
-                  pcb_add_zone: {
-                    available: false,
-                    backend: 'kicad-ipc',
-                    reason: 'KiCad IPC is unavailable.',
-                    minimumKiCadMajor: 9
-                  },
-                  pcb_set_design_rules: {
-                    available: false,
-                    backend: 'hybrid-file-ipc',
-                    reason: 'KiCad IPC is unavailable.',
-                    minimumKiCadMajor: 9
-                  },
-                  pcb_move_component: {
-                    available: false,
-                    backend: 'kicad-ipc',
-                    reason: 'KiCad IPC is unavailable.',
-                    minimumKiCadMajor: 9
-                  },
-                  pcb_delete_object: {
-                    available: false,
-                    backend: 'kicad-ipc',
-                    reason: 'KiCad IPC is unavailable.',
-                    minimumKiCadMajor: 9
-                  },
-                  sch_add_component: {
-                    available: false,
-                    backend: 'hybrid-file-ipc',
-                    reason: 'KiCad IPC is unavailable.',
-                    minimumKiCadMajor: 10
-                  },
-                  sch_add_wire: {
-                    available: false,
-                    backend: 'hybrid-file-ipc',
-                    reason: 'KiCad IPC is unavailable.',
-                    minimumKiCadMajor: 10
-                  },
-                  sch_modify_property: {
-                    available: false,
-                    backend: 'hybrid-file-ipc',
-                    reason: 'KiCad IPC is unavailable.',
-                    minimumKiCadMajor: 10
-                  }
-                },
-                chatgptConnectorCompatible: false,
-                cliExports: {
-                  ipc2581: false,
-                  odb: false,
-                  svg: false,
-                  dxf: false,
-                  step: false,
-                  render: false,
-                  spiceNetlist: false
-                }
-              },
-              diagnostics: [
-                'Live KiCad PCB context is unavailable: No PCB is open.'
-              ]
-            },
-            diagnostics: [
-              'Live KiCad PCB context is unavailable: No PCB is open.'
-            ]
+            serverInfo: serverInfoFixture({
+              transport: { statelessHttp: false }
+            })
           }
         }
       })
-    } as never);
-
-    const children = provider.getChildren();
-
-    expect(children.map((item) => item.label)).toEqual(
-      expect.arrayContaining([
-        'MCP connected',
-        'Transport',
-        'Profile',
-        'Server version',
-        'Capabilities',
-        'Install',
-        'Open MCP Log'
-      ])
-    );
-    expect(
-      provider.getTreeItem(
-        children.find((item) => item.label === 'Capabilities') as never
-      ).description
-    ).toBe('2 tools, 1 resources, 1 prompts, 1 diagnostic');
-    expect(
-      provider
-        .getChildren(
-          children.find((item) => item.label === 'Capabilities') as never
-        )
-        .map((item) => item.label)
-    ).toEqual(
-      expect.arrayContaining([
-        'Capability diagnostics',
-        'KiCad runtime',
-        'Operation modes'
-      ])
-    );
+    ).toBe('Disconnected');
   });
 
-  it('renders disconnected state as an actionable retry row', () => {
-    const provider = new McpToolsProvider({
-      getState: () => ({
-        kind: 'Disconnected',
-        available: true,
-        connected: false,
-        message: 'HTTP 503'
+  it('keeps the dashboard tree visual model stable', () => {
+    const provider = providerForState(
+      connectedState({
+        tools: ['kicad_get_version', 'run_drc', 'run_erc'],
+        serverInfo: serverInfoFixture({
+          transport: { statelessHttp: false },
+          capabilities: {
+            chatgptConnectorCompatible: false
+          }
+        })
       })
-    } as never);
-
-    const state = childrenByLabel(provider, 'MCP disconnected');
-    const diagnostic = childrenByLabel(provider, 'Last diagnostic');
-
-    expect(provider.getTreeItem(state as never).command).toEqual(
-      expect.objectContaining({ command: 'kicadstudio.mcp.retry' })
     );
-    expect(provider.getTreeItem(diagnostic as never).description).toBe(
-      'HTTP 503'
-    );
-  });
 
-  it('renders degraded state as an actionable protocol warning row', () => {
-    const provider = new McpToolsProvider({
-      getState: () => ({
-        kind: 'Degraded',
-        available: true,
-        connected: false,
-        message: 'MCP protocol contract failed: HTTP 421'
-      })
-    } as never);
-
-    const state = childrenByLabel(provider, 'MCP degraded');
-    const diagnostic = childrenByLabel(provider, 'Last diagnostic');
-
-    expect(provider.getTreeItem(state as never).command).toEqual(
-      expect.objectContaining({ command: 'kicadstudio.mcp.retry' })
-    );
-    expect(provider.getTreeItem(diagnostic as never).description).toBe(
-      'MCP protocol contract failed: HTTP 421'
-    );
+    expect(flattenTree(provider)).toMatchInlineSnapshot(`
+      [
+        "MCP connected with degraded capabilities :: 1.0.0",
+        "Compatibility dashboard :: degraded",
+        "Compatibility dashboard > Compatibility state :: Connected but degraded",
+        "Compatibility dashboard > Server contract :: 7",
+        "Compatibility dashboard > Server contract > Server :: kicad-mcp-pro",
+        "Compatibility dashboard > Server contract > Endpoint :: http://127.0.0.1:27185/mcp",
+        "Compatibility dashboard > Server contract > Transport mode :: streamable-http, stateful",
+        "Compatibility dashboard > Server contract > Profile :: full",
+        "Compatibility dashboard > Server contract > Protocol version :: 2025-11-25",
+        "Compatibility dashboard > Server contract > Tool schema version :: 1.0.0",
+        "Compatibility dashboard > Server contract > Compatibility :: degraded",
+        "Compatibility dashboard > KiCad runtime :: 4",
+        "Compatibility dashboard > KiCad runtime > KiCad CLI :: KiCad 10.0.3 (/usr/bin/kicad-cli)",
+        "Compatibility dashboard > KiCad runtime > Live GUI availability :: available",
+        "Compatibility dashboard > KiCad runtime > Live PCB context :: available",
+        "Compatibility dashboard > KiCad runtime > Live schematic context :: available",
+        "Compatibility dashboard > Advertised surface :: 5",
+        "Compatibility dashboard > Advertised surface > Advertised tools :: 3",
+        "Compatibility dashboard > Advertised surface > Advertised resources :: 1",
+        "Compatibility dashboard > Advertised surface > Advertised prompts :: 1",
+        "Compatibility dashboard > Advertised surface > Missing required tools :: 3",
+        "Compatibility dashboard > Advertised surface > Missing required tools > project_get_design_intent ::",
+        "Compatibility dashboard > Advertised surface > Missing required tools > export_bom ::",
+        "Compatibility dashboard > Advertised surface > Missing required tools > export_netlist ::",
+        "Compatibility dashboard > Advertised surface > Missing optional capabilities :: 2",
+        "Compatibility dashboard > Advertised surface > Missing optional capabilities > stateless Streamable HTTP transport ::",
+        "Compatibility dashboard > Advertised surface > Missing optional capabilities > ChatGPT connector compatibility ::",
+        "Compatibility dashboard > Health and remediation :: 4",
+        "Compatibility dashboard > Health and remediation > Last health check :: 2026-05-20T12:00:00.000Z",
+        "Compatibility dashboard > Health and remediation > Last error :: none",
+        "Compatibility dashboard > Health and remediation > Remediation hint :: Refresh capabilities, launch the local HTTP server, or open KiCad with the target project.",
+        "Compatibility dashboard > Health and remediation > Capability diagnostics :: none",
+        "Actions :: MCP operations",
+        "Actions > Reconnect ::",
+        "Actions > Refresh capabilities ::",
+        "Actions > Open MCP log ::",
+        "Actions > Save diagnostic bundle ::",
+        "Actions > Pick profile ::",
+        "Actions > Switch endpoint ::",
+        "Actions > Launch local MCP server ::",
+        "Actions > Open compatibility docs ::",
+        "Install :: uvx 1.0.0",
+        "Raw advertised capabilities :: 3 tools, 1 resources, 1 prompts",
+        "Raw advertised capabilities > Capability diagnostics :: none",
+        "Raw advertised capabilities > KiCad runtime :: live PCB",
+        "Raw advertised capabilities > Operation modes :: 7/8 available",
+        "Raw advertised capabilities > Operation modes > File-backed DRC :: available",
+        "Raw advertised capabilities > Operation modes > File-backed ERC :: available",
+        "Raw advertised capabilities > Operation modes > File-backed exports :: available",
+        "Raw advertised capabilities > Operation modes > Live PCB read :: available",
+        "Raw advertised capabilities > Operation modes > Live PCB write :: available",
+        "Raw advertised capabilities > Operation modes > Live schematic read :: available",
+        "Raw advertised capabilities > Operation modes > Live schematic write :: available",
+        "Raw advertised capabilities > Operation modes > ChatGPT connector :: unavailable",
+        "Raw advertised capabilities > Tools :: 3",
+        "Raw advertised capabilities > Tools > kicad_get_version ::",
+        "Raw advertised capabilities > Tools > run_drc ::",
+        "Raw advertised capabilities > Tools > run_erc ::",
+        "Raw advertised capabilities > Resources :: 1",
+        "Raw advertised capabilities > Resources > project://active ::",
+        "Raw advertised capabilities > Prompts :: 1",
+        "Raw advertised capabilities > Prompts > manufacturing-review ::",
+      ]
+    `);
   });
 });
 
-function childrenByLabel(provider: McpToolsProvider, label: string) {
-  const node = provider.getChildren().find((item) => item.label === label);
+function providerForState(state: McpConnectionState): McpToolsProvider {
+  return new McpToolsProvider({ getState: () => state } as never);
+}
+
+function connectedState(options: {
+  tools: string[];
+  serverInfo?: McpServerInfoContract;
+  diagnostics?: string[];
+}): McpConnectionState {
+  return {
+    kind: 'Connected',
+    available: true,
+    connected: true,
+    install: {
+      found: true,
+      command: 'uvx',
+      source: 'uvx',
+      version: '1.0.0'
+    },
+    server: {
+      version: '1.0.0',
+      compat: options.diagnostics?.length ? 'warn' : 'ok',
+      capturedAt: '2026-05-20T12:00:00.000Z',
+      capabilities: {
+        tools: options.tools,
+        resources: ['project://active'],
+        prompts: ['manufacturing-review'],
+        serverInfo: options.serverInfo ?? serverInfoFixture({}),
+        diagnostics: options.diagnostics
+      }
+    }
+  };
+}
+
+function serverInfoFixture(
+  overrides: {
+    transport?: Partial<McpServerInfoContract['transport']>;
+    kicad?: Partial<McpServerInfoContract['kicad']>;
+    capabilities?: Partial<McpServerInfoContract['capabilities']>;
+  } = {}
+): McpServerInfoContract {
+  const base: McpServerInfoContract = {
+    schemaVersion: '1.1.0',
+    server: 'kicad-mcp-pro',
+    version: '1.0.0',
+    mcpProtocolVersion: '2025-11-25',
+    toolSchemaVersion: '1.0.0',
+    compatibilityRange: {
+      kicadStudio: {
+        required: '>=1.0.0 <2.0.0',
+        recommended: '>=1.0.0 <2.0.0',
+        testedAgainst: '1.0.0'
+      },
+      kicadMcpPro: {
+        required: '>=1.0.0 <2.0.0',
+        testedAgainst: '1.0.0'
+      }
+    },
+    transport: {
+      type: 'streamable-http',
+      streamableHttp: true,
+      statelessHttp: true,
+      legacySse: false,
+      authRequired: false,
+      endpoint: 'http://127.0.0.1:27185/mcp',
+      ...overrides.transport
+    },
+    kicad: {
+      cliFound: true,
+      cliPath: '/usr/bin/kicad-cli',
+      cliVersion: 'KiCad 10.0.3',
+      ipcAvailable: true,
+      ipcVersion: '10.0.3',
+      ipcApiVersion: '10',
+      ipcMajorVersion: 10,
+      ipcEndpointSource: 'default',
+      livePcbContext: true,
+      liveSchematicContext: true,
+      ...overrides.kicad
+    },
+    capabilities: {
+      fileBackedDrc: true,
+      fileBackedErc: true,
+      fileBackedExports: true,
+      livePcbRead: true,
+      livePcbWrite: true,
+      liveSchematicRead: true,
+      liveSchematicWrite: true,
+      liveEditingTools: {},
+      chatgptConnectorCompatible: true,
+      cliExports: {
+        ipc2581: true,
+        odb: true,
+        svg: true,
+        dxf: true,
+        step: true,
+        render: true,
+        spiceNetlist: true
+      },
+      ...overrides.capabilities
+    },
+    diagnostics: []
+  };
+
+  return base;
+}
+
+function labels(nodes: ProviderNode[]): string[] {
+  return nodes.map((item) => item.label);
+}
+
+function child(nodes: ProviderNode[], label: string): ProviderNode {
+  const node = nodes.find((item) => item.label === label);
   expect(node).toBeDefined();
   return node!;
+}
+
+function treeDescription(
+  provider: McpToolsProvider,
+  nodes: ProviderNode[],
+  label: string
+): unknown {
+  return provider.getTreeItem(child(nodes, label)).description;
+}
+
+function stateLabelFor(state: McpConnectionState): unknown {
+  const provider = providerForState(state);
+  const dashboard = child(provider.getChildren(), 'Compatibility dashboard');
+  return treeDescription(
+    provider,
+    provider.getChildren(dashboard),
+    'Compatibility state'
+  );
+}
+
+function flattenTree(
+  provider: McpToolsProvider,
+  node?: unknown,
+  parent = ''
+): string[] {
+  return provider.getChildren(node as never).flatMap((childNode) => {
+    const item = provider.getTreeItem(childNode as never);
+    const label = `${parent}${childNode.label}`;
+    const description = item.description ? ` ${String(item.description)}` : '';
+    const current = `${label} ::${description}`;
+    const children = provider.getChildren(childNode as never);
+    return children.length
+      ? [current, ...flattenTree(provider, childNode, `${label} > `)]
+      : [current];
+  });
 }

--- a/docs/extension/troubleshooting.md
+++ b/docs/extension/troubleshooting.md
@@ -25,6 +25,18 @@ viewer and test strategy references:
 ## MCP Tools Are Disconnected
 
 Use the MCP Tools view to inspect endpoint, transport, profile, server-info, and capability state.
+The compatibility dashboard reports the MCP server name and version, endpoint and transport,
+protocol and tool schema versions, KiCad CLI path and version, live GUI availability, live PCB and
+schematic context, advertised tools/resources/prompts, missing required tools, missing optional
+capabilities, last health check, last error, and remediation hint.
+
+Treat a degraded dashboard state as a connected server with missing runtime guarantees. Common
+degraded causes include an unavailable live PCB context, VS Code stdio transport for HTTP-only
+workflows, disabled stateless Streamable HTTP, missing ChatGPT connector compatibility, or missing
+extension-required tools. Use the dashboard actions to reconnect, refresh capabilities, open or save
+the MCP log, pick a profile, switch endpoint, launch the local MCP server, or open compatibility
+docs.
+
 For setup details, see:
 
 - [MCP overview](../mcp/)


### PR DESCRIPTION
## Summary

- Replaced the MCP Tools view with a compatibility dashboard that surfaces server contract, endpoint/transport/profile, protocol and tool schema versions, KiCad runtime, advertised surface, missing required/optional capabilities, health diagnostics, remediation, and raw capability details.
- Added dashboard actions for reconnect, capability refresh, MCP log open/save, profile selection, endpoint switching, local server launch, and compatibility docs.
- Treat live PCB, stateless HTTP, ChatGPT connector, missing required tool, server-info, and VS Code stdio limitations as degraded states instead of showing connected-only status.
- Documented the dashboard troubleshooting flow.

## Linked issue

Closes #61
Linear: OASLANA-60

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- PASS: corepack pnpm install --frozen-lockfile
- PASS: corepack pnpm run format:check
- PASS: corepack pnpm run lint
- PASS: corepack pnpm run typecheck
- PASS: corepack pnpm --dir apps/vscode-extension exec jest test/unit/mcpToolsProvider.test.ts --runInBand --coverage=false
- PASS: corepack pnpm --dir apps/vscode-extension run test:unit (80 suites, 576 tests, 1 snapshot)
- PASS: corepack pnpm --dir apps/vscode-extension run test:a11y (71 tests)
- PASS: corepack pnpm --dir apps/vscode-extension run test:integration (13 tests)
- PASS: corepack pnpm run test
- PASS: corepack pnpm run build
- PASS: corepack pnpm run verify:dist
- PASS: corepack pnpm audit --audit-level high
- PASS: uvx pre-commit run --all-files
- PASS: gitleaks detect --source . --redact --verbose
- PASS: workflow deprecation scan for deprecated commands / Node runtimes
- PASS: corepack pnpm run check before the final stdio/disconnected status patch; the final patch reran the required install/format/lint/typecheck/test/build/verify/security chain.

## Protocol / MCP impact

Checklist reference: docs/architecture/protocol-change-checklist.md

- [ ] Not applicable; reason:
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [x] Extension MCP adapter updated
- [x] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

No MCP server schema, tool schema, compatibility matrix, or server-info payload changed. This PR consumes the existing server-info/capability contract in the VS Code MCP Tools dashboard.

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts