### PR TITLE
feat(kicad-studio): add viewer engine state

### DIFF
--- a/apps/vscode-extension/CHANGELOG.md
+++ b/apps/vscode-extension/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Add explicit KiCanvas/CLI SVG fallback/metadata-only viewer engine state,
+  toolbar engine badges, unsupported-control disabling, and regression coverage
+  for fallback diagnostics.
 - Restyle the KiCanvas viewer toolbar with VS Code theme tokens, compact
   spacing, and a single primary reload action for dark, light, and high-contrast
   themes.

--- a/apps/vscode-extension/media/kicanvas/viewer.css
+++ b/apps/vscode-extension/media/kicanvas/viewer.css
@@ -10,8 +10,12 @@ header h1{margin:0;font-size:13px;font-weight:650;white-space:nowrap;overflow:hi
 .btn-primary{border-color:var(--vscode-button-border,var(--vscode-contrastBorder,var(--vscode-button-background,var(--border))));background:var(--vscode-button-background);color:var(--vscode-button-foreground)}
 .btn-primary:hover{background:var(--vscode-button-hoverBackground,var(--vscode-button-background))}
 .btn-primary:active{background:var(--vscode-toolbar-activeBackground,var(--vscode-button-hoverBackground,var(--vscode-button-background)))}
+.btn:disabled,.btn[aria-disabled="true"]{opacity:.52;cursor:not-allowed}
 .btn:focus-visible{outline:2px solid var(--vscode-focusBorder,var(--accent));outline-offset:2px}
 @media (forced-colors:active){.btn{border-color:ButtonText}.btn-primary{border-color:Highlight}}
+.engine-badge{flex:0 0 auto;display:inline-flex;align-items:center;min-height:22px;padding:2px 7px;border:1px solid var(--vscode-badge-background,var(--border));border-radius:999px;background:var(--vscode-badge-background,var(--panel));color:var(--vscode-badge-foreground,var(--text));font:600 11px/1.35 var(--vscode-font-family,"Segoe UI",system-ui,sans-serif);white-space:nowrap}
+.engine-badge[data-engine-kind="cli-svg-fallback"]{border-color:var(--vscode-inputValidation-warningBorder,var(--vscode-badge-background,var(--border)))}
+.engine-badge[data-engine-kind="metadata-only"]{border-color:var(--vscode-descriptionForeground,var(--border));background:var(--vscode-editorWidget-background,var(--panel))}
 #viewer-status{flex:0 1 auto;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:12px}
 main{position:relative;overflow:hidden;background:var(--bg);min-width:0;min-height:0;display:flex;align-items:stretch}
 #viewer-mount{position:relative;flex:1 1 auto;display:flex;min-width:0;min-height:0}

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -892,6 +892,7 @@ export async function activate(
             )
           : undefined,
       visibleLayers: viewerState?.activeLayers,
+      viewerEngine: viewerState?.engine,
       activeVariant: await variantProvider.getActiveVariantName(),
       mcpConnected: mcpState?.connected ?? false,
       kicadVersion: cli?.version,

--- a/apps/vscode-extension/src/lm/languageModelChatProvider.ts
+++ b/apps/vscode-extension/src/lm/languageModelChatProvider.ts
@@ -204,6 +204,7 @@ function buildStudioContextSummary(context: StudioContext): string {
       cursorPosition: context.cursorPosition,
       activeSheetPath: context.activeSheetPath,
       visibleLayers: context.visibleLayers,
+      viewerEngine: context.viewerEngine,
       drcErrors: context.drcErrors.slice(0, 20)
     },
     null,

--- a/apps/vscode-extension/src/providers/baseKiCanvasEditorProvider.ts
+++ b/apps/vscode-extension/src/providers/baseKiCanvasEditorProvider.ts
@@ -24,6 +24,10 @@ import {
   kicanvasUri,
   viewerCssUri
 } from './viewerHtml';
+import {
+  createViewerEngineState,
+  isViewerEngineKind
+} from './viewer/viewerEngine';
 
 const PROGRESS_INLINE_WARNING_BYTES = 1 * 1024 * 1024;
 const LARGE_FILE_METADATA_BYTES = 512 * 1024;
@@ -57,9 +61,7 @@ interface PanelInfo {
 type ViewerSvgFallbackProvider = (
   uri: vscode.Uri
 ) => Promise<string | undefined>;
-type ViewerProjectResolver = (
-  uri: vscode.Uri
-) => ProjectContext | undefined;
+type ViewerProjectResolver = (uri: vscode.Uri) => ProjectContext | undefined;
 
 /**
  * Shared custom editor provider for KiCanvas-backed viewers.
@@ -215,9 +217,9 @@ export abstract class BaseKiCanvasEditorProvider
           }
           if (message.type === 'viewerState') {
             const info = this.panelInfo.get(webviewPanel);
-              const nextState = readViewerState(message.payload);
-              if (info && nextState) {
-                info.state = nextState;
+            const nextState = readViewerState(message.payload);
+            if (info && nextState) {
+              info.state = nextState;
               this.viewerState.updateState(document.uri, info.state, {
                 project: this.resolveProject?.(document.uri)
               });
@@ -734,10 +736,12 @@ function readViewerState(value: unknown): ViewerState | undefined {
 
   const selectedArea = readSelectedArea(payload['selectedArea']);
   const activeLayers = readStringArray(payload['activeLayers']);
+  const engine = readViewerEngineState(payload['engine']);
   return {
     zoom,
     grid,
     theme,
+    ...(engine ? { engine } : {}),
     ...(typeof payload['selectedReference'] === 'string'
       ? { selectedReference: payload['selectedReference'] }
       : {}),
@@ -761,6 +765,15 @@ function readViewerSelection(value: unknown): Partial<ViewerState> {
     ...(selectedArea ? { selectedArea } : {}),
     ...(activeLayers ? { activeLayers } : {})
   };
+}
+
+function readViewerEngineState(value: unknown): ViewerState['engine'] {
+  const payload = asRecord(value);
+  if (!payload || !isViewerEngineKind(payload['kind'])) {
+    return undefined;
+  }
+  const reason = asString(payload['reason']);
+  return createViewerEngineState(payload['kind'], reason);
 }
 
 function readSelectedArea(value: unknown):

--- a/apps/vscode-extension/src/providers/viewer/viewerEngine.ts
+++ b/apps/vscode-extension/src/providers/viewer/viewerEngine.ts
@@ -1,0 +1,73 @@
+import type {
+  ViewerEngineCapabilities,
+  ViewerEngineKind,
+  ViewerEngineState
+} from '../../types';
+
+const ENGINE_LABELS: Record<ViewerEngineKind, string> = {
+  kicanvas: 'KiCanvas',
+  'cli-svg-fallback': 'CLI SVG fallback',
+  'metadata-only': 'Metadata only'
+};
+
+const ENGINE_CAPABILITIES: Record<ViewerEngineKind, ViewerEngineCapabilities> =
+  {
+    kicanvas: {
+      interactive: true,
+      fit: true,
+      zoom: true,
+      exportPng: true,
+      exportSvg: true,
+      selection: true,
+      layers: true
+    },
+    'cli-svg-fallback': {
+      interactive: false,
+      fit: true,
+      zoom: true,
+      exportPng: true,
+      exportSvg: true,
+      selection: false,
+      layers: false
+    },
+    'metadata-only': {
+      interactive: false,
+      fit: false,
+      zoom: false,
+      exportPng: false,
+      exportSvg: true,
+      selection: false,
+      layers: false
+    }
+  };
+
+export function isViewerEngineKind(value: unknown): value is ViewerEngineKind {
+  return (
+    value === 'kicanvas' ||
+    value === 'cli-svg-fallback' ||
+    value === 'metadata-only'
+  );
+}
+
+export function createViewerEngineState(
+  kind: ViewerEngineKind,
+  reason?: string | undefined
+): ViewerEngineState {
+  return {
+    kind,
+    label: ENGINE_LABELS[kind],
+    ...(reason ? { reason } : {}),
+    capabilities: { ...ENGINE_CAPABILITIES[kind] }
+  };
+}
+
+export function cloneViewerEngineState(
+  state: ViewerEngineState
+): ViewerEngineState {
+  return {
+    kind: state.kind,
+    label: state.label,
+    ...(state.reason ? { reason: state.reason } : {}),
+    capabilities: { ...state.capabilities }
+  };
+}

--- a/apps/vscode-extension/src/providers/viewer/viewerPayload.ts
+++ b/apps/vscode-extension/src/providers/viewer/viewerPayload.ts
@@ -1,4 +1,9 @@
-import type { ViewerMetadata, ViewerState } from '../../types';
+import type {
+  ViewerEngineState,
+  ViewerMetadata,
+  ViewerState
+} from '../../types';
+import { createViewerEngineState } from './viewerEngine';
 
 export interface ViewerPayload {
   fileName: string;
@@ -7,11 +12,24 @@ export interface ViewerPayload {
   disabledReason: string;
   theme: string;
   fallbackBackground: string;
+  engine: ViewerEngineState;
   metadata?: ViewerMetadata | undefined;
   restoreState?: ViewerState | undefined;
 }
 
-export function createViewerPayload(options: ViewerPayload): ViewerPayload {
+export interface ViewerPayloadOptions extends Omit<ViewerPayload, 'engine'> {
+  initialEngine?: ViewerEngineState | undefined;
+}
+
+export function createViewerPayload(
+  options: ViewerPayloadOptions
+): ViewerPayload {
+  const engine =
+    options.initialEngine ??
+    createViewerEngineState(
+      options.disabledReason ? 'metadata-only' : 'kicanvas',
+      options.disabledReason || undefined
+    );
   return {
     fileName: options.fileName,
     fileType: options.fileType,
@@ -19,6 +37,7 @@ export function createViewerPayload(options: ViewerPayload): ViewerPayload {
     disabledReason: options.disabledReason,
     theme: options.theme,
     fallbackBackground: options.fallbackBackground,
+    engine,
     ...(options.metadata ? { metadata: options.metadata } : {}),
     ...(options.restoreState ? { restoreState: options.restoreState } : {})
   };

--- a/apps/vscode-extension/src/providers/viewerHtml.ts
+++ b/apps/vscode-extension/src/providers/viewerHtml.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
-import type { ViewerMetadata, ViewerState } from '../types';
+import type { ViewerEngineState, ViewerMetadata, ViewerState } from '../types';
 import { createNonce } from '../utils/nonce';
 import { getViewerSidebarWidth } from './viewer/viewerLayerPanel';
+import { createViewerEngineState } from './viewer/viewerEngine';
 import { createViewerPayload } from './viewer/viewerPayload';
 import { resolveViewerPalette } from './viewer/viewerPalette';
 import { compactHtmlDocument, escapeScriptJson } from './viewer/viewerTemplate';
@@ -23,6 +24,7 @@ export interface KiCanvasViewerHtmlOptions {
   disabledReason: string;
   theme?: string;
   fallbackBackground?: string;
+  initialEngine?: ViewerEngineState | undefined;
   metadata?: ViewerMetadata;
   restoreState?: ViewerState | undefined;
 }
@@ -42,9 +44,16 @@ export function createKiCanvasViewerHtml(
     disabledReason: options.disabledReason,
     theme: themeName,
     fallbackBackground: options.fallbackBackground ?? '',
+    ...(options.initialEngine ? { initialEngine: options.initialEngine } : {}),
     ...(options.metadata ? { metadata: options.metadata } : {}),
     ...(options.restoreState ? { restoreState: options.restoreState } : {})
   });
+  const initialEngine =
+    payload.engine ??
+    createViewerEngineState(
+      options.disabledReason ? 'metadata-only' : 'kicanvas',
+      options.disabledReason || undefined
+    );
 
   return injectWebviewLocalization(
     compactHtmlDocument(String.raw`<!DOCTYPE html>
@@ -92,6 +101,7 @@ export function createKiCanvasViewerHtml(
       <button class="btn" id="export-png-btn" type="button" aria-label="Export PNG">Export PNG</button>
       <button class="btn" id="export-svg-btn" type="button" aria-label="Export SVG">Export SVG</button>
     </div>
+    <span id="viewer-engine-badge" class="engine-badge" data-engine-kind="${escapeAttr(initialEngine.kind)}" title="${escapeAttr(initialEngine.reason ?? initialEngine.label)}">${escapeHtml(initialEngine.label)}</span>
     <span id="viewer-status">${escapeHtml(options.status)}</span>
   </header>
 
@@ -133,6 +143,10 @@ export function createKiCanvasViewerHtml(
     </div>
 
     <aside aria-label="Viewer side panel">
+      <div class="side-section" id="engine-section">
+        <h2>Viewer Engine</h2>
+        <div id="engine-summary" class="meta-row">${escapeHtml(initialEngine.reason ?? initialEngine.label)}</div>
+      </div>
       <div class="side-section">
         <h2>Viewer Tools</h2>
         <div class="side-actions">
@@ -190,10 +204,58 @@ export function createKiCanvasViewerHtml(
     const notesListEl    = document.getElementById('notes-list');
     const notesSection   = document.getElementById('notes-section');
     const selectionSummaryEl = document.getElementById('selection-summary');
+    const engineBadgeEl = document.getElementById('viewer-engine-badge');
+    const engineSummaryEl = document.getElementById('engine-summary');
+    const fitBtn = document.getElementById('fit-btn');
+    const zoomInBtn = document.getElementById('zoom-in-btn');
+    const zoomOutBtn = document.getElementById('zoom-out-btn');
+    const exportPngBtn = document.getElementById('export-png-btn');
+    const exportSvgBtn = document.getElementById('export-svg-btn');
+    const allLayersBtn = document.getElementById('all-layers-btn');
+    const noneLayersBtn = document.getElementById('none-layers-btn');
+    const copperLayersBtn = document.getElementById('copper-layers-btn');
 
     const payload = JSON.parse(
       document.getElementById('viewer-payload').textContent || '{}'
     );
+    const ViewerEngines = {
+      kicanvas: {
+        label: 'KiCanvas',
+        capabilities: {
+          interactive: true,
+          fit: true,
+          zoom: true,
+          exportPng: true,
+          exportSvg: true,
+          selection: true,
+          layers: true
+        }
+      },
+      'cli-svg-fallback': {
+        label: 'CLI SVG fallback',
+        capabilities: {
+          interactive: false,
+          fit: true,
+          zoom: true,
+          exportPng: true,
+          exportSvg: true,
+          selection: false,
+          layers: false
+        }
+      },
+      'metadata-only': {
+        label: 'Metadata only',
+        capabilities: {
+          interactive: false,
+          fit: false,
+          zoom: false,
+          exportPng: false,
+          exportSvg: true,
+          selection: false,
+          layers: false
+        }
+      }
+    };
     let keydownHandler = null;
     let fallbackSvgDataUrl = '';
     let fallbackSvgElement = null;
@@ -203,10 +265,12 @@ export function createKiCanvasViewerHtml(
     let fallbackSvgFitScale = 1;
     let fallbackSvgScale = 1;
     let fallbackResizeHandler = null;
-    let localState = payload.restoreState || {
+    let localState = {
       zoom: 1,
       grid: false,
-      theme: payload.theme || 'kicad'
+      theme: payload.theme || 'kicad',
+      ...(payload.restoreState || {}),
+      engine: payload.engine || createEngineState(payload.disabledReason ? 'metadata-only' : 'kicanvas', payload.disabledReason || undefined)
     };
 
     document.getElementById('reload-btn').addEventListener('click', () => initViewer());
@@ -215,13 +279,14 @@ export function createKiCanvasViewerHtml(
     document.getElementById('error-open-btn').addEventListener('click', openInKiCad);
     document.getElementById('export-png-btn').addEventListener('click', exportPng);
     document.getElementById('export-svg-btn').addEventListener('click', exportSvg);
-    document.getElementById('fit-btn').addEventListener('click', fitCurrentViewer);
-    document.getElementById('zoom-in-btn').addEventListener('click', () => zoomCurrentViewer(1));
-    document.getElementById('zoom-out-btn').addEventListener('click', () => zoomCurrentViewer(-1));
-    document.getElementById('all-layers-btn')?.addEventListener('click', () => setAllLayers(true));
-    document.getElementById('none-layers-btn')?.addEventListener('click', () => setAllLayers(false));
-    document.getElementById('copper-layers-btn')?.addEventListener('click', () => setCopperOnly());
+    fitBtn.addEventListener('click', fitCurrentViewer);
+    zoomInBtn.addEventListener('click', () => zoomCurrentViewer(1));
+    zoomOutBtn.addEventListener('click', () => zoomCurrentViewer(-1));
+    allLayersBtn?.addEventListener('click', () => setAllLayers(true));
+    noneLayersBtn?.addEventListener('click', () => setAllLayers(false));
+    copperLayersBtn?.addEventListener('click', () => setCopperOnly());
     renderSidebar();
+    updateEngineUi(localState.engine);
 
     window.addEventListener('message', (event) => {
       const msg = event.data || {};
@@ -236,7 +301,12 @@ export function createKiCanvasViewerHtml(
               ? msg.payload.fallbackBackground
               : payload.fallbackBackground;
           payload.restoreState   = msg.payload.restoreState || payload.restoreState;
-          localState             = payload.restoreState || localState;
+          payload.engine         = msg.payload.engine || payload.engine;
+          localState             = {
+            ...localState,
+            ...(payload.restoreState || {}),
+            engine: payload.engine || localState.engine
+          };
         }
         void initViewer();
       }
@@ -247,7 +317,10 @@ export function createKiCanvasViewerHtml(
             ? msg.payload.fallbackBackground
             : payload.fallbackBackground;
         payload.restoreState = msg.payload?.restoreState || payload.restoreState;
-        localState = payload.restoreState || localState;
+        localState = {
+          ...localState,
+          ...(payload.restoreState || {})
+        };
         void initViewer();
       }
       if (msg.type === 'setMetadata') {
@@ -281,9 +354,11 @@ export function createKiCanvasViewerHtml(
       setViewerSurfaceVisible(false);
       hideAll();
       showLoading('Waiting for KiCanvas…');
+      setEngineUiState('kicanvas');
 
       try {
         if (payload.disabledReason) {
+          setEngineState('metadata-only', payload.disabledReason);
           showEmpty(payload.disabledReason, '');
           return;
         }
@@ -350,6 +425,7 @@ export function createKiCanvasViewerHtml(
             return;
           }
           if (probablyEmpty) {
+            setEngineState('metadata-only', 'No drawable objects were detected.');
             showEmpty(
               payload.fileType === 'board'
                 ? 'This PCB file is structurally valid but currently only contains the board document skeleton.'
@@ -374,6 +450,7 @@ export function createKiCanvasViewerHtml(
               return;
             }
             if (probablyEmpty) {
+              setEngineState('metadata-only', 'No drawable objects were detected.');
               showEmpty(
                 payload.fileType === 'board'
                   ? 'This PCB file is structurally valid but currently only contains the board document skeleton.'
@@ -396,6 +473,7 @@ export function createKiCanvasViewerHtml(
         renderHopOverOverlay();
         hideAll();
         installKeyboardShortcuts(viewer);
+        setEngineState('kicanvas');
         setStatus('Interactive renderer loaded: ' + payload.fileName);
         vscode.postMessage({ type: 'ready', payload: { fileName: payload.fileName } });
 
@@ -751,13 +829,70 @@ export function createKiCanvasViewerHtml(
       });
     }
 
+    function createEngineState(kind, reason) {
+      const definition = ViewerEngines[kind] || ViewerEngines.kicanvas;
+      return {
+        kind: ViewerEngines[kind] ? kind : 'kicanvas',
+        label: definition.label,
+        ...(reason ? { reason } : {}),
+        capabilities: { ...definition.capabilities }
+      };
+    }
+
+    function setEngineState(kind, reason) {
+      setEngineUiState(kind, reason);
+      postViewerState();
+    }
+
+    function setEngineUiState(kind, reason) {
+      const engine = createEngineState(kind, reason);
+      localState = { ...localState, engine };
+      updateEngineUi(engine);
+    }
+
+    function updateEngineUi(engine) {
+      const nextEngine = engine || createEngineState('kicanvas');
+      if (engineBadgeEl) {
+        engineBadgeEl.textContent = nextEngine.label;
+        engineBadgeEl.dataset.engineKind = nextEngine.kind;
+        engineBadgeEl.title = nextEngine.reason || nextEngine.label;
+      }
+      if (engineSummaryEl) {
+        engineSummaryEl.textContent = nextEngine.reason || nextEngine.label;
+      }
+      setControlsForEngine(nextEngine);
+    }
+
+    function setControlsForEngine(engine) {
+      setControlDisabled(fitBtn, !engine.capabilities.fit);
+      setControlDisabled(zoomInBtn, !engine.capabilities.zoom);
+      setControlDisabled(zoomOutBtn, !engine.capabilities.zoom);
+      setControlDisabled(exportPngBtn, !engine.capabilities.exportPng);
+      setControlDisabled(exportSvgBtn, !engine.capabilities.exportSvg);
+      const layerControlsEnabled = Boolean(engine.capabilities.layers);
+      setControlDisabled(allLayersBtn, !layerControlsEnabled);
+      setControlDisabled(noneLayersBtn, !layerControlsEnabled);
+      setControlDisabled(copperLayersBtn, !layerControlsEnabled);
+    }
+
+    function setControlDisabled(control, disabled) {
+      if (!control) {
+        return;
+      }
+      control.disabled = Boolean(disabled);
+      control.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+    }
+
     function applyViewerState(viewer) {
       if (!payload.restoreState) {
         postViewerState();
         return;
       }
       viewer.setAttribute('theme', payload.restoreState.theme || payload.theme || 'kicad');
-      localState = payload.restoreState;
+      localState = {
+        ...payload.restoreState,
+        engine: localState.engine || payload.restoreState.engine
+      };
       updateSelectionSummary();
       postViewerState();
     }
@@ -1028,6 +1163,7 @@ export function createKiCanvasViewerHtml(
         return false;
       }
       showSvgFallback(svgText);
+      setEngineState('cli-svg-fallback', reason);
       setStatus('CLI SVG fallback loaded: ' + payload.fileName);
       return true;
     }

--- a/apps/vscode-extension/src/state/stateStores.ts
+++ b/apps/vscode-extension/src/state/stateStores.ts
@@ -8,6 +8,7 @@ import type {
   McpServerCard,
   ViewerState
 } from '../types';
+import { cloneViewerEngineState } from '../providers/viewer/viewerEngine';
 import { redactSensitiveText } from '../utils/secrets';
 import {
   cloneProjectContext,
@@ -531,6 +532,7 @@ function cloneSummary(summary: DiagnosticSummary): DiagnosticSummary {
 function cloneViewerState(state: ViewerState): ViewerState {
   return {
     ...state,
+    engine: state.engine ? cloneViewerEngineState(state.engine) : undefined,
     selectedArea: state.selectedArea ? { ...state.selectedArea } : undefined,
     activeLayers: state.activeLayers ? [...state.activeLayers] : undefined
   };

--- a/apps/vscode-extension/src/types.ts
+++ b/apps/vscode-extension/src/types.ts
@@ -48,6 +48,7 @@ export interface ViewerState {
   zoom: number;
   grid: boolean;
   theme: string;
+  engine?: ViewerEngineState | undefined;
   selectedReference?: string | undefined;
   selectedArea?:
     | {
@@ -58,6 +59,28 @@ export interface ViewerState {
       }
     | undefined;
   activeLayers?: string[] | undefined;
+}
+
+export type ViewerEngineKind =
+  | 'kicanvas'
+  | 'cli-svg-fallback'
+  | 'metadata-only';
+
+export interface ViewerEngineCapabilities {
+  interactive: boolean;
+  fit: boolean;
+  zoom: boolean;
+  exportPng: boolean;
+  exportSvg: boolean;
+  selection: boolean;
+  layers: boolean;
+}
+
+export interface ViewerEngineState {
+  kind: ViewerEngineKind;
+  label: string;
+  reason?: string | undefined;
+  capabilities: ViewerEngineCapabilities;
 }
 
 export interface ViewerInboundMessage {
@@ -426,6 +449,7 @@ export interface StudioContext {
     | undefined;
   activeSheetPath?: string | undefined;
   visibleLayers?: string[] | undefined;
+  viewerEngine?: ViewerEngineState | undefined;
   kicadVersion?: string | undefined;
   designBlocks?: string[] | undefined;
 }

--- a/apps/vscode-extension/test/a11y/accessibilityConformance.test.ts
+++ b/apps/vscode-extension/test/a11y/accessibilityConformance.test.ts
@@ -46,6 +46,11 @@ type ThemeFixture = {
     buttonSecondaryText: string;
   };
 };
+type ViewerEngineFixture = {
+  kind: 'kicanvas' | 'cli-svg-fallback';
+  label: string;
+  reason?: string;
+};
 
 const axeOptions: RunOptions = {
   runOnly: {
@@ -190,6 +195,40 @@ describe('WCAG 2.1 AA webview conformance gate', () => {
         );
         expect(secondaryAction.borderRadius).toBeLessThanOrEqual(6);
       }
+    }
+  );
+
+  it.each([
+    {
+      kind: 'kicanvas',
+      label: 'KiCanvas'
+    },
+    {
+      kind: 'cli-svg-fallback',
+      label: 'CLI SVG fallback',
+      reason: 'KiCanvas created a blank render surface.'
+    }
+  ] satisfies ViewerEngineFixture[])(
+    'captures viewer engine visual state for %s',
+    async (engine) => {
+      const theme = themeFixtures()[0]!;
+      await page.emulateMedia(theme.media);
+      await page.setContent(
+        prepareForAxe(createViewerToolbarHtml(engine), theme.css),
+        {
+          waitUntil: 'domcontentloaded'
+        }
+      );
+
+      const badge = page.locator('#viewer-engine-badge');
+      await expect(badge.count()).resolves.toBe(1);
+      await expect(badge.textContent()).resolves.toContain(engine.label);
+      await expect(badge.getAttribute('data-engine-kind')).resolves.toBe(
+        engine.kind
+      );
+
+      const screenshot = await page.locator('header').screenshot();
+      expect(screenshot.length).toBeGreaterThan(1000);
     }
   );
 });
@@ -548,7 +587,7 @@ function themeFixtures(): ThemeFixture[] {
   ];
 }
 
-function createViewerToolbarHtml(): string {
+function createViewerToolbarHtml(engine?: ViewerEngineFixture): string {
   return createKiCanvasViewerHtml({
     title: 'KiCad Studio Schematic Viewer',
     fileName: 'demo.kicad_sch',
@@ -558,7 +597,38 @@ function createViewerToolbarHtml(): string {
     kicanvasUri: 'vscode-resource:/media/kicanvas/kicanvas.js',
     viewerCssUri: 'vscode-resource:/media/kicanvas/viewer.css',
     base64: Buffer.from('(kicad_sch)').toString('base64'),
-    disabledReason: ''
+    disabledReason: '',
+    ...(engine
+      ? {
+          initialEngine: {
+            kind: engine.kind,
+            label: engine.label,
+            ...(engine.reason ? { reason: engine.reason } : {}),
+            capabilities:
+              engine.kind === 'kicanvas'
+                ? {
+                    interactive: true,
+                    fit: true,
+                    zoom: true,
+                    exportPng: true,
+                    exportSvg: true,
+                    selection: true,
+                    layers: true
+                  }
+                : {
+                    interactive: false,
+                    fit: true,
+                    zoom: true,
+                    exportPng: true,
+                    exportSvg: true,
+                    selection: false,
+                    layers: false
+                  }
+          }
+        }
+      : {})
+  } as Parameters<typeof createKiCanvasViewerHtml>[0] & {
+    initialEngine?: unknown;
   });
 }
 

--- a/apps/vscode-extension/test/unit/viewerHtml.test.ts
+++ b/apps/vscode-extension/test/unit/viewerHtml.test.ts
@@ -75,6 +75,52 @@ describe('createKiCanvasViewerHtml', () => {
     );
   });
 
+  it('models KiCanvas, CLI SVG fallback, and metadata-only engines in the viewer bootstrap', () => {
+    const html = createKiCanvasViewerHtml({
+      title: 'Viewer',
+      fileName: 'sample.kicad_sch',
+      fileType: 'schematic',
+      status: 'Opening interactive renderer...',
+      cspSource: 'vscode-resource:',
+      kicanvasUri: 'vscode-resource:/media/kicanvas/kicanvas.js',
+      base64: 'Zm9v',
+      disabledReason: ''
+    });
+
+    expect(html).toContain('id="viewer-engine-badge"');
+    expect(html).toContain('id="engine-summary"');
+    expect(html).toContain('data-engine-kind="kicanvas"');
+    expect(html).toContain("'cli-svg-fallback'");
+    expect(html).toContain("'metadata-only'");
+    expect(html).toContain('function setEngineState(kind, reason)');
+    expect(html).toContain('localState = { ...localState, engine };');
+    expect(html).toContain('function setControlsForEngine(engine)');
+    expect(html).toContain('setControlsForEngine(nextEngine);');
+  });
+
+  it('starts metadata-only mode with unsupported viewer controls disabled', () => {
+    const html = createKiCanvasViewerHtml({
+      title: 'Viewer',
+      fileName: 'oversized.kicad_pcb',
+      fileType: 'board',
+      status: 'Opening metadata preview...',
+      cspSource: 'vscode-resource:',
+      kicanvasUri: 'vscode-resource:/media/kicanvas/kicanvas.js',
+      base64: '',
+      disabledReason:
+        'Interactive render is disabled for files larger than 100 MB.'
+    });
+
+    expect(html).toContain('data-engine-kind="metadata-only"');
+    expect(html).toContain('Metadata only');
+    expect(html).toContain(
+      'setControlDisabled(fitBtn, !engine.capabilities.fit);'
+    );
+    expect(html).toContain(
+      'setControlDisabled(exportPngBtn, !engine.capabilities.exportPng);'
+    );
+  });
+
   it('supports exporting PNG from the SVG fallback surface', () => {
     const html = createKiCanvasViewerHtml({
       title: 'Viewer',

--- a/apps/vscode-extension/test/unit/viewerModules.test.ts
+++ b/apps/vscode-extension/test/unit/viewerModules.test.ts
@@ -26,8 +26,37 @@ describe('viewer helper modules', () => {
     ).toEqual(
       expect.objectContaining({
         fileName: 'board.kicad_pcb',
+        engine: expect.objectContaining({
+          kind: 'kicanvas',
+          capabilities: expect.objectContaining({ interactive: true })
+        }),
         metadata: expect.objectContaining({ layers: expect.any(Array) }),
         restoreState: expect.objectContaining({ zoom: 2 })
+      })
+    );
+  });
+
+  it('marks oversized viewer payloads as metadata-only with safe capabilities', () => {
+    expect(
+      createViewerPayload({
+        fileName: 'large-board.kicad_pcb',
+        fileType: 'board',
+        base64: '',
+        disabledReason: 'Interactive render is disabled for large files.',
+        theme: 'kicad',
+        fallbackBackground: '#001023'
+      }).engine
+    ).toEqual(
+      expect.objectContaining({
+        kind: 'metadata-only',
+        label: 'Metadata only',
+        reason: 'Interactive render is disabled for large files.',
+        capabilities: expect.objectContaining({
+          fit: false,
+          zoom: false,
+          exportPng: false,
+          exportSvg: true
+        })
       })
     );
   });

--- a/apps/vscode-extension/test/unit/viewerProviders.test.ts
+++ b/apps/vscode-extension/test/unit/viewerProviders.test.ts
@@ -340,6 +340,70 @@ describe.each([
     });
   });
 
+  it('persists viewer engine diagnostics from viewer state messages', async () => {
+    const viewerState = new ViewerStateStore();
+    const provider = new (ContextProvider as never as {
+      new (
+        context: vscode.ExtensionContext,
+        svgFallbackProvider: undefined,
+        viewerState: ViewerStateStore
+      ): InstanceType<typeof ContextProvider>;
+    })(
+      {
+        extensionUri: vscode.Uri.file('/extension')
+      } as vscode.ExtensionContext,
+      undefined,
+      viewerState
+    );
+    const panel = createPanel();
+    const document = {
+      uri: vscode.Uri.file(tempFile)
+    } as vscode.CustomDocument;
+
+    await provider.resolveCustomEditor(
+      document,
+      panel as unknown as vscode.WebviewPanel
+    );
+    await panel.fireMessage({
+      type: 'viewerState',
+      payload: {
+        zoom: 1,
+        grid: false,
+        theme: 'kicad',
+        engine: {
+          kind: 'cli-svg-fallback',
+          label: 'CLI SVG fallback',
+          reason: 'KiCanvas created a blank render surface for this file.',
+          capabilities: {
+            interactive: false,
+            fit: true,
+            zoom: true,
+            exportPng: true,
+            exportSvg: true,
+            selection: false,
+            layers: false
+          }
+        }
+      }
+    });
+
+    expect(viewerState.getState(document.uri)).toEqual(
+      expect.objectContaining({
+        engine: expect.objectContaining({
+          kind: 'cli-svg-fallback',
+          label: 'CLI SVG fallback',
+          reason: expect.stringContaining('blank render surface'),
+          capabilities: expect.objectContaining({
+            fit: true,
+            zoom: true,
+            exportPng: true,
+            layers: false
+          })
+        })
+      })
+    );
+  });
+
   it('untracks panels when the webview is disposed', async () => {
     const provider = new ContextProvider({
       extensionUri: vscode.Uri.file('/extension')

--- a/docs/changelog/kicad-studio.md
+++ b/docs/changelog/kicad-studio.md
@@ -4,6 +4,9 @@ Source: `apps/vscode-extension/CHANGELOG.md`
 
 ## [Unreleased]
 
+- Add explicit KiCanvas/CLI SVG fallback/metadata-only viewer engine state,
+  toolbar engine badges, unsupported-control disabling, and regression coverage
+  for fallback diagnostics.
 - Restyle the KiCanvas viewer toolbar with VS Code theme tokens, compact
   spacing, and a single primary reload action for dark, light, and high-contrast
   themes.


### PR DESCRIPTION
## Summary
- add a typed viewer engine state for KiCanvas, CLI SVG fallback, and metadata-only rendering
- surface the active engine in the viewer toolbar, side panel, diagnostics, persisted viewer state, and AI context summary
- disable unsupported controls when the fallback or metadata-only engine is active, while keeping supported SVG export available
- add DOM/unit/a11y visual coverage for engine modes and preserve the direct SVG fallback sizing regression coverage for #17

Linear: OASLANA-70
Closes #71

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist`
- `corepack pnpm run format:check`
- `corepack pnpm --filter kicadstudio run test:a11y`
- `corepack pnpm run check:docs-site`
- `corepack pnpm audit --audit-level high`
- `git diff --check`
- `corepack pnpm --filter kicadstudio run workflows:lint`
- `uvx pre-commit run --all-files`

## Freshness / deprecation
- checked current official VS Code Webviews UX, Webview API, and Theme Color docs before implementation
- no dependency versions or workflow files changed
- workflow deprecation scan found no `::set-output`, `::save-state`, `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION`, `node12`, `node16`, or `node20` hits

## Notes
- no release, tag, or publish performed
- local `gitleaks`, `trufflehog`, `actionlint`, and `yamllint` binaries were not installed on PATH; repository workflow lint, pre-commit, pnpm audit, and remote security checks remain the active verification path
- `corepack pnpm run build` prints the expected guarded `packages/mcp-npm` package-help warning because `kicad-mcp-pro==1.0.0` is not on PyPI and that script intentionally falls back with `|| true`
