### PR TITLE
chore(repo): add reproducible devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,96 @@
+# syntax=docker/dockerfile:1.7
+FROM mcr.microsoft.com/devcontainers/python:3.12-bookworm
+
+ARG ACTIONLINT_VERSION=1.7.12
+ARG UV_VERSION=0.11.12
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV KICAD_STUDIO_DEVCONTAINER=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    UV_LINK_MODE=copy \
+    UV_PYTHON=3.12
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      bash \
+      build-essential \
+      ca-certificates \
+      curl \
+      dbus \
+      dbus-x11 \
+      file \
+      git \
+      git-lfs \
+      gnupg \
+      jq \
+      less \
+      make \
+      pkg-config \
+      shellcheck \
+      sudo \
+      unzip \
+      xauth \
+      xvfb \
+      libasound2 \
+      libatk-bridge2.0-0 \
+      libatk1.0-0 \
+      libatspi2.0-0 \
+      libcairo2 \
+      libcups2 \
+      libdbus-1-3 \
+      libdrm2 \
+      libexpat1 \
+      libgbm1 \
+      libglib2.0-0 \
+      libgtk-3-0 \
+      libnspr4 \
+      libnss3 \
+      libpango-1.0-0 \
+      libx11-6 \
+      libxcb1 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxext6 \
+      libxfixes3 \
+      libxkbcommon0 \
+      libxrandr2 \
+      libxrender1 \
+      libxshmfence1 \
+    && if apt-cache show kicad >/dev/null 2>&1; then \
+      apt-get install -y --no-install-recommends kicad; \
+    else \
+      echo "KiCad is not available from current Debian apt sources; use host or canary lanes for KiCad GUI validation."; \
+    fi \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --no-cache-dir "uv==${UV_VERSION}" \
+    && uv --version \
+    && python --version
+
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) \
+        actionlint_arch="linux_amd64"; \
+        actionlint_sha="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"; \
+        ;; \
+      aarch64|arm64) \
+        actionlint_arch="linux_arm64"; \
+        actionlint_sha="325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6"; \
+        ;; \
+      *) \
+        echo "Unsupported architecture for actionlint: $(uname -m)" >&2; \
+        exit 1; \
+        ;; \
+    esac; \
+    curl -fsSLo /tmp/actionlint.tar.gz \
+      "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_${actionlint_arch}.tar.gz"; \
+    echo "${actionlint_sha}  /tmp/actionlint.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint; \
+    install -m 0755 /tmp/actionlint /usr/local/bin/actionlint; \
+    rm -f /tmp/actionlint /tmp/actionlint.tar.gz; \
+    actionlint -version
+
+RUN mkdir -p /ms-playwright /home/vscode/.cache/uv /home/vscode/.local/share/pnpm/store \
+    && chown -R vscode:vscode /ms-playwright /home/vscode/.cache /home/vscode/.local
+
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,59 @@
+{
+  "name": "KiCad Studio Kit",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "args": {
+      "ACTIONLINT_VERSION": "1.7.12",
+      "UV_VERSION": "0.11.12"
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "24",
+      "nodeGypDependencies": true,
+      "pnpmVersion": "none"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "remoteUser": "vscode",
+  "workspaceFolder": "/workspaces/kicad-studio-kit",
+  "containerEnv": {
+    "KICAD_STUDIO_DEVCONTAINER": "1",
+    "PLAYWRIGHT_BROWSERS_PATH": "/ms-playwright",
+    "UV_LINK_MODE": "copy",
+    "UV_PYTHON": "3.12"
+  },
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:${workspaceFolder}/packages/mcp-server/.venv/bin"
+  },
+  "mounts": [
+    "source=kicad-studio-kit-pnpm-store,target=/home/vscode/.local/share/pnpm/store,type=volume",
+    "source=kicad-studio-kit-uv-cache,target=/home/vscode/.cache/uv,type=volume"
+  ],
+  "postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
+  "waitFor": "postCreateCommand",
+  "init": true,
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-playwright.playwright",
+        "ms-python.python",
+        "redhat.vscode-yaml",
+        "tamasfe.even-better-toml"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "${workspaceFolder}/packages/mcp-server/.venv/bin/python",
+        "typescript.tsdk": "${workspaceFolder}/node_modules/typescript/lib"
+      }
+    }
+  }
+}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "${repo_root}"
+
+export KICAD_STUDIO_DEVCONTAINER="${KICAD_STUDIO_DEVCONTAINER:-1}"
+export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-/ms-playwright}"
+export UV_LINK_MODE="${UV_LINK_MODE:-copy}"
+export UV_PYTHON="${UV_PYTHON:-3.12}"
+
+echo "Configuring KiCad Studio Kit devcontainer in ${repo_root}"
+
+corepack enable pnpm
+corepack pnpm install --frozen-lockfile
+uv sync --all-extras --frozen --project packages/mcp-server
+
+if [[ "${KICAD_STUDIO_SKIP_PLAYWRIGHT_INSTALL:-0}" != "1" ]]; then
+  corepack pnpm --filter kicadstudio exec playwright install --with-deps chromium
+fi
+
+corepack pnpm run check:devcontainer
+corepack pnpm run dev-doctor -- --require-devcontainer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ corepack pnpm run check:boundaries
 corepack pnpm run check:version
 corepack pnpm run check:compatibility
 corepack pnpm run check:runtime-policy
