### PR TITLE
feat(repo): add user-facing KiCad examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ and best-effort KiCad CLI support for root checks and MCP tests.
 
 ## Examples
 
+- [Examples overview](examples/README.md)
 - [LED Basic KiCad example](examples/led-basic/README.md)
+- [USB-C Power Intake example](examples/usb-c-power/README.md)
+- [Buck Converter Review example](examples/buck-converter/README.md)
+- [Differential Pair Review example](examples/differential-pair-demo/README.md)
+- [Manufacturing Release example](examples/manufacturing-release-demo/README.md)
+- [MCP Workflow Demo](examples/mcp-demo/README.md)
 
 ## Publishing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,30 @@
 # Examples
 
-Examples are user-facing KiCad projects for extension, MCP, documentation, screenshot, and smoke-test workflows. They are intentionally separate from deterministic automated fixtures.
+Examples are user-facing KiCad projects for extension, MCP, documentation,
+screenshot, walkthrough, and release smoke workflows. They are intentionally
+separate from deterministic automated fixtures; tests should not depend on these
+files as golden outputs unless a future issue explicitly copies a scenario into
+the fixture corpus.
 
-| Example                            | Purpose                                                                                                                  |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| [led-basic](led-basic/README.md)   | Small KiCad 10 LED schematic and routed PCB for viewer, ERC/DRC, BOM, netlist, manufacturing export, and MCP smoke tests |
-| [mcp-docker](mcp-docker/README.md) | Docker Compose example for running `kicad-mcp-pro` over streamable HTTP with a read-only KiCad project mount             |
+## Project Examples
 
-Generated outputs such as Gerbers, drill files, reports, screenshots, and local MCP logs should stay outside git unless a future release smoke workflow explicitly needs them.
+| Example                                                            | Primary workflow focus                                 |
+| ------------------------------------------------------------------ | ------------------------------------------------------ |
+| [led-basic](led-basic/README.md)                                   | Basic schematic/PCB viewing, ERC/DRC, BOM, and netlist |
+| [usb-c-power](usb-c-power/README.md)                               | Power-intake review and degraded MCP handling          |
+| [buck-converter](buck-converter/README.md)                         | Power-stage review, BOM, netlist, ERC, and DRC         |
+| [differential-pair-demo](differential-pair-demo/README.md)         | High-speed review flow and connected MCP inspection    |
+| [manufacturing-release-demo](manufacturing-release-demo/README.md) | Manufacturing export release smoke workflow            |
+| [mcp-demo](mcp-demo/README.md)                                     | Connected and degraded MCP client workflows            |
+
+## Runtime Example
+
+| Example                            | Purpose                                                                                                      |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [mcp-docker](mcp-docker/README.md) | Docker Compose example for running `kicad-mcp-pro` over streamable HTTP with a read-only KiCad project mount |
+
+## Output Policy
+
+Generated outputs such as Gerbers, drill files, reports, screenshots, netlists,
+BOM exports, and local MCP logs should stay outside git. The repository ignores
+`examples/**/exports/`; use that directory when following smoke commands.

--- a/examples/buck-converter/BUCK_CONVERTER.kicad_pcb
+++ b/examples/buck-converter/BUCK_CONVERTER.kicad_pcb
@@ -1,0 +1,573 @@
+(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(title_block
+		(title "Buck Converter Review Demo")
+		(date "2026-05-20")
+		(rev "1.0.0")
+		(company "oaslananka")
+		(comment 1 "Buck converter review board for smoke workflows")
+	)
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user "F.Adhesive")
+		(11 "B.Adhes" user "B.Adhesive")
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user "F.Silkscreen")
+		(7 "B.SilkS" user "B.Silkscreen")
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user "User.Drawings")
+		(19 "Cmts.User" user "User.Comments")
+		(21 "Eco1.User" user "User.Eco1")
+		(23 "Eco2.User" user "User.Eco2")
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user "F.Courtyard")
+		(29 "B.CrtYd" user "B.Courtyard")
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+		(39 "User.1" user)
+		(41 "User.2" user)
+		(43 "User.3" user)
+		(45 "User.4" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting (front yes) (back yes))
+		(covering (front no) (back no))
+		(plugging (front no) (back no))
+		(capping no)
+		(filling no)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_55555555_5755f5ff)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions no)
+			(usegerberattributes yes)
+			(usegerberadvancedattributes yes)
+			(creategerberjobfile yes)
+			(dashed_line_dash_ratio 12)
+			(dashed_line_gap_ratio 3)
+			(svgprecision 4)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk no)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 1)
+			(scaleselection 1)
+			(outputdirectory "exports/gerbers")
+		)
+	)
+	(gr_rect (start 45 45) (end 75 58) (stroke (width 0.1) (type solid)) (fill no) (layer "Edge.Cuts") (uuid "22222222-2222-4222-8222-222222222001"))
+	(gr_text "Buck Review Demo" (at 60 46.5 0) (layer "F.SilkS") (uuid "22222222-2222-4222-8222-222222222002") (effects (font (size 1.1 1.1) (thickness 0.15))))
+	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 50 50 0)
+		(uuid "22222222-2222-4222-8222-222222222010")
+		(descr "Through hole straight pin header, 1x02, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x02 2.54mm single row")
+		(property "Reference" "J1"
+			(at 0 -2.38 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "POWER_IN"
+			(at 0 4.92 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "connector/pin_header_socket"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.38 -1.38)
+			(end 0 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 0)
+			(end -1.38 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end -1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end 1.38 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 3.92)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1.38 1.27)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.77 -1.77)
+			(end 1.77 4.32)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1.27 3.81)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 3.81)
+			(end -1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 1.27 90)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole rect
+			(at 0 0)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
+			(net "/VIN")
+			(pinfunction "Pin_1")
+			(pintype "passive"))
+		(pad "2" thru_hole circle
+			(at 0 2.54)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
+			(net "GND")
+			(pinfunction "Pin_2")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 60 50 0)
+		(uuid "22222222-2222-4222-8222-222222222020")
+		(descr "Resistor SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: IPC-SM-782 page 72, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf)")
+		(tags "resistor")
+		(property "Reference" "R1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.227064 -0.735)
+			(end 0.227064 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -0.227064 0.735)
+			(end 0.227064 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_rect
+			(start -1 -0.625)
+			(end 1 0.625)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
+			(net "/VIN")
+			(pinfunction "1")
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
+			(net "/LED_A")
+			(pinfunction "2")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 68 50 0)
+		(uuid "22222222-2222-4222-8222-222222222030")
+		(descr "LED SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: https://docs.google.com/spreadsheets/d/1BsfQQcO9C6DZCsRaXUlFlo91Tg2WpOkGARC1WS5S8t0/edit?usp=sharing)")
+		(tags "LED")
+		(property "Reference" "D1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GREEN"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.685 -0.96)
+			(end -1.685 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.685 0.96)
+			(end 1 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1 -0.96)
+			(end -1.685 -0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1 -0.3)
+			(end -1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1 0.6)
+			(end 1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.7 -0.6)
+			(end -1 -0.3)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 -0.6)
+			(end -0.7 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 0.6)
+			(end 1 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
+			(net "GND")
+			(pinfunction "K")
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
+			(net "/LED_A")
+			(pinfunction "A")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/LED_SMD.3dshapes/LED_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(segment (start 50 50) (end 59.0875 50) (width 0.35) (layer "F.Cu") (net "/VIN") (uuid "22222222-2222-4222-8222-222222222040"))
+	(segment (start 60.9125 50) (end 60.9125 47.5) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222041"))
+	(segment (start 60.9125 47.5) (end 68.9375 47.5) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222042"))
+	(segment (start 68.9375 47.5) (end 68.9375 50) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222043"))
+	(segment (start 67.0625 50) (end 67.0625 52.54) (width 0.35) (layer "F.Cu") (net "GND") (uuid "22222222-2222-4222-8222-222222222044"))
+	(segment (start 67.0625 52.54) (end 50 52.54) (width 0.35) (layer "F.Cu") (net "GND") (uuid "22222222-2222-4222-8222-222222222045"))
+)

--- a/examples/buck-converter/BUCK_CONVERTER.kicad_pro
+++ b/examples/buck-converter/BUCK_CONVERTER.kicad_pro
@@ -1,0 +1,656 @@
+{
+  "board": {
+    "3dviewports": [],
+    "design_settings": {
+      "defaults": {
+        "apply_defaults_to_fp_barcodes": false,
+        "apply_defaults_to_fp_dimensions": false,
+        "apply_defaults_to_fp_fields": false,
+        "apply_defaults_to_fp_shapes": false,
+        "apply_defaults_to_fp_text": false,
+        "board_outline_line_width": 0.05,
+        "copper_line_width": 0.2,
+        "copper_text_italic": false,
+        "copper_text_size_h": 1.5,
+        "copper_text_size_v": 1.5,
+        "copper_text_thickness": 0.3,
+        "copper_text_upright": false,
+        "courtyard_line_width": 0.05,
+        "dimension_precision": 4,
+        "dimension_units": 3,
+        "dimensions": {
+          "arrow_length": 1270000,
+          "extension_offset": 500000,
+          "keep_text_aligned": true,
+          "suppress_zeroes": true,
+          "text_position": 0,
+          "units_format": 0
+        },
+        "fab_line_width": 0.1,
+        "fab_text_italic": false,
+        "fab_text_size_h": 1.0,
+        "fab_text_size_v": 1.0,
+        "fab_text_thickness": 0.15,
+        "fab_text_upright": false,
+        "other_line_width": 0.1,
+        "other_text_italic": false,
+        "other_text_size_h": 1.0,
+        "other_text_size_v": 1.0,
+        "other_text_thickness": 0.15,
+        "other_text_upright": false,
+        "pads": {
+          "drill": 0.8,
+          "height": 1.27,
+          "width": 2.54
+        },
+        "silk_line_width": 0.1,
+        "silk_text_italic": false,
+        "silk_text_size_h": 1.0,
+        "silk_text_size_v": 1.0,
+        "silk_text_thickness": 0.1,
+        "silk_text_upright": false,
+        "zones": {
+          "border_display_style": 2,
+          "border_hatch_pitch": 0.5,
+          "corner_radius": 0.0,
+          "corner_smoothing": 0,
+          "fill_mode": 0,
+          "hatch_gap": 1.5,
+          "hatch_orientation": 0.0,
+          "hatch_smoothing_level": 0,
+          "hatch_smoothing_value": 0.1,
+          "hatch_thickness": 1.0,
+          "min_clearance": 0.5,
+          "min_island_area": 10.0,
+          "min_thickness": 0.25,
+          "pad_connection": 1,
+          "remove_islands": 0,
+          "thermal_relief_gap": 0.5,
+          "thermal_relief_spoke_width": 0.5
+        }
+      },
+      "diff_pair_dimensions": [],
+      "drc_exclusions": [],
+      "meta": {
+        "version": 2
+      },
+      "rule_severities": {
+        "annular_width": "error",
+        "clearance": "error",
+        "connection_width": "warning",
+        "copper_edge_clearance": "error",
+        "copper_sliver": "warning",
+        "courtyards_overlap": "error",
+        "creepage": "error",
+        "diff_pair_gap_out_of_range": "error",
+        "diff_pair_uncoupled_length_too_long": "error",
+        "drill_out_of_range": "error",
+        "duplicate_footprints": "warning",
+        "extra_footprint": "warning",
+        "footprint": "error",
+        "footprint_filters_mismatch": "ignore",
+        "footprint_symbol_field_mismatch": "warning",
+        "footprint_symbol_mismatch": "warning",
+        "footprint_type_mismatch": "ignore",
+        "hole_clearance": "error",
+        "hole_to_hole": "warning",
+        "holes_co_located": "warning",
+        "invalid_outline": "error",
+        "isolated_copper": "warning",
+        "item_on_disabled_layer": "error",
+        "items_not_allowed": "error",
+        "length_out_of_range": "error",
+        "lib_footprint_issues": "warning",
+        "lib_footprint_mismatch": "warning",
+        "malformed_courtyard": "error",
+        "microvia_drill_out_of_range": "error",
+        "mirrored_text_on_front_layer": "warning",
+        "missing_courtyard": "ignore",
+        "missing_footprint": "warning",
+        "missing_tuning_profile": "warning",
+        "net_conflict": "warning",
+        "nonmirrored_text_on_back_layer": "warning",
+        "npth_inside_courtyard": "error",
+        "padstack": "warning",
+        "pth_inside_courtyard": "error",
+        "shorting_items": "error",
+        "silk_edge_clearance": "warning",
+        "silk_over_copper": "warning",
+        "silk_overlap": "warning",
+        "skew_out_of_range": "error",
+        "solder_mask_bridge": "error",
+        "starved_thermal": "error",
+        "text_height": "warning",
+        "text_on_edge_cuts": "error",
+        "text_thickness": "warning",
+        "through_hole_pad_without_hole": "error",
+        "too_many_vias": "error",
+        "track_angle": "error",
+        "track_dangling": "warning",
+        "track_not_centered_on_via": "ignore",
+        "track_on_post_machined_layer": "error",
+        "track_segment_length": "error",
+        "track_width": "error",
+        "tracks_crossing": "error",
+        "tuning_profile_track_geometries": "ignore",
+        "unconnected_items": "error",
+        "unresolved_variable": "error",
+        "via_dangling": "warning",
+        "zones_intersect": "error"
+      },
+      "rules": {
+        "max_error": 0.005,
+        "min_clearance": 0.0,
+        "min_connection": 0.0,
+        "min_copper_edge_clearance": 0.5,
+        "min_groove_width": 0.0,
+        "min_hole_clearance": 0.25,
+        "min_hole_to_hole": 0.25,
+        "min_microvia_diameter": 0.2,
+        "min_microvia_drill": 0.1,
+        "min_resolved_spokes": 2,
+        "min_silk_clearance": 0.0,
+        "min_text_height": 0.8,
+        "min_text_thickness": 0.08,
+        "min_through_hole_diameter": 0.3,
+        "min_track_width": 0.2,
+        "min_via_annular_width": 0.1,
+        "min_via_diameter": 0.5,
+        "solder_mask_to_copper_clearance": 0.0,
+        "use_height_for_length_calcs": true
+      },
+      "teardrop_options": [
+        {
+          "td_onpthpad": true,
+          "td_onroundshapesonly": false,
+          "td_onsmdpad": true,
+          "td_ontrackend": false,
+          "td_onvia": true
+        }
+      ],
+      "teardrop_parameters": [
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_round_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_rect_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_track_end",
+          "td_width_to_size_filter_ratio": 0.9
+        }
+      ],
+      "track_widths": [],
+      "tuning_pattern_settings": {
+        "diff_pair_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 1.0
+        },
+        "diff_pair_skew_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        },
+        "single_track_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        }
+      },
+      "via_dimensions": [],
+      "zones_allow_external_fillets": false
+    },
+    "ipc2581": {
+      "bom_rev": "",
+      "dist": "",
+      "distpn": "",
+      "internal_id": "",
+      "mfg": "",
+      "mpn": "",
+      "sch_revision": ""
+    },
+    "layer_pairs": [],
+    "layer_presets": [],
+    "viewports": []
+  },
+  "boards": [],
+  "component_class_settings": {
+    "assignments": [],
+    "meta": {
+      "version": 0
+    },
+    "sheet_component_classes": {
+      "enabled": false
+    }
+  },
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "erc": {
+    "erc_exclusions": [],
+    "meta": {
+      "version": 0
+    },
+    "pin_map": [
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        2
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        2,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        2,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    ],
+    "rule_severities": {
+      "bus_definition_conflict": "error",
+      "bus_entry_needed": "error",
+      "bus_to_bus_conflict": "error",
+      "bus_to_net_conflict": "error",
+      "different_unit_footprint": "error",
+      "different_unit_net": "error",
+      "duplicate_reference": "error",
+      "duplicate_sheet_names": "error",
+      "endpoint_off_grid": "warning",
+      "extra_units": "error",
+      "field_name_whitespace": "warning",
+      "footprint_filter": "ignore",
+      "footprint_link_issues": "warning",
+      "four_way_junction": "ignore",
+      "ground_pin_not_ground": "warning",
+      "hier_label_mismatch": "error",
+      "isolated_pin_label": "warning",
+      "label_dangling": "error",
+      "label_multiple_wires": "warning",
+      "lib_symbol_issues": "warning",
+      "lib_symbol_mismatch": "warning",
+      "missing_bidi_pin": "warning",
+      "missing_input_pin": "warning",
+      "missing_power_pin": "error",
+      "missing_unit": "warning",
+      "multiple_net_names": "warning",
+      "net_not_bus_member": "warning",
+      "no_connect_connected": "warning",
+      "no_connect_dangling": "warning",
+      "pin_not_connected": "error",
+      "pin_not_driven": "error",
+      "pin_to_pin": "warning",
+      "power_pin_not_driven": "error",
+      "same_local_global_label": "warning",
+      "similar_label_and_power": "warning",
+      "similar_labels": "warning",
+      "similar_power": "warning",
+      "simulation_model_issue": "ignore",
+      "single_global_label": "ignore",
+      "stacked_pin_name": "warning",
+      "unannotated": "error",
+      "unconnected_wire_endpoint": "warning",
+      "undefined_netclass": "error",
+      "unit_value_mismatch": "error",
+      "unresolved_variable": "error",
+      "wire_dangling": "error"
+    }
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "BUCK_CONVERTER.kicad_pro",
+    "version": 3
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.2,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 2147483647,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.2,
+        "tuning_profile": "",
+        "via_diameter": 0.6,
+        "via_drill": 0.3,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 5
+    },
+    "net_colors": null,
+    "netclass_assignments": null,
+    "netclass_patterns": []
+  },
+  "pcbnew": {
+    "last_paths": {
+      "idf": "",
+      "netlist": "",
+      "plot": "",
+      "specctra_dsn": "",
+      "vrml": ""
+    },
+    "page_layout_descr_file": ""
+  },
+  "schematic": {
+    "annotate_start_num": 0,
+    "annotation": {
+      "method": 0,
+      "sort_order": 0
+    },
+    "bom_export_filename": "${PROJECTNAME}.csv",
+    "bom_fmt_presets": [],
+    "bom_fmt_settings": {
+      "field_delimiter": ",",
+      "keep_line_breaks": false,
+      "keep_tabs": false,
+      "name": "CSV",
+      "ref_delimiter": ",",
+      "ref_range_delimiter": "",
+      "string_delimiter": "\""
+    },
+    "bom_presets": [],
+    "bom_settings": {
+      "exclude_dnp": false,
+      "fields_ordered": [
+        {
+          "group_by": false,
+          "label": "Reference",
+          "name": "Reference",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Qty",
+          "name": "${QUANTITY}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Value",
+          "name": "Value",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "DNP",
+          "name": "${DNP}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Exclude from BOM",
+          "name": "${EXCLUDE_FROM_BOM}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Exclude from Board",
+          "name": "${EXCLUDE_FROM_BOARD}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Footprint",
+          "name": "Footprint",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Datasheet",
+          "name": "Datasheet",
+          "show": true
+        }
+      ],
+      "filter_string": "",
+      "group_symbols": true,
+      "include_excluded_from_bom": true,
+      "name": "Default Editing",
+      "sort_asc": true,
+      "sort_field": "Reference"
+    },
+    "bus_aliases": {},
+    "connection_grid_size": 50.0,
+    "drawing": {
+      "dashed_lines_dash_length_ratio": 12.0,
+      "dashed_lines_gap_length_ratio": 3.0,
+      "default_line_thickness": 6.0,
+      "default_text_size": 50.0,
+      "field_names": [],
+      "hop_over_size_choice": 0,
+      "intersheets_ref_own_page": false,
+      "intersheets_ref_prefix": "",
+      "intersheets_ref_short": false,
+      "intersheets_ref_show": false,
+      "intersheets_ref_suffix": "",
+      "junction_size_choice": 3,
+      "label_size_ratio": 0.375,
+      "operating_point_overlay_i_precision": 3,
+      "operating_point_overlay_i_range": "~A",
+      "operating_point_overlay_v_precision": 3,
+      "operating_point_overlay_v_range": "~V",
+      "overbar_offset_ratio": 1.23,
+      "pin_symbol_size": 25.0,
+      "text_offset_ratio": 0.15
+    },
+    "legacy_lib_dir": "",
+    "legacy_lib_list": [],
+    "meta": {
+      "version": 1
+    },
+    "page_layout_descr_file": "",
+    "plot_directory": "",
+    "reuse_designators": true,
+    "subpart_first_id": 65,
+    "subpart_id_separator": 0,
+    "top_level_sheets": [],
+    "used_designators": "",
+    "variants": []
+  },
+  "sheets": [],
+  "text_variables": {},
+  "tuning_profiles": {
+    "meta": {
+      "version": 0
+    },
+    "tuning_profiles_impedance_geometric": []
+  }
+}

