### PR TITLE
feat(kicad-studio/kicad-mcp-pro): add monorepo dev doctor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,15 @@ corepack pnpm run check:boundaries
 corepack pnpm run check:version
 corepack pnpm run check:compatibility
 corepack pnpm run check:runtime-policy
+corepack pnpm run check:dev-doctor
 corepack pnpm run check:devcontainer
+```
+
+For local setup diagnostics, run:
+
+```bash
+corepack pnpm run dev:doctor
+corepack pnpm run dev:doctor -- --json
 ```
 
 For extension-only work:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ All release surfaces are pinned to `1.0.0`:
 
 ```powershell
 corepack enable
+corepack pnpm run dev:doctor
 corepack pnpm install --frozen-lockfile
 uv sync --all-extras --frozen --project packages/mcp-server
 corepack pnpm run check:forbidden-refs
@@ -49,6 +50,7 @@ corepack pnpm run check:kicad-studio
 corepack pnpm run check:kicad-mcp-pro
 corepack pnpm run check:mcp-npm
 corepack pnpm run test:contract
+corepack pnpm run check:dev-doctor
 ```
 
 For a reproducible VS Code Dev Containers or GitHub Codespaces environment, use

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -24,6 +24,7 @@ Canonical repository: https://github.com/oaslananka/kicad-studio-kit/tree/main/a
 
 ```powershell
 corepack enable
+corepack pnpm run dev:doctor
 corepack pnpm install --frozen-lockfile
 corepack pnpm --filter kicadstudio run build
 corepack pnpm --filter kicadstudio run package
