### PR TITLE
test(kicad-studio): add security regression gates

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,3 +41,17 @@ jobs:
       - run: corepack pnpm run check:forbidden-refs
       - run: corepack pnpm audit --audit-level high
       - run: corepack pnpm --dir packages/mcp-server run security
+
+  extension-security-regressions:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - run: corepack enable
+      - run: corepack pnpm install --frozen-lockfile
+      - run: corepack pnpm --filter kicadstudio run test:security

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -63,7 +63,22 @@
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",
-      "description": "%kicadstudio.capabilities.untrustedWorkspaces.description%"
+      "description": "%kicadstudio.capabilities.untrustedWorkspaces.description%",
+      "restrictedConfigurations": [
+        "kicadstudio.kicadCliPath",
+        "kicadstudio.kicadPath",
+        "kicadstudio.defaultOutputDir",
+        "kicadstudio.cli.defineVars",
+        "kicadstudio.ai.localEndpoint",
+        "kicadstudio.ai.allowTools",
+        "kicadstudio.mcp.endpoint",
+        "kicadstudio.mcp.allowRemoteEndpoint",
+        "kicadstudio.mcp.allowLegacySse",
+        "kicadstudio.mcp.pushContext",
+        "kicadstudio.pcm.repositoryUrls",
+        "kicadstudio.pcm.configDir",
+        "kicadstudio.pcm.thirdPartyDir"
+      ]
     }
   },
   "activationEvents": [
@@ -2035,13 +2050,14 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "audit:ci": "pnpm audit --audit-level high",
     "check:staged": "lint-staged",
-    "check": "pnpm run format:check && pnpm run marketplace:check && pnpm run lint && pnpm run typecheck && pnpm run test:unit && pnpm run test:a11y && pnpm run build && pnpm run package && pnpm run package:validate",
+    "check": "pnpm run format:check && pnpm run marketplace:check && pnpm run lint && pnpm run typecheck && pnpm run test:unit && pnpm run test:security && pnpm run test:a11y && pnpm run build && pnpm run package && pnpm run package:validate",
     "check:workspace-trust": "node scripts/check-untrusted-workspace.js",
-    "check:ci": "pnpm run audit:ci && pnpm run format:check && pnpm run docs:check && pnpm run workflows:lint && pnpm run lint && pnpm run typecheck && pnpm run check:workspace-trust && pnpm run test:unit:coverage && pnpm run test:a11y && pnpm run build && pnpm run test:integration && pnpm run package && pnpm run package:validate && pnpm run release:dry-run && pnpm run check:bundle-size",
+    "check:ci": "pnpm run audit:ci && pnpm run format:check && pnpm run docs:check && pnpm run workflows:lint && pnpm run lint && pnpm run typecheck && pnpm run check:workspace-trust && pnpm run test:unit:coverage && pnpm run test:security && pnpm run test:a11y && pnpm run build && pnpm run test:integration && pnpm run package && pnpm run package:validate && pnpm run release:dry-run && pnpm run check:bundle-size",
     "compile-tests": "tsc -p tsconfig.test.json",
-    "test": "pnpm run test:unit && pnpm run test:integration",
+    "test": "pnpm run test:unit && pnpm run test:security && pnpm run test:integration",
     "test:unit": "jest --runInBand",
     "test:unit:coverage": "jest --runInBand --coverage",
+    "test:security": "jest --config jest.config.js --runInBand --coverage=false --testMatch \"<rootDir>/test/security/**/*.test.ts\"",
     "test:a11y": "jest --config jest.config.js --runInBand --coverage=false --testMatch \"<rootDir>/test/a11y/**/*.test.ts\"",
     "test:perf": "jest --config jest.config.js --runInBand --coverage=false --testMatch \"<rootDir>/test/performance/**/*.test.ts\"",
     "test:integration": "pnpm run compile-tests && node ./out/test/runTest.js",

--- a/apps/vscode-extension/scripts/check-untrusted-workspace.js
+++ b/apps/vscode-extension/scripts/check-untrusted-workspace.js
@@ -3,7 +3,25 @@ const path = require('node:path');
 
 const packagePath = path.join(__dirname, '..', 'package.json');
 const manifest = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
-const supported = manifest.capabilities?.untrustedWorkspaces?.supported;
+const untrustedWorkspaces = manifest.capabilities?.untrustedWorkspaces;
+const supported = untrustedWorkspaces?.supported;
+const restrictedConfigurations =
+  untrustedWorkspaces?.restrictedConfigurations ?? [];
+const requiredRestrictedConfigurations = [
+  'kicadstudio.kicadCliPath',
+  'kicadstudio.kicadPath',
+  'kicadstudio.defaultOutputDir',
+  'kicadstudio.cli.defineVars',
+  'kicadstudio.ai.localEndpoint',
+  'kicadstudio.ai.allowTools',
+  'kicadstudio.mcp.endpoint',
+  'kicadstudio.mcp.allowRemoteEndpoint',
+  'kicadstudio.mcp.allowLegacySse',
+  'kicadstudio.mcp.pushContext',
+  'kicadstudio.pcm.repositoryUrls',
+  'kicadstudio.pcm.configDir',
+  'kicadstudio.pcm.thirdPartyDir'
+];
 
 if (supported !== 'limited') {
   console.error(
@@ -12,4 +30,16 @@ if (supported !== 'limited') {
   process.exit(1);
 }
 
-console.log('Workspace trust capability is declared as limited.');
+const missing = requiredRestrictedConfigurations.filter(
+  (setting) => !restrictedConfigurations.includes(setting)
+);
+if (missing.length) {
+  console.error(
+    `package.json must list trust-sensitive settings in capabilities.untrustedWorkspaces.restrictedConfigurations: ${missing.join(', ')}`
+  );
+  process.exit(1);
+}
+
+console.log(
+  'Workspace trust capability is declared as limited with restricted trust-sensitive settings.'
+);

--- a/apps/vscode-extension/test/security/securityRegression.test.ts
+++ b/apps/vscode-extension/test/security/securityRegression.test.ts
@@ -1,0 +1,284 @@
+jest.mock('node:child_process', () => ({
+  spawn: jest.fn()
+}));
+
+import * as childProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { KiCadCliRunner } from '../../src/cli/kicadCliRunner';
+import { registerSecretCommands } from '../../src/commands/secretCommands';
+import { COMMANDS, OCTOPART_SECRET_KEY, SETTINGS } from '../../src/constants';
+import { McpClient } from '../../src/mcp/mcpClient';
+import { createKiCanvasViewerHtml } from '../../src/providers/viewerHtml';
+import { resolveWorkspaceOutputDir } from '../../src/utils/pathUtils';
+import {
+  __setConfiguration,
+  commands,
+  createExtensionContextMock,
+  window,
+  workspace
+} from '../unit/vscodeMock';
+
+type MockChildProcess = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+};
+
+function createChildProcessMock(): MockChildProcess {
+  const child = new EventEmitter() as MockChildProcess;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  return child;
+}
+
+const extensionRoot = fs.existsSync(
+  path.join(process.cwd(), 'apps', 'vscode-extension', 'package.json')
+)
+  ? path.join(process.cwd(), 'apps', 'vscode-extension')
+  : process.cwd();
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(
+    fs.readFileSync(path.join(extensionRoot, relativePath), 'utf8')
+  ) as T;
+}
+
+describe('OASLANA-45 security regression gates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    workspace.isTrusted = true;
+    __setConfiguration({});
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    workspace.isTrusted = true;
+  });
+
+  const originalFetch = global.fetch;
+
+  it('declares limited Workspace Trust and restricts settings that can drive execution, files, or endpoints', () => {
+    const manifest = readJson<{
+      capabilities?: {
+        untrustedWorkspaces?: {
+          supported?: unknown;
+          restrictedConfigurations?: string[];
+        };
+      };
+    }>('package.json');
+
+    const untrusted = manifest.capabilities?.untrustedWorkspaces;
+    expect(untrusted?.supported).toBe('limited');
+    expect(untrusted?.restrictedConfigurations).toEqual(
+      expect.arrayContaining([
+        SETTINGS.cliPath,
+        SETTINGS.kicadPath,
+        SETTINGS.outputDir,
+        SETTINGS.cliDefineVars,
+        SETTINGS.mcpEndpoint,
+        SETTINGS.mcpAllowRemoteEndpoint,
+        SETTINGS.mcpAllowLegacySse,
+        SETTINGS.pcmRepositoryUrls,
+        SETTINGS.pcmConfigDir,
+        SETTINGS.pcmThirdPartyDir
+      ])
+    );
+  });
+
+  it('keeps webview CSPs local and rejects remote script execution primitives', () => {
+    const generatedHtml = createKiCanvasViewerHtml({
+      title: 'Viewer',
+      fileName: 'sample.kicad_sch',
+      fileType: 'schematic',
+      status: 'Opening interactive renderer...',
+      cspSource: 'vscode-resource:',
+      kicanvasUri: 'vscode-resource:/media/kicanvas/kicanvas.js',
+      base64: 'Zm9v',
+      disabledReason: ''
+    });
+    const htmlFiles = [
+      generatedHtml,
+      ...[
+        'media/viewer/bom.html',
+        'media/viewer/diff.html',
+        'media/viewer/netlist.html',
+        'media/viewer/pcb.html',
+        'media/viewer/schematic.html'
+      ].map((filePath) =>
+        fs.readFileSync(path.join(extensionRoot, filePath), 'utf8')
+      )
+    ];
+
+    for (const html of htmlFiles) {
+      expect(html).toContain("default-src 'none'");
+      expect(html).not.toMatch(
+        /script-src[^">]*(?:https?:|unsafe-inline|unsafe-eval)/i
+      );
+      expect(html).toContain('nonce-');
+    }
+  });
+
+  it('keeps viewer message handlers behind an allowlist and payload-specific parsers', () => {
+    const providerSource = fs.readFileSync(
+      path.join(extensionRoot, 'src/providers/baseKiCanvasEditorProvider.ts'),
+      'utf8'
+    );
+
+    expect(providerSource).toContain(
+      'if (!hasType(message, VIEWER_OUTBOUND_MESSAGE_TYPES))'
+    );
+    expect(providerSource).toContain('readViewerState(message.payload)');
+    expect(providerSource).toContain('readViewerSelection(message.payload)');
+    expect(providerSource).toContain('parsePngDataUrl(dataUrl)');
+    expect(providerSource).toContain('PNG_SIGNATURE');
+    expect(providerSource).toContain('MAX_PNG_EXPORT_BYTES');
+  });
+
+  it('rejects output directories that escape the workspace through traversal, absolute paths, or symlinks', () => {
+    const workspaceFile = path.join(process.cwd(), 'package.json');
+    const externalDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kicadstudio-security-outside-')
+    );
+    const link = path.join(process.cwd(), '.tmp-oaslana45-outside-link');
+
+    try {
+      expect(() => resolveWorkspaceOutputDir(workspaceFile, '..')).toThrow(
+        'Output directory must stay inside the workspace'
+      );
+      expect(() =>
+        resolveWorkspaceOutputDir(workspaceFile, externalDir)
+      ).toThrow('Output directory must stay inside the workspace');
+
+      try {
+        fs.symlinkSync(
+          externalDir,
+          link,
+          process.platform === 'win32' ? 'junction' : 'dir'
+        );
+        expect(() =>
+          resolveWorkspaceOutputDir(workspaceFile, path.basename(link))
+        ).toThrow('Output directory must stay inside the workspace');
+      } catch {
+        // Symlink creation is not always permitted on developer machines.
+      }
+    } finally {
+      fs.rmSync(link, { recursive: true, force: true });
+      fs.rmSync(externalDir, { recursive: true, force: true });
+    }
+  });
+
+  it('runs shell-looking project paths as argv entries without enabling a shell', async () => {
+    const projectRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kicadstudio-security path ; touch blocked-')
+    );
+    const boardFile = path.join(projectRoot, 'board;rm -rf nope.kicad_pcb');
+    fs.writeFileSync(boardFile, '', 'utf8');
+    __setConfiguration({});
+    const detector = {
+      detect: jest.fn().mockResolvedValue({
+        path: '/usr/bin/kicad-cli',
+        version: '10.0.1',
+        versionLabel: 'KiCad 10.0.1',
+        source: 'path'
+      })
+    };
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn()
+    };
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock.mockImplementation(
+      (_command: string, _args: string[], options: { shell?: boolean }) => {
+        const child = createChildProcessMock();
+        expect(options.shell).not.toBe(true);
+        queueMicrotask(() => {
+          child.stdout.emit('data', Buffer.from('ok'));
+          child.emit('close', 0);
+        });
+        return child;
+      }
+    );
+
+    try {
+      const runner = new KiCadCliRunner(detector as never, logger as never);
+      await expect(
+        runner.run({
+          command: ['pcb', 'drc', boardFile],
+          cwd: projectRoot,
+          progressTitle: 'DRC'
+        })
+      ).resolves.toEqual(expect.objectContaining({ exitCode: 0 }));
+
+      expect(spawnMock.mock.calls[0]?.[1]).toEqual(
+        expect.arrayContaining([boardFile])
+      );
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects remote MCP endpoints by default and does not send network traffic', async () => {
+    __setConfiguration({
+      [SETTINGS.mcpEndpoint]: 'https://mcp.example.com',
+      [SETTINGS.mcpAllowRemoteEndpoint]: false,
+      [SETTINGS.mcpAllowLegacySse]: false,
+      [SETTINGS.mcpPushContext]: true
+    });
+    global.fetch = jest.fn() as typeof fetch;
+    const client = new McpClient(
+      createExtensionContextMock() as never,
+      {
+        detectKicadMcpPro: jest
+          .fn()
+          .mockResolvedValue({ found: true, source: 'uvx' })
+      } as never,
+      {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn()
+      } as never
+    );
+
+    await expect(client.testConnection()).rejects.toThrow(
+      'Refusing remote MCP endpoint'
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('never prints plaintext stored secrets in the disclosure command', async () => {
+    const context = createExtensionContextMock();
+    await context.secrets.store(OCTOPART_SECRET_KEY, 'octopart-secret-value');
+    const services = {
+      context,
+      aiProviders: {
+        getApiKey: jest
+          .fn()
+          .mockImplementation(async (provider: string) =>
+            provider === 'openai' ? 'sk-secret-openai-token' : undefined
+          ),
+        clearApiKey: jest.fn(),
+        clearAllApiKeys: jest.fn(),
+        setApiKey: jest.fn()
+      }
+    };
+
+    registerSecretCommands(services as never);
+    const handler = (commands.registerCommand as jest.Mock).mock.calls.find(
+      ([command]) => command === COMMANDS.showStoredSecrets
+    )?.[1] as () => Promise<void>;
+    await handler();
+
+    const rendered = (window.showInformationMessage as jest.Mock).mock.calls
+      .flat()
+      .join('\n');
+    expect(rendered).toContain('OpenAI (sk-s...oken)');
+    expect(rendered).toContain('Octopart/Nexar key');
+    expect(rendered).not.toContain('sk-secret-openai-token');
+    expect(rendered).not.toContain('octopart-secret-value');
+  });
+});