--- a/examples/buck-converter/BUCK_CONVERTER.kicad_sch
+++ b/examples/buck-converter/BUCK_CONVERTER.kicad_sch
@@ -1,0 +1,1394 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "11111111-1111-4111-8111-111111111111")
+	(paper "A4")
+	(title_block
+		(title "Buck Converter Review Demo")
+		(date "2026-05-20")
+		(rev "1.0.0")
+		(company "oaslananka")
+		(comment 1 "Buck converter review workflow sample")
+	)
+	(lib_symbols
+	(symbol "power:GND"
+		(power global)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 0 -3.81 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "GND_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GND_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "power:PWR_FLAG"
+		(power global)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "#FLG"
+			(at 0 1.905 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 0 3.81 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Special symbol for telling ERC where power comes from"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "flag power"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "PWR_FLAG_0_0"
+			(pin power_out line
+				(at 0 0 90)
+				(length 0)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "PWR_FLAG_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+		(symbol "Connector_Generic:Conn_01x02"
+
+				(pin_names
+
+					(offset 1.016)
+
+					(hide yes)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "J"
+
+					(at 0 2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "Conn_01x02"
+
+					(at 0 -5.08 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "connector"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "Connector*:*_1x??_*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "Conn_01x02_1_1"
+
+					(rectangle
+
+						(start -1.27 1.27)
+
+						(end 1.27 -3.81)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type background)
+
+						)
+
+					)
+
+					(rectangle
+
+						(start -1.27 0.127)
+
+						(end 0 -0.127)
+
+						(stroke
+
+							(width 0.1524)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(rectangle
+
+						(start -1.27 -2.413)
+
+						(end 0 -2.667)
+
+						(stroke
+
+							(width 0.1524)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at -5.08 0 0)
+
+						(length 3.81)
+
+						(name "Pin_1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at -5.08 -2.54 0)
+
+						(length 3.81)
+
+						(name "Pin_2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+		(symbol "Device:LED"
+
+				(pin_numbers
+
+					(hide yes)
+
+				)
+
+				(pin_names
+
+					(offset 1.016)
+
+					(hide yes)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "D"
+
+					(at 0 2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "LED"
+
+					(at 0 -2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Light emitting diode"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Sim.Pins" "1=K 2=A"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "LED diode"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "LED_0_1"
+
+					(polyline
+
+						(pts
+
+							(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.27 0) (xy 1.27 0)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.27 -1.27) (xy -1.27 1.27)
+
+						)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+
+						)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+				)
+
+				(symbol "LED_1_1"
+
+					(pin passive line
+
+						(at -3.81 0 0)
+
+						(length 2.54)
+
+						(name "K"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at 3.81 0 180)
+
+						(length 2.54)
+
+						(name "A"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+		(symbol "Device:R"
+
+				(pin_numbers
+
+					(hide yes)
+
+				)
+
+				(pin_names
+
+					(offset 0)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "R"
+
+					(at 2.032 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "R"
+
+					(at 0 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at -1.778 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Resistor"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "R res resistor"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "R_*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "R_0_1"
+
+					(rectangle
+
+						(start -1.016 -2.54)
+
+						(end 1.016 2.54)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+				)
+
+				(symbol "R_1_1"
+
+					(pin passive line
+
+						(at 0 3.81 270)
+
+						(length 1.27)
+
+						(name ""
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at 0 -3.81 90)
+
+						(length 1.27)
+
+						(name ""
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+	)
+	(wire (pts (xy 45.72 76.2) (xy 60.96 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111201"))
+	(wire (pts (xy 60.96 76.2) (xy 60.96 80.01)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111202"))
+	(wire (pts (xy 60.96 80.01) (xy 76.2 80.01)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111203"))
+	(wire (pts (xy 76.2 72.39) (xy 88.9 72.39)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111204"))
+	(wire (pts (xy 88.9 72.39) (xy 88.9 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111205"))
+	(wire (pts (xy 88.9 76.2) (xy 100.33 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111206"))
+	(wire (pts (xy 92.71 76.2) (xy 92.71 88.9)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111207"))
+	(wire (pts (xy 92.71 88.9) (xy 45.72 88.9)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111208"))
+	(wire (pts (xy 45.72 88.9) (xy 45.72 78.74)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111209"))
+	(label "VIN" (at 55.88 76.2 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left bottom)) (uuid "11111111-1111-4111-8111-111111111210"))
+	(label "LED_A" (at 82.55 72.39 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left bottom)) (uuid "11111111-1111-4111-8111-111111111211"))
+	(label "GND" (at 60.96 88.9 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left top)) (uuid "11111111-1111-4111-8111-111111111212"))
+	(junction (at 60.96 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111213"))
+	(junction (at 60.96 80.01) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111214"))
+	(junction (at 88.9 72.39) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111215"))
+	(junction (at 88.9 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111216"))
+	(junction (at 92.71 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111217"))
+	(junction (at 45.72 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111218"))
+	(junction (at 55.88 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111219"))
+	(junction (at 82.55 72.39) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111220"))
+	(junction (at 60.96 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111221"))
+	(junction (at 55.88 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111222"))
+	(symbol (lib_id "Connector_Generic:Conn_01x02") (at 50.8 76.2 0) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111120")
+		(property "Reference" "J1" (at 50.8 71.12 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "POWER_IN" (at 50.8 81.28 0) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical" (at 50.8 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 50.8 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111121"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111122"))
+		(instances (project "BUCK_CONVERTER" (path "/11111111-1111-4111-8111-111111111111" (reference "J1") (unit 1))))
+	)
+	(symbol (lib_id "Device:R") (at 76.2 76.2 180) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111130")
+		(property "Reference" "R1" (at 79.248 76.2 90) (effects (font (size 1.27 1.27))))
+		(property "Value" "1k" (at 73.66 76.2 90) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric" (at 74.422 76.2 90) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 76.2 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111131"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111132"))
+		(instances (project "BUCK_CONVERTER" (path "/11111111-1111-4111-8111-111111111111" (reference "R1") (unit 1))))
+	)
+	(symbol (lib_id "Device:LED") (at 96.52 76.2 0) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111140")
+		(property "Reference" "D1" (at 96.52 71.12 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "GREEN" (at 96.52 81.28 0) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric" (at 96.52 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 96.52 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111141"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111142"))
+		(instances (project "BUCK_CONVERTER" (path "/11111111-1111-4111-8111-111111111111" (reference "D1") (unit 1))))
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 55.88 76.2 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a070215c-109e-4928-adb5-dfae34334af5")
+		(property "Reference" "#PWRb9f8"
+			(at 57.912000000000006 76.2 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "PWR_FLAG"
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "BUCK_CONVERTER"
+				(path "/7991577d-b7da-48cd-94bd-41d15758bf53"
+					(reference "#PWRb9f8") (unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 60.96 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "02956efe-2170-4291-88b3-d3815889a4d6")
+		(property "Reference" "#PWR3203"
+			(at 62.992000000000004 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "GND"
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "BUCK_CONVERTER"
+				(path "/903d78a0-e55e-483a-98a9-fb79f44f8a61"
+					(reference "#PWR3203") (unit 1)
+			)
+		)
+	)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 55.88 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6f4f6f04-6aef-48cd-9626-bd0c33d37cb2")
+		(property "Reference" "#PWRd0a4"
+			(at 57.912000000000006 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "PWR_FLAG"
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "BUCK_CONVERTER"
+				(path "/11111111-1111-4111-8111-111111111111"
+					(reference "#PWRd0a4") (unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances (path "/" (page "1")))
+	(embedded_fonts no)
+)

--- a/examples/buck-converter/README.md
+++ b/examples/buck-converter/README.md
@@ -1,0 +1,54 @@
+# Buck Converter Review
+
+## Purpose
+
+Use this KiCad 10 project to exercise power-stage review flows without a large
+board. It demonstrates the Basic schematic and PCB viewer workflow, DRC and ERC
+workflow, and BOM and netlist workflow.
+
+## Files
+
+- `BUCK_CONVERTER.kicad_pro`: KiCad project.
+- `BUCK_CONVERTER.kicad_sch`: schematic smoke target for component and netlist review.
+- `BUCK_CONVERTER.kicad_pcb`: routed PCB smoke target for DRC and layout review.
+
+## KiCad Version Compatibility
+
+Verified with KiCad CLI `10.0.3`. This demo is a workflow sample, not a
+production buck-converter reference design.
+
+## Extension Workflow
+
+1. Open `examples/buck-converter` in VS Code.
+2. Inspect `BUCK_CONVERTER.kicad_sch` in the schematic viewer.
+3. Inspect `BUCK_CONVERTER.kicad_pcb` in the PCB viewer.
+4. Use the extension BOM, netlist, and diagnostics surfaces to verify review navigation.
+
+## MCP Workflow
+
+Start KiCad MCP Pro with this folder as `KICAD_MCP_PROJECT_DIR`, then run MCP
+tool discovery, project summary, and validation requests from a compatible MCP
+client. Stop the server afterward and verify the extension reports the degraded
+state cleanly.
+
+```powershell
+$env:KICAD_MCP_PROJECT_DIR = (Get-Location).Path
+kicad-mcp-pro --transport http --port 27185
+```
+
+## Smoke Commands
+
+```powershell
+$kicadCli = 'C:\Program Files\KiCad\10.0\bin\kicad-cli.exe'
+New-Item -ItemType Directory -Force exports | Out-Null
+& $kicadCli sch erc --format json --output exports\BUCK_CONVERTER-erc.json --severity-all --exit-code-violations BUCK_CONVERTER.kicad_sch
+& $kicadCli pcb drc --format json --output exports\BUCK_CONVERTER-drc.json --severity-all --schematic-parity --exit-code-violations BUCK_CONVERTER.kicad_pcb
+& $kicadCli sch export netlist --format kicadxml --output exports\BUCK_CONVERTER.net BUCK_CONVERTER.kicad_sch
+& $kicadCli sch export bom --output exports\BUCK_CONVERTER-bom.csv BUCK_CONVERTER.kicad_sch
+```
+
+## Expected Outputs
+
+Generated ERC, DRC, BOM, and netlist files are written under `exports/`. Keep
+those files out of git unless a future release-smoke issue promotes a specific
+artifact.

--- a/examples/differential-pair-demo/DIFFERENTIAL_PAIR_DEMO.kicad_pcb
+++ b/examples/differential-pair-demo/DIFFERENTIAL_PAIR_DEMO.kicad_pcb
@@ -1,0 +1,573 @@
+(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(title_block
+		(title "Differential Pair Review Demo")
+		(date "2026-05-20")
+		(rev "1.0.0")
+		(company "oaslananka")
+		(comment 1 "Differential-pair review board for smoke workflows")
+	)
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user "F.Adhesive")
+		(11 "B.Adhes" user "B.Adhesive")
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user "F.Silkscreen")
+		(7 "B.SilkS" user "B.Silkscreen")
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user "User.Drawings")
+		(19 "Cmts.User" user "User.Comments")
+		(21 "Eco1.User" user "User.Eco1")
+		(23 "Eco2.User" user "User.Eco2")
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user "F.Courtyard")
+		(29 "B.CrtYd" user "B.Courtyard")
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+		(39 "User.1" user)
+		(41 "User.2" user)
+		(43 "User.3" user)
+		(45 "User.4" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting (front yes) (back yes))
+		(covering (front no) (back no))
+		(plugging (front no) (back no))
+		(capping no)
+		(filling no)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_55555555_5755f5ff)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions no)
+			(usegerberattributes yes)
+			(usegerberadvancedattributes yes)
+			(creategerberjobfile yes)
+			(dashed_line_dash_ratio 12)
+			(dashed_line_gap_ratio 3)
+			(svgprecision 4)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk no)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 1)
+			(scaleselection 1)
+			(outputdirectory "exports/gerbers")
+		)
+	)
+	(gr_rect (start 45 45) (end 75 58) (stroke (width 0.1) (type solid)) (fill no) (layer "Edge.Cuts") (uuid "22222222-2222-4222-8222-222222222001"))
+	(gr_text "Diff Pair Demo" (at 60 46.5 0) (layer "F.SilkS") (uuid "22222222-2222-4222-8222-222222222002") (effects (font (size 1.1 1.1) (thickness 0.15))))
+	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 50 50 0)
+		(uuid "22222222-2222-4222-8222-222222222010")
+		(descr "Through hole straight pin header, 1x02, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x02 2.54mm single row")
+		(property "Reference" "J1"
+			(at 0 -2.38 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "POWER_IN"
+			(at 0 4.92 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "connector/pin_header_socket"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.38 -1.38)
+			(end 0 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 0)
+			(end -1.38 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end -1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end 1.38 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 3.92)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1.38 1.27)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.77 -1.77)
+			(end 1.77 4.32)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1.27 3.81)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 3.81)
+			(end -1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 1.27 90)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole rect
+			(at 0 0)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
+			(net "/VIN")
+			(pinfunction "Pin_1")
+			(pintype "passive"))
+		(pad "2" thru_hole circle
+			(at 0 2.54)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
+			(net "GND")
+			(pinfunction "Pin_2")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 60 50 0)
+		(uuid "22222222-2222-4222-8222-222222222020")
+		(descr "Resistor SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: IPC-SM-782 page 72, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf)")
+		(tags "resistor")
+		(property "Reference" "R1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.227064 -0.735)
+			(end 0.227064 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -0.227064 0.735)
+			(end 0.227064 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_rect
+			(start -1 -0.625)
+			(end 1 0.625)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
+			(net "/VIN")
+			(pinfunction "1")
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
+			(net "/LED_A")
+			(pinfunction "2")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 68 50 0)
+		(uuid "22222222-2222-4222-8222-222222222030")
+		(descr "LED SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: https://docs.google.com/spreadsheets/d/1BsfQQcO9C6DZCsRaXUlFlo91Tg2WpOkGARC1WS5S8t0/edit?usp=sharing)")
+		(tags "LED")
+		(property "Reference" "D1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GREEN"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.685 -0.96)
+			(end -1.685 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.685 0.96)
+			(end 1 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1 -0.96)
+			(end -1.685 -0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1 -0.3)
+			(end -1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1 0.6)
+			(end 1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.7 -0.6)
+			(end -1 -0.3)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 -0.6)
+			(end -0.7 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 0.6)
+			(end 1 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
+			(net "GND")
+			(pinfunction "K")
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
+			(net "/LED_A")
+			(pinfunction "A")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/LED_SMD.3dshapes/LED_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(segment (start 50 50) (end 59.0875 50) (width 0.35) (layer "F.Cu") (net "/VIN") (uuid "22222222-2222-4222-8222-222222222040"))
+	(segment (start 60.9125 50) (end 60.9125 47.5) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222041"))
+	(segment (start 60.9125 47.5) (end 68.9375 47.5) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222042"))
+	(segment (start 68.9375 47.5) (end 68.9375 50) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222043"))
+	(segment (start 67.0625 50) (end 67.0625 52.54) (width 0.35) (layer "F.Cu") (net "GND") (uuid "22222222-2222-4222-8222-222222222044"))
+	(segment (start 67.0625 52.54) (end 50 52.54) (width 0.35) (layer "F.Cu") (net "GND") (uuid "22222222-2222-4222-8222-222222222045"))
+)

--- a/examples/differential-pair-demo/DIFFERENTIAL_PAIR_DEMO.kicad_pro
+++ b/examples/differential-pair-demo/DIFFERENTIAL_PAIR_DEMO.kicad_pro
@@ -1,0 +1,656 @@
+{
+  "board": {
+    "3dviewports": [],
+    "design_settings": {
+      "defaults": {
+        "apply_defaults_to_fp_barcodes": false,
+        "apply_defaults_to_fp_dimensions": false,
+        "apply_defaults_to_fp_fields": false,
+        "apply_defaults_to_fp_shapes": false,
+        "apply_defaults_to_fp_text": false,
+        "board_outline_line_width": 0.05,
+        "copper_line_width": 0.2,
+        "copper_text_italic": false,
+        "copper_text_size_h": 1.5,
+        "copper_text_size_v": 1.5,
+        "copper_text_thickness": 0.3,
+        "copper_text_upright": false,
+        "courtyard_line_width": 0.05,
+        "dimension_precision": 4,
+        "dimension_units": 3,
+        "dimensions": {
+          "arrow_length": 1270000,
+          "extension_offset": 500000,
+          "keep_text_aligned": true,
+          "suppress_zeroes": true,
+          "text_position": 0,
+          "units_format": 0
+        },
+        "fab_line_width": 0.1,
+        "fab_text_italic": false,
+        "fab_text_size_h": 1.0,
+        "fab_text_size_v": 1.0,
+        "fab_text_thickness": 0.15,
+        "fab_text_upright": false,
+        "other_line_width": 0.1,
+        "other_text_italic": false,
+        "other_text_size_h": 1.0,
+        "other_text_size_v": 1.0,
+        "other_text_thickness": 0.15,
+        "other_text_upright": false,
+        "pads": {
+          "drill": 0.8,
+          "height": 1.27,
+          "width": 2.54
+        },
+        "silk_line_width": 0.1,
+        "silk_text_italic": false,
+        "silk_text_size_h": 1.0,
+        "silk_text_size_v": 1.0,
+        "silk_text_thickness": 0.1,
+        "silk_text_upright": false,
+        "zones": {
+          "border_display_style": 2,
+          "border_hatch_pitch": 0.5,
+          "corner_radius": 0.0,
+          "corner_smoothing": 0,
+          "fill_mode": 0,
+          "hatch_gap": 1.5,
+          "hatch_orientation": 0.0,
+          "hatch_smoothing_level": 0,
+          "hatch_smoothing_value": 0.1,
+          "hatch_thickness": 1.0,
+          "min_clearance": 0.5,
+          "min_island_area": 10.0,
+          "min_thickness": 0.25,
+          "pad_connection": 1,
+          "remove_islands": 0,
+          "thermal_relief_gap": 0.5,
+          "thermal_relief_spoke_width": 0.5
+        }
+      },
+      "diff_pair_dimensions": [],
+      "drc_exclusions": [],
+      "meta": {
+        "version": 2
+      },
+      "rule_severities": {
+        "annular_width": "error",
+        "clearance": "error",
+        "connection_width": "warning",
+        "copper_edge_clearance": "error",
+        "copper_sliver": "warning",
+        "courtyards_overlap": "error",
+        "creepage": "error",
+        "diff_pair_gap_out_of_range": "error",
+        "diff_pair_uncoupled_length_too_long": "error",
+        "drill_out_of_range": "error",
+        "duplicate_footprints": "warning",
+        "extra_footprint": "warning",
+        "footprint": "error",
+        "footprint_filters_mismatch": "ignore",
+        "footprint_symbol_field_mismatch": "warning",
+        "footprint_symbol_mismatch": "warning",
+        "footprint_type_mismatch": "ignore",
+        "hole_clearance": "error",
+        "hole_to_hole": "warning",
+        "holes_co_located": "warning",
+        "invalid_outline": "error",
+        "isolated_copper": "warning",
+        "item_on_disabled_layer": "error",
+        "items_not_allowed": "error",
+        "length_out_of_range": "error",
+        "lib_footprint_issues": "warning",
+        "lib_footprint_mismatch": "warning",
+        "malformed_courtyard": "error",
+        "microvia_drill_out_of_range": "error",
+        "mirrored_text_on_front_layer": "warning",
+        "missing_courtyard": "ignore",
+        "missing_footprint": "warning",
+        "missing_tuning_profile": "warning",
+        "net_conflict": "warning",
+        "nonmirrored_text_on_back_layer": "warning",
+        "npth_inside_courtyard": "error",
+        "padstack": "warning",
+        "pth_inside_courtyard": "error",
+        "shorting_items": "error",
+        "silk_edge_clearance": "warning",
+        "silk_over_copper": "warning",
+        "silk_overlap": "warning",
+        "skew_out_of_range": "error",
+        "solder_mask_bridge": "error",
+        "starved_thermal": "error",
+        "text_height": "warning",
+        "text_on_edge_cuts": "error",
+        "text_thickness": "warning",
+        "through_hole_pad_without_hole": "error",
+        "too_many_vias": "error",
+        "track_angle": "error",
+        "track_dangling": "warning",
+        "track_not_centered_on_via": "ignore",
+        "track_on_post_machined_layer": "error",
+        "track_segment_length": "error",
+        "track_width": "error",
+        "tracks_crossing": "error",
+        "tuning_profile_track_geometries": "ignore",
+        "unconnected_items": "error",
+        "unresolved_variable": "error",
+        "via_dangling": "warning",
+        "zones_intersect": "error"
+      },
+      "rules": {
+        "max_error": 0.005,
+        "min_clearance": 0.0,
+        "min_connection": 0.0,
+        "min_copper_edge_clearance": 0.5,
+        "min_groove_width": 0.0,
+        "min_hole_clearance": 0.25,
+        "min_hole_to_hole": 0.25,
+        "min_microvia_diameter": 0.2,
+        "min_microvia_drill": 0.1,
+        "min_resolved_spokes": 2,
+        "min_silk_clearance": 0.0,
+        "min_text_height": 0.8,
+        "min_text_thickness": 0.08,
+        "min_through_hole_diameter": 0.3,
+        "min_track_width": 0.2,
+        "min_via_annular_width": 0.1,
+        "min_via_diameter": 0.5,
+        "solder_mask_to_copper_clearance": 0.0,
+        "use_height_for_length_calcs": true
+      },
+      "teardrop_options": [
+        {
+          "td_onpthpad": true,
+          "td_onroundshapesonly": false,
+          "td_onsmdpad": true,
+          "td_ontrackend": false,
+          "td_onvia": true
+        }
+      ],
+      "teardrop_parameters": [
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_round_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_rect_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_track_end",
+          "td_width_to_size_filter_ratio": 0.9
+        }
+      ],
+      "track_widths": [],
+      "tuning_pattern_settings": {
+        "diff_pair_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 1.0
+        },
+        "diff_pair_skew_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        },
+        "single_track_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        }
+      },
+      "via_dimensions": [],
+      "zones_allow_external_fillets": false
+    },
+    "ipc2581": {
+      "bom_rev": "",
+      "dist": "",
+      "distpn": "",
+      "internal_id": "",
+      "mfg": "",
+      "mpn": "",
+      "sch_revision": ""
+    },
+    "layer_pairs": [],
+    "layer_presets": [],
+    "viewports": []
+  },
+  "boards": [],
+  "component_class_settings": {
+    "assignments": [],
+    "meta": {
+      "version": 0
+    },
+    "sheet_component_classes": {
+      "enabled": false
+    }
+  },
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "erc": {
+    "erc_exclusions": [],
+    "meta": {
+      "version": 0
+    },
+    "pin_map": [
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        2
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        2,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        2,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    ],
+    "rule_severities": {
+      "bus_definition_conflict": "error",
+      "bus_entry_needed": "error",
+      "bus_to_bus_conflict": "error",
+      "bus_to_net_conflict": "error",
+      "different_unit_footprint": "error",
+      "different_unit_net": "error",
+      "duplicate_reference": "error",
+      "duplicate_sheet_names": "error",
+      "endpoint_off_grid": "warning",
+      "extra_units": "error",
+      "field_name_whitespace": "warning",
+      "footprint_filter": "ignore",
+      "footprint_link_issues": "warning",
+      "four_way_junction": "ignore",
+      "ground_pin_not_ground": "warning",
+      "hier_label_mismatch": "error",
+      "isolated_pin_label": "warning",
+      "label_dangling": "error",
+      "label_multiple_wires": "warning",
+      "lib_symbol_issues": "warning",
+      "lib_symbol_mismatch": "warning",
+      "missing_bidi_pin": "warning",
+      "missing_input_pin": "warning",
+      "missing_power_pin": "error",
+      "missing_unit": "warning",
+      "multiple_net_names": "warning",
+      "net_not_bus_member": "warning",
+      "no_connect_connected": "warning",
+      "no_connect_dangling": "warning",
+      "pin_not_connected": "error",
+      "pin_not_driven": "error",
+      "pin_to_pin": "warning",
+      "power_pin_not_driven": "error",
+      "same_local_global_label": "warning",
+      "similar_label_and_power": "warning",
+      "similar_labels": "warning",
+      "similar_power": "warning",
+      "simulation_model_issue": "ignore",
+      "single_global_label": "ignore",
+      "stacked_pin_name": "warning",
+      "unannotated": "error",
+      "unconnected_wire_endpoint": "warning",
+      "undefined_netclass": "error",
+      "unit_value_mismatch": "error",
+      "unresolved_variable": "error",
+      "wire_dangling": "error"
+    }
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "DIFFERENTIAL_PAIR_DEMO.kicad_pro",
+    "version": 3
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.2,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 2147483647,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.2,
+        "tuning_profile": "",
+        "via_diameter": 0.6,
+        "via_drill": 0.3,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 5
+    },
+    "net_colors": null,
+    "netclass_assignments": null,
+    "netclass_patterns": []
+  },
+  "pcbnew": {
+    "last_paths": {
+      "idf": "",
+      "netlist": "",
+      "plot": "",
+      "specctra_dsn": "",
+      "vrml": ""
+    },
+    "page_layout_descr_file": ""
+  },
+  "schematic": {
+    "annotate_start_num": 0,
+    "annotation": {
+      "method": 0,
+      "sort_order": 0
+    },
+    "bom_export_filename": "${PROJECTNAME}.csv",
+    "bom_fmt_presets": [],
+    "bom_fmt_settings": {
+      "field_delimiter": ",",
+      "keep_line_breaks": false,
+      "keep_tabs": false,
+      "name": "CSV",
+      "ref_delimiter": ",",
+      "ref_range_delimiter": "",
+      "string_delimiter": "\""
+    },
+    "bom_presets": [],
+    "bom_settings": {
+      "exclude_dnp": false,
+      "fields_ordered": [
+        {
+          "group_by": false,
+          "label": "Reference",
+          "name": "Reference",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Qty",
+          "name": "${QUANTITY}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Value",
+          "name": "Value",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "DNP",
+          "name": "${DNP}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Exclude from BOM",
+          "name": "${EXCLUDE_FROM_BOM}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Exclude from Board",
+          "name": "${EXCLUDE_FROM_BOARD}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Footprint",
+          "name": "Footprint",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Datasheet",
+          "name": "Datasheet",
+          "show": true
+        }
+      ],
+      "filter_string": "",
+      "group_symbols": true,
+      "include_excluded_from_bom": true,
+      "name": "Default Editing",
+      "sort_asc": true,
+      "sort_field": "Reference"
+    },
+    "bus_aliases": {},
+    "connection_grid_size": 50.0,
+    "drawing": {
+      "dashed_lines_dash_length_ratio": 12.0,
+      "dashed_lines_gap_length_ratio": 3.0,
+      "default_line_thickness": 6.0,
+      "default_text_size": 50.0,
+      "field_names": [],
+      "hop_over_size_choice": 0,
+      "intersheets_ref_own_page": false,
+      "intersheets_ref_prefix": "",
+      "intersheets_ref_short": false,
+      "intersheets_ref_show": false,
+      "intersheets_ref_suffix": "",
+      "junction_size_choice": 3,
+      "label_size_ratio": 0.375,
+      "operating_point_overlay_i_precision": 3,
+      "operating_point_overlay_i_range": "~A",
+      "operating_point_overlay_v_precision": 3,
+      "operating_point_overlay_v_range": "~V",
+      "overbar_offset_ratio": 1.23,
+      "pin_symbol_size": 25.0,
+      "text_offset_ratio": 0.15
+    },
+    "legacy_lib_dir": "",
+    "legacy_lib_list": [],
+    "meta": {
+      "version": 1
+    },
+    "page_layout_descr_file": "",
+    "plot_directory": "",
+    "reuse_designators": true,
+    "subpart_first_id": 65,
+    "subpart_id_separator": 0,
+    "top_level_sheets": [],
+    "used_designators": "",
+    "variants": []
+  },
+  "sheets": [],
+  "text_variables": {},
+  "tuning_profiles": {
+    "meta": {
+      "version": 0
+    },
+    "tuning_profiles_impedance_geometric": []
+  }
+}

--- a/examples/differential-pair-demo/DIFFERENTIAL_PAIR_DEMO.kicad_sch
+++ b/examples/differential-pair-demo/DIFFERENTIAL_PAIR_DEMO.kicad_sch
@@ -1,0 +1,1394 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "11111111-1111-4111-8111-111111111111")
+	(paper "A4")
+	(title_block
+		(title "Differential Pair Review Demo")
+		(date "2026-05-20")
+		(rev "1.0.0")
+		(company "oaslananka")
+		(comment 1 "Differential-pair review workflow sample")
+	)
+	(lib_symbols
+	(symbol "power:GND"
+		(power global)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 0 -3.81 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "GND_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GND_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "power:PWR_FLAG"
+		(power global)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "#FLG"
+			(at 0 1.905 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 0 3.81 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Special symbol for telling ERC where power comes from"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "flag power"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "PWR_FLAG_0_0"
+			(pin power_out line
+				(at 0 0 90)
+				(length 0)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "PWR_FLAG_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+		(symbol "Connector_Generic:Conn_01x02"
+
+				(pin_names
+
+					(offset 1.016)
+
+					(hide yes)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "J"
+
+					(at 0 2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "Conn_01x02"
+
+					(at 0 -5.08 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "connector"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "Connector*:*_1x??_*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "Conn_01x02_1_1"
+
+					(rectangle
+
+						(start -1.27 1.27)
+
+						(end 1.27 -3.81)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type background)
+
+						)
+
+					)
+
+					(rectangle
+
+						(start -1.27 0.127)
+
+						(end 0 -0.127)
+
+						(stroke
+
+							(width 0.1524)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(rectangle
+
+						(start -1.27 -2.413)
+
+						(end 0 -2.667)
+
+						(stroke
+
+							(width 0.1524)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at -5.08 0 0)
+
+						(length 3.81)
+
+						(name "Pin_1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at -5.08 -2.54 0)
+
+						(length 3.81)
+
+						(name "Pin_2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+		(symbol "Device:LED"
+
+				(pin_numbers
+
+					(hide yes)
+
+				)
+
+				(pin_names
+
+					(offset 1.016)
+
+					(hide yes)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "D"
+
+					(at 0 2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "LED"
+
+					(at 0 -2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Light emitting diode"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Sim.Pins" "1=K 2=A"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "LED diode"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "LED_0_1"
+
+					(polyline
+
+						(pts
+
+							(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.27 0) (xy 1.27 0)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.27 -1.27) (xy -1.27 1.27)
+
+						)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+
+						)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+				)
+
+				(symbol "LED_1_1"
+
+					(pin passive line
+
+						(at -3.81 0 0)
+
+						(length 2.54)
+
+						(name "K"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at 3.81 0 180)
+
+						(length 2.54)
+
+						(name "A"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+		(symbol "Device:R"
+
+				(pin_numbers
+
+					(hide yes)
+
+				)
+
+				(pin_names
+
+					(offset 0)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "R"
+
+					(at 2.032 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "R"
+
+					(at 0 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at -1.778 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Resistor"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "R res resistor"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "R_*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "R_0_1"
+
+					(rectangle
+
+						(start -1.016 -2.54)
+
+						(end 1.016 2.54)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+				)
+
+				(symbol "R_1_1"
+
+					(pin passive line
+
+						(at 0 3.81 270)
+
+						(length 1.27)
+
+						(name ""
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at 0 -3.81 90)
+
+						(length 1.27)
+
+						(name ""
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+	)
+	(wire (pts (xy 45.72 76.2) (xy 60.96 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111201"))
+	(wire (pts (xy 60.96 76.2) (xy 60.96 80.01)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111202"))
+	(wire (pts (xy 60.96 80.01) (xy 76.2 80.01)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111203"))
+	(wire (pts (xy 76.2 72.39) (xy 88.9 72.39)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111204"))
+	(wire (pts (xy 88.9 72.39) (xy 88.9 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111205"))
+	(wire (pts (xy 88.9 76.2) (xy 100.33 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111206"))
+	(wire (pts (xy 92.71 76.2) (xy 92.71 88.9)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111207"))
+	(wire (pts (xy 92.71 88.9) (xy 45.72 88.9)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111208"))
+	(wire (pts (xy 45.72 88.9) (xy 45.72 78.74)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111209"))
+	(label "VIN" (at 55.88 76.2 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left bottom)) (uuid "11111111-1111-4111-8111-111111111210"))
+	(label "LED_A" (at 82.55 72.39 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left bottom)) (uuid "11111111-1111-4111-8111-111111111211"))
+	(label "GND" (at 60.96 88.9 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left top)) (uuid "11111111-1111-4111-8111-111111111212"))
+	(junction (at 60.96 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111213"))
+	(junction (at 60.96 80.01) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111214"))
+	(junction (at 88.9 72.39) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111215"))
+	(junction (at 88.9 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111216"))
+	(junction (at 92.71 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111217"))
+	(junction (at 45.72 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111218"))
+	(junction (at 55.88 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111219"))
+	(junction (at 82.55 72.39) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111220"))
+	(junction (at 60.96 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111221"))
+	(junction (at 55.88 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111222"))
+	(symbol (lib_id "Connector_Generic:Conn_01x02") (at 50.8 76.2 0) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111120")
+		(property "Reference" "J1" (at 50.8 71.12 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "POWER_IN" (at 50.8 81.28 0) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical" (at 50.8 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 50.8 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111121"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111122"))
+		(instances (project "DIFFERENTIAL_PAIR_DEMO" (path "/11111111-1111-4111-8111-111111111111" (reference "J1") (unit 1))))
+	)
+	(symbol (lib_id "Device:R") (at 76.2 76.2 180) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111130")
+		(property "Reference" "R1" (at 79.248 76.2 90) (effects (font (size 1.27 1.27))))
+		(property "Value" "1k" (at 73.66 76.2 90) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric" (at 74.422 76.2 90) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 76.2 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111131"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111132"))
+		(instances (project "DIFFERENTIAL_PAIR_DEMO" (path "/11111111-1111-4111-8111-111111111111" (reference "R1") (unit 1))))
+	)
+	(symbol (lib_id "Device:LED") (at 96.52 76.2 0) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111140")
+		(property "Reference" "D1" (at 96.52 71.12 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "GREEN" (at 96.52 81.28 0) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric" (at 96.52 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 96.52 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111141"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111142"))
+		(instances (project "DIFFERENTIAL_PAIR_DEMO" (path "/11111111-1111-4111-8111-111111111111" (reference "D1") (unit 1))))
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 55.88 76.2 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a070215c-109e-4928-adb5-dfae34334af5")
+		(property "Reference" "#PWRb9f8"
+			(at 57.912000000000006 76.2 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "PWR_FLAG"
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "DIFFERENTIAL_PAIR_DEMO"
+				(path "/7991577d-b7da-48cd-94bd-41d15758bf53"
+					(reference "#PWRb9f8") (unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 60.96 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "02956efe-2170-4291-88b3-d3815889a4d6")
+		(property "Reference" "#PWR3203"
+			(at 62.992000000000004 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "GND"
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "DIFFERENTIAL_PAIR_DEMO"
+				(path "/903d78a0-e55e-483a-98a9-fb79f44f8a61"
+					(reference "#PWR3203") (unit 1)
+			)
+		)
+	)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 55.88 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6f4f6f04-6aef-48cd-9626-bd0c33d37cb2")
+		(property "Reference" "#PWRd0a4"
+			(at 57.912000000000006 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "PWR_FLAG"
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "DIFFERENTIAL_PAIR_DEMO"
+				(path "/11111111-1111-4111-8111-111111111111"
+					(reference "#PWRd0a4") (unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances (path "/" (page "1")))
+	(embedded_fonts no)
+)

--- a/examples/differential-pair-demo/README.md
+++ b/examples/differential-pair-demo/README.md
@@ -1,0 +1,50 @@
+# Differential Pair Review
+
+## Purpose
+
+Use this KiCad 10 project to rehearse high-speed review UI and MCP flows with a
+small board. It demonstrates the Basic schematic and PCB viewer workflow, DRC
+and ERC workflow, and MCP connected workflow.
+
+## Files
+
+- `DIFFERENTIAL_PAIR_DEMO.kicad_pro`: KiCad project.
+- `DIFFERENTIAL_PAIR_DEMO.kicad_sch`: schematic smoke target for high-speed review navigation.
+- `DIFFERENTIAL_PAIR_DEMO.kicad_pcb`: routed PCB smoke target for viewer and DRC review.
+
+## KiCad Version Compatibility
+
+Verified with KiCad CLI `10.0.3`. This demo validates the review workflow shape
+only; it is not a production impedance-controlled layout.
+
+## Extension Workflow
+
+1. Open `examples/differential-pair-demo` in VS Code.
+2. Open `DIFFERENTIAL_PAIR_DEMO.kicad_pcb` and verify high-speed review panels can reference the active board.
+3. Open `DIFFERENTIAL_PAIR_DEMO.kicad_sch` and verify schematic navigation remains available.
+4. Run validation commands and inspect how results appear in Problems, status bar, and project views.
+
+## MCP Workflow
+
+Use the MCP connected workflow to run project summary and board-inspection tools
+against this folder. Confirm the MCP tools view displays connected state,
+capability metadata, and validation results for the active project.
+
+```powershell
+$env:KICAD_MCP_PROJECT_DIR = (Get-Location).Path
+kicad-mcp-pro --transport http --port 27185
+```
+
+## Smoke Commands
+
+```powershell
+$kicadCli = 'C:\Program Files\KiCad\10.0\bin\kicad-cli.exe'
+New-Item -ItemType Directory -Force exports | Out-Null
+& $kicadCli sch erc --format json --output exports\DIFFERENTIAL_PAIR_DEMO-erc.json --severity-all --exit-code-violations DIFFERENTIAL_PAIR_DEMO.kicad_sch
+& $kicadCli pcb drc --format json --output exports\DIFFERENTIAL_PAIR_DEMO-drc.json --severity-all --schematic-parity --exit-code-violations DIFFERENTIAL_PAIR_DEMO.kicad_pcb
+```
+
+## Expected Outputs
+
+Validation reports are written under `exports/`. Keep generated reports,
+screenshots, and MCP logs out of git.

--- a/examples/led-basic/README.md
+++ b/examples/led-basic/README.md
@@ -1,24 +1,46 @@
-# LED Basic KiCad Example
+# LED Basic
 
-This is a minimal KiCad 10 project for validating KiCad Studio and KiCad MCP Pro workflows without a large board.
+## Purpose
 
-## Circuit
-
-- `J1`: 2-pin power input.
-- `R1`: 1 kOhm series resistor.
-- `D1`: green LED.
-- Nets: `/VIN`, `/LED_A`, `GND`.
+Use this compact KiCad 10 project as the first smoke target for KiCad Studio and
+KiCad MCP Pro. It demonstrates the Basic schematic and PCB viewer workflow, DRC
+and ERC workflow, and BOM and netlist workflow without requiring a large board.
 
 ## Files
 
 - `KICAD_TEST.kicad_pro`: KiCad project.
-- `KICAD_TEST.kicad_sch`: schematic.
-- `KICAD_TEST.kicad_pcb`: routed PCB.
+- `KICAD_TEST.kicad_sch`: schematic with a two-pin input, current-limiting resistor, LED, and ground net.
+- `KICAD_TEST.kicad_pcb`: routed PCB suitable for viewer, DRC, and manufacturing-export smoke commands.
 
-## KiCad CLI smoke checks
+## KiCad Version Compatibility
+
+Verified with KiCad CLI `10.0.3`. The files use KiCad 10 project, schematic,
+and PCB formats and are intended as small demo assets rather than a reference
+electrical design.
+
+## Extension Workflow
+
+1. Open `examples/led-basic` in VS Code.
+2. Open `KICAD_TEST.kicad_sch` and verify the schematic viewer fits the sheet.
+3. Open `KICAD_TEST.kicad_pcb` and verify the PCB viewer, zoom controls, layer state, and project tree.
+4. Run the extension validation commands and confirm DRC/ERC status is visible in the UI.
+
+## MCP Workflow
+
+The MCP connected workflow uses this project as a read-only board inspection
+target. The MCP degraded workflow can be exercised by starting the extension
+without the server and confirming the UI keeps project files inspectable.
+
+```powershell
+$env:KICAD_MCP_PROJECT_DIR = (Get-Location).Path
+kicad-mcp-pro --transport http --port 27185
+```
+
+## Smoke Commands
 
 ```powershell
 $kicadCli = 'C:\Program Files\KiCad\10.0\bin\kicad-cli.exe'
+New-Item -ItemType Directory -Force exports | Out-Null
 & $kicadCli sch erc --format json --output exports\KICAD_TEST-erc.json --severity-all --exit-code-violations KICAD_TEST.kicad_sch
 & $kicadCli pcb drc --format json --output exports\KICAD_TEST-drc.json --severity-all --schematic-parity --exit-code-violations KICAD_TEST.kicad_pcb
 & $kicadCli sch export netlist --format kicadxml --output exports\KICAD_TEST.net KICAD_TEST.kicad_sch
@@ -27,19 +49,8 @@ $kicadCli = 'C:\Program Files\KiCad\10.0\bin\kicad-cli.exe'
 & $kicadCli pcb export drill --output exports\drill --generate-report --report-path exports\drill\KICAD_TEST-drill.rpt KICAD_TEST.kicad_pcb
 ```
 
-The project was verified with KiCad CLI `10.0.3` on Windows 11.
+## Expected Outputs
 
-## Extension smoke workflow
-
-1. Open this folder in VS Code.
-2. Open `KICAD_TEST.kicad_sch` and `KICAD_TEST.kicad_pcb`.
-3. Verify the schematic/PCB viewers, project tree, BOM/netlist panels, and DRC/ERC status.
-
-## MCP smoke workflow
-
-```powershell
-$env:KICAD_MCP_PROJECT_DIR = (Get-Location).Path
-kicad-mcp-pro --transport http --port 27185
-```
-
-Use the extension or a compatible MCP client to inspect the project, run validation tools, and export manufacturing files.
+Generated reports and manufacturing files are written under `exports/`, which is
+ignored by git. Keep screenshots or rendered outputs outside the repository
+unless a future release smoke workflow explicitly promotes them.

--- a/examples/manifest.json
+++ b/examples/manifest.json
@@ -1,0 +1,103 @@
+{
+  "version": 1,
+  "source": "OASLANA-77",
+  "policy": "User-facing examples are documentation and smoke-test projects, not deterministic fixtures.",
+  "examples": [
+    {
+      "id": "led-basic",
+      "title": "LED Basic",
+      "projectFiles": [
+        "KICAD_TEST.kicad_pro",
+        "KICAD_TEST.kicad_sch",
+        "KICAD_TEST.kicad_pcb"
+      ],
+      "workflows": [
+        "Basic schematic and PCB viewer",
+        "DRC and ERC workflow",
+        "BOM and netlist workflow"
+      ],
+      "compatibility": "KiCad 10.0.3",
+      "releaseSmoke": true
+    },
+    {
+      "id": "usb-c-power",
+      "title": "USB-C Power Intake",
+      "projectFiles": [
+        "USB_C_POWER.kicad_pro",
+        "USB_C_POWER.kicad_sch",
+        "USB_C_POWER.kicad_pcb"
+      ],
+      "workflows": [
+        "Basic schematic and PCB viewer",
+        "DRC and ERC workflow",
+        "MCP degraded workflow"
+      ],
+      "compatibility": "KiCad 10.0.3",
+      "releaseSmoke": false
+    },
+    {
+      "id": "buck-converter",
+      "title": "Buck Converter Review",
+      "projectFiles": [
+        "BUCK_CONVERTER.kicad_pro",
+        "BUCK_CONVERTER.kicad_sch",
+        "BUCK_CONVERTER.kicad_pcb"
+      ],
+      "workflows": [
+        "Basic schematic and PCB viewer",
+        "DRC and ERC workflow",
+        "BOM and netlist workflow"
+      ],
+      "compatibility": "KiCad 10.0.3",
+      "releaseSmoke": false
+    },
+    {
+      "id": "differential-pair-demo",
+      "title": "Differential Pair Review",
+      "projectFiles": [
+        "DIFFERENTIAL_PAIR_DEMO.kicad_pro",
+        "DIFFERENTIAL_PAIR_DEMO.kicad_sch",
+        "DIFFERENTIAL_PAIR_DEMO.kicad_pcb"
+      ],
+      "workflows": [
+        "Basic schematic and PCB viewer",
+        "DRC and ERC workflow",
+        "MCP connected workflow"
+      ],
+      "compatibility": "KiCad 10.0.3",
+      "releaseSmoke": false
+    },
+    {
+      "id": "manufacturing-release-demo",
+      "title": "Manufacturing Release",
+      "projectFiles": [
+        "MANUFACTURING_RELEASE_DEMO.kicad_pro",
+        "MANUFACTURING_RELEASE_DEMO.kicad_sch",
+        "MANUFACTURING_RELEASE_DEMO.kicad_pcb"
+      ],
+      "workflows": [
+        "DRC and ERC workflow",
+        "BOM and netlist workflow",
+        "Manufacturing export workflow"
+      ],
+      "compatibility": "KiCad 10.0.3",
+      "releaseSmoke": false
+    },
+    {
+      "id": "mcp-demo",
+      "title": "MCP Workflow Demo",
+      "projectFiles": [
+        "MCP_DEMO.kicad_pro",
+        "MCP_DEMO.kicad_sch",
+        "MCP_DEMO.kicad_pcb"
+      ],
+      "workflows": [
+        "Basic schematic and PCB viewer",
+        "MCP connected workflow",
+        "MCP degraded workflow"
+      ],
+      "compatibility": "KiCad 10.0.3",
+      "releaseSmoke": false
+    }
+  ]
+}

--- a/examples/manufacturing-release-demo/MANUFACTURING_RELEASE_DEMO.kicad_pcb
+++ b/examples/manufacturing-release-demo/MANUFACTURING_RELEASE_DEMO.kicad_pcb
@@ -1,0 +1,573 @@
+(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(title_block
+		(title "Manufacturing Release Demo")
+		(date "2026-05-20")
+		(rev "1.0.0")
+		(company "oaslananka")
+		(comment 1 "Manufacturing export review board for smoke workflows")
+	)
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user "F.Adhesive")
+		(11 "B.Adhes" user "B.Adhesive")
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user "F.Silkscreen")
+		(7 "B.SilkS" user "B.Silkscreen")
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user "User.Drawings")
+		(19 "Cmts.User" user "User.Comments")
+		(21 "Eco1.User" user "User.Eco1")
+		(23 "Eco2.User" user "User.Eco2")
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user "F.Courtyard")
+		(29 "B.CrtYd" user "B.Courtyard")
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+		(39 "User.1" user)
+		(41 "User.2" user)
+		(43 "User.3" user)
+		(45 "User.4" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting (front yes) (back yes))
+		(covering (front no) (back no))
+		(plugging (front no) (back no))
+		(capping no)
+		(filling no)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_55555555_5755f5ff)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions no)
+			(usegerberattributes yes)
+			(usegerberadvancedattributes yes)
+			(creategerberjobfile yes)
+			(dashed_line_dash_ratio 12)
+			(dashed_line_gap_ratio 3)
+			(svgprecision 4)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk no)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 1)
+			(scaleselection 1)
+			(outputdirectory "exports/gerbers")
+		)
+	)
+	(gr_rect (start 45 45) (end 75 58) (stroke (width 0.1) (type solid)) (fill no) (layer "Edge.Cuts") (uuid "22222222-2222-4222-8222-222222222001"))
+	(gr_text "Mfg Release Demo" (at 60 46.5 0) (layer "F.SilkS") (uuid "22222222-2222-4222-8222-222222222002") (effects (font (size 1.1 1.1) (thickness 0.15))))
+	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 50 50 0)
+		(uuid "22222222-2222-4222-8222-222222222010")
+		(descr "Through hole straight pin header, 1x02, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x02 2.54mm single row")
+		(property "Reference" "J1"
+			(at 0 -2.38 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "POWER_IN"
+			(at 0 4.92 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "connector/pin_header_socket"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.38 -1.38)
+			(end 0 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 0)
+			(end -1.38 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end -1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end 1.38 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 3.92)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1.38 1.27)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.77 -1.77)
+			(end 1.77 4.32)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1.27 3.81)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 3.81)
+			(end -1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 1.27 90)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole rect
+			(at 0 0)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
+			(net "/VIN")
+			(pinfunction "Pin_1")
+			(pintype "passive"))
+		(pad "2" thru_hole circle
+			(at 0 2.54)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
+			(net "GND")
+			(pinfunction "Pin_2")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 60 50 0)
+		(uuid "22222222-2222-4222-8222-222222222020")
+		(descr "Resistor SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: IPC-SM-782 page 72, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf)")
+		(tags "resistor")
+		(property "Reference" "R1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.227064 -0.735)
+			(end 0.227064 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -0.227064 0.735)
+			(end 0.227064 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_rect
+			(start -1 -0.625)
+			(end 1 0.625)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
+			(net "/VIN")
+			(pinfunction "1")
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
+			(net "/LED_A")
+			(pinfunction "2")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 68 50 0)
+		(uuid "22222222-2222-4222-8222-222222222030")
+		(descr "LED SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: https://docs.google.com/spreadsheets/d/1BsfQQcO9C6DZCsRaXUlFlo91Tg2WpOkGARC1WS5S8t0/edit?usp=sharing)")
+		(tags "LED")
+		(property "Reference" "D1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GREEN"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.685 -0.96)
+			(end -1.685 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.685 0.96)
+			(end 1 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1 -0.96)
+			(end -1.685 -0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1 -0.3)
+			(end -1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1 0.6)
+			(end 1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.7 -0.6)
+			(end -1 -0.3)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 -0.6)
+			(end -0.7 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 0.6)
+			(end 1 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
+			(net "GND")
+			(pinfunction "K")
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
+			(net "/LED_A")
+			(pinfunction "A")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/LED_SMD.3dshapes/LED_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(segment (start 50 50) (end 59.0875 50) (width 0.35) (layer "F.Cu") (net "/VIN") (uuid "22222222-2222-4222-8222-222222222040"))
+	(segment (start 60.9125 50) (end 60.9125 47.5) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222041"))
+	(segment (start 60.9125 47.5) (end 68.9375 47.5) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222042"))
+	(segment (start 68.9375 47.5) (end 68.9375 50) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222043"))
+	(segment (start 67.0625 50) (end 67.0625 52.54) (width 0.35) (layer "F.Cu") (net "GND") (uuid "22222222-2222-4222-8222-222222222044"))
+	(segment (start 67.0625 52.54) (end 50 52.54) (width 0.35) (layer "F.Cu") (net "GND") (uuid "22222222-2222-4222-8222-222222222045"))
+)

--- a/examples/manufacturing-release-demo/MANUFACTURING_RELEASE_DEMO.kicad_pro
+++ b/examples/manufacturing-release-demo/MANUFACTURING_RELEASE_DEMO.kicad_pro
@@ -1,0 +1,656 @@
+{
+  "board": {
+    "3dviewports": [],
+    "design_settings": {
+      "defaults": {
+        "apply_defaults_to_fp_barcodes": false,
+        "apply_defaults_to_fp_dimensions": false,
+        "apply_defaults_to_fp_fields": false,
+        "apply_defaults_to_fp_shapes": false,
+        "apply_defaults_to_fp_text": false,
+        "board_outline_line_width": 0.05,
+        "copper_line_width": 0.2,
+        "copper_text_italic": false,
+        "copper_text_size_h": 1.5,
+        "copper_text_size_v": 1.5,
+        "copper_text_thickness": 0.3,
+        "copper_text_upright": false,
+        "courtyard_line_width": 0.05,
+        "dimension_precision": 4,
+        "dimension_units": 3,
+        "dimensions": {
+          "arrow_length": 1270000,
+          "extension_offset": 500000,
+          "keep_text_aligned": true,
+          "suppress_zeroes": true,
+          "text_position": 0,
+          "units_format": 0
+        },
+        "fab_line_width": 0.1,
+        "fab_text_italic": false,
+        "fab_text_size_h": 1.0,
+        "fab_text_size_v": 1.0,
+        "fab_text_thickness": 0.15,
+        "fab_text_upright": false,
+        "other_line_width": 0.1,
+        "other_text_italic": false,
+        "other_text_size_h": 1.0,
+        "other_text_size_v": 1.0,
+        "other_text_thickness": 0.15,
+        "other_text_upright": false,
+        "pads": {
+          "drill": 0.8,
+          "height": 1.27,
+          "width": 2.54
+        },
+        "silk_line_width": 0.1,
+        "silk_text_italic": false,
+        "silk_text_size_h": 1.0,
+        "silk_text_size_v": 1.0,
+        "silk_text_thickness": 0.1,
+        "silk_text_upright": false,
+        "zones": {
+          "border_display_style": 2,
+          "border_hatch_pitch": 0.5,
+          "corner_radius": 0.0,
+          "corner_smoothing": 0,
+          "fill_mode": 0,
+          "hatch_gap": 1.5,
+          "hatch_orientation": 0.0,
+          "hatch_smoothing_level": 0,
+          "hatch_smoothing_value": 0.1,
+          "hatch_thickness": 1.0,
+          "min_clearance": 0.5,
+          "min_island_area": 10.0,
+          "min_thickness": 0.25,
+          "pad_connection": 1,
+          "remove_islands": 0,
+          "thermal_relief_gap": 0.5,
+          "thermal_relief_spoke_width": 0.5
+        }
+      },
+      "diff_pair_dimensions": [],
+      "drc_exclusions": [],
+      "meta": {
+        "version": 2
+      },
+      "rule_severities": {
+        "annular_width": "error",
+        "clearance": "error",
+        "connection_width": "warning",
+        "copper_edge_clearance": "error",
+        "copper_sliver": "warning",
+        "courtyards_overlap": "error",
+        "creepage": "error",
+        "diff_pair_gap_out_of_range": "error",
+        "diff_pair_uncoupled_length_too_long": "error",
+        "drill_out_of_range": "error",
+        "duplicate_footprints": "warning",
+        "extra_footprint": "warning",
+        "footprint": "error",
+        "footprint_filters_mismatch": "ignore",
+        "footprint_symbol_field_mismatch": "warning",
+        "footprint_symbol_mismatch": "warning",
+        "footprint_type_mismatch": "ignore",
+        "hole_clearance": "error",
+        "hole_to_hole": "warning",
+        "holes_co_located": "warning",
+        "invalid_outline": "error",
+        "isolated_copper": "warning",
+        "item_on_disabled_layer": "error",
+        "items_not_allowed": "error",
+        "length_out_of_range": "error",
+        "lib_footprint_issues": "warning",
+        "lib_footprint_mismatch": "warning",
+        "malformed_courtyard": "error",
+        "microvia_drill_out_of_range": "error",
+        "mirrored_text_on_front_layer": "warning",
+        "missing_courtyard": "ignore",
+        "missing_footprint": "warning",
+        "missing_tuning_profile": "warning",
+        "net_conflict": "warning",
+        "nonmirrored_text_on_back_layer": "warning",
+        "npth_inside_courtyard": "error",
+        "padstack": "warning",
+        "pth_inside_courtyard": "error",
+        "shorting_items": "error",
+        "silk_edge_clearance": "warning",
+        "silk_over_copper": "warning",
+        "silk_overlap": "warning",
+        "skew_out_of_range": "error",
+        "solder_mask_bridge": "error",
+        "starved_thermal": "error",
+        "text_height": "warning",
+        "text_on_edge_cuts": "error",
+        "text_thickness": "warning",
+        "through_hole_pad_without_hole": "error",
+        "too_many_vias": "error",
+        "track_angle": "error",
+        "track_dangling": "warning",
+        "track_not_centered_on_via": "ignore",
+        "track_on_post_machined_layer": "error",
+        "track_segment_length": "error",
+        "track_width": "error",
+        "tracks_crossing": "error",
+        "tuning_profile_track_geometries": "ignore",
+        "unconnected_items": "error",
+        "unresolved_variable": "error",
+        "via_dangling": "warning",
+        "zones_intersect": "error"
+      },
+      "rules": {
+        "max_error": 0.005,
+        "min_clearance": 0.0,
+        "min_connection": 0.0,
+        "min_copper_edge_clearance": 0.5,
+        "min_groove_width": 0.0,
+        "min_hole_clearance": 0.25,
+        "min_hole_to_hole": 0.25,
+        "min_microvia_diameter": 0.2,
+        "min_microvia_drill": 0.1,
+        "min_resolved_spokes": 2,
+        "min_silk_clearance": 0.0,
+        "min_text_height": 0.8,
+        "min_text_thickness": 0.08,
+        "min_through_hole_diameter": 0.3,
+        "min_track_width": 0.2,
+        "min_via_annular_width": 0.1,
+        "min_via_diameter": 0.5,
+        "solder_mask_to_copper_clearance": 0.0,
+        "use_height_for_length_calcs": true
+      },
+      "teardrop_options": [
+        {
+          "td_onpthpad": true,
+          "td_onroundshapesonly": false,
+          "td_onsmdpad": true,
+          "td_ontrackend": false,
+          "td_onvia": true
+        }
+      ],
+      "teardrop_parameters": [
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_round_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_rect_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_track_end",
+          "td_width_to_size_filter_ratio": 0.9
+        }
+      ],
+      "track_widths": [],
+      "tuning_pattern_settings": {
+        "diff_pair_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 1.0
+        },
+        "diff_pair_skew_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        },
+        "single_track_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        }
+      },
+      "via_dimensions": [],
+      "zones_allow_external_fillets": false
+    },
+    "ipc2581": {
+      "bom_rev": "",
+      "dist": "",
+      "distpn": "",
+      "internal_id": "",
+      "mfg": "",
+      "mpn": "",
+      "sch_revision": ""
+    },
+    "layer_pairs": [],
+    "layer_presets": [],
+    "viewports": []
+  },
+  "boards": [],
+  "component_class_settings": {
+    "assignments": [],
+    "meta": {
+      "version": 0
+    },
+    "sheet_component_classes": {
+      "enabled": false
+    }
+  },
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "erc": {
+    "erc_exclusions": [],
+    "meta": {
+      "version": 0
+    },
+    "pin_map": [
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        2
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        2,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        2,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    ],
+    "rule_severities": {
+      "bus_definition_conflict": "error",
+      "bus_entry_needed": "error",
+      "bus_to_bus_conflict": "error",
+      "bus_to_net_conflict": "error",
+      "different_unit_footprint": "error",
+      "different_unit_net": "error",
+      "duplicate_reference": "error",
+      "duplicate_sheet_names": "error",
+      "endpoint_off_grid": "warning",
+      "extra_units": "error",
+      "field_name_whitespace": "warning",
+      "footprint_filter": "ignore",
+      "footprint_link_issues": "warning",
+      "four_way_junction": "ignore",
+      "ground_pin_not_ground": "warning",
+      "hier_label_mismatch": "error",
+      "isolated_pin_label": "warning",
+      "label_dangling": "error",
+      "label_multiple_wires": "warning",
+      "lib_symbol_issues": "warning",
+      "lib_symbol_mismatch": "warning",
+      "missing_bidi_pin": "warning",
+      "missing_input_pin": "warning",
+      "missing_power_pin": "error",
+      "missing_unit": "warning",
+      "multiple_net_names": "warning",
+      "net_not_bus_member": "warning",
+      "no_connect_connected": "warning",
+      "no_connect_dangling": "warning",
+      "pin_not_connected": "error",
+      "pin_not_driven": "error",
+      "pin_to_pin": "warning",
+      "power_pin_not_driven": "error",
+      "same_local_global_label": "warning",
+      "similar_label_and_power": "warning",
+      "similar_labels": "warning",
+      "similar_power": "warning",
+      "simulation_model_issue": "ignore",
+      "single_global_label": "ignore",
+      "stacked_pin_name": "warning",
+      "unannotated": "error",
+      "unconnected_wire_endpoint": "warning",
+      "undefined_netclass": "error",
+      "unit_value_mismatch": "error",
+      "unresolved_variable": "error",
+      "wire_dangling": "error"
+    }
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "MANUFACTURING_RELEASE_DEMO.kicad_pro",
+    "version": 3
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.2,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 2147483647,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.2,
+        "tuning_profile": "",
+        "via_diameter": 0.6,
+        "via_drill": 0.3,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 5
+    },
+    "net_colors": null,
+    "netclass_assignments": null,
+    "netclass_patterns": []
+  },
+  "pcbnew": {
+    "last_paths": {
+      "idf": "",
+      "netlist": "",
+      "plot": "",
+      "specctra_dsn": "",
+      "vrml": ""
+    },
+    "page_layout_descr_file": ""
+  },
+  "schematic": {
+    "annotate_start_num": 0,
+    "annotation": {
+      "method": 0,
+      "sort_order": 0
+    },
+    "bom_export_filename": "${PROJECTNAME}.csv",
+    "bom_fmt_presets": [],
+    "bom_fmt_settings": {
+      "field_delimiter": ",",
+      "keep_line_breaks": false,
+      "keep_tabs": false,
+      "name": "CSV",
+      "ref_delimiter": ",",
+      "ref_range_delimiter": "",
+      "string_delimiter": "\""
+    },
+    "bom_presets": [],
+    "bom_settings": {
+      "exclude_dnp": false,
+      "fields_ordered": [
+        {
+          "group_by": false,
+          "label": "Reference",
+          "name": "Reference",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Qty",
+          "name": "${QUANTITY}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Value",
+          "name": "Value",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "DNP",
+          "name": "${DNP}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Exclude from BOM",
+          "name": "${EXCLUDE_FROM_BOM}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Exclude from Board",
+          "name": "${EXCLUDE_FROM_BOARD}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Footprint",
+          "name": "Footprint",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Datasheet",
+          "name": "Datasheet",
+          "show": true
+        }
+      ],
+      "filter_string": "",
+      "group_symbols": true,
+      "include_excluded_from_bom": true,
+      "name": "Default Editing",
+      "sort_asc": true,
+      "sort_field": "Reference"
+    },
+    "bus_aliases": {},
+    "connection_grid_size": 50.0,
+    "drawing": {
+      "dashed_lines_dash_length_ratio": 12.0,
+      "dashed_lines_gap_length_ratio": 3.0,
+      "default_line_thickness": 6.0,
+      "default_text_size": 50.0,
+      "field_names": [],
+      "hop_over_size_choice": 0,
+      "intersheets_ref_own_page": false,
+      "intersheets_ref_prefix": "",
+      "intersheets_ref_short": false,
+      "intersheets_ref_show": false,
+      "intersheets_ref_suffix": "",
+      "junction_size_choice": 3,
+      "label_size_ratio": 0.375,
+      "operating_point_overlay_i_precision": 3,
+      "operating_point_overlay_i_range": "~A",
+      "operating_point_overlay_v_precision": 3,
+      "operating_point_overlay_v_range": "~V",
+      "overbar_offset_ratio": 1.23,
+      "pin_symbol_size": 25.0,
+      "text_offset_ratio": 0.15
+    },
+    "legacy_lib_dir": "",
+    "legacy_lib_list": [],
+    "meta": {
+      "version": 1
+    },
+    "page_layout_descr_file": "",
+    "plot_directory": "",
+    "reuse_designators": true,
+    "subpart_first_id": 65,
+    "subpart_id_separator": 0,
+    "top_level_sheets": [],
+    "used_designators": "",
+    "variants": []
+  },
+  "sheets": [],
+  "text_variables": {},
+  "tuning_profiles": {
+    "meta": {
+      "version": 0
+    },
+    "tuning_profiles_impedance_geometric": []
+  }
+}

--- a/examples/manufacturing-release-demo/MANUFACTURING_RELEASE_DEMO.kicad_sch
+++ b/examples/manufacturing-release-demo/MANUFACTURING_RELEASE_DEMO.kicad_sch
@@ -1,0 +1,1394 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "11111111-1111-4111-8111-111111111111")
+	(paper "A4")
+	(title_block
+		(title "Manufacturing Release Demo")
+		(date "2026-05-20")
+		(rev "1.0.0")
+		(company "oaslananka")
+		(comment 1 "Manufacturing release workflow sample")
+	)
+	(lib_symbols
+	(symbol "power:GND"
+		(power global)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 0 -3.81 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "GND_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GND_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "power:PWR_FLAG"
+		(power global)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "#FLG"
+			(at 0 1.905 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 0 3.81 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Special symbol for telling ERC where power comes from"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "flag power"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "PWR_FLAG_0_0"
+			(pin power_out line
+				(at 0 0 90)
+				(length 0)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "PWR_FLAG_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+		(symbol "Connector_Generic:Conn_01x02"
+
+				(pin_names
+
+					(offset 1.016)
+
+					(hide yes)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "J"
+
+					(at 0 2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "Conn_01x02"
+
+					(at 0 -5.08 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "connector"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "Connector*:*_1x??_*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "Conn_01x02_1_1"
+
+					(rectangle
+
+						(start -1.27 1.27)
+
+						(end 1.27 -3.81)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type background)
+
+						)
+
+					)
+
+					(rectangle
+
+						(start -1.27 0.127)
+
+						(end 0 -0.127)
+
+						(stroke
+
+							(width 0.1524)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(rectangle
+
+						(start -1.27 -2.413)
+
+						(end 0 -2.667)
+
+						(stroke
+
+							(width 0.1524)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at -5.08 0 0)
+
+						(length 3.81)
+
+						(name "Pin_1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at -5.08 -2.54 0)
+
+						(length 3.81)
+
+						(name "Pin_2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+		(symbol "Device:LED"
+
+				(pin_numbers
+
+					(hide yes)
+
+				)
+
+				(pin_names
+
+					(offset 1.016)
+
+					(hide yes)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "D"
+
+					(at 0 2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "LED"
+
+					(at 0 -2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Light emitting diode"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Sim.Pins" "1=K 2=A"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "LED diode"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "LED_0_1"
+
+					(polyline
+
+						(pts
+
+							(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.27 0) (xy 1.27 0)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.27 -1.27) (xy -1.27 1.27)
+
+						)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+
+						)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+				)
+
+				(symbol "LED_1_1"
+
+					(pin passive line
+
+						(at -3.81 0 0)
+
+						(length 2.54)
+
+						(name "K"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at 3.81 0 180)
+
+						(length 2.54)
+
+						(name "A"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+		(symbol "Device:R"
+
+				(pin_numbers
+
+					(hide yes)
+
+				)
+
+				(pin_names
+
+					(offset 0)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "R"
+
+					(at 2.032 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "R"
+
+					(at 0 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at -1.778 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Resistor"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "R res resistor"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "R_*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "R_0_1"
+
+					(rectangle
+
+						(start -1.016 -2.54)
+
+						(end 1.016 2.54)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+				)
+
+				(symbol "R_1_1"
+
+					(pin passive line
+
+						(at 0 3.81 270)
+
+						(length 1.27)
+
+						(name ""
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at 0 -3.81 90)
+
+						(length 1.27)
+
+						(name ""
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+	)
+	(wire (pts (xy 45.72 76.2) (xy 60.96 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111201"))
+	(wire (pts (xy 60.96 76.2) (xy 60.96 80.01)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111202"))
+	(wire (pts (xy 60.96 80.01) (xy 76.2 80.01)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111203"))
+	(wire (pts (xy 76.2 72.39) (xy 88.9 72.39)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111204"))
+	(wire (pts (xy 88.9 72.39) (xy 88.9 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111205"))
+	(wire (pts (xy 88.9 76.2) (xy 100.33 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111206"))
+	(wire (pts (xy 92.71 76.2) (xy 92.71 88.9)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111207"))
+	(wire (pts (xy 92.71 88.9) (xy 45.72 88.9)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111208"))
+	(wire (pts (xy 45.72 88.9) (xy 45.72 78.74)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111209"))
+	(label "VIN" (at 55.88 76.2 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left bottom)) (uuid "11111111-1111-4111-8111-111111111210"))
+	(label "LED_A" (at 82.55 72.39 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left bottom)) (uuid "11111111-1111-4111-8111-111111111211"))
+	(label "GND" (at 60.96 88.9 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left top)) (uuid "11111111-1111-4111-8111-111111111212"))
+	(junction (at 60.96 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111213"))
+	(junction (at 60.96 80.01) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111214"))
+	(junction (at 88.9 72.39) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111215"))
+	(junction (at 88.9 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111216"))
+	(junction (at 92.71 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111217"))
+	(junction (at 45.72 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111218"))
+	(junction (at 55.88 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111219"))
+	(junction (at 82.55 72.39) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111220"))
+	(junction (at 60.96 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111221"))
+	(junction (at 55.88 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111222"))
+	(symbol (lib_id "Connector_Generic:Conn_01x02") (at 50.8 76.2 0) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111120")
+		(property "Reference" "J1" (at 50.8 71.12 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "POWER_IN" (at 50.8 81.28 0) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical" (at 50.8 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 50.8 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111121"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111122"))
+		(instances (project "MANUFACTURING_RELEASE_DEMO" (path "/11111111-1111-4111-8111-111111111111" (reference "J1") (unit 1))))
+	)
+	(symbol (lib_id "Device:R") (at 76.2 76.2 180) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111130")
+		(property "Reference" "R1" (at 79.248 76.2 90) (effects (font (size 1.27 1.27))))
+		(property "Value" "1k" (at 73.66 76.2 90) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric" (at 74.422 76.2 90) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 76.2 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111131"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111132"))
+		(instances (project "MANUFACTURING_RELEASE_DEMO" (path "/11111111-1111-4111-8111-111111111111" (reference "R1") (unit 1))))
+	)
+	(symbol (lib_id "Device:LED") (at 96.52 76.2 0) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111140")
+		(property "Reference" "D1" (at 96.52 71.12 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "GREEN" (at 96.52 81.28 0) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric" (at 96.52 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 96.52 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111141"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111142"))
+		(instances (project "MANUFACTURING_RELEASE_DEMO" (path "/11111111-1111-4111-8111-111111111111" (reference "D1") (unit 1))))
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 55.88 76.2 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a070215c-109e-4928-adb5-dfae34334af5")
+		(property "Reference" "#PWRb9f8"
+			(at 57.912000000000006 76.2 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "PWR_FLAG"
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "MANUFACTURING_RELEASE_DEMO"
+				(path "/7991577d-b7da-48cd-94bd-41d15758bf53"
+					(reference "#PWRb9f8") (unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 60.96 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "02956efe-2170-4291-88b3-d3815889a4d6")
+		(property "Reference" "#PWR3203"
+			(at 62.992000000000004 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "GND"
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "MANUFACTURING_RELEASE_DEMO"
+				(path "/903d78a0-e55e-483a-98a9-fb79f44f8a61"
+					(reference "#PWR3203") (unit 1)
+			)
+		)
+	)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 55.88 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6f4f6f04-6aef-48cd-9626-bd0c33d37cb2")
+		(property "Reference" "#PWRd0a4"
+			(at 57.912000000000006 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "PWR_FLAG"
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "MANUFACTURING_RELEASE_DEMO"
+				(path "/11111111-1111-4111-8111-111111111111"
+					(reference "#PWRd0a4") (unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances (path "/" (page "1")))
+	(embedded_fonts no)
+)

--- a/examples/manufacturing-release-demo/README.md
+++ b/examples/manufacturing-release-demo/README.md
@@ -1,0 +1,54 @@
+# Manufacturing Release
+
+## Purpose
+
+Use this KiCad 10 project to rehearse release-candidate manufacturing checks. It
+demonstrates the DRC and ERC workflow, BOM and netlist workflow, and
+Manufacturing export workflow.
+
+## Files
+
+- `MANUFACTURING_RELEASE_DEMO.kicad_pro`: KiCad project.
+- `MANUFACTURING_RELEASE_DEMO.kicad_sch`: schematic smoke target for ERC, BOM, and netlist export.
+- `MANUFACTURING_RELEASE_DEMO.kicad_pcb`: routed PCB smoke target for DRC, Gerber, and drill export.
+
+## KiCad Version Compatibility
+
+Verified with KiCad CLI `10.0.3`. This demo validates export workflow behavior
+and should not be treated as a board fabrication reference.
+
+## Extension Workflow
+
+1. Open `examples/manufacturing-release-demo` in VS Code.
+2. Run validation commands from the extension and confirm the manufacturing release gate is visible.
+3. Use the project tree to inspect schematic, PCB, BOM, netlist, and manufacturing surfaces.
+4. Confirm generated export paths stay under `exports/`.
+
+## MCP Workflow
+
+Start KiCad MCP Pro with this folder selected, then run manufacturing and
+validation tools from a compatible MCP client. Use the MCP connected workflow to
+confirm the server can inspect the project before exporting.
+
+```powershell
+$env:KICAD_MCP_PROJECT_DIR = (Get-Location).Path
+kicad-mcp-pro --transport http --port 27185
+```
+
+## Smoke Commands
+
+```powershell
+$kicadCli = 'C:\Program Files\KiCad\10.0\bin\kicad-cli.exe'
+New-Item -ItemType Directory -Force exports | Out-Null
+& $kicadCli sch erc --format json --output exports\MANUFACTURING_RELEASE_DEMO-erc.json --severity-all --exit-code-violations MANUFACTURING_RELEASE_DEMO.kicad_sch
+& $kicadCli pcb drc --format json --output exports\MANUFACTURING_RELEASE_DEMO-drc.json --severity-all --schematic-parity --exit-code-violations MANUFACTURING_RELEASE_DEMO.kicad_pcb
+& $kicadCli sch export netlist --format kicadxml --output exports\MANUFACTURING_RELEASE_DEMO.net MANUFACTURING_RELEASE_DEMO.kicad_sch
+& $kicadCli sch export bom --output exports\MANUFACTURING_RELEASE_DEMO-bom.csv MANUFACTURING_RELEASE_DEMO.kicad_sch
+& $kicadCli pcb export gerbers --board-plot-params --output exports\gerbers MANUFACTURING_RELEASE_DEMO.kicad_pcb
+& $kicadCli pcb export drill --output exports\drill --generate-report --report-path exports\drill\MANUFACTURING_RELEASE_DEMO-drill.rpt MANUFACTURING_RELEASE_DEMO.kicad_pcb
+```
+
+## Expected Outputs
+
+Generated ERC, DRC, BOM, netlist, Gerber, and drill outputs are written under
+`exports/`. Do not commit those artifacts.

--- a/examples/mcp-demo/MCP_DEMO.kicad_pcb
+++ b/examples/mcp-demo/MCP_DEMO.kicad_pcb
@@ -1,0 +1,573 @@
+(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(title_block
+		(title "MCP Workflow Demo")
+		(date "2026-05-20")
+		(rev "1.0.0")
+		(company "oaslananka")
+		(comment 1 "MCP workflow review board for smoke workflows")
+	)
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user "F.Adhesive")
+		(11 "B.Adhes" user "B.Adhesive")
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user "F.Silkscreen")
+		(7 "B.SilkS" user "B.Silkscreen")
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user "User.Drawings")
+		(19 "Cmts.User" user "User.Comments")
+		(21 "Eco1.User" user "User.Eco1")
+		(23 "Eco2.User" user "User.Eco2")
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user "F.Courtyard")
+		(29 "B.CrtYd" user "B.Courtyard")
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+		(39 "User.1" user)
+		(41 "User.2" user)
+		(43 "User.3" user)
+		(45 "User.4" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting (front yes) (back yes))
+		(covering (front no) (back no))
+		(plugging (front no) (back no))
+		(capping no)
+		(filling no)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_55555555_5755f5ff)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions no)
+			(usegerberattributes yes)
+			(usegerberadvancedattributes yes)
+			(creategerberjobfile yes)
+			(dashed_line_dash_ratio 12)
+			(dashed_line_gap_ratio 3)
+			(svgprecision 4)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk no)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 1)
+			(scaleselection 1)
+			(outputdirectory "exports/gerbers")
+		)
+	)
+	(gr_rect (start 45 45) (end 75 58) (stroke (width 0.1) (type solid)) (fill no) (layer "Edge.Cuts") (uuid "22222222-2222-4222-8222-222222222001"))
+	(gr_text "MCP Workflow Demo" (at 60 46.5 0) (layer "F.SilkS") (uuid "22222222-2222-4222-8222-222222222002") (effects (font (size 1.1 1.1) (thickness 0.15))))
+	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 50 50 0)
+		(uuid "22222222-2222-4222-8222-222222222010")
+		(descr "Through hole straight pin header, 1x02, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x02 2.54mm single row")
+		(property "Reference" "J1"
+			(at 0 -2.38 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "POWER_IN"
+			(at 0 4.92 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "connector/pin_header_socket"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.38 -1.38)
+			(end 0 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 0)
+			(end -1.38 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end -1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end 1.38 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 3.92)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1.38 1.27)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.77 -1.77)
+			(end 1.77 4.32)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1.27 3.81)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 3.81)
+			(end -1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 1.27 90)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole rect
+			(at 0 0)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
+			(net "/VIN")
+			(pinfunction "Pin_1")
+			(pintype "passive"))
+		(pad "2" thru_hole circle
+			(at 0 2.54)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
+			(net "GND")
+			(pinfunction "Pin_2")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 60 50 0)
+		(uuid "22222222-2222-4222-8222-222222222020")
+		(descr "Resistor SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: IPC-SM-782 page 72, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf)")
+		(tags "resistor")
+		(property "Reference" "R1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.227064 -0.735)
+			(end 0.227064 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -0.227064 0.735)
+			(end 0.227064 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_rect
+			(start -1 -0.625)
+			(end 1 0.625)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
+			(net "/VIN")
+			(pinfunction "1")
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
+			(net "/LED_A")
+			(pinfunction "2")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 68 50 0)
+		(uuid "22222222-2222-4222-8222-222222222030")
+		(descr "LED SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: https://docs.google.com/spreadsheets/d/1BsfQQcO9C6DZCsRaXUlFlo91Tg2WpOkGARC1WS5S8t0/edit?usp=sharing)")
+		(tags "LED")
+		(property "Reference" "D1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GREEN"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.685 -0.96)
+			(end -1.685 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.685 0.96)
+			(end 1 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1 -0.96)
+			(end -1.685 -0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1 -0.3)
+			(end -1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1 0.6)
+			(end 1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.7 -0.6)
+			(end -1 -0.3)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 -0.6)
+			(end -0.7 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 0.6)
+			(end 1 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
+			(net "GND")
+			(pinfunction "K")
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
+			(net "/LED_A")
+			(pinfunction "A")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/LED_SMD.3dshapes/LED_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(segment (start 50 50) (end 59.0875 50) (width 0.35) (layer "F.Cu") (net "/VIN") (uuid "22222222-2222-4222-8222-222222222040"))
+	(segment (start 60.9125 50) (end 60.9125 47.5) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222041"))
+	(segment (start 60.9125 47.5) (end 68.9375 47.5) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222042"))
+	(segment (start 68.9375 47.5) (end 68.9375 50) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222043"))
+	(segment (start 67.0625 50) (end 67.0625 52.54) (width 0.35) (layer "F.Cu") (net "GND") (uuid "22222222-2222-4222-8222-222222222044"))
+	(segment (start 67.0625 52.54) (end 50 52.54) (width 0.35) (layer "F.Cu") (net "GND") (uuid "22222222-2222-4222-8222-222222222045"))
+)

--- a/examples/mcp-demo/MCP_DEMO.kicad_pro
+++ b/examples/mcp-demo/MCP_DEMO.kicad_pro
@@ -1,0 +1,656 @@
+{
+  "board": {
+    "3dviewports": [],
+    "design_settings": {
+      "defaults": {
+        "apply_defaults_to_fp_barcodes": false,
+        "apply_defaults_to_fp_dimensions": false,
+        "apply_defaults_to_fp_fields": false,
+        "apply_defaults_to_fp_shapes": false,
+        "apply_defaults_to_fp_text": false,
+        "board_outline_line_width": 0.05,
+        "copper_line_width": 0.2,
+        "copper_text_italic": false,
+        "copper_text_size_h": 1.5,
+        "copper_text_size_v": 1.5,
+        "copper_text_thickness": 0.3,
+        "copper_text_upright": false,
+        "courtyard_line_width": 0.05,
+        "dimension_precision": 4,
+        "dimension_units": 3,
+        "dimensions": {
+          "arrow_length": 1270000,
+          "extension_offset": 500000,
+          "keep_text_aligned": true,
+          "suppress_zeroes": true,
+          "text_position": 0,
+          "units_format": 0
+        },
+        "fab_line_width": 0.1,
+        "fab_text_italic": false,
+        "fab_text_size_h": 1.0,
+        "fab_text_size_v": 1.0,
+        "fab_text_thickness": 0.15,
+        "fab_text_upright": false,
+        "other_line_width": 0.1,
+        "other_text_italic": false,
+        "other_text_size_h": 1.0,
+        "other_text_size_v": 1.0,
+        "other_text_thickness": 0.15,
+        "other_text_upright": false,
+        "pads": {
+          "drill": 0.8,
+          "height": 1.27,
+          "width": 2.54
+        },
+        "silk_line_width": 0.1,
+        "silk_text_italic": false,
+        "silk_text_size_h": 1.0,
+        "silk_text_size_v": 1.0,
+        "silk_text_thickness": 0.1,
+        "silk_text_upright": false,
+        "zones": {
+          "border_display_style": 2,
+          "border_hatch_pitch": 0.5,
+          "corner_radius": 0.0,
+          "corner_smoothing": 0,
+          "fill_mode": 0,
+          "hatch_gap": 1.5,
+          "hatch_orientation": 0.0,
+          "hatch_smoothing_level": 0,
+          "hatch_smoothing_value": 0.1,
+          "hatch_thickness": 1.0,
+          "min_clearance": 0.5,
+          "min_island_area": 10.0,
+          "min_thickness": 0.25,
+          "pad_connection": 1,
+          "remove_islands": 0,
+          "thermal_relief_gap": 0.5,
+          "thermal_relief_spoke_width": 0.5
+        }
+      },
+      "diff_pair_dimensions": [],
+      "drc_exclusions": [],
+      "meta": {
+        "version": 2
+      },
+      "rule_severities": {
+        "annular_width": "error",
+        "clearance": "error",
+        "connection_width": "warning",
+        "copper_edge_clearance": "error",
+        "copper_sliver": "warning",
+        "courtyards_overlap": "error",
+        "creepage": "error",
+        "diff_pair_gap_out_of_range": "error",
+        "diff_pair_uncoupled_length_too_long": "error",
+        "drill_out_of_range": "error",
+        "duplicate_footprints": "warning",
+        "extra_footprint": "warning",
+        "footprint": "error",
+        "footprint_filters_mismatch": "ignore",
+        "footprint_symbol_field_mismatch": "warning",
+        "footprint_symbol_mismatch": "warning",
+        "footprint_type_mismatch": "ignore",
+        "hole_clearance": "error",
+        "hole_to_hole": "warning",
+        "holes_co_located": "warning",
+        "invalid_outline": "error",
+        "isolated_copper": "warning",
+        "item_on_disabled_layer": "error",
+        "items_not_allowed": "error",
+        "length_out_of_range": "error",
+        "lib_footprint_issues": "warning",
+        "lib_footprint_mismatch": "warning",
+        "malformed_courtyard": "error",
+        "microvia_drill_out_of_range": "error",
+        "mirrored_text_on_front_layer": "warning",
+        "missing_courtyard": "ignore",
+        "missing_footprint": "warning",
+        "missing_tuning_profile": "warning",
+        "net_conflict": "warning",
+        "nonmirrored_text_on_back_layer": "warning",
+        "npth_inside_courtyard": "error",
+        "padstack": "warning",
+        "pth_inside_courtyard": "error",
+        "shorting_items": "error",
+        "silk_edge_clearance": "warning",
+        "silk_over_copper": "warning",
+        "silk_overlap": "warning",
+        "skew_out_of_range": "error",
+        "solder_mask_bridge": "error",
+        "starved_thermal": "error",
+        "text_height": "warning",
+        "text_on_edge_cuts": "error",
+        "text_thickness": "warning",
+        "through_hole_pad_without_hole": "error",
+        "too_many_vias": "error",
+        "track_angle": "error",
+        "track_dangling": "warning",
+        "track_not_centered_on_via": "ignore",
+        "track_on_post_machined_layer": "error",
+        "track_segment_length": "error",
+        "track_width": "error",
+        "tracks_crossing": "error",
+        "tuning_profile_track_geometries": "ignore",
+        "unconnected_items": "error",
+        "unresolved_variable": "error",
+        "via_dangling": "warning",
+        "zones_intersect": "error"
+      },
+      "rules": {
+        "max_error": 0.005,
+        "min_clearance": 0.0,
+        "min_connection": 0.0,
+        "min_copper_edge_clearance": 0.5,
+        "min_groove_width": 0.0,
+        "min_hole_clearance": 0.25,
+        "min_hole_to_hole": 0.25,
+        "min_microvia_diameter": 0.2,
+        "min_microvia_drill": 0.1,
+        "min_resolved_spokes": 2,
+        "min_silk_clearance": 0.0,
+        "min_text_height": 0.8,
+        "min_text_thickness": 0.08,
+        "min_through_hole_diameter": 0.3,
+        "min_track_width": 0.2,
+        "min_via_annular_width": 0.1,
+        "min_via_diameter": 0.5,
+        "solder_mask_to_copper_clearance": 0.0,
+        "use_height_for_length_calcs": true
+      },
+      "teardrop_options": [
+        {
+          "td_onpthpad": true,
+          "td_onroundshapesonly": false,
+          "td_onsmdpad": true,
+          "td_ontrackend": false,
+          "td_onvia": true
+        }
+      ],
+      "teardrop_parameters": [
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_round_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_rect_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_track_end",
+          "td_width_to_size_filter_ratio": 0.9
+        }
+      ],
+      "track_widths": [],
+      "tuning_pattern_settings": {
+        "diff_pair_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 1.0
+        },
+        "diff_pair_skew_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        },
+        "single_track_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        }
+      },
+      "via_dimensions": [],
+      "zones_allow_external_fillets": false
+    },
+    "ipc2581": {
+      "bom_rev": "",
+      "dist": "",
+      "distpn": "",
+      "internal_id": "",
+      "mfg": "",
+      "mpn": "",
+      "sch_revision": ""
+    },
+    "layer_pairs": [],
+    "layer_presets": [],
+    "viewports": []
+  },
+  "boards": [],
+  "component_class_settings": {
+    "assignments": [],
+    "meta": {
+      "version": 0
+    },
+    "sheet_component_classes": {
+      "enabled": false
+    }
+  },
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "erc": {
+    "erc_exclusions": [],
+    "meta": {
+      "version": 0
+    },
+    "pin_map": [
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        2
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        2,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        2,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    ],
+    "rule_severities": {
+      "bus_definition_conflict": "error",
+      "bus_entry_needed": "error",
+      "bus_to_bus_conflict": "error",
+      "bus_to_net_conflict": "error",
+      "different_unit_footprint": "error",
+      "different_unit_net": "error",
+      "duplicate_reference": "error",
+      "duplicate_sheet_names": "error",
+      "endpoint_off_grid": "warning",
+      "extra_units": "error",
+      "field_name_whitespace": "warning",
+      "footprint_filter": "ignore",
+      "footprint_link_issues": "warning",
+      "four_way_junction": "ignore",
+      "ground_pin_not_ground": "warning",
+      "hier_label_mismatch": "error",
+      "isolated_pin_label": "warning",
+      "label_dangling": "error",
+      "label_multiple_wires": "warning",
+      "lib_symbol_issues": "warning",
+      "lib_symbol_mismatch": "warning",
+      "missing_bidi_pin": "warning",
+      "missing_input_pin": "warning",
+      "missing_power_pin": "error",
+      "missing_unit": "warning",
+      "multiple_net_names": "warning",
+      "net_not_bus_member": "warning",
+      "no_connect_connected": "warning",
+      "no_connect_dangling": "warning",
+      "pin_not_connected": "error",
+      "pin_not_driven": "error",
+      "pin_to_pin": "warning",
+      "power_pin_not_driven": "error",
+      "same_local_global_label": "warning",
+      "similar_label_and_power": "warning",
+      "similar_labels": "warning",
+      "similar_power": "warning",
+      "simulation_model_issue": "ignore",
+      "single_global_label": "ignore",
+      "stacked_pin_name": "warning",
+      "unannotated": "error",
+      "unconnected_wire_endpoint": "warning",
+      "undefined_netclass": "error",
+      "unit_value_mismatch": "error",
+      "unresolved_variable": "error",
+      "wire_dangling": "error"
+    }
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "MCP_DEMO.kicad_pro",
+    "version": 3
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.2,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 2147483647,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.2,
+        "tuning_profile": "",
+        "via_diameter": 0.6,
+        "via_drill": 0.3,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 5
+    },
+    "net_colors": null,
+    "netclass_assignments": null,
+    "netclass_patterns": []
+  },
+  "pcbnew": {
+    "last_paths": {
+      "idf": "",
+      "netlist": "",
+      "plot": "",
+      "specctra_dsn": "",
+      "vrml": ""
+    },
+    "page_layout_descr_file": ""
+  },
+  "schematic": {
+    "annotate_start_num": 0,
+    "annotation": {
+      "method": 0,
+      "sort_order": 0
+    },
+    "bom_export_filename": "${PROJECTNAME}.csv",
+    "bom_fmt_presets": [],
+    "bom_fmt_settings": {
+      "field_delimiter": ",",
+      "keep_line_breaks": false,
+      "keep_tabs": false,
+      "name": "CSV",
+      "ref_delimiter": ",",
+      "ref_range_delimiter": "",
+      "string_delimiter": "\""
+    },
+    "bom_presets": [],
+    "bom_settings": {
+      "exclude_dnp": false,
+      "fields_ordered": [
+        {
+          "group_by": false,
+          "label": "Reference",
+          "name": "Reference",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Qty",
+          "name": "${QUANTITY}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Value",
+          "name": "Value",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "DNP",
+          "name": "${DNP}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Exclude from BOM",
+          "name": "${EXCLUDE_FROM_BOM}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Exclude from Board",
+          "name": "${EXCLUDE_FROM_BOARD}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Footprint",
+          "name": "Footprint",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Datasheet",
+          "name": "Datasheet",
+          "show": true
+        }
+      ],
+      "filter_string": "",
+      "group_symbols": true,
+      "include_excluded_from_bom": true,
+      "name": "Default Editing",
+      "sort_asc": true,
+      "sort_field": "Reference"
+    },
+    "bus_aliases": {},
+    "connection_grid_size": 50.0,
+    "drawing": {
+      "dashed_lines_dash_length_ratio": 12.0,
+      "dashed_lines_gap_length_ratio": 3.0,
+      "default_line_thickness": 6.0,
+      "default_text_size": 50.0,
+      "field_names": [],
+      "hop_over_size_choice": 0,
+      "intersheets_ref_own_page": false,
+      "intersheets_ref_prefix": "",
+      "intersheets_ref_short": false,
+      "intersheets_ref_show": false,
+      "intersheets_ref_suffix": "",
+      "junction_size_choice": 3,
+      "label_size_ratio": 0.375,
+      "operating_point_overlay_i_precision": 3,
+      "operating_point_overlay_i_range": "~A",
+      "operating_point_overlay_v_precision": 3,
+      "operating_point_overlay_v_range": "~V",
+      "overbar_offset_ratio": 1.23,
+      "pin_symbol_size": 25.0,
+      "text_offset_ratio": 0.15
+    },
+    "legacy_lib_dir": "",
+    "legacy_lib_list": [],
+    "meta": {
+      "version": 1
+    },
+    "page_layout_descr_file": "",
+    "plot_directory": "",
+    "reuse_designators": true,
+    "subpart_first_id": 65,
+    "subpart_id_separator": 0,
+    "top_level_sheets": [],
+    "used_designators": "",
+    "variants": []
+  },
+  "sheets": [],
+  "text_variables": {},
+  "tuning_profiles": {
+    "meta": {
+      "version": 0
+    },
+    "tuning_profiles_impedance_geometric": []
+  }
+}

--- a/examples/mcp-demo/MCP_DEMO.kicad_sch
+++ b/examples/mcp-demo/MCP_DEMO.kicad_sch
@@ -1,0 +1,1394 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "11111111-1111-4111-8111-111111111111")
+	(paper "A4")
+	(title_block
+		(title "MCP Workflow Demo")
+		(date "2026-05-20")
+		(rev "1.0.0")
+		(company "oaslananka")
+		(comment 1 "MCP connected and degraded workflow sample")
+	)
+	(lib_symbols
+	(symbol "power:GND"
+		(power global)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 0 -3.81 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "GND_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GND_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "power:PWR_FLAG"
+		(power global)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "#FLG"
+			(at 0 1.905 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 0 3.81 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Special symbol for telling ERC where power comes from"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "flag power"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "PWR_FLAG_0_0"
+			(pin power_out line
+				(at 0 0 90)
+				(length 0)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "PWR_FLAG_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+		(symbol "Connector_Generic:Conn_01x02"
+
+				(pin_names
+
+					(offset 1.016)
+
+					(hide yes)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "J"
+
+					(at 0 2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "Conn_01x02"
+
+					(at 0 -5.08 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "connector"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "Connector*:*_1x??_*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "Conn_01x02_1_1"
+
+					(rectangle
+
+						(start -1.27 1.27)
+
+						(end 1.27 -3.81)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type background)
+
+						)
+
+					)
+
+					(rectangle
+
+						(start -1.27 0.127)
+
+						(end 0 -0.127)
+
+						(stroke
+
+							(width 0.1524)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(rectangle
+
+						(start -1.27 -2.413)
+
+						(end 0 -2.667)
+
+						(stroke
+
+							(width 0.1524)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at -5.08 0 0)
+
+						(length 3.81)
+
+						(name "Pin_1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at -5.08 -2.54 0)
+
+						(length 3.81)
+
+						(name "Pin_2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+		(symbol "Device:LED"
+
+				(pin_numbers
+
+					(hide yes)
+
+				)
+
+				(pin_names
+
+					(offset 1.016)
+
+					(hide yes)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "D"
+
+					(at 0 2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "LED"
+
+					(at 0 -2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Light emitting diode"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Sim.Pins" "1=K 2=A"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "LED diode"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "LED_0_1"
+
+					(polyline
+
+						(pts
+
+							(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.27 0) (xy 1.27 0)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.27 -1.27) (xy -1.27 1.27)
+
+						)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+
+						)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+				)
+
+				(symbol "LED_1_1"
+
+					(pin passive line
+
+						(at -3.81 0 0)
+
+						(length 2.54)
+
+						(name "K"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at 3.81 0 180)
+
+						(length 2.54)
+
+						(name "A"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+		(symbol "Device:R"
+
+				(pin_numbers
+
+					(hide yes)
+
+				)
+
+				(pin_names
+
+					(offset 0)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "R"
+
+					(at 2.032 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "R"
+
+					(at 0 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at -1.778 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Resistor"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "R res resistor"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "R_*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "R_0_1"
+
+					(rectangle
+
+						(start -1.016 -2.54)
+
+						(end 1.016 2.54)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+				)
+
+				(symbol "R_1_1"
+
+					(pin passive line
+
+						(at 0 3.81 270)
+
+						(length 1.27)
+
+						(name ""
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at 0 -3.81 90)
+
+						(length 1.27)
+
+						(name ""
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+	)
+	(wire (pts (xy 45.72 76.2) (xy 60.96 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111201"))
+	(wire (pts (xy 60.96 76.2) (xy 60.96 80.01)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111202"))
+	(wire (pts (xy 60.96 80.01) (xy 76.2 80.01)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111203"))
+	(wire (pts (xy 76.2 72.39) (xy 88.9 72.39)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111204"))
+	(wire (pts (xy 88.9 72.39) (xy 88.9 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111205"))
+	(wire (pts (xy 88.9 76.2) (xy 100.33 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111206"))
+	(wire (pts (xy 92.71 76.2) (xy 92.71 88.9)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111207"))
+	(wire (pts (xy 92.71 88.9) (xy 45.72 88.9)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111208"))
+	(wire (pts (xy 45.72 88.9) (xy 45.72 78.74)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111209"))
+	(label "VIN" (at 55.88 76.2 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left bottom)) (uuid "11111111-1111-4111-8111-111111111210"))
+	(label "LED_A" (at 82.55 72.39 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left bottom)) (uuid "11111111-1111-4111-8111-111111111211"))
+	(label "GND" (at 60.96 88.9 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left top)) (uuid "11111111-1111-4111-8111-111111111212"))
+	(junction (at 60.96 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111213"))
+	(junction (at 60.96 80.01) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111214"))
+	(junction (at 88.9 72.39) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111215"))
+	(junction (at 88.9 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111216"))
+	(junction (at 92.71 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111217"))
+	(junction (at 45.72 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111218"))
+	(junction (at 55.88 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111219"))
+	(junction (at 82.55 72.39) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111220"))
+	(junction (at 60.96 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111221"))
+	(junction (at 55.88 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111222"))
+	(symbol (lib_id "Connector_Generic:Conn_01x02") (at 50.8 76.2 0) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111120")
+		(property "Reference" "J1" (at 50.8 71.12 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "POWER_IN" (at 50.8 81.28 0) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical" (at 50.8 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 50.8 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111121"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111122"))
+		(instances (project "MCP_DEMO" (path "/11111111-1111-4111-8111-111111111111" (reference "J1") (unit 1))))
+	)
+	(symbol (lib_id "Device:R") (at 76.2 76.2 180) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111130")
+		(property "Reference" "R1" (at 79.248 76.2 90) (effects (font (size 1.27 1.27))))
+		(property "Value" "1k" (at 73.66 76.2 90) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric" (at 74.422 76.2 90) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 76.2 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111131"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111132"))
+		(instances (project "MCP_DEMO" (path "/11111111-1111-4111-8111-111111111111" (reference "R1") (unit 1))))
+	)
+	(symbol (lib_id "Device:LED") (at 96.52 76.2 0) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111140")
+		(property "Reference" "D1" (at 96.52 71.12 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "GREEN" (at 96.52 81.28 0) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric" (at 96.52 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 96.52 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111141"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111142"))
+		(instances (project "MCP_DEMO" (path "/11111111-1111-4111-8111-111111111111" (reference "D1") (unit 1))))
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 55.88 76.2 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a070215c-109e-4928-adb5-dfae34334af5")
+		(property "Reference" "#PWRb9f8"
+			(at 57.912000000000006 76.2 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "PWR_FLAG"
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "MCP_DEMO"
+				(path "/7991577d-b7da-48cd-94bd-41d15758bf53"
+					(reference "#PWRb9f8") (unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 60.96 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "02956efe-2170-4291-88b3-d3815889a4d6")
+		(property "Reference" "#PWR3203"
+			(at 62.992000000000004 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "GND"
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "MCP_DEMO"
+				(path "/903d78a0-e55e-483a-98a9-fb79f44f8a61"
+					(reference "#PWR3203") (unit 1)
+			)
+		)
+	)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 55.88 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6f4f6f04-6aef-48cd-9626-bd0c33d37cb2")
+		(property "Reference" "#PWRd0a4"
+			(at 57.912000000000006 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "PWR_FLAG"
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "MCP_DEMO"
+				(path "/11111111-1111-4111-8111-111111111111"
+					(reference "#PWRd0a4") (unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances (path "/" (page "1")))
+	(embedded_fonts no)
+)

--- a/examples/mcp-demo/README.md
+++ b/examples/mcp-demo/README.md
@@ -1,0 +1,50 @@
+# MCP Workflow Demo
+
+## Purpose
+
+Use this KiCad 10 project to validate MCP client setup and fallback behavior
+with a small board. It demonstrates the Basic schematic and PCB viewer workflow,
+MCP connected workflow, and MCP degraded workflow.
+
+## Files
+
+- `MCP_DEMO.kicad_pro`: KiCad project.
+- `MCP_DEMO.kicad_sch`: schematic smoke target for MCP project summary and validation tools.
+- `MCP_DEMO.kicad_pcb`: routed PCB smoke target for board inspection tools.
+
+## KiCad Version Compatibility
+
+Verified with KiCad CLI `10.0.3`. This demo is intentionally small so MCP client
+setup problems are easier to isolate.
+
+## Extension Workflow
+
+1. Open `examples/mcp-demo` in VS Code.
+2. Open `MCP_DEMO.kicad_sch` and `MCP_DEMO.kicad_pcb`.
+3. Open the MCP tools view and verify connected, disconnected, and degraded states.
+4. Confirm the project remains inspectable when the MCP server is unavailable.
+
+## MCP Workflow
+
+Start the server for the MCP connected workflow, then point a compatible client
+at `http://127.0.0.1:27185/mcp`. Stop the server for the MCP degraded workflow
+and confirm clients report a clean connection failure.
+
+```powershell
+$env:KICAD_MCP_PROJECT_DIR = (Get-Location).Path
+kicad-mcp-pro --transport http --port 27185
+```
+
+## Smoke Commands
+
+```powershell
+$kicadCli = 'C:\Program Files\KiCad\10.0\bin\kicad-cli.exe'
+New-Item -ItemType Directory -Force exports | Out-Null
+& $kicadCli sch erc --format json --output exports\MCP_DEMO-erc.json --severity-all --exit-code-violations MCP_DEMO.kicad_sch
+& $kicadCli pcb drc --format json --output exports\MCP_DEMO-drc.json --severity-all --schematic-parity --exit-code-violations MCP_DEMO.kicad_pcb
+```
+
+## Expected Outputs
+
+Generated reports, screenshots, and MCP logs stay under `exports/` or another
+ignored local path. Do not commit runtime output from this example.

--- a/examples/usb-c-power/README.md
+++ b/examples/usb-c-power/README.md
@@ -1,0 +1,53 @@
+# USB-C Power Intake
+
+## Purpose
+
+Use this KiCad 10 project to rehearse a compact power-input review flow before
+working with a larger USB-C design. It demonstrates the Basic schematic and PCB
+viewer workflow, DRC and ERC workflow, and MCP degraded workflow with small files
+that are easy to inspect in code review.
+
+## Files
+
+- `USB_C_POWER.kicad_pro`: KiCad project.
+- `USB_C_POWER.kicad_sch`: schematic smoke target for power-input review steps.
+- `USB_C_POWER.kicad_pcb`: routed PCB smoke target for board viewer, DRC, and export checks.
+
+## KiCad Version Compatibility
+
+Verified with KiCad CLI `10.0.3`. This demo is intentionally small and is not a
+production USB-C reference design; use it to validate workflow behavior,
+diagnostic surfaces, and file handling.
+
+## Extension Workflow
+
+1. Open `examples/usb-c-power` in VS Code.
+2. Open `USB_C_POWER.kicad_sch` and verify the schematic viewer loads without generated reports.
+3. Open `USB_C_POWER.kicad_pcb` and verify fit-to-screen, zoom, and project tree behavior.
+4. Run validation commands and confirm power-review diagnostics are displayed without blocking navigation.
+
+## MCP Workflow
+
+Run the MCP connected workflow when a local server is available. For the MCP
+degraded workflow, stop the server and confirm KiCad Studio still opens the
+project, explains the unavailable MCP state, and keeps read-only project
+inspection available.
+
+```powershell
+$env:KICAD_MCP_PROJECT_DIR = (Get-Location).Path
+kicad-mcp-pro --transport http --port 27185
+```
+
+## Smoke Commands
+
+```powershell
+$kicadCli = 'C:\Program Files\KiCad\10.0\bin\kicad-cli.exe'
+New-Item -ItemType Directory -Force exports | Out-Null
+& $kicadCli sch erc --format json --output exports\USB_C_POWER-erc.json --severity-all --exit-code-violations USB_C_POWER.kicad_sch
+& $kicadCli pcb drc --format json --output exports\USB_C_POWER-drc.json --severity-all --schematic-parity --exit-code-violations USB_C_POWER.kicad_pcb
+```
+
+## Expected Outputs
+
+ERC and DRC reports are generated under `exports/`. Do not commit generated
+reports, screenshots, or local MCP logs from this example.

--- a/examples/usb-c-power/USB_C_POWER.kicad_pcb
+++ b/examples/usb-c-power/USB_C_POWER.kicad_pcb
@@ -1,0 +1,573 @@
+(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(title_block
+		(title "USB-C Power Intake Demo")
+		(date "2026-05-20")
+		(rev "1.0.0")
+		(company "oaslananka")
+		(comment 1 "USB-C power review board for smoke workflows")
+	)
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user "F.Adhesive")
+		(11 "B.Adhes" user "B.Adhesive")
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user "F.Silkscreen")
+		(7 "B.SilkS" user "B.Silkscreen")
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user "User.Drawings")
+		(19 "Cmts.User" user "User.Comments")
+		(21 "Eco1.User" user "User.Eco1")
+		(23 "Eco2.User" user "User.Eco2")
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user "F.Courtyard")
+		(29 "B.CrtYd" user "B.Courtyard")
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+		(39 "User.1" user)
+		(41 "User.2" user)
+		(43 "User.3" user)
+		(45 "User.4" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting (front yes) (back yes))
+		(covering (front no) (back no))
+		(plugging (front no) (back no))
+		(capping no)
+		(filling no)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_55555555_5755f5ff)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions no)
+			(usegerberattributes yes)
+			(usegerberadvancedattributes yes)
+			(creategerberjobfile yes)
+			(dashed_line_dash_ratio 12)
+			(dashed_line_gap_ratio 3)
+			(svgprecision 4)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk no)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 1)
+			(scaleselection 1)
+			(outputdirectory "exports/gerbers")
+		)
+	)
+	(gr_rect (start 45 45) (end 75 58) (stroke (width 0.1) (type solid)) (fill no) (layer "Edge.Cuts") (uuid "22222222-2222-4222-8222-222222222001"))
+	(gr_text "USB-C Power Demo" (at 60 46.5 0) (layer "F.SilkS") (uuid "22222222-2222-4222-8222-222222222002") (effects (font (size 1.1 1.1) (thickness 0.15))))
+	(footprint "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 50 50 0)
+		(uuid "22222222-2222-4222-8222-222222222010")
+		(descr "Through hole straight pin header, 1x02, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x02 2.54mm single row")
+		(property "Reference" "J1"
+			(at 0 -2.38 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "POWER_IN"
+			(at 0 4.92 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "connector/pin_header_socket"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.38 -1.38)
+			(end 0 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 0)
+			(end -1.38 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end -1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end 1.38 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.38 3.92)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1.38 1.27)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.77 -1.77)
+			(end 1.77 4.32)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1.27 3.81)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1.27 3.81)
+			(end -1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 1.27 90)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole rect
+			(at 0 0)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
+			(net "/VIN")
+			(pinfunction "Pin_1")
+			(pintype "passive"))
+		(pad "2" thru_hole circle
+			(at 0 2.54)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+
+			(net "GND")
+			(pinfunction "Pin_2")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 60 50 0)
+		(uuid "22222222-2222-4222-8222-222222222020")
+		(descr "Resistor SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: IPC-SM-782 page 72, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf)")
+		(tags "resistor")
+		(property "Reference" "R1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1k"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.227064 -0.735)
+			(end 0.227064 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -0.227064 0.735)
+			(end 0.227064 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_rect
+			(start -1 -0.625)
+			(end 1 0.625)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
+			(net "/VIN")
+			(pinfunction "1")
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9125 0)
+			(size 1.025 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.243902)
+
+			(net "/LED_A")
+			(pinfunction "2")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0805_2012Metric"
+		(version 20260206)
+		(generator "kicad-footprint-generator")
+		(layer "F.Cu")
+		(at 68 50 0)
+		(uuid "22222222-2222-4222-8222-222222222030")
+		(descr "LED SMD 0805 (2012 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: https://docs.google.com/spreadsheets/d/1BsfQQcO9C6DZCsRaXUlFlo91Tg2WpOkGARC1WS5S8t0/edit?usp=sharing)")
+		(tags "LED")
+		(property "Reference" "D1"
+			(at 0 -1.65 0)
+			(layer "F.SilkS")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GREEN"
+			(at 0 1.65 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.685 -0.96)
+			(end -1.685 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start -1.685 0.96)
+			(end 1 0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_line
+			(start 1 -0.96)
+			(end -1.685 -0.96)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+		)
+		(fp_rect
+			(start -1.68 -0.95)
+			(end 1.68 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+		)
+		(fp_line
+			(start -1 -0.3)
+			(end -1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -1 0.6)
+			(end 1 0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start -0.7 -0.6)
+			(end -1 -0.3)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 -0.6)
+			(end -0.7 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_line
+			(start 1 0.6)
+			(end 1 -0.6)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.08)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
+			(net "GND")
+			(pinfunction "K")
+			(pintype "passive"))
+		(pad "2" smd roundrect
+			(at 0.9375 0)
+			(size 0.975 1.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+
+			(net "/LED_A")
+			(pinfunction "A")
+			(pintype "passive"))
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/LED_SMD.3dshapes/LED_0805_2012Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(segment (start 50 50) (end 59.0875 50) (width 0.35) (layer "F.Cu") (net "/VIN") (uuid "22222222-2222-4222-8222-222222222040"))
+	(segment (start 60.9125 50) (end 60.9125 47.5) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222041"))
+	(segment (start 60.9125 47.5) (end 68.9375 47.5) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222042"))
+	(segment (start 68.9375 47.5) (end 68.9375 50) (width 0.35) (layer "F.Cu") (net "/LED_A") (uuid "22222222-2222-4222-8222-222222222043"))
+	(segment (start 67.0625 50) (end 67.0625 52.54) (width 0.35) (layer "F.Cu") (net "GND") (uuid "22222222-2222-4222-8222-222222222044"))
+	(segment (start 67.0625 52.54) (end 50 52.54) (width 0.35) (layer "F.Cu") (net "GND") (uuid "22222222-2222-4222-8222-222222222045"))
+)

--- a/examples/usb-c-power/USB_C_POWER.kicad_pro
+++ b/examples/usb-c-power/USB_C_POWER.kicad_pro
@@ -1,0 +1,656 @@
+{
+  "board": {
+    "3dviewports": [],
+    "design_settings": {
+      "defaults": {
+        "apply_defaults_to_fp_barcodes": false,
+        "apply_defaults_to_fp_dimensions": false,
+        "apply_defaults_to_fp_fields": false,
+        "apply_defaults_to_fp_shapes": false,
+        "apply_defaults_to_fp_text": false,
+        "board_outline_line_width": 0.05,
+        "copper_line_width": 0.2,
+        "copper_text_italic": false,
+        "copper_text_size_h": 1.5,
+        "copper_text_size_v": 1.5,
+        "copper_text_thickness": 0.3,
+        "copper_text_upright": false,
+        "courtyard_line_width": 0.05,
+        "dimension_precision": 4,
+        "dimension_units": 3,
+        "dimensions": {
+          "arrow_length": 1270000,
+          "extension_offset": 500000,
+          "keep_text_aligned": true,
+          "suppress_zeroes": true,
+          "text_position": 0,
+          "units_format": 0
+        },
+        "fab_line_width": 0.1,
+        "fab_text_italic": false,
+        "fab_text_size_h": 1.0,
+        "fab_text_size_v": 1.0,
+        "fab_text_thickness": 0.15,
+        "fab_text_upright": false,
+        "other_line_width": 0.1,
+        "other_text_italic": false,
+        "other_text_size_h": 1.0,
+        "other_text_size_v": 1.0,
+        "other_text_thickness": 0.15,
+        "other_text_upright": false,
+        "pads": {
+          "drill": 0.8,
+          "height": 1.27,
+          "width": 2.54
+        },
+        "silk_line_width": 0.1,
+        "silk_text_italic": false,
+        "silk_text_size_h": 1.0,
+        "silk_text_size_v": 1.0,
+        "silk_text_thickness": 0.1,
+        "silk_text_upright": false,
+        "zones": {
+          "border_display_style": 2,
+          "border_hatch_pitch": 0.5,
+          "corner_radius": 0.0,
+          "corner_smoothing": 0,
+          "fill_mode": 0,
+          "hatch_gap": 1.5,
+          "hatch_orientation": 0.0,
+          "hatch_smoothing_level": 0,
+          "hatch_smoothing_value": 0.1,
+          "hatch_thickness": 1.0,
+          "min_clearance": 0.5,
+          "min_island_area": 10.0,
+          "min_thickness": 0.25,
+          "pad_connection": 1,
+          "remove_islands": 0,
+          "thermal_relief_gap": 0.5,
+          "thermal_relief_spoke_width": 0.5
+        }
+      },
+      "diff_pair_dimensions": [],
+      "drc_exclusions": [],
+      "meta": {
+        "version": 2
+      },
+      "rule_severities": {
+        "annular_width": "error",
+        "clearance": "error",
+        "connection_width": "warning",
+        "copper_edge_clearance": "error",
+        "copper_sliver": "warning",
+        "courtyards_overlap": "error",
+        "creepage": "error",
+        "diff_pair_gap_out_of_range": "error",
+        "diff_pair_uncoupled_length_too_long": "error",
+        "drill_out_of_range": "error",
+        "duplicate_footprints": "warning",
+        "extra_footprint": "warning",
+        "footprint": "error",
+        "footprint_filters_mismatch": "ignore",
+        "footprint_symbol_field_mismatch": "warning",
+        "footprint_symbol_mismatch": "warning",
+        "footprint_type_mismatch": "ignore",
+        "hole_clearance": "error",
+        "hole_to_hole": "warning",
+        "holes_co_located": "warning",
+        "invalid_outline": "error",
+        "isolated_copper": "warning",
+        "item_on_disabled_layer": "error",
+        "items_not_allowed": "error",
+        "length_out_of_range": "error",
+        "lib_footprint_issues": "warning",
+        "lib_footprint_mismatch": "warning",
+        "malformed_courtyard": "error",
+        "microvia_drill_out_of_range": "error",
+        "mirrored_text_on_front_layer": "warning",
+        "missing_courtyard": "ignore",
+        "missing_footprint": "warning",
+        "missing_tuning_profile": "warning",
+        "net_conflict": "warning",
+        "nonmirrored_text_on_back_layer": "warning",
+        "npth_inside_courtyard": "error",
+        "padstack": "warning",
+        "pth_inside_courtyard": "error",
+        "shorting_items": "error",
+        "silk_edge_clearance": "warning",
+        "silk_over_copper": "warning",
+        "silk_overlap": "warning",
+        "skew_out_of_range": "error",
+        "solder_mask_bridge": "error",
+        "starved_thermal": "error",
+        "text_height": "warning",
+        "text_on_edge_cuts": "error",
+        "text_thickness": "warning",
+        "through_hole_pad_without_hole": "error",
+        "too_many_vias": "error",
+        "track_angle": "error",
+        "track_dangling": "warning",
+        "track_not_centered_on_via": "ignore",
+        "track_on_post_machined_layer": "error",
+        "track_segment_length": "error",
+        "track_width": "error",
+        "tracks_crossing": "error",
+        "tuning_profile_track_geometries": "ignore",
+        "unconnected_items": "error",
+        "unresolved_variable": "error",
+        "via_dangling": "warning",
+        "zones_intersect": "error"
+      },
+      "rules": {
+        "max_error": 0.005,
+        "min_clearance": 0.0,
+        "min_connection": 0.0,
+        "min_copper_edge_clearance": 0.5,
+        "min_groove_width": 0.0,
+        "min_hole_clearance": 0.25,
+        "min_hole_to_hole": 0.25,
+        "min_microvia_diameter": 0.2,
+        "min_microvia_drill": 0.1,
+        "min_resolved_spokes": 2,
+        "min_silk_clearance": 0.0,
+        "min_text_height": 0.8,
+        "min_text_thickness": 0.08,
+        "min_through_hole_diameter": 0.3,
+        "min_track_width": 0.2,
+        "min_via_annular_width": 0.1,
+        "min_via_diameter": 0.5,
+        "solder_mask_to_copper_clearance": 0.0,
+        "use_height_for_length_calcs": true
+      },
+      "teardrop_options": [
+        {
+          "td_onpthpad": true,
+          "td_onroundshapesonly": false,
+          "td_onsmdpad": true,
+          "td_ontrackend": false,
+          "td_onvia": true
+        }
+      ],
+      "teardrop_parameters": [
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_round_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_rect_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_track_end",
+          "td_width_to_size_filter_ratio": 0.9
+        }
+      ],
+      "track_widths": [],
+      "tuning_pattern_settings": {
+        "diff_pair_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 1.0
+        },
+        "diff_pair_skew_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        },
+        "single_track_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        }
+      },
+      "via_dimensions": [],
+      "zones_allow_external_fillets": false
+    },
+    "ipc2581": {
+      "bom_rev": "",
+      "dist": "",
+      "distpn": "",
+      "internal_id": "",
+      "mfg": "",
+      "mpn": "",
+      "sch_revision": ""
+    },
+    "layer_pairs": [],
+    "layer_presets": [],
+    "viewports": []
+  },
+  "boards": [],
+  "component_class_settings": {
+    "assignments": [],
+    "meta": {
+      "version": 0
+    },
+    "sheet_component_classes": {
+      "enabled": false
+    }
+  },
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "erc": {
+    "erc_exclusions": [],
+    "meta": {
+      "version": 0
+    },
+    "pin_map": [
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        2
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        2,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        2,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    ],
+    "rule_severities": {
+      "bus_definition_conflict": "error",
+      "bus_entry_needed": "error",
+      "bus_to_bus_conflict": "error",
+      "bus_to_net_conflict": "error",
+      "different_unit_footprint": "error",
+      "different_unit_net": "error",
+      "duplicate_reference": "error",
+      "duplicate_sheet_names": "error",
+      "endpoint_off_grid": "warning",
+      "extra_units": "error",
+      "field_name_whitespace": "warning",
+      "footprint_filter": "ignore",
+      "footprint_link_issues": "warning",
+      "four_way_junction": "ignore",
+      "ground_pin_not_ground": "warning",
+      "hier_label_mismatch": "error",
+      "isolated_pin_label": "warning",
+      "label_dangling": "error",
+      "label_multiple_wires": "warning",
+      "lib_symbol_issues": "warning",
+      "lib_symbol_mismatch": "warning",
+      "missing_bidi_pin": "warning",
+      "missing_input_pin": "warning",
+      "missing_power_pin": "error",
+      "missing_unit": "warning",
+      "multiple_net_names": "warning",
+      "net_not_bus_member": "warning",
+      "no_connect_connected": "warning",
+      "no_connect_dangling": "warning",
+      "pin_not_connected": "error",
+      "pin_not_driven": "error",
+      "pin_to_pin": "warning",
+      "power_pin_not_driven": "error",
+      "same_local_global_label": "warning",
+      "similar_label_and_power": "warning",
+      "similar_labels": "warning",
+      "similar_power": "warning",
+      "simulation_model_issue": "ignore",
+      "single_global_label": "ignore",
+      "stacked_pin_name": "warning",
+      "unannotated": "error",
+      "unconnected_wire_endpoint": "warning",
+      "undefined_netclass": "error",
+      "unit_value_mismatch": "error",
+      "unresolved_variable": "error",
+      "wire_dangling": "error"
+    }
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "USB_C_POWER.kicad_pro",
+    "version": 3
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.2,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 2147483647,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.2,
+        "tuning_profile": "",
+        "via_diameter": 0.6,
+        "via_drill": 0.3,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 5
+    },
+    "net_colors": null,
+    "netclass_assignments": null,
+    "netclass_patterns": []
+  },
+  "pcbnew": {
+    "last_paths": {
+      "idf": "",
+      "netlist": "",
+      "plot": "",
+      "specctra_dsn": "",
+      "vrml": ""
+    },
+    "page_layout_descr_file": ""
+  },
+  "schematic": {
+    "annotate_start_num": 0,
+    "annotation": {
+      "method": 0,
+      "sort_order": 0
+    },
+    "bom_export_filename": "${PROJECTNAME}.csv",
+    "bom_fmt_presets": [],
+    "bom_fmt_settings": {
+      "field_delimiter": ",",
+      "keep_line_breaks": false,
+      "keep_tabs": false,
+      "name": "CSV",
+      "ref_delimiter": ",",
+      "ref_range_delimiter": "",
+      "string_delimiter": "\""
+    },
+    "bom_presets": [],
+    "bom_settings": {
+      "exclude_dnp": false,
+      "fields_ordered": [
+        {
+          "group_by": false,
+          "label": "Reference",
+          "name": "Reference",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Qty",
+          "name": "${QUANTITY}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Value",
+          "name": "Value",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "DNP",
+          "name": "${DNP}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Exclude from BOM",
+          "name": "${EXCLUDE_FROM_BOM}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Exclude from Board",
+          "name": "${EXCLUDE_FROM_BOARD}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Footprint",
+          "name": "Footprint",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Datasheet",
+          "name": "Datasheet",
+          "show": true
+        }
+      ],
+      "filter_string": "",
+      "group_symbols": true,
+      "include_excluded_from_bom": true,
+      "name": "Default Editing",
+      "sort_asc": true,
+      "sort_field": "Reference"
+    },
+    "bus_aliases": {},
+    "connection_grid_size": 50.0,
+    "drawing": {
+      "dashed_lines_dash_length_ratio": 12.0,
+      "dashed_lines_gap_length_ratio": 3.0,
+      "default_line_thickness": 6.0,
+      "default_text_size": 50.0,
+      "field_names": [],
+      "hop_over_size_choice": 0,
+      "intersheets_ref_own_page": false,
+      "intersheets_ref_prefix": "",
+      "intersheets_ref_short": false,
+      "intersheets_ref_show": false,
+      "intersheets_ref_suffix": "",
+      "junction_size_choice": 3,
+      "label_size_ratio": 0.375,
+      "operating_point_overlay_i_precision": 3,
+      "operating_point_overlay_i_range": "~A",
+      "operating_point_overlay_v_precision": 3,
+      "operating_point_overlay_v_range": "~V",
+      "overbar_offset_ratio": 1.23,
+      "pin_symbol_size": 25.0,
+      "text_offset_ratio": 0.15
+    },
+    "legacy_lib_dir": "",
+    "legacy_lib_list": [],
+    "meta": {
+      "version": 1
+    },
+    "page_layout_descr_file": "",
+    "plot_directory": "",
+    "reuse_designators": true,
+    "subpart_first_id": 65,
+    "subpart_id_separator": 0,
+    "top_level_sheets": [],
+    "used_designators": "",
+    "variants": []
+  },
+  "sheets": [],
+  "text_variables": {},
+  "tuning_profiles": {
+    "meta": {
+      "version": 0
+    },
+    "tuning_profiles_impedance_geometric": []
+  }
+}

--- a/examples/usb-c-power/USB_C_POWER.kicad_sch
+++ b/examples/usb-c-power/USB_C_POWER.kicad_sch
@@ -1,0 +1,1394 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "11111111-1111-4111-8111-111111111111")
+	(paper "A4")
+	(title_block
+		(title "USB-C Power Intake Demo")
+		(date "2026-05-20")
+		(rev "1.0.0")
+		(company "oaslananka")
+		(comment 1 "USB-C power intake workflow sample")
+	)
+	(lib_symbols
+	(symbol "power:GND"
+		(power global)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "#PWR"
+			(at 0 -6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 0 -3.81 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "global power"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "GND_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(symbol "GND_1_1"
+			(pin power_in line
+				(at 0 0 270)
+				(length 0)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+	(symbol "power:PWR_FLAG"
+		(power global)
+		(pin_numbers
+			(hide yes)
+		)
+		(pin_names
+			(offset 0)
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "#FLG"
+			(at 0 1.905 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 0 3.81 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Special symbol for telling ERC where power comes from"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "ki_keywords" "flag power"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(symbol "PWR_FLAG_0_0"
+			(pin power_out line
+				(at 0 0 90)
+				(length 0)
+				(name ""
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(symbol "PWR_FLAG_0_1"
+			(polyline
+				(pts
+					(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+				)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+		(symbol "Connector_Generic:Conn_01x02"
+
+				(pin_names
+
+					(offset 1.016)
+
+					(hide yes)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "J"
+
+					(at 0 2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "Conn_01x02"
+
+					(at 0 -5.08 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "connector"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "Connector*:*_1x??_*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "Conn_01x02_1_1"
+
+					(rectangle
+
+						(start -1.27 1.27)
+
+						(end 1.27 -3.81)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type background)
+
+						)
+
+					)
+
+					(rectangle
+
+						(start -1.27 0.127)
+
+						(end 0 -0.127)
+
+						(stroke
+
+							(width 0.1524)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(rectangle
+
+						(start -1.27 -2.413)
+
+						(end 0 -2.667)
+
+						(stroke
+
+							(width 0.1524)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at -5.08 0 0)
+
+						(length 3.81)
+
+						(name "Pin_1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at -5.08 -2.54 0)
+
+						(length 3.81)
+
+						(name "Pin_2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+		(symbol "Device:LED"
+
+				(pin_numbers
+
+					(hide yes)
+
+				)
+
+				(pin_names
+
+					(offset 1.016)
+
+					(hide yes)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "D"
+
+					(at 0 2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "LED"
+
+					(at 0 -2.54 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Light emitting diode"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Sim.Pins" "1=K 2=A"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "LED diode"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "LED_0_1"
+
+					(polyline
+
+						(pts
+
+							(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.27 0) (xy 1.27 0)
+
+						)
+
+						(stroke
+
+							(width 0)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy -1.27 -1.27) (xy -1.27 1.27)
+
+						)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+					(polyline
+
+						(pts
+
+							(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+
+						)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+				)
+
+				(symbol "LED_1_1"
+
+					(pin passive line
+
+						(at -3.81 0 0)
+
+						(length 2.54)
+
+						(name "K"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at 3.81 0 180)
+
+						(length 2.54)
+
+						(name "A"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+		(symbol "Device:R"
+
+				(pin_numbers
+
+					(hide yes)
+
+				)
+
+				(pin_names
+
+					(offset 0)
+
+				)
+
+				(exclude_from_sim no)
+
+				(in_bom yes)
+
+				(on_board yes)
+
+				(in_pos_files yes)
+
+				(duplicate_pin_numbers_are_jumpers no)
+
+				(property "Reference" "R"
+
+					(at 2.032 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Value" "R"
+
+					(at 0 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Footprint" ""
+
+					(at -1.778 0 90)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Datasheet" ""
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "Description" "Resistor"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_keywords" "R res resistor"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(property "ki_fp_filters" "R_*"
+
+					(at 0 0 0)
+
+					(show_name no)
+
+					(do_not_autoplace no)
+
+					(hide yes)
+
+					(effects
+
+						(font
+
+							(size 1.27 1.27)
+
+						)
+
+					)
+
+				)
+
+				(symbol "R_0_1"
+
+					(rectangle
+
+						(start -1.016 -2.54)
+
+						(end 1.016 2.54)
+
+						(stroke
+
+							(width 0.254)
+
+							(type default)
+
+						)
+
+						(fill
+
+							(type none)
+
+						)
+
+					)
+
+				)
+
+				(symbol "R_1_1"
+
+					(pin passive line
+
+						(at 0 3.81 270)
+
+						(length 1.27)
+
+						(name ""
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "1"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+					(pin passive line
+
+						(at 0 -3.81 90)
+
+						(length 1.27)
+
+						(name ""
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+						(number "2"
+
+							(effects
+
+								(font
+
+									(size 1.27 1.27)
+
+								)
+
+							)
+
+						)
+
+					)
+
+				)
+
+				(embedded_fonts no)
+
+			)
+	)
+	(wire (pts (xy 45.72 76.2) (xy 60.96 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111201"))
+	(wire (pts (xy 60.96 76.2) (xy 60.96 80.01)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111202"))
+	(wire (pts (xy 60.96 80.01) (xy 76.2 80.01)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111203"))
+	(wire (pts (xy 76.2 72.39) (xy 88.9 72.39)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111204"))
+	(wire (pts (xy 88.9 72.39) (xy 88.9 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111205"))
+	(wire (pts (xy 88.9 76.2) (xy 100.33 76.2)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111206"))
+	(wire (pts (xy 92.71 76.2) (xy 92.71 88.9)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111207"))
+	(wire (pts (xy 92.71 88.9) (xy 45.72 88.9)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111208"))
+	(wire (pts (xy 45.72 88.9) (xy 45.72 78.74)) (stroke (width 0) (type default)) (uuid "11111111-1111-4111-8111-111111111209"))
+	(label "VIN" (at 55.88 76.2 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left bottom)) (uuid "11111111-1111-4111-8111-111111111210"))
+	(label "LED_A" (at 82.55 72.39 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left bottom)) (uuid "11111111-1111-4111-8111-111111111211"))
+	(label "GND" (at 60.96 88.9 0) (fields_autoplaced yes) (effects (font (size 1.27 1.27)) (justify left top)) (uuid "11111111-1111-4111-8111-111111111212"))
+	(junction (at 60.96 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111213"))
+	(junction (at 60.96 80.01) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111214"))
+	(junction (at 88.9 72.39) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111215"))
+	(junction (at 88.9 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111216"))
+	(junction (at 92.71 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111217"))
+	(junction (at 45.72 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111218"))
+	(junction (at 55.88 76.2) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111219"))
+	(junction (at 82.55 72.39) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111220"))
+	(junction (at 60.96 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111221"))
+	(junction (at 55.88 88.9) (diameter 0) (color 0 0 0 0) (uuid "11111111-1111-4111-8111-111111111222"))
+	(symbol (lib_id "Connector_Generic:Conn_01x02") (at 50.8 76.2 0) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111120")
+		(property "Reference" "J1" (at 50.8 71.12 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "POWER_IN" (at 50.8 81.28 0) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical" (at 50.8 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 50.8 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111121"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111122"))
+		(instances (project "USB_C_POWER" (path "/11111111-1111-4111-8111-111111111111" (reference "J1") (unit 1))))
+	)
+	(symbol (lib_id "Device:R") (at 76.2 76.2 180) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111130")
+		(property "Reference" "R1" (at 79.248 76.2 90) (effects (font (size 1.27 1.27))))
+		(property "Value" "1k" (at 73.66 76.2 90) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric" (at 74.422 76.2 90) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 76.2 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111131"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111132"))
+		(instances (project "USB_C_POWER" (path "/11111111-1111-4111-8111-111111111111" (reference "R1") (unit 1))))
+	)
+	(symbol (lib_id "Device:LED") (at 96.52 76.2 0) (unit 1) (exclude_from_sim no) (in_bom yes) (on_board yes) (dnp no)
+		(uuid "11111111-1111-4111-8111-111111111140")
+		(property "Reference" "D1" (at 96.52 71.12 0) (effects (font (size 1.27 1.27))))
+		(property "Value" "GREEN" (at 96.52 81.28 0) (effects (font (size 1.27 1.27))))
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric" (at 96.52 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(property "Datasheet" "" (at 96.52 76.2 0) (effects (font (size 1.27 1.27)) hide))
+		(pin "1" (uuid "11111111-1111-4111-8111-111111111141"))
+		(pin "2" (uuid "11111111-1111-4111-8111-111111111142"))
+		(instances (project "USB_C_POWER" (path "/11111111-1111-4111-8111-111111111111" (reference "D1") (unit 1))))
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 55.88 76.2 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a070215c-109e-4928-adb5-dfae34334af5")
+		(property "Reference" "#PWRb9f8"
+			(at 57.912000000000006 76.2 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "PWR_FLAG"
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 55.88 76.2 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "USB_C_POWER"
+				(path "/7991577d-b7da-48cd-94bd-41d15758bf53"
+					(reference "#PWRb9f8") (unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 60.96 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "02956efe-2170-4291-88b3-d3815889a4d6")
+		(property "Reference" "#PWR3203"
+			(at 62.992000000000004 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "GND"
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 60.96 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "USB_C_POWER"
+				(path "/903d78a0-e55e-483a-98a9-fb79f44f8a61"
+					(reference "#PWR3203") (unit 1)
+			)
+		)
+	)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 55.88 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6f4f6f04-6aef-48cd-9626-bd0c33d37cb2")
+		(property "Reference" "#PWRd0a4"
+			(at 57.912000000000006 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Value" "PWR_FLAG"
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)))
+		)
+		(property "Footprint" ""
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(property "Datasheet" "~"
+			(at 55.88 88.9 0)
+			(effects (font (size 1.27 1.27)) (hide yes))
+		)
+		(instances
+			(project "USB_C_POWER"
+				(path "/11111111-1111-4111-8111-111111111111"
+					(reference "#PWRd0a4") (unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances (path "/" (page "1")))
+	(embedded_fonts no)
+)

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "check:performance-budgets": "node scripts/check-performance-budgets.mjs && node --test scripts/check-performance-budgets.test.mjs",
     "test:beta-program": "node --test scripts/check-beta-program.test.mjs",
     "check:beta-program": "node scripts/check-beta-program.mjs && pnpm run test:beta-program",
+    "check:examples": "node scripts/check-examples.mjs && node --test scripts/check-examples.test.mjs",
     "docs:generate": "node scripts/generate-docs-site.mjs",
     "docs:lint": "node scripts/check-docs-site.mjs --markdown",
     "docs:links": "node scripts/check-docs-site.mjs --links",
@@ -69,7 +70,7 @@
     "check:docs-site": "pnpm --dir packages/mcp-server run docs:tools:check && pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "check:publish": "node scripts/check-publish-preflight.mjs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.0",

--- a/scripts/check-examples.mjs
+++ b/scripts/check-examples.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { dirname, extname, join, relative, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const examplesRoot = join(repoRoot, "examples");
+const manifestPath = join(examplesRoot, "manifest.json");
+
+const requiredExampleIds = [
+  "led-basic",
+  "usb-c-power",
+  "buck-converter",
+  "differential-pair-demo",
+  "manufacturing-release-demo",
+  "mcp-demo",
+];
+
+const requiredWorkflowPhrases = [
+  "Basic schematic and PCB viewer",
+  "DRC and ERC workflow",
+  "BOM and netlist workflow",
+  "Manufacturing export workflow",
+  "MCP connected workflow",
+  "MCP degraded workflow",
+];
+
+const requiredReadmeSections = [
+  "## Purpose",
+  "## Files",
+  "## KiCad Version Compatibility",
+  "## Extension Workflow",
+  "## MCP Workflow",
+  "## Smoke Commands",
+  "## Expected Outputs",
+];
+
+const forbiddenGeneratedOutputs = new Set([
+  ".bom",
+  ".csv",
+  ".drl",
+  ".gbr",
+  ".gbrjob",
+  ".net",
+  ".pos",
+  ".rpt",
+  ".step",
+  ".stp",
+  ".svg",
+  ".zip",
+]);
+
+function toPosixPath(path) {
+  return path.split(sep).join("/");
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function includesNormalized(haystack, needle) {
+  const normalizedHaystack = haystack.replace(/\s+/gu, " ");
+  const normalizedNeedle = needle.replace(/\s+/gu, " ");
+  return normalizedHaystack.includes(normalizedNeedle);
+}
+
+function assertFile(path, errors) {
+  if (!existsSync(path) || !statSync(path).isFile()) {
+    errors.push(`Missing file: ${toPosixPath(relative(repoRoot, path))}`);
+  }
+}
+
+function assertDirectory(path, errors) {
+  if (!existsSync(path) || !statSync(path).isDirectory()) {
+    errors.push(`Missing directory: ${toPosixPath(relative(repoRoot, path))}`);
+  }
+}
+
+function walkFiles(directory) {
+  if (!existsSync(directory)) {
+    return [];
+  }
+
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(absolutePath));
+    } else if (entry.isFile()) {
+      files.push(absolutePath);
+    }
+  }
+  return files;
+}
+
+function validateRootWiring(errors) {
+  const packageJson = readJson(join(repoRoot, "package.json"));
+  if (
+    packageJson.scripts?.["check:examples"] !==
+    "node scripts/check-examples.mjs && node --test scripts/check-examples.test.mjs"
+  ) {
+    errors.push("package.json must define check:examples");
+  }
+  if (!packageJson.scripts?.check?.includes("pnpm run check:examples")) {
+    errors.push("package.json check must run check:examples");
+  }
+
+  const rootReadme = readFileSync(join(repoRoot, "README.md"), "utf8");
+  if (!rootReadme.includes("examples/README.md")) {
+    errors.push("README.md must link to examples/README.md");
+  }
+}
+
+function validateManifest(errors) {
+  assertFile(manifestPath, errors);
+  if (!existsSync(manifestPath)) {
+    return undefined;
+  }
+
+  const manifest = readJson(manifestPath);
+  if (manifest.version !== 1) {
+    errors.push("examples/manifest.json must use version 1");
+  }
+  if (manifest.source !== "OASLANA-77") {
+    errors.push("examples/manifest.json must identify source OASLANA-77");
+  }
+  if (!manifest.policy?.includes("not deterministic fixtures")) {
+    errors.push(
+      "examples/manifest.json must state examples are not deterministic fixtures",
+    );
+  }
+
+  const ids = new Set(manifest.examples?.map((example) => example.id) ?? []);
+  for (const expectedId of requiredExampleIds) {
+    if (!ids.has(expectedId)) {
+      errors.push(`examples/manifest.json missing example ${expectedId}`);
+    }
+  }
+
+  const workflowCoverage = new Set(
+    (manifest.examples ?? []).flatMap((example) => example.workflows ?? []),
+  );
+  for (const phrase of requiredWorkflowPhrases) {
+    if (!workflowCoverage.has(phrase)) {
+      errors.push(`examples/manifest.json missing workflow: ${phrase}`);
+    }
+  }
+
+  return manifest;
+}
+
+function validateExamplesOverview(manifest, errors) {
+  const readmePath = join(examplesRoot, "README.md");
+  assertFile(readmePath, errors);
+  if (!existsSync(readmePath) || !manifest) {
+    return;
+  }
+
+  const readme = readFileSync(readmePath, "utf8");
+  for (const id of requiredExampleIds) {
+    if (!readme.includes(`${id}/README.md`)) {
+      errors.push(`examples/README.md must link to ${id}/README.md`);
+    }
+  }
+  for (const phrase of [
+    "separate from deterministic automated fixtures",
+    "release smoke",
+  ]) {
+    if (!readme.includes(phrase)) {
+      errors.push(`examples/README.md must mention ${phrase}`);
+    }
+  }
+}
+
+function validateExample(example, errors) {
+  const exampleRoot = join(examplesRoot, example.id);
+  assertDirectory(exampleRoot, errors);
+  if (!existsSync(exampleRoot)) {
+    return;
+  }
+
+  const readmePath = join(exampleRoot, "README.md");
+  assertFile(readmePath, errors);
+  const readme = existsSync(readmePath) ? readFileSync(readmePath, "utf8") : "";
+
+  if (!readme.startsWith(`# ${example.title}`)) {
+    errors.push(`${example.id}/README.md must start with the manifest title`);
+  }
+
+  for (const heading of requiredReadmeSections) {
+    if (!readme.includes(heading)) {
+      errors.push(`${example.id}/README.md missing ${heading}`);
+    }
+  }
+
+  for (const workflow of example.workflows ?? []) {
+    if (!includesNormalized(readme, workflow)) {
+      errors.push(`${example.id}/README.md missing workflow ${workflow}`);
+    }
+  }
+
+  const projectFiles = example.projectFiles ?? [];
+  for (const file of projectFiles) {
+    assertFile(join(exampleRoot, file), errors);
+  }
+
+  const projectExtensions = new Set(projectFiles.map((file) => extname(file)));
+  for (const extension of [".kicad_pro", ".kicad_sch", ".kicad_pcb"]) {
+    if (!projectExtensions.has(extension)) {
+      errors.push(`${example.id} must declare a ${extension} project file`);
+    }
+  }
+
+  for (const file of walkFiles(exampleRoot)) {
+    const relativePath = toPosixPath(relative(exampleRoot, file));
+    if (relativePath === "README.md" || projectFiles.includes(relativePath)) {
+      continue;
+    }
+    if (forbiddenGeneratedOutputs.has(extname(file).toLowerCase())) {
+      errors.push(
+        `${example.id} must not commit generated output ${relativePath}`,
+      );
+    }
+  }
+}
+
+function runKiCadSmoke(manifest, errors) {
+  const smokeExample = manifest.examples.find(
+    (example) => example.releaseSmoke,
+  );
+  if (!smokeExample) {
+    errors.push("examples/manifest.json must mark one releaseSmoke example");
+    return;
+  }
+
+  const projectRoot = join(examplesRoot, smokeExample.id);
+  const schematic = smokeExample.projectFiles.find((file) =>
+    file.endsWith(".kicad_sch"),
+  );
+  const board = smokeExample.projectFiles.find((file) =>
+    file.endsWith(".kicad_pcb"),
+  );
+  const outputDir = mkdtempSync(join(tmpdir(), "kicad-examples-"));
+
+  try {
+    const erc = spawnSync(
+      "kicad-cli",
+      [
+        "sch",
+        "erc",
+        "--format",
+        "json",
+        "--output",
+        join(outputDir, `${smokeExample.id}-erc.json`),
+        "--severity-all",
+        "--exit-code-violations",
+        join(projectRoot, schematic),
+      ],
+      { encoding: "utf8" },
+    );
+    if (erc.status !== 0) {
+      errors.push(`kicad-cli ERC failed for ${smokeExample.id}: ${erc.stderr}`);
+    }
+
+    const drc = spawnSync(
+      "kicad-cli",
+      [
+        "pcb",
+        "drc",
+        "--format",
+        "json",
+        "--output",
+        join(outputDir, `${smokeExample.id}-drc.json`),
+        "--severity-all",
+        "--schematic-parity",
+        "--exit-code-violations",
+        join(projectRoot, board),
+      ],
+      { encoding: "utf8" },
+    );
+    if (drc.status !== 0) {
+      errors.push(`kicad-cli DRC failed for ${smokeExample.id}: ${drc.stderr}`);
+    }
+  } finally {
+    rmSync(outputDir, { force: true, recursive: true });
+  }
+}
+
+const errors = [];
+validateRootWiring(errors);
+const manifest = validateManifest(errors);
+validateExamplesOverview(manifest, errors);
+
+if (manifest) {
+  for (const example of manifest.examples ?? []) {
+    validateExample(example, errors);
+  }
+
+  if (process.argv.includes("--kicad-cli")) {
+    runKiCadSmoke(manifest, errors);
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Examples contract violations found:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  console.error("Run `corepack pnpm run check:examples` after fixing.");
+  process.exit(1);
+}
+
+console.log(
+  `Examples contract is current: ${requiredExampleIds.length} project examples`,
+);

--- a/scripts/check-examples.test.mjs
+++ b/scripts/check-examples.test.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("root package wires the examples contract into repository checks", () => {
+  const packageJson = JSON.parse(
+    readFileSync(join(repoRoot, "package.json"), "utf8"),
+  );
+
+  assert.equal(
+    packageJson.scripts["check:examples"],
+    "node scripts/check-examples.mjs && node --test scripts/check-examples.test.mjs",
+  );
+  assert.match(packageJson.scripts.check, /pnpm run check:examples/u);
+});
+
+test("user-facing examples satisfy the OASLANA-77 repository contract", () => {
+  execFileSync(process.execPath, ["scripts/check-examples.mjs"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the full OASLANA-77 user-facing examples layout under `examples/`: `led-basic`, `usb-c-power`, `buck-converter`, `differential-pair-demo`, `manufacturing-release-demo`, and `mcp-demo`.
- Adds `examples/manifest.json` plus `scripts/check-examples.mjs` / `scripts/check-examples.test.mjs` so the examples contract is enforced by the root check.
- Updates the root README and example docs with workflow steps, KiCad compatibility, smoke commands, and output policy.

## Linked issue

Closes #78
Linear: OASLANA-77

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

Passed locally:

- `node --test scripts/check-examples.test.mjs` (red first before implementation, then green)
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run format:check`
- `corepack pnpm run check:examples`
- `node scripts/check-examples.mjs --kicad-cli`
- ERC/DRC smoke over all six example projects with KiCad CLI `10.0.3`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist`
- `corepack pnpm run check`
- `gitleaks detect --source . --redact --verbose`
- workflow deprecation grep for deprecated Actions commands / node12 / node16 / node20
- `git diff --check`
- `uvx pre-commit run --all-files`

Notes:

- `corepack pnpm run build` prints the existing guarded `mcp-npm` PyPI reachability message for unpublished `kicad-mcp-pro==1.0.0`, but the build script intentionally treats that wrapper smoke as non-fatal and exits successfully.
- `corepack pnpm run check` retains the existing MCP submission readiness `pypi reachability | WARN | offline or unavailable: HTTP Error 404: Not Found`; the gate passes and this PR does not touch MCP/Python package publishing.

## Protocol / MCP impact

- [x] Not applicable; reason: this PR adds user-facing example projects/docs and a repository examples contract check. It does not change MCP tool names, schemas, transport behavior, compatibility metadata, server-info payloads, or extension adapter behavior.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [ ] Release notes considered for both products
- [x] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