@@ -80,6 +81,7 @@ Release notes for Marketplace and Open VSX users live in [CHANGELOG.md](CHANGELO
 ## Local Development
 
 ```powershell
+corepack pnpm run dev:doctor -- --ci
 corepack pnpm install --frozen-lockfile
 corepack pnpm --filter kicadstudio run marketplace:check
 corepack pnpm --filter kicadstudio run build

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,7 +12,15 @@ corepack pnpm run check:boundaries
 corepack pnpm run check:version
 corepack pnpm run check:compatibility
 corepack pnpm run check:runtime-policy
+corepack pnpm run check:dev-doctor
 corepack pnpm run check:devcontainer
+```
+
+For local setup diagnostics:
+
+```bash
+corepack pnpm run dev:doctor
+corepack pnpm run dev:doctor -- --json
 ```
 
 Product-scoped checks:

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -29,6 +29,7 @@ corepack enable pnpm
 corepack pnpm install --frozen-lockfile
 uv sync --all-extras --frozen --project packages/mcp-server
 corepack pnpm --filter kicadstudio exec playwright install --with-deps chromium
+corepack pnpm run check:dev-doctor
 corepack pnpm run check:devcontainer
 corepack pnpm run dev-doctor -- --require-devcontainer
 ```
@@ -45,8 +46,10 @@ uv run --project packages/mcp-server --all-extras pytest
 ```
 
 `corepack pnpm run check:devcontainer` validates the container contract without
-building the image. `corepack pnpm run dev-doctor -- --require-devcontainer`
-checks the active environment marker and the required command-line tools.
+building the image. `corepack pnpm run dev:doctor -- --json` emits a
+machine-readable environment report for CI/debug logs.
+`corepack pnpm run dev-doctor -- --require-devcontainer` checks the active
+environment marker and the required command-line tools.
 
 ## Test Coverage
 

--- a/package.json
+++ b/package.json
@@ -55,8 +55,10 @@
     "check:testing-strategy": "node scripts/check-testing-strategy.mjs",
     "check:protocol-pr-template": "node scripts/check-protocol-pr-template.mjs",
     "check:kicad-gui-smoke": "node scripts/check-kicad-gui-smoke.mjs",
+    "check:dev-doctor": "node scripts/dev-doctor.mjs --ci --strict",
     "check:devcontainer": "node scripts/check-devcontainer.mjs && node --test scripts/check-devcontainer.test.mjs scripts/dev-doctor.test.mjs",
     "dev-doctor": "node scripts/dev-doctor.mjs",
+    "dev:doctor": "node scripts/dev-doctor.mjs",
     "check:performance-budgets": "node scripts/check-performance-budgets.mjs && node --test scripts/check-performance-budgets.test.mjs",
     "test:beta-program": "node --test scripts/check-beta-program.test.mjs",
     "check:beta-program": "node scripts/check-beta-program.mjs && pnpm run test:beta-program",
@@ -70,7 +72,7 @@
     "check:docs-site": "pnpm --dir packages/mcp-server run docs:tools:check && pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "check:publish": "node scripts/check-publish-preflight.mjs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:testing-strategy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.0",

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -42,9 +42,14 @@ The deprecated HTTP+SSE fallback routes are disabled by default. Set
 ## Install
 
 ```bash
+corepack pnpm run dev:doctor -- --ci
 uvx kicad-mcp-pro@1.0.0 --help
 npx @oaslananka/kicad-mcp-pro@1.0.0 --help
 ```
+
+For source checkouts, `corepack pnpm run dev:doctor` validates Node, pnpm,
+Python, uv, MCP server CLI startup/version reporting, fixture corpus, protocol
+schemas, common development ports, and optional Cloudflare tunnel tooling.
 
 ## Package Metadata
 

--- a/scripts/check-devcontainer.mjs
+++ b/scripts/check-devcontainer.mjs
@@ -222,8 +222,19 @@ export function validateDevcontainerRepository(repoRoot = DEFAULT_REPO_ROOT) {
   if (scripts["dev-doctor"] !== "node scripts/dev-doctor.mjs") {
     errors.push("package.json must define dev-doctor");
   }
+  if (scripts["dev:doctor"] !== "node scripts/dev-doctor.mjs") {
+    errors.push("package.json must define dev:doctor");
+  }
+  if (
+    scripts["check:dev-doctor"] !== "node scripts/dev-doctor.mjs --ci --strict"
+  ) {
+    errors.push("package.json must define check:dev-doctor");
+  }
   if (!scripts.check?.includes("pnpm run check:devcontainer")) {
     errors.push("package.json check must run check:devcontainer");
+  }
+  if (!scripts.check?.includes("pnpm run check:dev-doctor")) {
+    errors.push("package.json check must run check:dev-doctor");
   }
 
   return errors;

--- a/scripts/check-devcontainer.test.mjs
+++ b/scripts/check-devcontainer.test.mjs
@@ -28,5 +28,14 @@ test("root scripts expose devcontainer and dev-doctor checks", () => {
     packageJson.scripts["dev-doctor"],
     "node scripts/dev-doctor.mjs",
   );
+  assert.equal(
+    packageJson.scripts["dev:doctor"],
+    "node scripts/dev-doctor.mjs",
+  );
+  assert.equal(
+    packageJson.scripts["check:dev-doctor"],
+    "node scripts/dev-doctor.mjs --ci --strict",
+  );
+  assert.match(packageJson.scripts.check, /pnpm run check:dev-doctor/);
   assert.match(packageJson.scripts.check, /pnpm run check:devcontainer/);
 });

--- a/scripts/dev-doctor.mjs
+++ b/scripts/dev-doctor.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import net from "node:net";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -89,7 +90,24 @@ function readPackageJson(repoRoot) {
   return JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"));
 }
 
+function firstLine(value) {
+  return String(value).split(/\r?\n/u).find(Boolean) ?? "";
+}
+
 function run(command, args, options = {}) {
+  if (options.commandRunner) {
+    const result = options.commandRunner(command, args, {
+      cwd: options.cwd ?? DEFAULT_REPO_ROOT,
+    });
+    return {
+      ok: result.ok,
+      status: result.status ?? (result.ok ? 0 : 1),
+      stdout: String(result.stdout ?? "").trim(),
+      stderr: String(result.stderr ?? "").trim(),
+      error: result.error,
+    };
+  }
+
   const result = spawnSync(command, args, {
     cwd: options.cwd ?? DEFAULT_REPO_ROOT,
     encoding: "utf8",
@@ -104,106 +122,621 @@ function run(command, args, options = {}) {
   };
 }
 
-function firstLine(value) {
-  return value.split(/\r?\n/u).find(Boolean) ?? "";
+function makeCheck({ id, label, category, required = true, ok, detail, hint }) {
+  return {
+    id,
+    label,
+    category,
+    required,
+    ok,
+    status: ok ? "pass" : required ? "fail" : "warn",
+    detail: detail || "(no detail)",
+    hint,
+  };
 }
 
-function toolCheck(id, label, command, args, options = {}) {
+function commandCheck(id, label, category, command, args, options = {}) {
   const result = run(command, args, options);
   const output = firstLine(
     result.stdout || result.stderr || result.error || "",
   );
-  return {
+  return makeCheck({
     id,
     label,
+    category,
     required: options.required ?? true,
     ok: result.ok,
     detail: output || `exit ${result.status ?? "unknown"}`,
-  };
+    hint: options.hint,
+  });
 }
 
-export function createDoctorReport(
+function versionCommandCheck(id, label, category, candidates, range, options) {
+  let lastResult = null;
+  for (const [command, args] of candidates) {
+    const result = run(command, args, options);
+    lastResult = result;
+    if (result.ok) {
+      const detail = firstLine(result.stdout || result.stderr);
+      return makeCheck({
+        id,
+        label,
+        category,
+        required: true,
+        ok: satisfiesSimpleRange(detail, range),
+        detail,
+        hint: options.hint,
+      });
+    }
+  }
+
+  return makeCheck({
+    id,
+    label,
+    category,
+    required: true,
+    ok: false,
+    detail: firstLine(
+      lastResult?.stdout || lastResult?.stderr || lastResult?.error || "",
+    ),
+    hint: options.hint,
+  });
+}
+
+function hasSupportedKicadVersion(output) {
+  const parsed = parseVersion(output);
+  return Boolean(parsed && parsed[0] >= 8 && parsed[0] <= 10);
+}
+
+function readOptionalText(repoRoot, relativePath) {
+  try {
+    return readFileSync(path.join(repoRoot, relativePath), "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function workspaceScriptsCheck(packageJson) {
+  const scripts = packageJson.scripts ?? {};
+  const exactScripts = {
+    "dev-doctor": "node scripts/dev-doctor.mjs",
+    "dev:doctor": "node scripts/dev-doctor.mjs",
+    "check:dev-doctor": "node scripts/dev-doctor.mjs --ci --strict",
+    "check:kicad-studio": "pnpm --filter kicadstudio run check",
+    "check:kicad-mcp-pro": "pnpm --dir packages/mcp-server run check",
+    "check:mcp-npm": "pnpm --dir packages/mcp-npm run check",
+    "check:fixtures": "node scripts/generate-kicad-fixture-corpus.mjs --check",
+  };
+  const includesScripts = {
+    "test:contract":
+      "pnpm --dir packages/mcp-server run test:transport-contract",
+  };
+  const missing = Object.entries(exactScripts)
+    .filter(([name, expected]) => scripts[name] !== expected)
+    .map(([name]) => name);
+  missing.push(
+    ...Object.entries(includesScripts)
+      .filter(([name, expected]) => !scripts[name]?.includes(expected))
+      .map(([name]) => name),
+  );
+
+  return makeCheck({
+    id: "workspace-scripts",
+    label: "Root workspace scripts",
+    category: "workspace",
+    required: true,
+    ok: missing.length === 0,
+    detail:
+      missing.length === 0
+        ? "required root scripts are available"
+        : `missing or mismatched scripts: ${missing.join(", ")}`,
+    hint: "Restore the root package.json script entrypoints used by CI and contributors.",
+  });
+}
+
+function fixtureManifestCheck(repoRoot) {
+  const manifestPath = path.join(
+    repoRoot,
+    "apps",
+    "vscode-extension",
+    "test",
+    "fixtures",
+    "kicad",
+    "manifest.json",
+  );
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const fixtureCount = Number(manifest.fixtureCount ?? 0);
+    return makeCheck({
+      id: "fixture-manifest",
+      label: "KiCad fixture corpus manifest",
+      category: "fixtures",
+      required: true,
+      ok: fixtureCount > 0 && Array.isArray(manifest.fixtures),
+      detail: `${fixtureCount} fixture(s) declared`,
+      hint: "Regenerate fixtures with `corepack pnpm run fixtures:kicad:generate`.",
+    });
+  } catch (error) {
+    return makeCheck({
+      id: "fixture-manifest",
+      label: "KiCad fixture corpus manifest",
+      category: "fixtures",
+      required: true,
+      ok: false,
+      detail: error.message,
+      hint: "Regenerate fixtures with `corepack pnpm run fixtures:kicad:generate`.",
+    });
+  }
+}
+
+function protocolSchemasCheck(repoRoot) {
+  const schemaRoot = path.join(
+    repoRoot,
+    "packages",
+    "protocol-schemas",
+    "schemas",
+  );
+  try {
+    const schemaFiles = readdirSync(schemaRoot).filter((file) =>
+      file.endsWith(".schema.json"),
+    );
+    const invalid = [];
+    for (const file of schemaFiles) {
+      const schema = JSON.parse(
+        readFileSync(path.join(schemaRoot, file), "utf8"),
+      );
+      if (!schema.$schema || !schema.$id || !schema.type) {
+        invalid.push(file);
+      }
+    }
+    return makeCheck({
+      id: "protocol-schemas",
+      label: "Protocol schemas",
+      category: "protocol",
+      required: true,
+      ok: schemaFiles.length > 0 && invalid.length === 0,
+      detail:
+        invalid.length === 0
+          ? `${schemaFiles.length} schema file(s) parsed`
+          : `invalid schema metadata: ${invalid.join(", ")}`,
+      hint: "Keep packages/protocol-schemas/schemas/*.schema.json parseable and versioned.",
+    });
+  } catch (error) {
+    return makeCheck({
+      id: "protocol-schemas",
+      label: "Protocol schemas",
+      category: "protocol",
+      required: true,
+      ok: false,
+      detail: error.message,
+      hint: "Restore packages/protocol-schemas/schemas and run protocol contract checks.",
+    });
+  }
+}
+
+function extensionDependenciesCheck(repoRoot) {
+  const packagePath = path.join(
+    repoRoot,
+    "apps",
+    "vscode-extension",
+    "package.json",
+  );
+  const nodeModulesPath = path.join(
+    repoRoot,
+    "apps",
+    "vscode-extension",
+    "node_modules",
+  );
+  return makeCheck({
+    id: "vscode-extension-deps",
+    label: "VS Code extension dependencies",
+    category: "workspace",
+    required: true,
+    ok: existsSync(packagePath) && existsSync(nodeModulesPath),
+    detail: existsSync(nodeModulesPath)
+      ? "apps/vscode-extension/node_modules is present"
+      : "apps/vscode-extension/node_modules is missing",
+    hint: "Run `corepack pnpm install --frozen-lockfile` from the repository root.",
+  });
+}
+
+function mcpVersionDetail(result) {
+  try {
+    const payload = JSON.parse(result.stdout);
+    const version = payload.package?.version;
+    return version ? `kicad-mcp-pro ${version}` : firstLine(result.stdout);
+  } catch {
+    return firstLine(result.stdout || result.stderr || result.error || "");
+  }
+}
+
+function findPortOwner(port, repoRoot, commandRunner) {
+  if (process.platform === "win32") {
+    const result = run("netstat", ["-ano", "-p", "tcp"], {
+      cwd: repoRoot,
+      commandRunner,
+    });
+    const ownerLine = result.stdout
+      .split(/\r?\n/u)
+      .find((line) => line.includes(`:${port}`) && /LISTENING/u.test(line));
+    return ownerLine ? ownerLine.trim() : "owner process not found";
+  }
+
+  const lsof = run("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN"], {
+    cwd: repoRoot,
+    commandRunner,
+  });
+  if (lsof.ok && lsof.stdout) {
+    return (
+      firstLine(lsof.stdout.split(/\r?\n/u).slice(1).join("\n")) || lsof.stdout
+    );
+  }
+
+  const ss = run("ss", ["-ltnp"], { cwd: repoRoot, commandRunner });
+  const ownerLine = ss.stdout
+    .split(/\r?\n/u)
+    .find((line) => line.includes(`:${port}`));
+  return ownerLine ? ownerLine.trim() : "owner process not found";
+}
+
+async function probePort(port, repoRoot, commandRunner) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", (error) => {
+      if (error.code === "EADDRINUSE") {
+        resolve({
+          ok: false,
+          detail: `127.0.0.1:${port} in use (${findPortOwner(port, repoRoot, commandRunner)})`,
+        });
+      } else {
+        resolve({
+          ok: false,
+          detail: `127.0.0.1:${port} unavailable: ${error.message}`,
+        });
+      }
+    });
+    server.listen(port, "127.0.0.1", () => {
+      server.close(() => {
+        resolve({ ok: true, detail: `127.0.0.1:${port} available` });
+      });
+    });
+  });
+}
+
+async function portsCheck(repoRoot, options) {
+  const ports = [27185, 3334, 3335];
+  const results = await Promise.all(
+    ports.map((port) =>
+      (
+        options.portProbe ??
+        ((value) => probePort(value, repoRoot, options.commandRunner))
+      )(port),
+    ),
+  );
+
+  return makeCheck({
+    id: "ports",
+    label: "Project development ports",
+    category: "network",
+    required: false,
+    ok: results.every((result) => result.ok),
+    detail: results.map((result) => result.detail).join("; "),
+    hint: "Stop the owning process or configure an alternate port for MCP/preview tooling.",
+  });
+}
+
+export async function createDoctorReport(
   repoRoot = DEFAULT_REPO_ROOT,
-  env = process.env,
+  options = {},
 ) {
   const packageJson = readPackageJson(repoRoot);
-  const environment = detectDevelopmentEnvironment(env);
+  const env = options.env ?? process.env;
+  const environment = {
+    platform: process.platform,
+    arch: process.arch,
+    ...detectDevelopmentEnvironment(env),
+  };
   const nodeRange = packageJson.engines?.node ?? ">=24.11.0 <25";
   const pnpmRange = packageJson.engines?.pnpm ?? ">=11.0.0 <12";
+  const pythonRange = ">=3.12";
+  const commandOptions = {
+    cwd: repoRoot,
+    commandRunner: options.commandRunner,
+  };
+  const developerToolRequired = !options.ci || environment.isDevcontainer;
   const checks = [];
 
-  checks.push({
-    id: "node",
-    label: `Node ${nodeRange}`,
-    required: true,
-    ok: satisfiesSimpleRange(process.versions.node, nodeRange),
-    detail: process.version,
-  });
-
-  const pnpm = run("corepack", ["pnpm", "--version"], { cwd: repoRoot });
-  checks.push({
-    id: "pnpm",
-    label: `pnpm ${pnpmRange}`,
-    required: true,
-    ok: pnpm.ok && satisfiesSimpleRange(pnpm.stdout, pnpmRange),
-    detail: firstLine(pnpm.stdout || pnpm.stderr || pnpm.error || ""),
-  });
-
-  const python = run("python3", ["--version"], { cwd: repoRoot });
-  checks.push({
-    id: "python",
-    label: "Python >=3.12",
-    required: true,
-    ok:
-      python.ok &&
-      satisfiesSimpleRange(python.stdout || python.stderr, ">=3.12"),
-    detail: firstLine(python.stdout || python.stderr || python.error || ""),
-  });
-
-  checks.push(toolCheck("uv", "uv", "uv", ["--version"]));
-  checks.push(toolCheck("corepack", "Corepack", "corepack", ["--version"]));
   checks.push(
-    toolCheck("shellcheck", "shellcheck", "shellcheck", ["--version"]),
-  );
-  checks.push(
-    toolCheck("actionlint", "actionlint", "actionlint", ["-version"]),
-  );
-  checks.push(toolCheck("gh", "GitHub CLI", "gh", ["--version"]));
-  checks.push(toolCheck("xvfb", "Xvfb", "xvfb-run", ["--help"]));
-  checks.push(
-    toolCheck("kicad-cli", "KiCad CLI", "kicad-cli", ["version"], {
-      required: false,
+    makeCheck({
+      id: "node",
+      label: `Node ${nodeRange}`,
+      category: "runtime",
+      required: true,
+      ok: satisfiesSimpleRange(process.versions.node, nodeRange),
+      detail: process.version,
+      hint: "Install the Node version declared in .node-version and package.json engines.",
     }),
   );
 
+  const pnpm = run("corepack", ["pnpm", "--version"], commandOptions);
+  checks.push(
+    makeCheck({
+      id: "pnpm",
+      label: `pnpm ${pnpmRange}`,
+      category: "runtime",
+      required: true,
+      ok: pnpm.ok && satisfiesSimpleRange(pnpm.stdout, pnpmRange),
+      detail: firstLine(pnpm.stdout || pnpm.stderr || pnpm.error || ""),
+      hint: "Run `corepack enable` and use the pnpm version declared by packageManager.",
+    }),
+  );
+
+  checks.push(
+    versionCommandCheck(
+      "python",
+      `Python ${pythonRange}`,
+      "runtime",
+      [
+        ["python3", ["--version"]],
+        ["python", ["--version"]],
+        ["py", ["-3", "--version"]],
+      ],
+      pythonRange,
+      {
+        ...commandOptions,
+        hint: "Install Python 3.12 or newer and make it available as python3 or python.",
+      },
+    ),
+  );
+
+  checks.push(
+    commandCheck("uv", "uv", "tools", "uv", ["--version"], {
+      ...commandOptions,
+      hint: "Install uv from https://docs.astral.sh/uv/.",
+    }),
+  );
+  checks.push(
+    commandCheck("corepack", "Corepack", "tools", "corepack", ["--version"], {
+      ...commandOptions,
+      hint: "Install Node with Corepack and run `corepack enable`.",
+    }),
+  );
+  checks.push(
+    commandCheck(
+      "shellcheck",
+      "shellcheck",
+      "tools",
+      "shellcheck",
+      ["--version"],
+      {
+        ...commandOptions,
+        required: developerToolRequired,
+        hint: "Install shellcheck for workflow and shell script validation.",
+      },
+    ),
+  );
+  checks.push(
+    commandCheck(
+      "actionlint",
+      "actionlint",
+      "tools",
+      "actionlint",
+      ["-version"],
+      {
+        ...commandOptions,
+        required: developerToolRequired,
+        hint: "Install actionlint for GitHub Actions workflow validation.",
+      },
+    ),
+  );
+  checks.push(
+    commandCheck("gh", "GitHub CLI", "tools", "gh", ["--version"], {
+      ...commandOptions,
+      required: developerToolRequired,
+      hint: "Install GitHub CLI and authenticate with `gh auth login`.",
+    }),
+  );
+  checks.push(
+    commandCheck("xvfb", "Xvfb", "tools", "xvfb-run", ["--help"], {
+      ...commandOptions,
+      required: developerToolRequired,
+      hint: "Install Xvfb for headless VS Code and KiCad GUI smoke tests on Linux.",
+    }),
+  );
+
+  const mcpWorkspace = run(
+    "uv",
+    [
+      "run",
+      "--project",
+      "packages/mcp-server",
+      "--all-extras",
+      "python",
+      "-c",
+      "import kicad_mcp; print('kicad_mcp import ok')",
+    ],
+    commandOptions,
+  );
+  checks.push(
+    makeCheck({
+      id: "mcp-workspace",
+      label: "uv resolves MCP server workspace",
+      category: "workspace",
+      required: true,
+      ok: mcpWorkspace.ok,
+      detail: firstLine(
+        mcpWorkspace.stdout || mcpWorkspace.stderr || mcpWorkspace.error || "",
+      ),
+      hint: "Run `uv sync --all-extras --frozen --project packages/mcp-server`.",
+    }),
+  );
+
+  const kicad = run("kicad-cli", ["version"], commandOptions);
+  const kicadDetail = firstLine(
+    kicad.stdout || kicad.stderr || kicad.error || "",
+  );
+  checks.push(
+    makeCheck({
+      id: "kicad-cli",
+      label: "KiCad CLI 8.x/9.x/10.x",
+      category: "tools",
+      required: !options.ci,
+      ok: kicad.ok && hasSupportedKicadVersion(kicadDetail),
+      detail: kicadDetail,
+      hint: "Install a supported KiCad CLI or set the extension kicad-cli path.",
+    }),
+  );
+
+  checks.push(extensionDependenciesCheck(repoRoot));
+
+  const mcpHelp = run(
+    "uv",
+    [
+      "run",
+      "--project",
+      "packages/mcp-server",
+      "--all-extras",
+      "kicad-mcp-pro",
+      "--help",
+    ],
+    commandOptions,
+  );
+  checks.push(
+    makeCheck({
+      id: "mcp-help",
+      label: "kicad-mcp-pro --help",
+      category: "mcp",
+      required: true,
+      ok: mcpHelp.ok,
+      detail: firstLine(
+        mcpHelp.stdout || mcpHelp.stderr || mcpHelp.error || "",
+      ),
+      hint: "Run `uv sync --all-extras --frozen --project packages/mcp-server`.",
+    }),
+  );
+
+  const mcpVersion = run(
+    "uv",
+    [
+      "run",
+      "--project",
+      "packages/mcp-server",
+      "--all-extras",
+      "kicad-mcp-pro",
+      "version",
+      "--json",
+    ],
+    commandOptions,
+  );
+  checks.push(
+    makeCheck({
+      id: "mcp-version",
+      label: "kicad-mcp-pro version",
+      category: "mcp",
+      required: true,
+      ok: mcpVersion.ok,
+      detail: mcpVersionDetail(mcpVersion),
+      hint: "Verify the MCP server CLI can report version metadata.",
+    }),
+  );
+
+  checks.push(
+    commandCheck(
+      "cloudflared",
+      "Cloudflare tunnel tool",
+      "optional",
+      "cloudflared",
+      ["--version"],
+      {
+        ...commandOptions,
+        required: false,
+        hint: "Install cloudflared only when testing remote tunnel workflows.",
+      },
+    ),
+  );
+
+  checks.push(await portsCheck(repoRoot, options));
+  checks.push(workspaceScriptsCheck(packageJson));
+  checks.push(fixtureManifestCheck(repoRoot));
+  checks.push(
+    commandCheck(
+      "fixture-corpus",
+      "KiCad fixture corpus validation",
+      "fixtures",
+      "corepack",
+      ["pnpm", "run", "check:fixtures"],
+      {
+        ...commandOptions,
+        hint: "Run `corepack pnpm run fixtures:kicad:generate` and commit the generated corpus.",
+      },
+    ),
+  );
+  checks.push(protocolSchemasCheck(repoRoot));
+
+  const compatibility = readOptionalText(repoRoot, "compatibility.yaml");
+  checks.push(
+    makeCheck({
+      id: "compatibility-matrix",
+      label: "Compatibility matrix",
+      category: "workspace",
+      required: true,
+      ok:
+        compatibility.includes('primary: "10.0.x"') &&
+        compatibility.includes('range: ">=24.11.0 <25"') &&
+        compatibility.includes('range: ">=3.12"'),
+      detail: compatibility
+        ? "compatibility.yaml contains runtime baselines"
+        : "missing",
+      hint: "Keep compatibility.yaml aligned with package engines and support docs.",
+    }),
+  );
+
+  const failedRequired = checks.some((check) => check.required && !check.ok);
+
   return {
+    schemaVersion: 1,
+    status: failedRequired ? "failed" : "ok",
     environment,
     checks,
   };
 }
 
-function printHuman(report) {
+export function formatHumanReport(report) {
   const envSummary = report.environment.isDevcontainer
     ? `devcontainer detected (${report.environment.markers.join(", ")})`
     : "devcontainer marker not detected";
-  console.log(`Environment: ${envSummary}`);
+  const lines = [
+    "KiCad Studio Kit dev-doctor",
+    `Status: ${report.status}`,
+    `Environment: ${report.environment.platform}/${report.environment.arch}; ${envSummary}`,
+  ];
 
   for (const check of report.checks) {
-    const status = check.ok ? "pass" : check.required ? "fail" : "warn";
-    console.log(`[${status}] ${check.label}: ${check.detail}`);
+    lines.push(`[${check.status}] ${check.label}: ${check.detail}`);
+    if (!check.ok) {
+      lines.push(`  hint: ${check.hint}`);
+    }
   }
+
+  return lines.join("\n");
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   const args = new Set(process.argv.slice(2));
-  const report = createDoctorReport();
+  const report = await createDoctorReport(DEFAULT_REPO_ROOT, {
+    env: process.env,
+    ci: args.has("--ci"),
+  });
   const requireDevcontainer = args.has("--require-devcontainer");
   const strict = args.has("--strict") || report.environment.isDevcontainer;
 
   if (args.has("--json")) {
     console.log(JSON.stringify(report, null, 2));
   } else {
-    printHuman(report);
+    console.log(formatHumanReport(report));
   }
 
   if (requireDevcontainer && !report.environment.isDevcontainer) {

--- a/scripts/dev-doctor.test.mjs
+++ b/scripts/dev-doctor.test.mjs
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
+  createDoctorReport,
   detectDevelopmentEnvironment,
+  formatHumanReport,
   satisfiesSimpleRange,
 } from "./dev-doctor.mjs";
 
@@ -35,4 +40,205 @@ test("dev-doctor enforces the repository Node runtime policy", () => {
   assert.equal(satisfiesSimpleRange("24.16.0", ">=24.11.0 <25"), true);
   assert.equal(satisfiesSimpleRange("24.10.0", ">=24.11.0 <25"), false);
   assert.equal(satisfiesSimpleRange("25.0.0", ">=24.11.0 <25"), false);
+});
+
+test("dev-doctor reports the full CI-safe monorepo environment contract", async () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), "kicad-dev-doctor-"));
+  try {
+    mkdirSync(path.join(repoRoot, "apps/vscode-extension/node_modules/.bin"), {
+      recursive: true,
+    });
+    mkdirSync(path.join(repoRoot, "packages/mcp-server"), { recursive: true });
+    mkdirSync(
+      path.join(repoRoot, "apps/vscode-extension/test/fixtures/kicad"),
+      { recursive: true },
+    );
+    mkdirSync(path.join(repoRoot, "packages/protocol-schemas/schemas"), {
+      recursive: true,
+    });
+    writeFileSync(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify(
+        {
+          packageManager: "pnpm@11.0.8",
+          engines: { node: ">=24.11.0 <25", pnpm: ">=11.0.0 <12" },
+          scripts: {
+            "dev-doctor": "node scripts/dev-doctor.mjs",
+            "dev:doctor": "node scripts/dev-doctor.mjs",
+            "check:dev-doctor": "node scripts/dev-doctor.mjs --ci --strict",
+            "check:kicad-studio": "pnpm --filter kicadstudio run check",
+            "check:kicad-mcp-pro": "pnpm --dir packages/mcp-server run check",
+            "check:mcp-npm": "pnpm --dir packages/mcp-npm run check",
+            "check:fixtures":
+              "node scripts/generate-kicad-fixture-corpus.mjs --check",
+            "test:contract":
+              "pnpm --dir packages/mcp-server run test:transport-contract",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    writeFileSync(path.join(repoRoot, ".node-version"), "24\n");
+    writeFileSync(path.join(repoRoot, ".python-version"), "3.12\n");
+    writeFileSync(
+      path.join(repoRoot, "apps/vscode-extension/package.json"),
+      JSON.stringify({ name: "kicadstudio" }),
+    );
+    writeFileSync(
+      path.join(repoRoot, "compatibility.yaml"),
+      [
+        "schemaVersion: 1",
+        "kicad:",
+        '  primary: "10.0.x"',
+        "node:",
+        '  range: ">=24.11.0 <25"',
+        "python:",
+        '  range: ">=3.12"',
+      ].join("\n"),
+    );
+    writeFileSync(
+      path.join(
+        repoRoot,
+        "apps/vscode-extension/test/fixtures/kicad/manifest.json",
+      ),
+      JSON.stringify({ schemaVersion: 1, fixtureCount: 1, fixtures: [] }),
+    );
+    writeFileSync(
+      path.join(
+        repoRoot,
+        "packages/protocol-schemas/schemas/kicad-mcp-server-info.schema.json",
+      ),
+      JSON.stringify({
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        $id: "https://example.invalid/schema.json",
+        type: "object",
+      }),
+    );
+
+    const report = await createDoctorReport(repoRoot, {
+      env: { KICAD_STUDIO_DEVCONTAINER: "1" },
+      ci: true,
+      commandRunner(command, args) {
+        const joined = [command, ...args].join(" ");
+        if (joined === "corepack pnpm --version") {
+          return { ok: true, status: 0, stdout: "11.0.8", stderr: "" };
+        }
+        if (joined === "python3 --version") {
+          return { ok: true, status: 0, stdout: "Python 3.12.3", stderr: "" };
+        }
+        if (joined === "uv --version") {
+          return { ok: true, status: 0, stdout: "uv 0.11.12", stderr: "" };
+        }
+        if (joined.includes("import kicad_mcp")) {
+          return {
+            ok: true,
+            status: 0,
+            stdout: "kicad_mcp import ok",
+            stderr: "",
+          };
+        }
+        if (joined.includes("kicad-mcp-pro --help")) {
+          return {
+            ok: true,
+            status: 0,
+            stdout: "Usage: kicad-mcp-pro",
+            stderr: "",
+          };
+        }
+        if (joined.includes("kicad-mcp-pro version --json")) {
+          return {
+            ok: true,
+            status: 0,
+            stdout: JSON.stringify({ package: { version: "1.0.0" } }),
+            stderr: "",
+          };
+        }
+        if (joined === "corepack pnpm run check:fixtures") {
+          return {
+            ok: true,
+            status: 0,
+            stdout: "Fixture corpus is current.",
+            stderr: "",
+          };
+        }
+        if (joined === "kicad-cli version") {
+          return { ok: false, status: 127, stdout: "", stderr: "not found" };
+        }
+        if (joined === "cloudflared --version") {
+          return { ok: false, status: 127, stdout: "", stderr: "not found" };
+        }
+        return { ok: true, status: 0, stdout: `${command} ok`, stderr: "" };
+      },
+      portProbe(port) {
+        return Promise.resolve({
+          ok: true,
+          detail: `127.0.0.1:${port} available`,
+        });
+      },
+    });
+
+    const byId = new Map(report.checks.map((check) => [check.id, check]));
+    assert.equal(report.schemaVersion, 1);
+    assert.equal(report.status, "ok");
+    assert.deepEqual(
+      [
+        "node",
+        "pnpm",
+        "python",
+        "uv",
+        "mcp-workspace",
+        "kicad-cli",
+        "vscode-extension-deps",
+        "mcp-help",
+        "mcp-version",
+        "cloudflared",
+        "ports",
+        "workspace-scripts",
+        "fixture-corpus",
+        "protocol-schemas",
+      ].filter((id) => !byId.has(id)),
+      [],
+    );
+    assert.equal(byId.get("kicad-cli").required, false);
+    assert.equal(byId.get("cloudflared").required, false);
+    assert.equal(byId.get("mcp-version").detail, "kicad-mcp-pro 1.0.0");
+    assert.equal(
+      report.checks.every(
+        (check) => typeof check.hint === "string" && check.hint.length > 0,
+      ),
+      true,
+    );
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("dev-doctor human output includes actionable fix hints", () => {
+  const output = formatHumanReport({
+    schemaVersion: 1,
+    status: "failed",
+    environment: {
+      platform: "linux",
+      arch: "x64",
+      isDevcontainer: false,
+      isCodespaces: false,
+      markers: [],
+    },
+    checks: [
+      {
+        id: "uv",
+        label: "uv",
+        category: "tools",
+        required: true,
+        ok: false,
+        status: "fail",
+        detail: "command not found",
+        hint: "Install uv from https://docs.astral.sh/uv/.",
+      },
+    ],
+  });
+
+  assert.match(output, /Status: failed/);
+  assert.match(output, /hint: Install uv/);
 });

--- a/scripts/generate-docs-site.mjs
+++ b/scripts/generate-docs-site.mjs
@@ -391,7 +391,15 @@ corepack pnpm run check:boundaries
 corepack pnpm run check:version
 corepack pnpm run check:compatibility
 corepack pnpm run check:runtime-policy
+corepack pnpm run check:dev-doctor
 corepack pnpm run check:devcontainer
+\`\`\`
+
+For local setup diagnostics:
+
+\`\`\`bash
+corepack pnpm run dev:doctor
+corepack pnpm run dev:doctor -- --json
 \`\`\`
 
 Product-scoped checks:


### PR DESCRIPTION
## Summary

- Adds a root `dev:doctor` / `check:dev-doctor` environment checker for the monorepo.
- Reports human-readable and JSON diagnostics for Node, pnpm, Python, uv, KiCad CLI, MCP startup/version, VS Code extension deps, optional Cloudflare tunnel tooling, common dev ports, fixtures, schemas, compatibility matrix, and root scripts.
- Wires the checker into root `check`, devcontainer validation, regression tests, and contributor/product docs.

Linear: OASLANA-58

## Linked issue

Closes #59

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run format:check`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist`
- `corepack pnpm run check:dev-doctor`
- `node --test scripts/dev-doctor.test.mjs scripts/check-devcontainer.test.mjs`
- `corepack pnpm run docs:check-generated`
- `corepack pnpm run check:devcontainer`
- `corepack pnpm dev:doctor --json` (JSON output verified; full local mode correctly reports missing `actionlint` plus optional `cloudflared` with fix hints on this host)
- `corepack pnpm run check`
- `gitleaks detect --source . --redact --verbose`
- `git diff --check`
- workflow deprecation grep for deprecated workflow commands and node12/node16/node20 references
- `uvx pre-commit run --all-files`
- `corepack pnpm run check:release-please` after commit subject was amended to the required multi-product scope

Commit: `11f2168c9482daeceff89f74806b21697d4fc9df`

## Protocol / MCP impact

No protocol/tool schema/transport behavior changes. This adds contributor diagnostics that execute existing MCP CLI help/version checks and validate existing schemas.

- [x] Not applicable; reason: no MCP tool names, tool schemas, transport behavior, capabilities payloads, or extension adapter contracts changed.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [x] Contract tests updated
- [x] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Cheap gates were clean before opening PR
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage, or an explicit maintainer-approved exception
- [x] CHANGELOG entry not needed for contributor tooling/docs change
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