+corepack pnpm run check:devcontainer
 ```
 
 For extension-only work:
@@ -52,6 +53,13 @@ Runtime support changes must also follow [docs/support-matrix.md](docs/support-m
 Changing `engines.vscode`, Python `requires-python`, or the primary KiCad support line requires
 the matching `compatibility.yaml` update, this support matrix update, and product changelog context
 when a lower runtime boundary is introduced.
+
+## Dev Container
+
+The repository includes a VS Code Dev Containers and GitHub Codespaces setup in
+[docs/devcontainer.md](docs/devcontainer.md). Inside the container,
+`corepack pnpm run dev-doctor -- --require-devcontainer` confirms the
+devcontainer marker and required tools.
 
 ## Issue order
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ corepack pnpm run check:mcp-npm
 corepack pnpm run test:contract
 ```
 
+For a reproducible VS Code Dev Containers or GitHub Codespaces environment, use
+the checked-in [devcontainer configuration](docs/devcontainer.md). The container
+sets up Node, pnpm, Python, uv, Playwright, shellcheck, actionlint, GitHub CLI,
+and best-effort KiCad CLI support for root checks and MCP tests.
+
 ## Architecture
 
 - [Searchable documentation site](https://oaslananka.github.io/kicad-studio-kit/)
@@ -58,6 +63,7 @@ corepack pnpm run test:contract
 - [Product boundaries](docs/architecture/product-boundaries.md)
 - [Release model](docs/architecture/release-model.md)
 - [Testing strategy](docs/testing-strategy.md)
+- [Dev container](docs/devcontainer.md)
 - [KiCad fixture corpus](docs/kicad-fixture-corpus.md)
 - [Integration model](docs/integration/kicad-studio-mcp.md)
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -109,6 +109,7 @@ export default defineConfig({
         text: "Contribute",
         items: [
           { text: "Contributing", link: "/contributing" },
+          { text: "Dev Container", link: "/devcontainer" },
           { text: "Contributors", link: "/contributors" },
           { text: "Fixture Corpus", link: "/kicad-fixture-corpus" },
           { text: "Performance Baselines", link: "/performance-baselines" },

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,6 +12,7 @@ corepack pnpm run check:boundaries
 corepack pnpm run check:version
 corepack pnpm run check:compatibility
 corepack pnpm run check:runtime-policy
+corepack pnpm run check:devcontainer
 ```
 
 Product-scoped checks:
@@ -78,3 +79,10 @@ Contributor requirements:
 See [accessibility conformance target](accessibility.md) for the full policy.
 
 Runtime support changes must follow the [support matrix](support-matrix.md).
+
+## Dev Container
+
+Use the [dev container](devcontainer.md) for reproducible VS Code Dev Containers
+or GitHub Codespaces setup. Inside the container,
+`corepack pnpm run dev-doctor -- --require-devcontainer` confirms the
+devcontainer marker and required tools.

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,0 +1,86 @@
+# Dev Container
+
+The repository includes a Development Containers configuration for a repeatable
+KiCad Studio Kit workspace in VS Code Dev Containers and GitHub Codespaces.
+
+## Runtime Baseline
+
+The container follows the repository support matrix:
+
+| Tool              | Container source                                                                                |
+| ----------------- | ----------------------------------------------------------------------------------------------- |
+| Node 24           | official `ghcr.io/devcontainers/features/node:1` feature with `version: "24"`                   |
+| pnpm 11           | root `packageManager` through Corepack, with the Node feature not installing a global pnpm      |
+| Python 3.12       | official `mcr.microsoft.com/devcontainers/python:3.12-bookworm` base image                      |
+| uv 0.11.12        | pinned Python package install, matching the MCP container policy                                |
+| actionlint 1.7.12 | pinned upstream release archive with SHA-256 verification                                       |
+| shellcheck        | Debian package                                                                                  |
+| GitHub CLI        | official `ghcr.io/devcontainers/features/github-cli:1` feature                                  |
+| Playwright        | Chromium browser install in `postCreateCommand.sh` with browser binaries under `/ms-playwright` |
+| KiCad CLI         | best-effort Debian `kicad` package install when available from the base image apt sources       |
+
+## First Start
+
+Open the repository in a devcontainer from VS Code or create a GitHub Codespace
+from the repository. The `postCreateCommand.sh` script runs:
+
+```bash
+corepack enable pnpm
+corepack pnpm install --frozen-lockfile
+uv sync --all-extras --frozen --project packages/mcp-server
+corepack pnpm --filter kicadstudio exec playwright install --with-deps chromium
+corepack pnpm run check:devcontainer
+corepack pnpm run dev-doctor -- --require-devcontainer
+```
+
+After setup, the same root checks used by CI can run inside the container:
+
+```bash
+corepack pnpm run lint
+corepack pnpm run typecheck
+corepack pnpm run test
+corepack pnpm run build
+corepack pnpm run verify:dist
+uv run --project packages/mcp-server --all-extras pytest
+```
+
+`corepack pnpm run check:devcontainer` validates the container contract without
+building the image. `corepack pnpm run dev-doctor -- --require-devcontainer`
+checks the active environment marker and the required command-line tools.
+
+## Test Coverage
+
+Extension unit tests, Playwright-backed tests, and headless VS Code integration
+tests are supported where the host container runtime permits nested Electron and
+browser processes. The image includes `xvfb`, Playwright Linux dependencies, and
+the VS Code extension test dependencies installed from the root lockfile.
+
+MCP server tests are supported through the normal uv workflow:
+
+```bash
+uv sync --all-extras --frozen --project packages/mcp-server
+uv run --project packages/mcp-server --all-extras pytest
+```
+
+## KiCad Limitations
+
+The container installs KiCad CLI only where the Debian package is available from
+the base image apt repositories. That package is a smoke-test convenience, not
+the release-blocking KiCad 10 baseline. Primary KiCad 10 validation still uses
+the support matrix, the KiCad canary lanes, and host/AppImage environments.
+
+Real KiCad GUI tests are not guaranteed inside Codespaces or every local Docker
+runtime because they depend on host graphics, sandboxing, and Electron display
+support. Use the container for reproducible root checks, MCP tests, Playwright
+browser tests, and headless extension tests; use host or canary lanes for real
+KiCad GUI validation.
+
+## Codespaces Prebuilds
+
+The repository now has a stable `.devcontainer/devcontainer.json`, Dockerfile,
+and post-create script. Repository-level Codespaces prebuilds can be enabled in
+GitHub Codespaces settings after this configuration builds successfully on the
+default branch. GitHub prebuilds do not run `postCreateCommand`, so dependency
+prewarming should be moved to `onCreateCommand` or `updateContentCommand` only
+after a measured prebuild pass proves the command duration and cache behavior are
+acceptable.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "check:testing-strategy": "node scripts/check-testing-strategy.mjs",
     "check:protocol-pr-template": "node scripts/check-protocol-pr-template.mjs",
     "check:kicad-gui-smoke": "node scripts/check-kicad-gui-smoke.mjs",
+    "check:devcontainer": "node scripts/check-devcontainer.mjs && node --test scripts/check-devcontainer.test.mjs scripts/dev-doctor.test.mjs",
+    "dev-doctor": "node scripts/dev-doctor.mjs",
     "check:performance-budgets": "node scripts/check-performance-budgets.mjs && node --test scripts/check-performance-budgets.test.mjs",
     "test:beta-program": "node --test scripts/check-beta-program.test.mjs",
     "check:beta-program": "node scripts/check-beta-program.mjs && pnpm run test:beta-program",
@@ -67,7 +69,7 @@
     "check:docs-site": "pnpm --dir packages/mcp-server run docs:tools:check && pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "check:publish": "node scripts/check-publish-preflight.mjs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.0",

--- a/scripts/check-devcontainer.mjs
+++ b/scripts/check-devcontainer.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SCRIPT_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = path.resolve(SCRIPT_ROOT, "..");
+const EXPECTED_CHECK_SCRIPT =
+  "node scripts/check-devcontainer.mjs && node --test scripts/check-devcontainer.test.mjs scripts/dev-doctor.test.mjs";
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readText(repoRoot, relativePath, errors) {
+  const filePath = path.join(repoRoot, relativePath);
+  try {
+    return readFileSync(filePath, "utf8");
+  } catch (error) {
+    errors.push(`Missing ${relativePath}: ${error.message}`);
+    return "";
+  }
+}
+
+function readJson(repoRoot, relativePath, errors) {
+  const text = readText(repoRoot, relativePath, errors);
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    errors.push(`${relativePath} must be strict JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireIncludes(errors, source, text, phrase) {
+  if (!text.includes(phrase)) {
+    errors.push(`${source} must include ${JSON.stringify(phrase)}`);
+  }
+}
+
+function requireArrayIncludes(errors, source, values, expected) {
+  if (!Array.isArray(values) || !values.includes(expected)) {
+    errors.push(`${source} must include ${expected}`);
+  }
+}
+
+function requireExecutable(errors, repoRoot, relativePath) {
+  const filePath = path.join(repoRoot, relativePath);
+  if (!existsSync(filePath)) {
+    errors.push(`${relativePath} must exist`);
+    return;
+  }
+  if (process.platform !== "win32" && (statSync(filePath).mode & 0o111) === 0) {
+    errors.push(`${relativePath} must be executable`);
+  }
+}
+
+function validateDevcontainerJson(errors, config) {
+  if (!isRecord(config)) {
+    errors.push(".devcontainer/devcontainer.json must be a JSON object");
+    return;
+  }
+
+  if (config.name !== "KiCad Studio Kit") {
+    errors.push("devcontainer name must be KiCad Studio Kit");
+  }
+  if (config.build?.dockerfile !== "Dockerfile") {
+    errors.push("devcontainer build.dockerfile must be Dockerfile");
+  }
+  if (config.build?.context !== "..") {
+    errors.push("devcontainer build.context must be ..");
+  }
+  if (config.remoteUser !== "vscode") {
+    errors.push("devcontainer remoteUser must be vscode");
+  }
+  if (config.postCreateCommand !== "bash .devcontainer/postCreateCommand.sh") {
+    errors.push("devcontainer postCreateCommand must run postCreateCommand.sh");
+  }
+  if (config.waitFor !== "postCreateCommand") {
+    errors.push("devcontainer waitFor must be postCreateCommand");
+  }
+
+  const containerEnv = config.containerEnv ?? {};
+  for (const [name, expected] of Object.entries({
+    KICAD_STUDIO_DEVCONTAINER: "1",
+    PLAYWRIGHT_BROWSERS_PATH: "/ms-playwright",
+    UV_LINK_MODE: "copy",
+    UV_PYTHON: "3.12",
+  })) {
+    if (containerEnv[name] !== expected) {
+      errors.push(`devcontainer containerEnv.${name} must be ${expected}`);
+    }
+  }
+
+  const nodeFeature =
+    config.features?.["ghcr.io/devcontainers/features/node:1"];
+  if (!isRecord(nodeFeature)) {
+    errors.push(
+      "devcontainer must include the official Node devcontainer feature",
+    );
+  } else {
+    if (nodeFeature.version !== "24") {
+      errors.push("Node devcontainer feature must install Node 24");
+    }
+    if (nodeFeature.pnpmVersion !== "none") {
+      errors.push("Node devcontainer feature must leave pnpm to Corepack");
+    }
+    if (nodeFeature.nodeGypDependencies !== true) {
+      errors.push(
+        "Node devcontainer feature must install node-gyp dependencies",
+      );
+    }
+  }
+  if (
+    !isRecord(config.features?.["ghcr.io/devcontainers/features/github-cli:1"])
+  ) {
+    errors.push("devcontainer must include the official GitHub CLI feature");
+  }
+
+  const extensions = config.customizations?.vscode?.extensions;
+  for (const extension of [
+    "charliermarsh.ruff",
+    "dbaeumer.vscode-eslint",
+    "ms-playwright.playwright",
+    "ms-python.python",
+  ]) {
+    requireArrayIncludes(
+      errors,
+      "devcontainer VS Code extensions",
+      extensions,
+      extension,
+    );
+  }
+}
+
+export function validateDevcontainerRepository(repoRoot = DEFAULT_REPO_ROOT) {
+  const errors = [];
+  const config = readJson(repoRoot, ".devcontainer/devcontainer.json", errors);
+  const dockerfile = readText(repoRoot, ".devcontainer/Dockerfile", errors);
+  const postCreate = readText(
+    repoRoot,
+    ".devcontainer/postCreateCommand.sh",
+    errors,
+  );
+  const docs = readText(repoRoot, "docs/devcontainer.md", errors);
+  const readme = readText(repoRoot, "README.md", errors);
+  const contributing = readText(repoRoot, "CONTRIBUTING.md", errors);
+  const docsContributing = readText(repoRoot, "docs/contributing.md", errors);
+  const packageJson = readJson(repoRoot, "package.json", errors);
+
+  validateDevcontainerJson(errors, config);
+  requireExecutable(errors, repoRoot, ".devcontainer/postCreateCommand.sh");
+
+  for (const phrase of [
+    "FROM mcr.microsoft.com/devcontainers/python:3.12-bookworm",
+    "ARG ACTIONLINT_VERSION=1.7.12",
+    "ARG UV_VERSION=0.11.12",
+    "shellcheck",
+    "apt-cache show kicad",
+    "actionlint_${ACTIONLINT_VERSION}_${actionlint_arch}.tar.gz",
+    "sha256sum -c -",
+    "PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
+    "USER vscode",
+  ]) {
+    requireIncludes(errors, ".devcontainer/Dockerfile", dockerfile, phrase);
+  }
+
+  for (const phrase of [
+    "corepack enable pnpm",
+    "corepack pnpm install --frozen-lockfile",
+    "uv sync --all-extras --frozen --project packages/mcp-server",
+    "corepack pnpm --filter kicadstudio exec playwright install --with-deps chromium",
+    "corepack pnpm run check:devcontainer",
+    "corepack pnpm run dev-doctor -- --require-devcontainer",
+  ]) {
+    requireIncludes(
+      errors,
+      ".devcontainer/postCreateCommand.sh",
+      postCreate,
+      phrase,
+    );
+  }
+
+  for (const phrase of [
+    "Node 24",
+    "pnpm 11",
+    "Python 3.12",
+    "uv 0.11.12",
+    "actionlint 1.7.12",
+    "shellcheck",
+    "GitHub CLI",
+    "Playwright",
+    "KiCad GUI",
+    "corepack pnpm run dev-doctor -- --require-devcontainer",
+    "corepack pnpm run check:devcontainer",
+  ]) {
+    requireIncludes(errors, "docs/devcontainer.md", docs, phrase);
+  }
+
+  requireIncludes(errors, "README.md", readme, "docs/devcontainer.md");
+  requireIncludes(
+    errors,
+    "CONTRIBUTING.md",
+    contributing,
+    "corepack pnpm run check:devcontainer",
+  );
+  requireIncludes(
+    errors,
+    "docs/contributing.md",
+    docsContributing,
+    "corepack pnpm run check:devcontainer",
+  );
+
+  const scripts = packageJson?.scripts ?? {};
+  if (scripts["check:devcontainer"] !== EXPECTED_CHECK_SCRIPT) {
+    errors.push("package.json must define check:devcontainer");
+  }
+  if (scripts["dev-doctor"] !== "node scripts/dev-doctor.mjs") {
+    errors.push("package.json must define dev-doctor");
+  }
+  if (!scripts.check?.includes("pnpm run check:devcontainer")) {
+    errors.push("package.json check must run check:devcontainer");
+  }
+
+  return errors;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const errors = validateDevcontainerRepository();
+  if (errors.length > 0) {
+    console.error("Devcontainer validation failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log("Devcontainer validation passed.");
+  }
+}

--- a/scripts/check-devcontainer.test.mjs
+++ b/scripts/check-devcontainer.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { validateDevcontainerRepository } from "./check-devcontainer.mjs";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+test("devcontainer configuration satisfies the OASLANA-65 contract", () => {
+  assert.deepEqual(validateDevcontainerRepository(REPO_ROOT), []);
+});
+
+test("root scripts expose devcontainer and dev-doctor checks", () => {
+  const packageJson = JSON.parse(
+    readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"),
+  );
+
+  assert.equal(
+    packageJson.scripts["check:devcontainer"],
+    "node scripts/check-devcontainer.mjs && node --test scripts/check-devcontainer.test.mjs scripts/dev-doctor.test.mjs",
+  );
+  assert.equal(
+    packageJson.scripts["dev-doctor"],
+    "node scripts/dev-doctor.mjs",
+  );
+  assert.match(packageJson.scripts.check, /pnpm run check:devcontainer/);
+});

--- a/scripts/dev-doctor.mjs
+++ b/scripts/dev-doctor.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SCRIPT_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = path.resolve(SCRIPT_ROOT, "..");
+
+function parseVersion(version) {
+  const match = String(version).match(/v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+  if (!match) {
+    return null;
+  }
+  return [match[1], match[2] ?? "0", match[3] ?? "0"].map((part) =>
+    Number.parseInt(part, 10),
+  );
+}
+
+function compareVersions(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] > right[index]) {
+      return 1;
+    }
+    if (left[index] < right[index]) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+export function satisfiesSimpleRange(version, range) {
+  const parsedVersion = parseVersion(version);
+  if (!parsedVersion) {
+    return false;
+  }
+
+  return range
+    .split(/\s+/u)
+    .filter(Boolean)
+    .every((part) => {
+      const match = part.match(/^(>=|>|<=|<|=)?(.+)$/u);
+      if (!match) {
+        return false;
+      }
+      const operator = match[1] ?? "=";
+      const target = parseVersion(match[2]);
+      if (!target) {
+        return false;
+      }
+      const comparison = compareVersions(parsedVersion, target);
+      if (operator === ">=") {
+        return comparison >= 0;
+      }
+      if (operator === ">") {
+        return comparison > 0;
+      }
+      if (operator === "<=") {
+        return comparison <= 0;
+      }
+      if (operator === "<") {
+        return comparison < 0;
+      }
+      return comparison === 0;
+    });
+}
+
+export function detectDevelopmentEnvironment(env = process.env) {
+  const markers = [];
+  if (env.KICAD_STUDIO_DEVCONTAINER === "1") {
+    markers.push("KICAD_STUDIO_DEVCONTAINER=1");
+  }
+  if (env.DEVCONTAINER === "true") {
+    markers.push("DEVCONTAINER=true");
+  }
+  if (env.CODESPACES === "true") {
+    markers.push("CODESPACES=true");
+  }
+
+  return {
+    isDevcontainer: markers.length > 0,
+    isCodespaces: env.CODESPACES === "true",
+    markers,
+  };
+}
+
+function readPackageJson(repoRoot) {
+  return JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? DEFAULT_REPO_ROOT,
+    encoding: "utf8",
+    shell: false,
+  });
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: (result.stdout ?? "").trim(),
+    stderr: (result.stderr ?? "").trim(),
+    error: result.error?.message,
+  };
+}
+
+function firstLine(value) {
+  return value.split(/\r?\n/u).find(Boolean) ?? "";
+}
+
+function toolCheck(id, label, command, args, options = {}) {
+  const result = run(command, args, options);
+  const output = firstLine(
+    result.stdout || result.stderr || result.error || "",
+  );
+  return {
+    id,
+    label,
+    required: options.required ?? true,
+    ok: result.ok,
+    detail: output || `exit ${result.status ?? "unknown"}`,
+  };
+}
+
+export function createDoctorReport(
+  repoRoot = DEFAULT_REPO_ROOT,
+  env = process.env,
+) {
+  const packageJson = readPackageJson(repoRoot);
+  const environment = detectDevelopmentEnvironment(env);
+  const nodeRange = packageJson.engines?.node ?? ">=24.11.0 <25";
+  const pnpmRange = packageJson.engines?.pnpm ?? ">=11.0.0 <12";
+  const checks = [];
+
+  checks.push({
+    id: "node",
+    label: `Node ${nodeRange}`,
+    required: true,
+    ok: satisfiesSimpleRange(process.versions.node, nodeRange),
+    detail: process.version,
+  });
+
+  const pnpm = run("corepack", ["pnpm", "--version"], { cwd: repoRoot });
+  checks.push({
+    id: "pnpm",
+    label: `pnpm ${pnpmRange}`,
+    required: true,
+    ok: pnpm.ok && satisfiesSimpleRange(pnpm.stdout, pnpmRange),
+    detail: firstLine(pnpm.stdout || pnpm.stderr || pnpm.error || ""),
+  });
+
+  const python = run("python3", ["--version"], { cwd: repoRoot });
+  checks.push({
+    id: "python",
+    label: "Python >=3.12",
+    required: true,
+    ok:
+      python.ok &&
+      satisfiesSimpleRange(python.stdout || python.stderr, ">=3.12"),
+    detail: firstLine(python.stdout || python.stderr || python.error || ""),
+  });
+
+  checks.push(toolCheck("uv", "uv", "uv", ["--version"]));
+  checks.push(toolCheck("corepack", "Corepack", "corepack", ["--version"]));
+  checks.push(
+    toolCheck("shellcheck", "shellcheck", "shellcheck", ["--version"]),
+  );
+  checks.push(
+    toolCheck("actionlint", "actionlint", "actionlint", ["-version"]),
+  );
+  checks.push(toolCheck("gh", "GitHub CLI", "gh", ["--version"]));
+  checks.push(toolCheck("xvfb", "Xvfb", "xvfb-run", ["--help"]));
+  checks.push(
+    toolCheck("kicad-cli", "KiCad CLI", "kicad-cli", ["version"], {
+      required: false,
+    }),
+  );
+
+  return {
+    environment,
+    checks,
+  };
+}
+
+function printHuman(report) {
+  const envSummary = report.environment.isDevcontainer
+    ? `devcontainer detected (${report.environment.markers.join(", ")})`
+    : "devcontainer marker not detected";
+  console.log(`Environment: ${envSummary}`);
+
+  for (const check of report.checks) {
+    const status = check.ok ? "pass" : check.required ? "fail" : "warn";
+    console.log(`[${status}] ${check.label}: ${check.detail}`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = new Set(process.argv.slice(2));
+  const report = createDoctorReport();
+  const requireDevcontainer = args.has("--require-devcontainer");
+  const strict = args.has("--strict") || report.environment.isDevcontainer;
+
+  if (args.has("--json")) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printHuman(report);
+  }
+
+  if (requireDevcontainer && !report.environment.isDevcontainer) {
+    console.error("Expected a devcontainer environment marker.");
+    process.exitCode = 1;
+  } else if (
+    strict &&
+    report.checks.some((check) => check.required && !check.ok)
+  ) {
+    process.exitCode = 1;
+  }
+}

--- a/scripts/dev-doctor.test.mjs
+++ b/scripts/dev-doctor.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  detectDevelopmentEnvironment,
+  satisfiesSimpleRange,
+} from "./dev-doctor.mjs";
+
+test("dev-doctor detects the devcontainer marker and Codespaces", () => {
+  assert.deepEqual(
+    detectDevelopmentEnvironment({
+      KICAD_STUDIO_DEVCONTAINER: "1",
+    }),
+    {
+      isDevcontainer: true,
+      isCodespaces: false,
+      markers: ["KICAD_STUDIO_DEVCONTAINER=1"],
+    },
+  );
+
+  assert.deepEqual(
+    detectDevelopmentEnvironment({
+      CODESPACES: "true",
+    }),
+    {
+      isDevcontainer: true,
+      isCodespaces: true,
+      markers: ["CODESPACES=true"],
+    },
+  );
+});
+
+test("dev-doctor enforces the repository Node runtime policy", () => {
+  assert.equal(satisfiesSimpleRange("24.11.0", ">=24.11.0 <25"), true);
+  assert.equal(satisfiesSimpleRange("24.16.0", ">=24.11.0 <25"), true);
+  assert.equal(satisfiesSimpleRange("24.10.0", ">=24.11.0 <25"), false);
+  assert.equal(satisfiesSimpleRange("25.0.0", ">=24.11.0 <25"), false);
+});

--- a/scripts/generate-docs-site.mjs
+++ b/scripts/generate-docs-site.mjs
@@ -391,6 +391,7 @@ corepack pnpm run check:boundaries
 corepack pnpm run check:version
 corepack pnpm run check:compatibility
 corepack pnpm run check:runtime-policy
+corepack pnpm run check:devcontainer
 \`\`\`
 
 Product-scoped checks:
@@ -457,6 +458,13 @@ Contributor requirements:
 See [accessibility conformance target](accessibility.md) for the full policy.
 
 Runtime support changes must follow the [support matrix](support-matrix.md).
+
+## Dev Container
+
+Use the [dev container](devcontainer.md) for reproducible VS Code Dev Containers
+or GitHub Codespaces setup. Inside the container,
+\`corepack pnpm run dev-doctor -- --require-devcontainer\` confirms the
+devcontainer marker and required tools.
 `;
 }
 


### PR DESCRIPTION
## Summary
- Adds `.devcontainer/devcontainer.json`, `.devcontainer/Dockerfile`, and `.devcontainer/postCreateCommand.sh` for VS Code Dev Containers and GitHub Codespaces.
- Adds `check:devcontainer` and a minimum `dev-doctor` CLI so the repo validates the devcontainer contract and detects `KICAD_STUDIO_DEVCONTAINER=1` / Codespaces environments.
- Documents supported root checks, extension/MCP test coverage, Codespaces prebuild limits, and real KiCad GUI limitations.

Closes #66
Linear: https://linear.app/oaslananka/issue/OASLANA-65/add-devcontainer-and-optional-codespaces-prebuild-for-reproducible

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run format:check`
- `corepack pnpm exec prettier --check .devcontainer/devcontainer.json package.json README.md CONTRIBUTING.md docs/devcontainer.md docs/contributing.md docs/.vitepress/config.mts scripts/check-devcontainer.mjs scripts/check-devcontainer.test.mjs scripts/dev-doctor.mjs scripts/dev-doctor.test.mjs scripts/generate-docs-site.mjs`
- `shellcheck .devcontainer/postCreateCommand.sh`
- `corepack pnpm run check:devcontainer`
- `corepack pnpm run dev-doctor -- --json`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist`
- `uv sync --all-extras --frozen && uv run --all-extras pytest` from `packages/mcp-server`
- `corepack pnpm run check`
- `gitleaks detect --source . --redact --verbose`
- workflow deprecation grep: `::set-output|::save-state|ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION|node12|node16|node20`

## Notes
- The full local devcontainer feature build was not run because the Dev Containers CLI is not installed in this environment. The Docker CLI is present, but a plain Dockerfile build would not apply devcontainer features, so the stronger local signal is the checked-in contract validator plus the full repository validation chain.
- Existing MCP submission readiness reports `pypi reachability | WARN | offline or unavailable: HTTP Error 404: Not Found`; the gate passes and this is unrelated to this change.
- Running `uv run --project packages/mcp-server --all-extras pytest` from the repo root is cwd-sensitive for one existing metadata lint test; the requested `uv sync && uv run pytest` command passes from `packages/mcp-server`, and repo scripts use that package harness.

## Source Verification
- Dev Container spec: https://containers.dev/implementors/json_reference/
- GitHub Codespaces devcontainer/prebuild docs: https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers and https://docs.github.com/en/codespaces/prebuilding-your-codespaces/about-github-codespaces-prebuilds
- Devcontainers image/features: https://raw.githubusercontent.com/devcontainers/images/main/src/python/README.md, https://raw.githubusercontent.com/devcontainers/features/main/src/node/devcontainer-feature.json, https://raw.githubusercontent.com/devcontainers/features/main/src/github-cli/devcontainer-feature.json
- Node releases: https://nodejs.org/en/about/previous-releases
- pnpm installation/Corepack docs: https://pnpm.io/installation
- uv Docker integration docs: https://docs.astral.sh/uv/guides/integration/docker/
- KiCad Linux downloads: https://www.kicad.org/download/linux/
- actionlint releases: https://github.com/rhysd/actionlint/releases