### PR DESCRIPTION
## Summary

Adds OASLANA-45 security regression coverage for Workspace Trust, local process execution, path escapes, webview CSP/message validation, MCP endpoint rejection, and secret disclosure masking. The extension manifest now restricts trust-sensitive settings, and the Security workflow has a dedicated extension security regression job.

## Linked issue

Closes #46
Linear: https://linear.app/oaslananka/issue/OASLANA-45/add-security-and-workspace-trust-regression-tests-for-local-process

## Type of change

- [ ] type:bug
- [ ] type:feature
- [ ] type:docs
- [ ] type:refactor
- [ ] type:perf
- [x] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm install --frozen-lockfile` passed
- `corepack pnpm run lint` passed
- `corepack pnpm run typecheck` passed
- `corepack pnpm run test` passed
- `corepack pnpm run build` passed
- `corepack pnpm run verify:dist` passed
- `corepack pnpm --filter kicadstudio run test:security` passed (7 tests)
- `corepack pnpm --filter kicadstudio run check:workspace-trust` passed
- `corepack pnpm --filter kicadstudio run workflows:lint` passed
- `corepack pnpm --filter kicadstudio run check:ci` passed
- `gitleaks detect --source . --redact --verbose` passed
- `uvx pre-commit run --all-files` passed
- Workflow deprecation grep passed
- `git diff --check` passed

## Protocol / MCP impact

Complete this section when the PR changes MCP tool names, tool schemas,
capability metadata, transport behavior, server-info payloads, compatibility
metadata, or extension adapter behavior. For non-protocol PRs, mark it not
applicable and state why.

Checklist reference: `docs/architecture/protocol-change-checklist.md`

- [x] Not applicable; reason: regression tests and CI wiring only, no MCP protocol/schema/transport/runtime adapter behavior changed
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [ ] Docs updated
- [ ] Release notes considered for both products
- [ ] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean (not applicable: opened ready after local gates passed)
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [x] CHANGELOG entry (if user-visible; not applicable, test/CI only)
- [x] Docs updated (if user-visible; not applicable, test/CI only)
- [x] No new committed secrets or build artifacts
