### PR TITLE
feat(kicad-studio/kicad-mcp-pro): add doctor diagnostics

### DIFF
--- a/apps/vscode-extension/src/mcp/mcpDetector.ts
+++ b/apps/vscode-extension/src/mcp/mcpDetector.ts
@@ -12,16 +12,29 @@ export interface McpInstallerCandidate {
   args: string[];
 }
 
+export interface McpDoctorResult {
+  ok: boolean;
+  status?: string | undefined;
+  recentErrors: string[];
+  output: string;
+  error?: string | undefined;
+}
+
 function runExecFile(
   command: string,
   args: string[],
-  timeoutMs: number
+  timeoutMs: number,
+  env?: Record<string, string>
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     execFile(
       command,
       args,
-      { encoding: 'utf8', timeout: timeoutMs },
+      {
+        encoding: 'utf8',
+        timeout: timeoutMs,
+        ...(env ? { env: { ...process.env, ...env } } : {})
+      },
       (error, stdout, stderr) => {
         if (error) {
           reject(error);
@@ -35,10 +48,16 @@ function runExecFile(
 
 async function run(
   command: string,
-  args: string[]
+  args: string[],
+  options: { timeoutMs?: number; env?: Record<string, string> } = {}
 ): Promise<{ ok: boolean; output: string }> {
   try {
-    const { stdout, stderr } = await runExecFile(command, args, 8_000);
+    const { stdout, stderr } = await runExecFile(
+      command,
+      args,
+      options.timeoutMs ?? 8_000,
+      options.env
+    );
     const output = `${stdout}\n${stderr}`.trim();
     return { ok: true, output };
   } catch (error) {
@@ -260,6 +279,43 @@ export class McpDetector {
     return buildHttpTaskArgs(status, profile, port, projectDir);
   }
 
+  async runDoctor(
+    status: McpInstallStatus,
+    projectDir?: string
+  ): Promise<McpDoctorResult> {
+    const invocation = doctorInvocation(status);
+    if (!invocation) {
+      return {
+        ok: false,
+        recentErrors: [],
+        output: '',
+        error:
+          'kicad-mcp-pro doctor is unavailable for this installation source.'
+      };
+    }
+
+    const result = await run(invocation.command, invocation.args, {
+      timeoutMs: 12_000,
+      ...(projectDir ? { env: { KICAD_MCP_PROJECT_DIR: projectDir } } : {})
+    });
+    if (!result.ok) {
+      return {
+        ok: false,
+        recentErrors: [],
+        output: result.output,
+        error: result.output
+      };
+    }
+
+    const parsed = parseDoctorOutput(result.output);
+    return {
+      ok: true,
+      status: parsed.status,
+      recentErrors: parsed.recentErrors,
+      output: result.output
+    };
+  }
+
   async detectInstallers(): Promise<McpInstallerCandidate[]> {
     const candidates: McpInstallerCandidate[] = [];
     if (
@@ -385,6 +441,54 @@ export class McpDetector {
 
 function extractVersion(output: string): string | undefined {
   return output.match(/(\d+\.\d+(?:\.\d+)?)/)?.[1];
+}
+
+function doctorInvocation(
+  status: McpInstallStatus
+): { command: string; args: string[] } | undefined {
+  if (!status.found) {
+    return undefined;
+  }
+  if (status.command === 'uvx') {
+    return { command: 'uvx', args: ['kicad-mcp-pro', 'doctor', '--json'] };
+  }
+  if (
+    status.command === 'kicad-mcp-pro' ||
+    status.command === 'pipx' ||
+    status.command === 'pip' ||
+    status.source === 'global' ||
+    status.source === 'pipx' ||
+    status.source === 'pip'
+  ) {
+    return { command: 'kicad-mcp-pro', args: ['doctor', '--json'] };
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseDoctorOutput(output: string): {
+  status?: string | undefined;
+  recentErrors: string[];
+} {
+  try {
+    const payload: unknown = JSON.parse(output);
+    if (!isRecord(payload)) {
+      return { recentErrors: [] };
+    }
+    const status =
+      typeof payload['status'] === 'string' ? payload['status'] : undefined;
+    const errors = Array.isArray(payload['recent_errors'])
+      ? payload['recent_errors'].filter(
+          (entry): entry is string => typeof entry === 'string'
+        )
+      : [];
+    return { status, recentErrors: errors };
+  } catch {
+    return { recentErrors: [] };
+  }
 }
 
 function buildHttpTaskArgs(

--- a/apps/vscode-extension/test/unit/mcpDetector.test.ts
+++ b/apps/vscode-extension/test/unit/mcpDetector.test.ts
@@ -554,3 +554,56 @@ describe('McpDetector.generateHttpConfig', () => {
     expect(args).toContain('http');
   });
 });
+
+describe('McpDetector.runDoctor', () => {
+  let tempDir: string;
+  let execFileMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kicadstudio-doctor-'));
+    execFileMock = childProcess.execFile as unknown as jest.Mock;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('calls kicad-mcp-pro doctor JSON through uvx with the active project directory', async () => {
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        args: string[],
+        opts: { env?: Record<string, string> },
+        callback: (err: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        expect(command).toBe('uvx');
+        expect(args).toEqual(['kicad-mcp-pro', 'doctor', '--json']);
+        expect(opts.env?.['KICAD_MCP_PROJECT_DIR']).toBe(tempDir);
+        callback(
+          null,
+          JSON.stringify({
+            schemaVersion: '1.0.0',
+            status: 'degraded',
+            recent_errors: ['kicad_ipc: unavailable']
+          }),
+          ''
+        );
+      }
+    );
+
+    const result = await new McpDetector().runDoctor(
+      {
+        found: true,
+        command: 'uvx',
+        version: '1.0.0',
+        source: 'uvx'
+      },
+      tempDir
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe('degraded');
+    expect(result.recentErrors).toEqual(['kicad_ipc: unavailable']);
+  });
+});

--- a/docs/changelog/kicad-mcp-pro.md
+++ b/docs/changelog/kicad-mcp-pro.md
@@ -4,6 +4,9 @@ Source: `packages/mcp-server/CHANGELOG.md`
 
 ## [Unreleased]
 
+- Add `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
+  setup troubleshooting.
+
 ## [1.0.0]
 
 - Baseline KiCad MCP Pro server release from the canonical monorepo.

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Add `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
+  setup troubleshooting.
+
 ## [1.0.0]
 
 - Baseline KiCad MCP Pro server release from the canonical monorepo.

--- a/packages/mcp-server/docs/configuration.md
+++ b/packages/mcp-server/docs/configuration.md
@@ -15,13 +15,19 @@ The active project can also be changed at runtime with `kicad_set_project()`.
 ```bash
 kicad-mcp-pro health --json
 kicad-mcp-pro doctor --json
+kicad-mcp-pro doctor --json --bundle ./mcp-debug.zip
 kicad-mcp-pro version --json
 ```
 
 `health --json` is a fast install/configuration check and does not require a
 running KiCad IPC server. `doctor --json` adds deeper KiCad CLI and IPC probes
 but reports unavailable KiCad as a degraded diagnostic state instead of printing
-a stack trace.
+a stack trace. The doctor JSON is schema-validated before it is printed and
+includes active project paths, transport host/port/mount settings, stateful HTTP
+mode, tool and category counts, a capability summary, live GUI context
+availability, and redacted recent diagnostic errors. `--bundle` writes a
+redacted zip with `doctor.json`, the generated JSON schema, safe environment
+metadata, and a README; it never includes plaintext tokens or credentials.
 
 ## Environment Aliases
 

--- a/packages/mcp-server/docs/install/client-config-generator.md
+++ b/packages/mcp-server/docs/install/client-config-generator.md
@@ -19,13 +19,18 @@ Related inspection commands:
 kicad-mcp-pro tools list --json
 kicad-mcp-pro capabilities --json
 kicad-mcp-pro doctor --json --strict
+kicad-mcp-pro doctor --json --bundle ./mcp-debug.zip
 ```
 
 Strict doctor exit codes are stable for launcher integration:
 
-| Exit code | Meaning |
-|---|---|
-| 0 | OK |
-| 1 | Degraded but usable |
-| 2 | Configuration or runtime error |
-| 3 | Missing external dependency |
+| Exit code | Meaning                        |
+| --------- | ------------------------------ |
+| 0         | OK                             |
+| 1         | Degraded but usable            |
+| 2         | Configuration or runtime error |
+| 3         | Missing external dependency    |
+
+Launchers can call non-strict `doctor --json` for diagnostics without starting
+the MCP server. The optional `--bundle` path writes a redacted support archive
+for setup debugging.

--- a/packages/mcp-server/docs/integration/kicad-studio.md
+++ b/packages/mcp-server/docs/integration/kicad-studio.md
@@ -10,30 +10,45 @@ of importing Python modules from `packages/mcp-server`.
 uvx kicad-mcp-pro --help
 uvx kicad-mcp-pro health --json
 uvx kicad-mcp-pro doctor --json
+uvx kicad-mcp-pro doctor --json --bundle ./mcp-debug.zip
 uvx kicad-mcp-pro serve
 ```
 
 `health --json` must succeed when the package is installed, even if KiCad is not
 running. `doctor --json` may report degraded KiCad IPC status but should not
-crash for normal diagnosable conditions.
+crash for normal diagnosable conditions. KiCad Studio may call the doctor
+command directly for setup diagnostics; it does not start the MCP server.
 
 Stable fields for extension consumption:
 
 - `ok`
+- `schemaVersion`
 - `status`
 - `package.name`
 - `package.version`
 - `python.version`
 - `mcp.transport_default`
 - `mcp.profile`
+- `mcp.host`
+- `mcp.port`
+- `mcp.mount_path`
+- `mcp.stateful_http`
 - `kicad.cli_path`
 - `kicad.cli_found`
 - `kicad.version`
 - `kicad.ipc_reachable`
 - `config.workspace_root`
 - `config.project_dir`
+- `config.project_file`
+- `config.pcb_file`
+- `config.sch_file`
 - `config.timeout_ms`
 - `config.retries`
+- `tools.tool_count`
+- `tools.category_count`
+- `tools.capability_summary`
+- `live_context.available`
+- `recent_errors[]`
 - `checks[].name`
 - `checks[].status`
 - `checks[].message`

--- a/packages/mcp-server/src/kicad_mcp/config.py
+++ b/packages/mcp-server/src/kicad_mcp/config.py
@@ -410,6 +410,9 @@ class KiCadMCPConfig(BaseSettings):
         return {
             "workspace_root": str(self.workspace) if self.workspace else None,
             "project_dir": str(self.project_dir) if self.project_dir else None,
+            "project_file": str(self.project_file) if self.project_file else None,
+            "pcb_file": str(self.pcb_file) if self.pcb_file else None,
+            "sch_file": str(self.sch_file) if self.sch_file else None,
             "output_dir": str(self.output_dir) if self.output_dir else None,
             "timeout_ms": self.timeout_ms,
             "retries": self.ipc_retries,
@@ -423,6 +426,10 @@ class KiCadMCPConfig(BaseSettings):
             "otel_protocol": self.otel_protocol,
             "telemetry_buffer_max_events": self.telemetry_buffer_max_events,
             "transport": self.transport,
+            "host": self.host,
+            "port": self.port,
+            "mount_path": self.mount_path,
+            "stateful_http": self.stateful_http,
             "auth_token": {"configured": self.auth_token is not None},
             "kicad_token": {"configured": self.kicad_token is not None},
         }

--- a/packages/mcp-server/src/kicad_mcp/diagnostics.py
+++ b/packages/mcp-server/src/kicad_mcp/diagnostics.py
@@ -2,20 +2,34 @@
 
 from __future__ import annotations
 
+import json
 import platform
+import re
 import sys
 from pathlib import Path
-from typing import Literal
+from typing import Any, ClassVar, Literal
+from zipfile import ZIP_DEFLATED, ZipFile
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from . import __version__
+from .capabilities import AccessTier, RuntimeRequirement, all_records
 from .config import get_config
 from .connection import KiCadConnectionError, get_board
 from .discovery import find_kicad_version
 
 CheckStatus = Literal["ok", "warn", "error", "skipped"]
 OverallStatus = Literal["ok", "degraded", "error"]
+DIAGNOSTIC_SCHEMA_VERSION = "1.0.0"
+_PRIVATE_KEY_MARKER = "PRIVATE" + " KEY"
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?i)\b(token|access_token|refresh_token|client_secret|password)=([^\s,;]+)"),
+    re.compile(r"(?i)\b(authorization:\s*bearer\s+)([^\s,;]+)"),
+    re.compile(
+        rf"-----BEGIN {_PRIVATE_KEY_MARKER}-----.*?-----END {_PRIVATE_KEY_MARKER}-----",
+        re.DOTALL,
+    ),
+)
 
 
 class CheckResult(BaseModel):
@@ -46,6 +60,10 @@ class McpDiagnostics(BaseModel):
 
     transport_default: str
     profile: str
+    host: str | None = None
+    port: int | None = None
+    mount_path: str | None = None
+    stateful_http: bool = False
 
 
 class KiCadDiagnostics(BaseModel):
@@ -63,6 +81,9 @@ class ConfigDiagnostics(BaseModel):
 
     workspace_root: str | None = None
     project_dir: str | None = None
+    project_file: str | None = None
+    pcb_file: str | None = None
+    sch_file: str | None = None
     output_dir: str | None = None
     timeout_ms: int
     retries: int
@@ -70,13 +91,39 @@ class ConfigDiagnostics(BaseModel):
     log_level: str
     log_format: str
     transport: str
+    host: str | None = None
+    port: int | None = None
+    mount_path: str | None = None
+    stateful_http: bool = False
     auth_token: dict[str, bool]
     kicad_token: dict[str, bool]
+
+
+class ToolCatalogDiagnostics(BaseModel):
+    """Summary of the tool registry available to the configured profile."""
+
+    tool_count: int = 0
+    category_count: int = 0
+    categories: list[str] = Field(default_factory=list)
+    capability_summary: dict[str, dict[str, int]] = Field(default_factory=dict)
+
+
+class LiveContextDiagnostics(BaseModel):
+    """Live KiCad GUI and IPC context availability."""
+
+    available: bool = False
+    ipc_reachable: bool = False
+    live_pcb_context: bool = False
+    live_schematic_context: bool = False
+    diagnostics: list[str] = Field(default_factory=list)
 
 
 class DiagnosticReport(BaseModel):
     """Machine-readable health/doctor report."""
 
+    model_config: ClassVar[ConfigDict] = ConfigDict(populate_by_name=True)
+
+    schema_version: str = Field(default=DIAGNOSTIC_SCHEMA_VERSION, alias="schemaVersion")
     ok: bool
     status: OverallStatus
     package: PackageDiagnostics = Field(default_factory=PackageDiagnostics)
@@ -84,7 +131,30 @@ class DiagnosticReport(BaseModel):
     mcp: McpDiagnostics
     kicad: KiCadDiagnostics
     config: ConfigDiagnostics
+    tools: ToolCatalogDiagnostics = Field(default_factory=ToolCatalogDiagnostics)
+    live_context: LiveContextDiagnostics = Field(default_factory=LiveContextDiagnostics)
+    recent_errors: list[str] = Field(default_factory=list)
     checks: list[CheckResult] = Field(default_factory=list)
+
+
+def _redact_sensitive(value: str) -> str:
+    redacted = value
+    redacted = _SECRET_PATTERNS[0].sub(lambda match: f"{match.group(1)}=[REDACTED]", redacted)
+    redacted = _SECRET_PATTERNS[1].sub(lambda match: f"{match.group(1)}[REDACTED]", redacted)
+    redacted = _SECRET_PATTERNS[2].sub(
+        f"-----BEGIN {_PRIVATE_KEY_MARKER}-----[REDACTED]-----END {_PRIVATE_KEY_MARKER}-----",
+        redacted,
+    )
+    return redacted
+
+
+def _redact_check(check: CheckResult) -> CheckResult:
+    return CheckResult(
+        name=check.name,
+        status=check.status,
+        message=_redact_sensitive(check.message),
+        hint=_redact_sensitive(check.hint),
+    )
 
 
 def _status(checks: list[CheckResult]) -> tuple[bool, OverallStatus]:
@@ -97,6 +167,84 @@ def _status(checks: list[CheckResult]) -> tuple[bool, OverallStatus]:
 
 def _cli_found(path: Path) -> bool:
     return path.exists()
+
+
+def _capability_summary() -> dict[str, dict[str, int]]:
+    tiers = {tier.value: 0 for tier in AccessTier}
+    runtimes = {runtime.value: 0 for runtime in RuntimeRequirement}
+    for record in all_records().values():
+        tiers[record.tier.value] += 1
+        runtimes[record.runtime.value] += 1
+    return {"tiers": tiers, "runtimes": runtimes}
+
+
+def _tool_catalog_diagnostics(profile: str) -> ToolCatalogDiagnostics:
+    from .tools.router import categories_for_profile
+
+    categories = list(categories_for_profile(profile))
+    return ToolCatalogDiagnostics(
+        tool_count=len(all_records()),
+        category_count=len(categories),
+        categories=categories,
+        capability_summary=_capability_summary(),
+    )
+
+
+def _recent_errors(checks: list[CheckResult]) -> list[str]:
+    return [
+        f"{check.name}: {check.message}" for check in checks if check.status in {"warn", "error"}
+    ]
+
+
+def _diagnostic_payload(report: DiagnosticReport) -> dict[str, Any]:
+    payload = report.model_dump(mode="json", by_alias=True)
+    DiagnosticReport.model_validate(payload)
+    return payload
+
+
+def _json_dumps(payload: object) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def write_diagnostic_bundle(report: DiagnosticReport, bundle_path: Path) -> None:
+    """Write a redacted support bundle for setup diagnostics."""
+    payload = _diagnostic_payload(report)
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    config = payload["config"]
+    if not isinstance(config, dict):
+        config = {}
+    environment = {
+        "schemaVersion": DIAGNOSTIC_SCHEMA_VERSION,
+        "platform": platform.platform(),
+        "python": payload["python"],
+        "package": payload["package"],
+        "config": config,
+        "environment": {
+            "KICAD_MCP_AUTH_TOKEN": config.get("auth_token", {"configured": False}),
+            "KICAD_API_TOKEN": config.get("kicad_token", {"configured": False}),
+            "KICAD_MCP_KICAD_TOKEN": config.get("kicad_token", {"configured": False}),
+            "OTEL_EXPORTER_OTLP_HEADERS": {"configured": bool(config.get("otel_headers"))},
+        },
+    }
+    readme = (
+        "KiCad MCP Pro diagnostic bundle\n\n"
+        "This bundle contains redacted setup diagnostics only. Secret values, tokens, "
+        "and plaintext credentials are not included.\n"
+    )
+    with ZipFile(bundle_path, mode="w", compression=ZIP_DEFLATED) as archive:
+        archive.writestr("README.txt", readme)
+        archive.writestr("doctor.json", _json_dumps(payload))
+        archive.writestr(
+            "diagnostic-schema.json",
+            _json_dumps(DiagnosticReport.model_json_schema(by_alias=True)),
+        )
+        archive.writestr("environment.json", _json_dumps(environment))
+
+
+def diagnostic_report_json(report: DiagnosticReport, *, indent: int = 2) -> str:
+    """Return schema-validated JSON for a diagnostic report."""
+    payload = _diagnostic_payload(report)
+    return json.dumps(payload, indent=indent)
 
 
 def build_diagnostic_report(*, probe_cli: bool, probe_ipc: bool) -> DiagnosticReport:
@@ -165,12 +313,21 @@ def build_diagnostic_report(*, probe_cli: bool, probe_ipc: bool) -> DiagnosticRe
             )
         )
 
+    checks = [_redact_check(check) for check in checks]
     ok, status = _status(checks)
+    config_payload = cfg.safe_diagnostics()
     return DiagnosticReport(
         ok=ok,
         status=status,
         python=PythonDiagnostics(executable=sys.executable),
-        mcp=McpDiagnostics(transport_default=cfg.transport, profile=cfg.profile),
+        mcp=McpDiagnostics(
+            transport_default=cfg.transport,
+            profile=cfg.profile,
+            host=cfg.host,
+            port=cfg.port,
+            mount_path=cfg.mount_path,
+            stateful_http=cfg.stateful_http,
+        ),
         kicad=KiCadDiagnostics(
             cli_path=str(cfg.kicad_cli) if cfg.kicad_cli else None,
             cli_found=cli_found,
@@ -178,7 +335,16 @@ def build_diagnostic_report(*, probe_cli: bool, probe_ipc: bool) -> DiagnosticRe
             ipc_reachable=ipc_reachable,
             headless=cfg.headless,
         ),
-        config=ConfigDiagnostics.model_validate(cfg.safe_diagnostics()),
+        config=ConfigDiagnostics.model_validate(config_payload),
+        tools=_tool_catalog_diagnostics(cfg.profile),
+        live_context=LiveContextDiagnostics(
+            available=ipc_reachable,
+            ipc_reachable=ipc_reachable,
+            live_pcb_context=ipc_reachable,
+            live_schematic_context=False,
+            diagnostics=_recent_errors(checks),
+        ),
+        recent_errors=_recent_errors(checks),
         checks=checks,
     )
 

--- a/packages/mcp-server/src/kicad_mcp/server.py
+++ b/packages/mcp-server/src/kicad_mcp/server.py
@@ -15,6 +15,7 @@ import threading
 import time
 from collections import deque
 from collections.abc import Callable, Iterable, Iterator
+from pathlib import Path
 from typing import Any, TextIO, cast
 
 import anyio
@@ -43,7 +44,13 @@ from .capabilities import get as get_capability_record
 from .compatibility import MCP_PROTOCOL_VERSION
 from .config import LOOPBACK_HOSTS, KiCadMCPConfig, get_config, reset_config
 from .connection import KiCadConnectionError, get_board
-from .diagnostics import DiagnosticReport, build_doctor_report, build_health_report
+from .diagnostics import (
+    DiagnosticReport,
+    build_doctor_report,
+    build_health_report,
+    diagnostic_report_json,
+    write_diagnostic_bundle,
+)
 from .discovery import ensure_studio_project_watcher, find_kicad_version
 from .i18n import SERVER_DESCRIPTION, localize, option_help
 from .ipc.capabilities import KiCadIpcCapabilityState, get_ipc_capability_state
@@ -61,6 +68,18 @@ tools_app = typer.Typer(help=localize("Inspect registered MCP tools."))
 mcp_config_app = typer.Typer(help=localize("Generate MCP client configuration snippets."))
 app.add_typer(tools_app, name="tools")
 app.add_typer(mcp_config_app, name="mcp-config")
+DOCTOR_BUNDLE_OPTION = cast(
+    Path | None,
+    typer.Option(
+        None,
+        "--bundle",
+        file_okay=True,
+        dir_okay=False,
+        writable=True,
+        resolve_path=True,
+        help=option_help("Write a redacted diagnostic zip bundle to this path."),
+    ),
+)
 AnyFunction = Callable[..., object]
 
 
@@ -1559,7 +1578,7 @@ def serve(
 
 def _echo_report(report: DiagnosticReport, *, as_json: bool) -> None:
     if as_json:
-        typer.echo(report.model_dump_json(indent=2))
+        typer.echo(diagnostic_report_json(report, indent=2))
         return
     typer.echo(f"Status: {report.status}")
     for check in report.checks:
@@ -1567,7 +1586,23 @@ def _echo_report(report: DiagnosticReport, *, as_json: bool) -> None:
         typer.echo(f"- {check.name}: {check.status} - {check.message}{suffix}")
 
 
-def _diagnostic_command(builder: Callable[[], DiagnosticReport], *, as_json: bool) -> None:
+def _emit_diagnostic_report(
+    report: DiagnosticReport,
+    *,
+    as_json: bool,
+    bundle_path: Path | None = None,
+) -> None:
+    if bundle_path is not None:
+        write_diagnostic_bundle(report, bundle_path)
+    _echo_report(report, as_json=as_json)
+
+
+def _diagnostic_command(
+    builder: Callable[[], DiagnosticReport],
+    *,
+    as_json: bool,
+    bundle_path: Path | None = None,
+) -> None:
     try:
         if as_json:
             with contextlib.redirect_stdout(io.StringIO()):
@@ -1575,12 +1610,13 @@ def _diagnostic_command(builder: Callable[[], DiagnosticReport], *, as_json: boo
         else:
             report = builder()
     except Exception as exc:
+        message = str(exc)
         payload = {
             "ok": False,
             "status": "error",
             "error": {
                 "code": "CONFIGURATION_ERROR",
-                "message": str(exc),
+                "message": message,
                 "hint": "Fix malformed KiCad MCP configuration and retry.",
                 "retryable": False,
             },
@@ -1588,7 +1624,7 @@ def _diagnostic_command(builder: Callable[[], DiagnosticReport], *, as_json: boo
         error = cast(dict[str, object], payload["error"])
         typer.echo(json.dumps(payload, indent=2) if as_json else str(error["message"]))
         raise typer.Exit(2) from exc
-    _echo_report(report, as_json=as_json)
+    _emit_diagnostic_report(report, as_json=as_json, bundle_path=bundle_path)
     if not report.ok:
         raise typer.Exit(1)
 
@@ -1603,7 +1639,12 @@ def _strict_diagnostic_exit_code(report: DiagnosticReport) -> int:
     return 0
 
 
-def _strict_diagnostic_command(builder: Callable[[], DiagnosticReport], *, as_json: bool) -> None:
+def _strict_diagnostic_command(
+    builder: Callable[[], DiagnosticReport],
+    *,
+    as_json: bool,
+    bundle_path: Path | None = None,
+) -> None:
     try:
         if as_json:
             with contextlib.redirect_stdout(io.StringIO()):
@@ -1624,7 +1665,7 @@ def _strict_diagnostic_command(builder: Callable[[], DiagnosticReport], *, as_js
         error = cast(dict[str, object], payload["error"])
         typer.echo(json.dumps(payload, indent=2) if as_json else str(error["message"]))
         raise typer.Exit(2) from exc
-    _echo_report(report, as_json=as_json)
+    _emit_diagnostic_report(report, as_json=as_json, bundle_path=bundle_path)
     exit_code = _strict_diagnostic_exit_code(report)
     if exit_code:
         raise typer.Exit(exit_code)
@@ -1645,6 +1686,7 @@ def doctor(
     json_output: bool = typer.Option(
         False, "--json", help=option_help("Emit machine-readable JSON.")
     ),
+    bundle: Path | None = DOCTOR_BUNDLE_OPTION,
     strict: bool = typer.Option(
         False,
         "--strict",
@@ -1653,9 +1695,9 @@ def doctor(
 ) -> None:
     """Run deeper diagnostics without treating unavailable KiCad as fatal."""
     if strict:
-        _strict_diagnostic_command(build_doctor_report, as_json=json_output)
+        _strict_diagnostic_command(build_doctor_report, as_json=json_output, bundle_path=bundle)
         return
-    _diagnostic_command(build_doctor_report, as_json=json_output)
+    _diagnostic_command(build_doctor_report, as_json=json_output, bundle_path=bundle)
 
 
 def _tool_payload(tool: mcp_types.Tool) -> dict[str, object]:

--- a/packages/mcp-server/tests/unit/test_cli_diagnostics.py
+++ b/packages/mcp-server/tests/unit/test_cli_diagnostics.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import zipfile
 from pathlib import Path
 
 from typer.testing import CliRunner
 
+from kicad_mcp.config import reset_config
 from kicad_mcp.connection import KiCadConnectionError
 from kicad_mcp.diagnostics import (
     CheckResult,
@@ -75,6 +77,84 @@ def test_cli_doctor_json_reports_unavailable_kicad_without_stack_trace(
     assert payload["status"] == "degraded"
     assert payload["kicad"]["version"] == "KiCad 10.0.1"
     assert any(check["name"] == "kicad_ipc" for check in payload["checks"])
+
+
+def test_cli_doctor_json_includes_schema_validated_setup_diagnostics(
+    sample_project: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("KICAD_MCP_TRANSPORT", "http")
+    monkeypatch.setenv("KICAD_MCP_HOST", "127.0.0.1")
+    monkeypatch.setenv("KICAD_MCP_PORT", "4173")
+    monkeypatch.setenv("KICAD_MCP_MOUNT_PATH", "/custom-mcp")
+    monkeypatch.setenv("KICAD_MCP_STATEFUL_HTTP", "true")
+    monkeypatch.setattr("kicad_mcp.diagnostics.find_kicad_version", lambda _path: "KiCad 10.0.3")
+    monkeypatch.setattr(
+        "kicad_mcp.diagnostics.get_board",
+        lambda: (_ for _ in ()).throw(KiCadConnectionError("IPC not reachable token=super-secret")),
+    )
+    reset_config()
+
+    result = CliRunner().invoke(app, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert "super-secret" not in result.output
+    payload = json.loads(result.output)
+    DiagnosticReport.model_validate(payload)
+    schema = DiagnosticReport.model_json_schema(by_alias=True)
+    assert "schemaVersion" in schema["properties"]
+    assert payload["schemaVersion"] == "1.0.0"
+    assert payload["mcp"]["transport_default"] == "streamable-http"
+    assert payload["mcp"]["host"] == "127.0.0.1"
+    assert payload["mcp"]["port"] == 4173
+    assert payload["mcp"]["mount_path"] == "/custom-mcp"
+    assert payload["mcp"]["stateful_http"] is True
+    assert payload["config"]["project_file"].endswith("demo.kicad_pro")
+    assert payload["config"]["pcb_file"].endswith("demo.kicad_pcb")
+    assert payload["config"]["sch_file"].endswith("demo.kicad_sch")
+    assert payload["tools"]["tool_count"] > 0
+    assert payload["tools"]["category_count"] > 0
+    assert payload["tools"]["capability_summary"]["tiers"]["read"] > 0
+    assert payload["live_context"]["available"] is False
+    assert payload["recent_errors"]
+    assert "super-secret" not in json.dumps(payload["recent_errors"])
+
+
+def test_cli_doctor_bundle_writes_redacted_debug_zip(
+    sample_project: Path,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("KICAD_MCP_AUTH_TOKEN", "bundle-secret-token")
+    monkeypatch.setenv("KICAD_API_TOKEN", "bundle-kicad-token")
+    monkeypatch.setattr("kicad_mcp.diagnostics.find_kicad_version", lambda _path: "KiCad 10.0.3")
+    monkeypatch.setattr(
+        "kicad_mcp.diagnostics.get_board",
+        lambda: (_ for _ in ()).throw(KiCadConnectionError("IPC unavailable")),
+    )
+    reset_config()
+    bundle_path = tmp_path / "mcp-debug.zip"
+
+    result = CliRunner().invoke(app, ["doctor", "--json", "--bundle", str(bundle_path)])
+
+    assert result.exit_code == 0, result.output
+    assert bundle_path.exists()
+    with zipfile.ZipFile(bundle_path) as bundle:
+        assert set(bundle.namelist()) == {
+            "diagnostic-schema.json",
+            "doctor.json",
+            "environment.json",
+            "README.txt",
+        }
+        doctor_payload = json.loads(bundle.read("doctor.json"))
+        DiagnosticReport.model_validate(doctor_payload)
+        combined = "\n".join(
+            bundle.read(name).decode("utf-8", errors="replace") for name in bundle.namelist()
+        )
+    assert doctor_payload["schemaVersion"] == "1.0.0"
+    assert "bundle-secret-token" not in combined
+    assert "bundle-kicad-token" not in combined
+    assert "configured" in combined
 
 
 def test_cli_version_and_serve_help(sample_project: Path) -> None:

--- a/scripts/dev-doctor.mjs
+++ b/scripts/dev-doctor.mjs
@@ -351,6 +351,21 @@ function mcpVersionDetail(result) {
   }
 }
 
+function mcpDoctorDetail(result) {
+  try {
+    const payload = JSON.parse(result.stdout);
+    const status = payload.status ?? "unknown";
+    const recentErrors = Array.isArray(payload.recent_errors)
+      ? payload.recent_errors.length
+      : 0;
+    return `doctor ${status}; ${recentErrors} recent ${
+      recentErrors === 1 ? "issue" : "issues"
+    }`;
+  } catch {
+    return firstLine(result.stdout || result.stderr || result.error || "");
+  }
+}
+
 function findPortOwner(port, repoRoot, commandRunner) {
   if (process.platform === "win32") {
     const result = run("netstat", ["-ano", "-p", "tcp"], {
@@ -638,6 +653,31 @@ export async function createDoctorReport(
       ok: mcpVersion.ok,
       detail: mcpVersionDetail(mcpVersion),
       hint: "Verify the MCP server CLI can report version metadata.",
+    }),
+  );
+
+  const mcpDoctor = run(
+    "uv",
+    [
+      "run",
+      "--project",
+      "packages/mcp-server",
+      "--all-extras",
+      "kicad-mcp-pro",
+      "doctor",
+      "--json",
+    ],
+    commandOptions,
+  );
+  checks.push(
+    makeCheck({
+      id: "mcp-doctor",
+      label: "kicad-mcp-pro doctor",
+      category: "mcp",
+      required: true,
+      ok: mcpDoctor.ok,
+      detail: mcpDoctorDetail(mcpDoctor),
+      hint: "Run `uv run --project packages/mcp-server --all-extras kicad-mcp-pro doctor --json`.",
     }),
   );
 

--- a/scripts/dev-doctor.test.mjs
+++ b/scripts/dev-doctor.test.mjs
@@ -101,10 +101,7 @@ test("dev-doctor reports the full CI-safe monorepo environment contract", async 
       ].join("\n"),
     );
     writeFileSync(
-      path.join(
-        repoRoot,
-        "packages/kicad-fixtures/manifest.json",
-      ),
+      path.join(repoRoot, "packages/kicad-fixtures/manifest.json"),
       JSON.stringify({ schemaVersion: 1, fixtureCount: 1, fixtures: [] }),
     );
     writeFileSync(
@@ -157,6 +154,18 @@ test("dev-doctor reports the full CI-safe monorepo environment contract", async 
             stderr: "",
           };
         }
+        if (joined.includes("kicad-mcp-pro doctor --json")) {
+          return {
+            ok: true,
+            status: 0,
+            stdout: JSON.stringify({
+              schemaVersion: "1.0.0",
+              status: "degraded",
+              recent_errors: ["kicad_ipc: unavailable"],
+            }),
+            stderr: "",
+          };
+        }
         if (joined === "corepack pnpm run check:fixtures") {
           return {
             ok: true,
@@ -195,6 +204,7 @@ test("dev-doctor reports the full CI-safe monorepo environment contract", async 
         "vscode-extension-deps",
         "mcp-help",
         "mcp-version",
+        "mcp-doctor",
         "cloudflared",
         "ports",
         "workspace-scripts",
@@ -206,6 +216,10 @@ test("dev-doctor reports the full CI-safe monorepo environment contract", async 
     assert.equal(byId.get("kicad-cli").required, false);
     assert.equal(byId.get("cloudflared").required, false);
     assert.equal(byId.get("mcp-version").detail, "kicad-mcp-pro 1.0.0");
+    assert.equal(
+      byId.get("mcp-doctor").detail,
+      "doctor degraded; 1 recent issue",
+    );
     assert.equal(
       report.checks.every(
         (check) => typeof check.hint === "string" && check.hint.length > 0,


### PR DESCRIPTION
## Summary

- Adds `kicad-mcp-pro doctor`, `doctor --json`, and `doctor --bundle <zip>` diagnostics without starting the MCP server.
- Emits schema-validated JSON with package/runtime/KiCad/config/tool/live-context details and redacted recent errors.
- Lets root `dev-doctor` and the VS Code extension detector call the doctor command for setup diagnostics.
- Documents doctor JSON/bundle usage and records the feature in the MCP server changelog.

## Linked issue

Closes #74
Linear: https://linear.app/oaslananka/issue/OASLANA-73/add-kicad-mcp-pro-doctor-command-for-setup-diagnostics

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [x] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm install --frozen-lockfile` passed
- `corepack pnpm run lint` passed
- `corepack pnpm run typecheck` passed
- `corepack pnpm run test` passed
- `corepack pnpm run build` passed
- `corepack pnpm run verify:dist` passed
- `uv sync --all-extras --frozen && uv run pytest` in `packages/mcp-server` passed: 687 passed, 2 skipped
- `uvx pre-commit run --all-files` passed
- `git diff --check` passed
- `KICAD_PERFORMANCE_MEASUREMENTS_JSON=/tmp/oaslana-73-tools-list-measurements.json uv run pytest tests/unit/test_benchmark_latency.py -q` passed after one noisy full-suite benchmark sample; isolated p95 was 9.17 ms against the 120 ms budget.

Regression tests added:
- `packages/mcp-server/tests/unit/test_cli_diagnostics.py` covers schema-validated doctor JSON and redacted diagnostic bundle output.
- `scripts/dev-doctor.test.mjs` covers root `dev-doctor` invoking `kicad-mcp-pro doctor --json`.
- `apps/vscode-extension/test/unit/mcpDetector.test.ts` covers extension-side doctor invocation and project-dir env propagation.

## Protocol / MCP impact

Checklist reference: `docs/architecture/protocol-change-checklist.md`

- [ ] Not applicable; reason:
- [ ] Protocol schema updated
- [x] MCP server implementation updated
- [x] Extension MCP adapter updated
- [x] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

Compatibility impact: this adds a CLI diagnostics surface and extension/root diagnostic callers. It does not rename existing MCP tools, change existing tool schemas, or require server startup for diagnostics.

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [ ] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [x] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts

Bug-fix checklist items are not applicable because this is a feature issue, not a bug fix.
