### PR TITLE
feat(kicad-studio/kicad-mcp-pro): add operating modes

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -961,7 +961,7 @@
           "group": "navigation"
         },
         {
-          "when": "view == kicadstudio.drcRules && kicadstudio.workspaceTrusted && kicadstudio.mcpConnected",
+          "when": "view == kicadstudio.drcRules && kicadstudio.workspaceTrusted && kicadstudio.mcpConnected && kicadstudio.mcpWriteMode",
           "command": "kicadstudio.drcRule.addWithMcp",
           "group": "navigation"
         },
@@ -1132,7 +1132,7 @@
         },
         {
           "command": "kicadstudio.manufacturing.release",
-          "when": "kicadstudio.mcpConnected && kicadstudio.hasProject && kicadstudio.workspaceTrusted"
+          "when": "kicadstudio.mcpConnected && kicadstudio.hasProject && kicadstudio.workspaceTrusted && kicadstudio.mcpManufacturingMode"
         },
         {
           "command": "kicadstudio.showStoredSecrets"
@@ -1149,7 +1149,7 @@
         },
         {
           "command": "kicadstudio.drcRule.addWithMcp",
-          "when": "kicadstudio.workspaceTrusted && kicadstudio.mcpConnected"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.mcpConnected && kicadstudio.mcpWriteMode"
         },
         {
           "command": "kicadstudio.drcRule.createDefault",
@@ -1795,7 +1795,7 @@
         "modelDescription": "%kicadstudio.contributes.languageModelTools.0.modelDescription%",
         "canBeReferencedInPrompt": true,
         "icon": "$(beaker)",
-        "when": "kicadstudio.hasProject",
+        "when": "kicadstudio.hasProject && kicadstudio.mcpManufacturingMode",
         "inputSchema": {
           "type": "object",
           "properties": {

--- a/apps/vscode-extension/src/constants.ts
+++ b/apps/vscode-extension/src/constants.ts
@@ -173,6 +173,10 @@ export const CONTEXT_KEYS = {
   mcpDisconnected: 'kicadstudio.mcpDisconnected',
   mcpVsCodeStdio: 'kicadstudio.mcpVsCodeStdio',
   mcpProfile: 'kicadstudio.mcpProfile',
+  mcpOperatingMode: 'kicadstudio.mcpOperatingMode',
+  mcpWriteMode: 'kicadstudio.mcpWriteMode',
+  mcpManufacturingMode: 'kicadstudio.mcpManufacturingMode',
+  mcpExperimentalMode: 'kicadstudio.mcpExperimentalMode',
   hasVariants: 'kicadstudio.hasVariants',
   workspaceTrusted: 'kicadstudio.workspaceTrusted'
 } as const;

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -764,6 +764,9 @@ export async function activate(
       CONTEXT_KEYS.mcpVsCodeStdio,
       state.kind === 'VsCodeStdio'
     );
+    const activeMode =
+      state.server?.capabilities.serverInfo?.operatingMode.active ?? 'unknown';
+    await setMcpOperatingModeContexts(activeMode);
     mcpState.update(state);
 
     if (
@@ -808,6 +811,30 @@ export async function activate(
       'setContext',
       CONTEXT_KEYS.mcpVsCodeStdio,
       false
+    );
+    await setMcpOperatingModeContexts('unknown');
+  }
+
+  async function setMcpOperatingModeContexts(mode: string): Promise<void> {
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpOperatingMode,
+      mode
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpWriteMode,
+      mode === 'write' || mode === 'experimental'
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpManufacturingMode,
+      mode === 'manufacturing' || mode === 'experimental'
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpExperimentalMode,
+      mode === 'experimental'
     );
   }
 

--- a/apps/vscode-extension/src/lm/api.ts
+++ b/apps/vscode-extension/src/lm/api.ts
@@ -132,15 +132,49 @@ export function createMcpStdioServerDefinition(args: {
   command: string;
   args: string[];
   cwd: vscode.Uri;
-  env: Record<string, string>;
+  env: Record<string, string | number | null>;
   version?: string | undefined;
 }): unknown | undefined {
   const ctor = (
     vscode as unknown as {
-      McpStdioServerDefinition?: new (value: unknown) => unknown;
+      McpStdioServerDefinition?: new (...values: unknown[]) => unknown;
     }
   ).McpStdioServerDefinition;
-  return typeof ctor === 'function' ? new ctor(args) : undefined;
+  if (typeof ctor !== 'function') {
+    return undefined;
+  }
+  if (ctor.length > 1) {
+    return createPositionalMcpStdioServerDefinition(ctor, args);
+  }
+  try {
+    return new ctor(args);
+  } catch {
+    return createPositionalMcpStdioServerDefinition(ctor, args);
+  }
+}
+
+function createPositionalMcpStdioServerDefinition(
+  ctor: new (...values: unknown[]) => unknown,
+  args: {
+    label: string;
+    command: string;
+    args: string[];
+    cwd: vscode.Uri;
+    env: Record<string, string | number | null>;
+    version?: string | undefined;
+  }
+): unknown {
+  const definition = new ctor(
+    args.label,
+    args.command,
+    args.args,
+    args.env,
+    args.version
+  );
+  if (isRecord(definition)) {
+    definition['cwd'] = args.cwd;
+  }
+  return definition;
 }
 
 export function flattenLanguageModelMessages(

--- a/apps/vscode-extension/src/mcp/mcpClient.ts
+++ b/apps/vscode-extension/src/mcp/mcpClient.ts
@@ -65,6 +65,7 @@ export class McpClient {
   private lastInstall: McpInstallStatus = { found: false, source: 'none' };
   private sessionId: string | undefined;
   private initializePromise: Promise<void> | undefined;
+  private connectionTestPromise: Promise<McpConnectionState> | undefined;
   private nextRpcId = 1;
   private readonly maxRetries: number;
   private readonly retryBaseDelayMs: number;
@@ -121,6 +122,19 @@ export class McpClient {
   }
 
   async testConnection(): Promise<McpConnectionState> {
+    if (this.connectionTestPromise) {
+      return this.connectionTestPromise;
+    }
+
+    this.connectionTestPromise = this.runConnectionTest();
+    try {
+      return await this.connectionTestPromise;
+    } finally {
+      this.connectionTestPromise = undefined;
+    }
+  }
+
+  private async runConnectionTest(): Promise<McpConnectionState> {
     if (vscode.workspace.isTrusted === false) {
       return this.setState({
         kind: 'Disconnected',
@@ -314,9 +328,7 @@ export class McpClient {
     }
   }
 
-  async fetchFixQueue(
-    args: Record<string, unknown> = {}
-  ): Promise<FixItem[]> {
+  async fetchFixQueue(args: Record<string, unknown> = {}): Promise<FixItem[]> {
     const resource = await this.readResource('kicad://project/fix_queue');
     const items =
       (Array.isArray(resource?.['items']) ? resource['items'] : undefined) ??
@@ -1017,6 +1029,15 @@ function cloneServerInfoContract(
     },
     transport: { ...serverInfo.transport },
     kicad: { ...serverInfo.kicad },
+    operatingMode: {
+      ...serverInfo.operatingMode,
+      available: [...serverInfo.operatingMode.available],
+      toolAvailability: Object.fromEntries(
+        Object.entries(serverInfo.operatingMode.toolAvailability).map(
+          ([name, availability]) => [name, { ...availability }]
+        )
+      )
+    },
     capabilities: {
       ...serverInfo.capabilities,
       cliExports: { ...serverInfo.capabilities.cliExports }

--- a/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
@@ -33,6 +33,7 @@ type CompatibilityDashboard = {
   endpoint: string;
   transportMode: string;
   profile: string;
+  operatingMode: string;
   protocolVersion: string;
   toolSchemaVersion: string;
   compatibility: string;
@@ -177,6 +178,7 @@ function buildCompatibilityDashboard(
     endpoint,
     transportMode: transportDescription(state, serverInfo),
     profile: profile ?? 'default',
+    operatingMode: serverInfo?.operatingMode.active ?? 'unknown',
     protocolVersion: serverInfo?.mcpProtocolVersion ?? 'unknown',
     toolSchemaVersion: serverInfo?.toolSchemaVersion ?? 'unknown',
     compatibility: compatibilityDescription(state, status),
@@ -301,6 +303,7 @@ function compatibilityDashboardNode(
         dashboardField('Endpoint', dashboard.endpoint),
         dashboardField('Transport mode', dashboard.transportMode),
         dashboardField('Profile', dashboard.profile),
+        dashboardField('Operating mode', dashboard.operatingMode),
         dashboardField('Protocol version', dashboard.protocolVersion),
         dashboardField('Tool schema version', dashboard.toolSchemaVersion),
         dashboardField('Compatibility', dashboard.compatibility)
@@ -605,19 +608,40 @@ function operationModesNode(
   ];
   return {
     label: 'Operation modes',
-    description: `${modes.filter((mode) => mode.enabled).length}/${modes.length} available`,
+    description: serverInfo.operatingMode.active,
     tooltip: modes
       .map(
         (mode) => `${mode.label}: ${mode.enabled ? 'available' : 'unavailable'}`
       )
       .join('\n'),
     icon: 'checklist',
-    children: modes.map((mode) => ({
-      label: mode.label,
-      description: mode.enabled ? 'available' : 'unavailable',
-      icon: mode.enabled ? 'pass' : 'circle-slash'
-    }))
+    children: [
+      {
+        label: 'Active operating mode',
+        description: serverInfo.operatingMode.active,
+        tooltip: `Default: ${serverInfo.operatingMode.default}`,
+        icon: modeIcon(serverInfo.operatingMode.active)
+      },
+      ...modes.map((mode) => ({
+        label: mode.label,
+        description: mode.enabled ? 'available' : 'unavailable',
+        icon: mode.enabled ? 'pass' : 'circle-slash'
+      }))
+    ]
   };
+}
+
+function modeIcon(mode: string): string {
+  if (mode === 'experimental') {
+    return 'beaker';
+  }
+  if (mode === 'manufacturing') {
+    return 'package';
+  }
+  if (mode === 'write') {
+    return 'edit';
+  }
+  return 'shield';
 }
 
 function capabilityFlag(

--- a/apps/vscode-extension/src/state/stateStores.ts
+++ b/apps/vscode-extension/src/state/stateStores.ts
@@ -586,6 +586,7 @@ function cloneCapabilities(capabilities: McpCapabilityCard): McpCapabilityCard {
           },
           transport: { ...serverInfo.transport },
           kicad: { ...serverInfo.kicad },
+          operatingMode: cloneOperatingMode(serverInfo),
           capabilities: {
             ...serverInfo.capabilities,
             cliExports: {
@@ -595,5 +596,30 @@ function cloneCapabilities(capabilities: McpCapabilityCard): McpCapabilityCard {
           diagnostics: [...(serverInfo.diagnostics ?? [])]
         }
       : undefined
+  };
+}
+
+function cloneOperatingMode(
+  serverInfo: NonNullable<McpCapabilityCard['serverInfo']>
+): NonNullable<McpCapabilityCard['serverInfo']>['operatingMode'] {
+  const mode = serverInfo.operatingMode;
+  if (!mode) {
+    return {
+      active: 'readonly',
+      default: 'readonly',
+      available: ['readonly', 'write', 'manufacturing', 'experimental'],
+      experimentalEnabled: false,
+      toolAvailability: {}
+    };
+  }
+  return {
+    ...mode,
+    available: [...mode.available],
+    toolAvailability: Object.fromEntries(
+      Object.entries(mode.toolAvailability).map(([name, availability]) => [
+        name,
+        { ...availability }
+      ])
+    )
   };
 }

--- a/apps/vscode-extension/test/integration/realServer/extensionHost.flow.test.ts
+++ b/apps/vscode-extension/test/integration/realServer/extensionHost.flow.test.ts
@@ -8,8 +8,7 @@ import { withRealServer } from './setup';
 const REQUIRED_EXTENSION_HOST_TOOLS = [
   'project_quality_gate_report',
   'pcb_placement_quality_gate',
-  'pcb_transfer_quality_gate',
-  'manufacturing_quality_gate'
+  'pcb_transfer_quality_gate'
 ] as const;
 
 suite('Real Pair Extension Host', () => {
@@ -17,6 +16,11 @@ suite('Real Pair Extension Host', () => {
     this.timeout(180000);
 
     await withRealServer(async (server) => {
+      const tools = await server.listTools();
+      for (const tool of REQUIRED_EXTENSION_HOST_TOOLS) {
+        assert.ok(tools.includes(tool), `Missing real-pair tool ${tool}`);
+      }
+
       await configureMcpEndpoint(server.endpoint);
 
       const extension = vscode.extensions.getExtension(EXTENSION_ID);
@@ -28,12 +32,6 @@ suite('Real Pair Extension Host', () => {
       assert.strictEqual(extension.isActive, true);
 
       await vscode.commands.executeCommand(COMMANDS.retryMcp);
-
-      const tools = await server.listTools();
-      for (const tool of REQUIRED_EXTENSION_HOST_TOOLS) {
-        assert.ok(tools.includes(tool), `Missing real-pair tool ${tool}`);
-      }
-
       await vscode.commands.executeCommand(
         COMMANDS.qualityGateRunThis,
         placementGate()

--- a/apps/vscode-extension/test/unit/languageModelMcpProvider.test.ts
+++ b/apps/vscode-extension/test/unit/languageModelMcpProvider.test.ts
@@ -35,6 +35,57 @@ describe('language model MCP server definition provider', () => {
     expect(definition.value.env['KICAD_MCP_PROFILE']).toBe('full');
   });
 
+  it('falls back to the VS Code 1.115 positional stdio constructor', async () => {
+    const api = vscode as unknown as { McpStdioServerDefinition: unknown };
+    const original = api.McpStdioServerDefinition;
+    api.McpStdioServerDefinition = class PositionalMcpStdioServerDefinition {
+      cwd?: vscode.Uri;
+
+      constructor(
+        public readonly label: string,
+        public readonly command: string,
+        public readonly args: string[] = [],
+        public readonly env: Record<string, string | number | null> = {},
+        public readonly version?: string
+      ) {
+        if (typeof label !== 'string') {
+          throw new Error('label must be string');
+        }
+      }
+    };
+
+    try {
+      const definition = (await createKicadMcpServerDefinition(
+        {
+          detectKicadMcpPro: jest.fn()
+        } as never,
+        {
+          found: true,
+          command: 'kicad-mcp-pro',
+          version: '0.8.1',
+          source: 'global'
+        }
+      )) as {
+        label: string;
+        command: string;
+        args: string[];
+        env: Record<string, string | number | null>;
+        cwd?: vscode.Uri;
+        version?: string;
+      };
+
+      expect(definition.label).toBe('KiCad MCP Pro (bundled)');
+      expect(definition.command).toBe('kicad-mcp-pro');
+      expect(definition.env['KICAD_MCP_PROFILE']).toBe('full');
+      expect(definition.cwd?.fsPath).toBe(
+        workspace.workspaceFolders[0]?.uri.fsPath
+      );
+      expect(definition.version).toBe('0.8.1');
+    } finally {
+      api.McpStdioServerDefinition = original;
+    }
+  });
+
   it('registers the provider when the VS Code API is available', () => {
     const context =
       createExtensionContextMock() as unknown as vscode.ExtensionContext;

--- a/apps/vscode-extension/test/unit/mcpClient.test.ts
+++ b/apps/vscode-extension/test/unit/mcpClient.test.ts
@@ -110,6 +110,57 @@ describe('McpClient', () => {
     );
   }
 
+  it('coalesces concurrent connection tests onto one MCP probe', async () => {
+    let releaseInitialize: (() => void) | undefined;
+    const initializeResponse = new Promise((resolve) => {
+      releaseInitialize = () =>
+        resolve(
+          createJsonResponse({
+            result: {
+              serverInfo: { version: '1.0.0' },
+              capabilities: { tools: [], resources: [], prompts: [] }
+            }
+          })
+        );
+    });
+    global.fetch = jest.fn((_input, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        method?: string;
+      };
+      if (body.method === 'initialize') {
+        return initializeResponse;
+      }
+      return Promise.resolve(createJsonResponse({ result: { tools: [] } }));
+    }) as typeof fetch;
+    const detector = {
+      detectKicadMcpPro: jest
+        .fn()
+        .mockResolvedValue({ found: true, source: 'uvx' })
+    };
+    const client = new McpClient(
+      createExtensionContextMock() as never,
+      detector as never,
+      {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn()
+      } as never
+    );
+
+    const first = client.testConnection();
+    const second = client.testConnection();
+
+    await Promise.resolve();
+    expect(detector.detectKicadMcpPro).toHaveBeenCalledTimes(1);
+    releaseInitialize?.();
+    const [firstState, secondState] = await Promise.all([first, second]);
+
+    expect(firstState.kind).toBe('Connected');
+    expect(secondState.kind).toBe('Connected');
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
   it('does not probe or push MCP context in restricted workspaces', async () => {
     workspace.isTrusted = false;
     global.fetch = jest.fn() as typeof fetch;

--- a/apps/vscode-extension/test/unit/mcpClient.versionGate.test.ts
+++ b/apps/vscode-extension/test/unit/mcpClient.versionGate.test.ts
@@ -44,7 +44,7 @@ function wellKnownServerInfoResult() {
       version: '1.0.0'
     },
     serverInfoContract: {
-      schemaVersion: '1.1.0',
+      schemaVersion: '1.2.0',
       server: 'kicad-mcp-pro',
       version: '1.0.0',
       mcpProtocolVersion: '2025-11-25',
@@ -79,6 +79,24 @@ function wellKnownServerInfoResult() {
         ipcEndpointSource: 'default',
         livePcbContext: false,
         liveSchematicContext: false
+      },
+      operatingMode: {
+        active: 'readonly',
+        default: 'readonly',
+        available: ['readonly', 'write', 'manufacturing', 'experimental'],
+        experimentalEnabled: false,
+        toolAvailability: {
+          kicad_get_version: {
+            available: true,
+            requiredMode: 'readonly',
+            reason: null
+          },
+          pcb_add_track: {
+            available: false,
+            requiredMode: 'write',
+            reason: 'Requires write operating mode.'
+          }
+        }
       },
       capabilities: {
         fileBackedDrc: true,
@@ -283,7 +301,7 @@ describe('McpClient version gate', () => {
         createJsonResponse({
           ...wellKnownResult('1.0.0'),
           serverInfoContract: {
-            schemaVersion: '1.1.0',
+            schemaVersion: '1.2.0',
             server: 'other-server'
           }
         })
@@ -330,7 +348,7 @@ describe('McpClient version gate', () => {
     const state = await createClient().testConnection();
 
     expect(state.server?.compat).toBe('warn');
-    expect(state.server?.capabilities.serverInfo?.schemaVersion).toBe('1.1.0');
+    expect(state.server?.capabilities.serverInfo?.schemaVersion).toBe('1.2.0');
   });
 
   it('blocks tool calls after an incompatible initialize response', async () => {

--- a/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
@@ -55,6 +55,7 @@ describe('McpToolsProvider', () => {
       'Endpoint',
       'Transport mode',
       'Profile',
+      'Operating mode',
       'Protocol version',
       'Tool schema version',
       'Compatibility'
@@ -249,11 +250,12 @@ describe('McpToolsProvider', () => {
         "MCP connected with degraded capabilities :: 1.0.0",
         "Compatibility dashboard :: degraded",
         "Compatibility dashboard > Compatibility state :: Connected but degraded",
-        "Compatibility dashboard > Server contract :: 7",
+        "Compatibility dashboard > Server contract :: 8",
         "Compatibility dashboard > Server contract > Server :: kicad-mcp-pro",
         "Compatibility dashboard > Server contract > Endpoint :: http://127.0.0.1:27185/mcp",
         "Compatibility dashboard > Server contract > Transport mode :: streamable-http, stateful",
         "Compatibility dashboard > Server contract > Profile :: full",
+        "Compatibility dashboard > Server contract > Operating mode :: readonly",
         "Compatibility dashboard > Server contract > Protocol version :: 2025-11-25",
         "Compatibility dashboard > Server contract > Tool schema version :: 1.0.0",
         "Compatibility dashboard > Server contract > Compatibility :: degraded",
@@ -291,7 +293,8 @@ describe('McpToolsProvider', () => {
         "Raw advertised capabilities :: 3 tools, 1 resources, 1 prompts",
         "Raw advertised capabilities > Capability diagnostics :: none",
         "Raw advertised capabilities > KiCad runtime :: live PCB",
-        "Raw advertised capabilities > Operation modes :: 7/8 available",
+        "Raw advertised capabilities > Operation modes :: readonly",
+        "Raw advertised capabilities > Operation modes > Active operating mode :: readonly",
         "Raw advertised capabilities > Operation modes > File-backed DRC :: available",
         "Raw advertised capabilities > Operation modes > File-backed ERC :: available",
         "Raw advertised capabilities > Operation modes > File-backed exports :: available",
@@ -355,7 +358,7 @@ function serverInfoFixture(
   } = {}
 ): McpServerInfoContract {
   const base: McpServerInfoContract = {
-    schemaVersion: '1.1.0',
+    schemaVersion: '1.2.0',
     server: 'kicad-mcp-pro',
     version: '1.0.0',
     mcpProtocolVersion: '2025-11-25',
@@ -392,6 +395,34 @@ function serverInfoFixture(
       livePcbContext: true,
       liveSchematicContext: true,
       ...overrides.kicad
+    },
+    operatingMode: {
+      active: 'readonly',
+      default: 'readonly',
+      available: ['readonly', 'write', 'manufacturing', 'experimental'],
+      experimentalEnabled: false,
+      toolAvailability: {
+        kicad_get_version: {
+          available: true,
+          requiredMode: 'readonly',
+          reason: null
+        },
+        pcb_add_track: {
+          available: false,
+          requiredMode: 'write',
+          reason: 'Requires write operating mode.'
+        },
+        export_manufacturing_package: {
+          available: false,
+          requiredMode: 'manufacturing',
+          reason: 'Requires manufacturing operating mode.'
+        },
+        route_tune_length: {
+          available: false,
+          requiredMode: 'experimental',
+          reason: 'Requires experimental operating mode.'
+        }
+      }
     },
     capabilities: {
       fileBackedDrc: true,

--- a/docs/mcp/api-reference.md
+++ b/docs/mcp/api-reference.md
@@ -26,6 +26,7 @@ and `compatibility.yaml`. Refresh with `corepack pnpm run docs:generate`.
 | `compatibilityRange` | object | yes |  |
 | `transport` | object | yes |  |
 | `kicad` | object | yes |  |
+| `operatingMode` | object | yes |  |
 | `capabilities` | object | yes |  |
 | `diagnostics` | array | yes |  |
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -191,7 +191,7 @@ Total public tools: 255.
 | `sch_add_component` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | yes | Add a schematic component through the hybrid IPC reload path. |
 | `sch_add_global_label` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a global label, preserving the requested shape and rotation. |
 | `sch_add_hierarchical_label` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a hierarchical label, preserving the requested shape and rotation. |
-| `sch_add_jumper` | agent_full | no | yes | no | no | no | Add a jumper symbol to the schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MCP cl... |
+| `sch_add_jumper` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a jumper symbol to the schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MCP cl... |
 | `sch_add_label` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a schematic label, snapping its anchor to the 2.54 mm grid by default. |
 | `sch_add_missing_junctions` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | yes | no | Insert missing schematic junctions at T-intersection wire endpoints. This KiCad MCP Pro tool supports production EDA... |
 | `sch_add_no_connect` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a no-connect marker, snapping it to the 2.54 mm grid by default. |
@@ -224,12 +224,12 @@ Total public tools: 255.
 | `sch_list_templates` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | yes | no | List all available reference subcircuit templates. |
 | `sch_modify_property` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | yes | Modify a schematic symbol property by reference. This KiCad MCP Pro tool supports production EDA automation workflows... |
 | `sch_move_symbol` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Move an existing symbol instance to a new absolute coordinate. |
-| `sch_reload` | agent_full | no | no | no | no | no | Ask KiCad to reload the active schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MC... |
+| `sch_reload` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | no | no | Ask KiCad to reload the active schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MC... |
 | `sch_route_wire_between_pins` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Route deterministic Manhattan wire segments between two placed symbol pins. |
 | `sch_set_hop_over` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | yes | no | Toggle KiCad 10 hop-over display in the active project settings. |
 | `sch_set_sheet_size` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | yes | no | Change the schematic sheet (paper) size. |
-| `sch_swap_gates` | agent_full | no | no | no | yes | no | Record a gate-swap back-annotation intent for a multi-unit component. |
-| `sch_swap_pins` | agent_full | no | no | no | yes | no | Record a pin-swap back-annotation intent for a component. |
+| `sch_swap_gates` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | yes | no | Record a gate-swap back-annotation intent for a multi-unit component. |
+| `sch_swap_pins` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | yes | no | Record a pin-swap back-annotation intent for a component. |
 | `sch_trace_net` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | no | no | Trace a named net through the active schematic and matching child sheets. |
 | `sch_update_properties` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Update a property on a placed symbol. This KiCad MCP Pro tool supports production EDA automation workflows for MCP cl... |
 | `schematic_connectivity_gate` | agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic | no | no | no | yes | no | Evaluate whether schematic structure and hierarchy look electrically meaningful. This KiCad MCP Pro tool supports pro... |
@@ -449,7 +449,7 @@ Total public tools: 255.
 - `sch_add_component`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=yes.
 - `sch_add_global_label`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_add_hierarchical_label`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
-- `sch_add_jumper`: profiles=agent_full; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
+- `sch_add_jumper`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_add_label`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_add_missing_junctions`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_add_no_connect`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
@@ -482,12 +482,12 @@ Total public tools: 255.
 - `sch_list_templates`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_modify_property`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=yes.
 - `sch_move_symbol`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
-- `sch_reload`: profiles=agent_full; readOnly=no; destructive=no; openWorld=no; headless=no; requiresKiCadRunning=no.
+- `sch_reload`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_route_wire_between_pins`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_set_hop_over`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_set_sheet_size`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=yes; requiresKiCadRunning=no.
-- `sch_swap_gates`: profiles=agent_full; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
-- `sch_swap_pins`: profiles=agent_full; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
+- `sch_swap_gates`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
+- `sch_swap_pins`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_trace_net`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_update_properties`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `schematic_connectivity_gate`: profiles=agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.

--- a/packages/mcp-server/docs/client-configuration.md
+++ b/packages/mcp-server/docs/client-configuration.md
@@ -21,12 +21,16 @@ Recommended environment:
 ```text
 KICAD_MCP_PROJECT_DIR=/absolute/path/to/your/kicad-project
 KICAD_MCP_PROFILE=pcb_only
+KICAD_MCP_OPERATING_MODE=readonly
 ```
 
 Use `KICAD_MCP_PROFILE=full` if you want every tool category. Preferred focused profiles are
 `minimal`, `pcb_only`, `schematic_only`, `manufacturing`, `high_speed`, `power`,
 `simulation`, and `analysis`. Legacy aliases `pcb` and `schematic` still work for older
-client configs.
+client configs. Profiles select a tool category set; `KICAD_MCP_OPERATING_MODE` is the
+risk gate applied on top. The default mode is `readonly`. Use `write` only for schematic
+or PCB source edits, `manufacturing` for release/export handoff tools, and `experimental`
+for routing, tuning, and unstable helpers.
 
 ## VS Code And GitHub Copilot
 
@@ -44,7 +48,8 @@ configuration for global setup. GitHub Copilot in VS Code uses the same MCP serv
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only"
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       }
     }
   }

--- a/packages/mcp-server/docs/configuration.md
+++ b/packages/mcp-server/docs/configuration.md
@@ -10,6 +10,32 @@ Configuration is resolved in this order:
 
 The active project can also be changed at runtime with `kicad_set_project()`.
 
+## Operating Modes
+
+`KICAD_MCP_OPERATING_MODE` controls the risk level of the advertised and executable
+tool surface. It is applied after the server profile, so a profile can narrow categories
+while the operating mode still blocks unsafe calls.
+
+| Mode | Tool surface |
+| ---- | ------------ |
+| `readonly` | Default. Project, schematic, PCB, DRC/ERC, BOM, netlist, and source-safe export inspection. |
+| `write` | `readonly` plus controlled schematic and PCB source modifications and save operations. |
+| `manufacturing` | `readonly` plus manufacturing package and handoff workflows. General schematic/PCB write tools stay hidden. |
+| `experimental` | Full opt-in surface including write, manufacturing, routing, tuning, and unstable tools. |
+
+Equivalent CLI usage:
+
+```bash
+kicad-mcp-pro --mode readonly
+kicad-mcp-pro serve --mode write
+kicad-mcp-pro tools list --mode manufacturing
+```
+
+The legacy `--experimental` flag remains accepted and maps to `--mode experimental`
+when no explicit mode is supplied. `kicad_get_server_info` reports the active mode,
+the default mode, and structured per-tool mode availability so clients can disable
+features before invoking blocked tools.
+
 ## CLI Diagnostics
 
 ```bash

--- a/packages/mcp-server/docs/tools-reference.generated.md
+++ b/packages/mcp-server/docs/tools-reference.generated.md
@@ -182,7 +182,7 @@ Total public tools: 255.
 | `sch_add_component` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | yes | Add a schematic component through the hybrid IPC reload path. |
 | `sch_add_global_label` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a global label, preserving the requested shape and rotation. |
 | `sch_add_hierarchical_label` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a hierarchical label, preserving the requested shape and rotation. |
-| `sch_add_jumper` | agent_full | no | yes | no | no | no | Add a jumper symbol to the schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MCP cl... |
+| `sch_add_jumper` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a jumper symbol to the schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MCP cl... |
 | `sch_add_label` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a schematic label, snapping its anchor to the 2.54 mm grid by default. |
 | `sch_add_missing_junctions` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | yes | no | Insert missing schematic junctions at T-intersection wire endpoints. This KiCad MCP Pro tool supports production EDA... |
 | `sch_add_no_connect` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a no-connect marker, snapping it to the 2.54 mm grid by default. |
@@ -215,12 +215,12 @@ Total public tools: 255.
 | `sch_list_templates` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | yes | no | List all available reference subcircuit templates. |
 | `sch_modify_property` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | yes | Modify a schematic symbol property by reference. This KiCad MCP Pro tool supports production EDA automation workflows... |
 | `sch_move_symbol` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Move an existing symbol instance to a new absolute coordinate. |
-| `sch_reload` | agent_full | no | no | no | no | no | Ask KiCad to reload the active schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MC... |
+| `sch_reload` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | no | no | Ask KiCad to reload the active schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MC... |
 | `sch_route_wire_between_pins` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Route deterministic Manhattan wire segments between two placed symbol pins. |
 | `sch_set_hop_over` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | yes | no | Toggle KiCad 10 hop-over display in the active project settings. |
 | `sch_set_sheet_size` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | yes | no | Change the schematic sheet (paper) size. |
-| `sch_swap_gates` | agent_full | no | no | no | yes | no | Record a gate-swap back-annotation intent for a multi-unit component. |
-| `sch_swap_pins` | agent_full | no | no | no | yes | no | Record a pin-swap back-annotation intent for a component. |
+| `sch_swap_gates` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | yes | no | Record a gate-swap back-annotation intent for a multi-unit component. |
+| `sch_swap_pins` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | yes | no | Record a pin-swap back-annotation intent for a component. |
 | `sch_trace_net` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | no | no | Trace a named net through the active schematic and matching child sheets. |
 | `sch_update_properties` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Update a property on a placed symbol. This KiCad MCP Pro tool supports production EDA automation workflows for MCP cl... |
 | `schematic_connectivity_gate` | agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic | no | no | no | yes | no | Evaluate whether schematic structure and hierarchy look electrically meaningful. This KiCad MCP Pro tool supports pro... |
@@ -440,7 +440,7 @@ Total public tools: 255.
 - `sch_add_component`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=yes.
 - `sch_add_global_label`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_add_hierarchical_label`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
-- `sch_add_jumper`: profiles=agent_full; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
+- `sch_add_jumper`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_add_label`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_add_missing_junctions`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_add_no_connect`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
@@ -473,12 +473,12 @@ Total public tools: 255.
 - `sch_list_templates`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_modify_property`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=yes.
 - `sch_move_symbol`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
-- `sch_reload`: profiles=agent_full; readOnly=no; destructive=no; openWorld=no; headless=no; requiresKiCadRunning=no.
+- `sch_reload`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_route_wire_between_pins`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_set_hop_over`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_set_sheet_size`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=yes; requiresKiCadRunning=no.
-- `sch_swap_gates`: profiles=agent_full; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
-- `sch_swap_pins`: profiles=agent_full; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
+- `sch_swap_gates`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
+- `sch_swap_pins`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_trace_net`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_update_properties`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `schematic_connectivity_gate`: profiles=agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.

--- a/packages/mcp-server/docs/tools-reference.md
+++ b/packages/mcp-server/docs/tools-reference.md
@@ -313,7 +313,7 @@ Total public tools: 255.
 | `sch_add_component` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | yes | Add a schematic component through the hybrid IPC reload path. |
 | `sch_add_global_label` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a global label, preserving the requested shape and rotation. |
 | `sch_add_hierarchical_label` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a hierarchical label, preserving the requested shape and rotation. |
-| `sch_add_jumper` | agent_full | no | yes | no | no | no | Add a jumper symbol to the schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MCP cl... |
+| `sch_add_jumper` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a jumper symbol to the schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MCP cl... |
 | `sch_add_label` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a schematic label, snapping its anchor to the 2.54 mm grid by default. |
 | `sch_add_missing_junctions` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | yes | no | Insert missing schematic junctions at T-intersection wire endpoints. This KiCad MCP Pro tool supports production EDA... |
 | `sch_add_no_connect` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Add a no-connect marker, snapping it to the 2.54 mm grid by default. |
@@ -346,12 +346,12 @@ Total public tools: 255.
 | `sch_list_templates` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | yes | no | List all available reference subcircuit templates. |
 | `sch_modify_property` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | yes | Modify a schematic symbol property by reference. This KiCad MCP Pro tool supports production EDA automation workflows... |
 | `sch_move_symbol` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Move an existing symbol instance to a new absolute coordinate. |
-| `sch_reload` | agent_full | no | no | no | no | no | Ask KiCad to reload the active schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MC... |
+| `sch_reload` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | no | no | Ask KiCad to reload the active schematic. This KiCad MCP Pro tool supports production EDA automation workflows for MC... |
 | `sch_route_wire_between_pins` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Route deterministic Manhattan wire segments between two placed symbol pins. |
 | `sch_set_hop_over` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | yes | no | Toggle KiCad 10 hop-over display in the active project settings. |
 | `sch_set_sheet_size` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | yes | no | Change the schematic sheet (paper) size. |
-| `sch_swap_gates` | agent_full | no | no | no | yes | no | Record a gate-swap back-annotation intent for a multi-unit component. |
-| `sch_swap_pins` | agent_full | no | no | no | yes | no | Record a pin-swap back-annotation intent for a component. |
+| `sch_swap_gates` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | yes | no | Record a gate-swap back-annotation intent for a multi-unit component. |
+| `sch_swap_pins` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | yes | no | Record a pin-swap back-annotation intent for a component. |
 | `sch_trace_net` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | no | no | no | no | Trace a named net through the active schematic and matching child sheets. |
 | `sch_update_properties` | agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation | no | yes | no | no | no | Update a property on a placed symbol. This KiCad MCP Pro tool supports production EDA automation workflows for MCP cl... |
 | `schematic_connectivity_gate` | agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic | no | no | no | yes | no | Evaluate whether schematic structure and hierarchy look electrically meaningful. This KiCad MCP Pro tool supports pro... |
@@ -571,7 +571,7 @@ Total public tools: 255.
 - `sch_add_component`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=yes.
 - `sch_add_global_label`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_add_hierarchical_label`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
-- `sch_add_jumper`: profiles=agent_full; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
+- `sch_add_jumper`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_add_label`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_add_missing_junctions`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_add_no_connect`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
@@ -604,12 +604,12 @@ Total public tools: 255.
 - `sch_list_templates`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_modify_property`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=yes.
 - `sch_move_symbol`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
-- `sch_reload`: profiles=agent_full; readOnly=no; destructive=no; openWorld=no; headless=no; requiresKiCadRunning=no.
+- `sch_reload`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_route_wire_between_pins`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_set_hop_over`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_set_sheet_size`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=yes; requiresKiCadRunning=no.
-- `sch_swap_gates`: profiles=agent_full; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
-- `sch_swap_pins`: profiles=agent_full; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
+- `sch_swap_gates`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
+- `sch_swap_pins`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.
 - `sch_trace_net`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=no; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `sch_update_properties`: profiles=agent_full, builder, critic, full, high_speed, power, schematic, schematic_only, simulation; readOnly=no; destructive=yes; openWorld=no; headless=no; requiresKiCadRunning=no.
 - `schematic_connectivity_gate`: profiles=agent_full, analysis, builder, critic, full, high_speed, manufacturing, pcb, power, release_manager, schematic; readOnly=no; destructive=no; openWorld=no; headless=yes; requiresKiCadRunning=no.

--- a/packages/mcp-server/pyproject.toml
+++ b/packages/mcp-server/pyproject.toml
@@ -129,6 +129,7 @@ addopts = "-q"
 markers = [
   "benchmark: lightweight performance regression checks with committed baselines",
   "gui: real KiCad GUI smoke tests for scheduled/manual environments",
+  "mcp_mode(mode): run the test with an explicit KiCad MCP operating mode",
   "slow: tests that are useful for scheduled/full validation but skipped by fast loops",
 ]
 

--- a/packages/mcp-server/scripts/generate_tools_reference.py
+++ b/packages/mcp-server/scripts/generate_tools_reference.py
@@ -4,12 +4,14 @@ import argparse
 import contextlib
 import inspect
 import io
+import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 from mcp.types import ToolAnnotations
 
+from kicad_mcp.config import reset_config
 from kicad_mcp.server import build_server
 from kicad_mcp.tools.metadata import get_tool_metadata, infer_tool_annotations
 from kicad_mcp.tools.router import available_profiles
@@ -33,11 +35,21 @@ class ToolRow:
 
 
 def _registered_tools(profile: str) -> dict[str, object]:
+    previous_mode = os.environ.get("KICAD_MCP_OPERATING_MODE")
+    os.environ["KICAD_MCP_OPERATING_MODE"] = "experimental"
+    reset_config()
     buffer = io.StringIO()
-    with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(buffer):
-        server = build_server(profile=profile)
-    server.filter_runtime_tools = False
-    return {tool.name: tool for tool in server.list_tools_sync()}
+    try:
+        with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(buffer):
+            server = build_server(profile=profile)
+        server.filter_runtime_tools = False
+        return {tool.name: tool for tool in server.list_tools_sync()}
+    finally:
+        if previous_mode is None:
+            os.environ.pop("KICAD_MCP_OPERATING_MODE", None)
+        else:
+            os.environ["KICAD_MCP_OPERATING_MODE"] = previous_mode
+        reset_config()
 
 
 def _annotation_bool(annotations: ToolAnnotations, field: str) -> bool:

--- a/packages/mcp-server/src/kicad_mcp/config.py
+++ b/packages/mcp-server/src/kicad_mcp/config.py
@@ -108,6 +108,10 @@ class KiCadMCPConfig(BaseSettings):
         "schematic",
         "agent_full",
     ] = Field(default="full")
+    operating_mode: Literal["readonly", "write", "manufacturing", "experimental"] = Field(
+        default="readonly",
+        description="Risk-oriented tool exposure mode.",
+    )
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(default="INFO")
     log_format: Literal["json", "text", "console"] = Field(default="console")
     log_file: Path | None = Field(default=None)
@@ -259,6 +263,17 @@ class KiCadMCPConfig(BaseSettings):
     def _normalize_lowercase_literals(cls, value: object) -> object:
         if isinstance(value, str):
             return value.strip().casefold()
+        return value
+
+    @field_validator("operating_mode", mode="before")
+    @classmethod
+    def _normalize_operating_mode(cls, value: object) -> object:
+        if value in (None, ""):
+            return "readonly"
+        if isinstance(value, str):
+            normalized = value.strip().casefold().replace("_", "-")
+            aliases = {"read-only": "readonly", "ro": "readonly", "mfg": "manufacturing"}
+            return aliases.get(normalized, normalized)
         return value
 
     @field_validator("kicad_cli")

--- a/packages/mcp-server/src/kicad_mcp/operating_modes.py
+++ b/packages/mcp-server/src/kicad_mcp/operating_modes.py
@@ -1,0 +1,259 @@
+"""Operating mode policy for KiCad MCP Pro tool exposure and execution."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+
+from .capabilities import AccessTier, all_records, get
+from .config import get_config
+from .tools.router import EXPERIMENTAL_TOOL_NAMES, TOOL_CATEGORIES
+
+
+class OperatingMode(StrEnum):
+    """Risk-oriented MCP operating modes."""
+
+    READONLY = "readonly"
+    WRITE = "write"
+    MANUFACTURING = "manufacturing"
+    EXPERIMENTAL = "experimental"
+
+
+DEFAULT_OPERATING_MODE = OperatingMode.READONLY
+OPERATING_MODE_VALUES = tuple(mode.value for mode in OperatingMode)
+
+_ALLOWED_REQUIREMENTS: dict[OperatingMode, frozenset[OperatingMode]] = {
+    OperatingMode.READONLY: frozenset({OperatingMode.READONLY}),
+    OperatingMode.WRITE: frozenset({OperatingMode.READONLY, OperatingMode.WRITE}),
+    OperatingMode.MANUFACTURING: frozenset({OperatingMode.READONLY, OperatingMode.MANUFACTURING}),
+    OperatingMode.EXPERIMENTAL: frozenset(OperatingMode),
+}
+
+_MANUFACTURING_TOOL_NAMES = frozenset(
+    {
+        "export_manufacturing_package",
+        "manufacturing_quality_gate",
+        "check_design_for_manufacture",
+    }
+)
+_WRITE_TOOL_NAMES = frozenset(
+    {
+        "project_set_design_intent",
+        "project_auto_fix_loop",
+        "project_full_validation_loop",
+        "kicad_create_new_project",
+        "dfm_load_manufacturer_profile",
+    }
+)
+_WRITE_PREFIXES = (
+    "pcb_add",
+    "pcb_align",
+    "pcb_auto",
+    "pcb_bga",
+    "pcb_block_create",
+    "pcb_block_place",
+    "pcb_delete",
+    "pcb_group",
+    "pcb_highlight",
+    "pcb_move",
+    "pcb_place_",
+    "pcb_refill",
+    "pcb_route",
+    "pcb_save",
+    "pcb_set",
+    "pcb_sync",
+    "sch_add",
+    "sch_auto",
+    "sch_build",
+    "sch_create",
+    "sch_delete",
+    "sch_instantiate",
+    "sch_modify",
+    "sch_move",
+    "sch_reload",
+    "sch_route",
+    "sch_set",
+    "sch_update",
+    "variant_create",
+    "variant_set",
+    "lib_assign",
+    "lib_bind",
+    "lib_create",
+    "lib_generate",
+    "sim_add",
+    "drc_rule_create",
+    "drc_rule_delete",
+    "drc_rule_enable",
+    "vcs_",
+)
+
+
+@dataclass(frozen=True)
+class ToolOperatingModeAvailability:
+    """Mode-gating status for a single tool."""
+
+    available: bool
+    required_mode: OperatingMode
+    reason: str | None
+
+    def as_contract(self) -> dict[str, object]:
+        """Return the protocol-schema shape used by server-info."""
+        return {
+            "available": self.available,
+            "requiredMode": self.required_mode.value,
+            "reason": self.reason,
+        }
+
+
+def parse_operating_mode(value: object) -> OperatingMode:
+    """Normalize a CLI/config value into an operating mode."""
+    if isinstance(value, OperatingMode):
+        return value
+    raw = str(value or DEFAULT_OPERATING_MODE.value).strip().casefold()
+    normalized = raw.replace("_", "-")
+    aliases = {
+        "read-only": OperatingMode.READONLY.value,
+        "read_only": OperatingMode.READONLY.value,
+        "ro": OperatingMode.READONLY.value,
+        "mfg": OperatingMode.MANUFACTURING.value,
+    }
+    candidate = aliases.get(normalized, normalized)
+    if candidate == "read-only":
+        candidate = OperatingMode.READONLY.value
+    return OperatingMode(candidate)
+
+
+def active_operating_mode(config: object | None = None) -> OperatingMode:
+    """Return the effective operating mode from configuration."""
+    cfg = config or get_config()
+    if bool(getattr(cfg, "enable_experimental_tools", False)):
+        return OperatingMode.EXPERIMENTAL
+    return parse_operating_mode(getattr(cfg, "operating_mode", DEFAULT_OPERATING_MODE.value))
+
+
+def tool_required_mode(tool_name: str) -> OperatingMode:
+    """Return the minimum operating mode required by a tool."""
+    if _is_experimental_tool(tool_name):
+        return OperatingMode.EXPERIMENTAL
+    if _is_manufacturing_tool(tool_name):
+        return OperatingMode.MANUFACTURING
+
+    record = get(tool_name)
+    if record is not None:
+        if record.tier is AccessTier.WRITE or record.tier is AccessTier.PUBLISH:
+            return OperatingMode.WRITE
+        if record.tier is AccessTier.HUMAN_ONLY:
+            return OperatingMode.MANUFACTURING
+        return OperatingMode.READONLY
+
+    if _is_write_tool(tool_name):
+        return OperatingMode.WRITE
+    return OperatingMode.READONLY
+
+
+def is_tool_allowed_in_mode(tool_name: str, mode: OperatingMode | str | None = None) -> bool:
+    """Return whether a tool may be discovered or executed in the active mode."""
+    active = parse_operating_mode(mode) if mode is not None else active_operating_mode()
+    required = tool_required_mode(tool_name)
+    return required in _ALLOWED_REQUIREMENTS[active]
+
+
+def tool_availability(
+    tool_name: str,
+    mode: OperatingMode | str | None = None,
+) -> ToolOperatingModeAvailability:
+    """Return structured mode availability for a tool."""
+    active = parse_operating_mode(mode) if mode is not None else active_operating_mode()
+    required = tool_required_mode(tool_name)
+    available = required in _ALLOWED_REQUIREMENTS[active]
+    return ToolOperatingModeAvailability(
+        available=available,
+        required_mode=required,
+        reason=None if available else required_mode_reason(required),
+    )
+
+
+def known_tool_names() -> tuple[str, ...]:
+    """Return tool names known to profile routing or capability metadata."""
+    names = set(all_records())
+    for category in TOOL_CATEGORIES.values():
+        names.update(category["tools"])
+    return tuple(sorted(names))
+
+
+def operating_mode_contract(config: object | None = None) -> dict[str, object]:
+    """Return server-info metadata for the effective operating mode."""
+    cfg = config or get_config()
+    active = active_operating_mode(cfg)
+    return {
+        "active": active.value,
+        "default": DEFAULT_OPERATING_MODE.value,
+        "available": list(OPERATING_MODE_VALUES),
+        "experimentalEnabled": active is OperatingMode.EXPERIMENTAL,
+        "toolAvailability": {
+            name: tool_availability(name, active).as_contract() for name in known_tool_names()
+        },
+    }
+
+
+def filter_tools_for_mode[T](
+    tools: Iterable[T],
+    mode: OperatingMode | str | None = None,
+) -> list[T]:
+    """Filter MCP tool objects according to operating mode policy."""
+    active = parse_operating_mode(mode) if mode is not None else active_operating_mode()
+    return [
+        tool for tool in tools if is_tool_allowed_in_mode(str(getattr(tool, "name", "")), active)
+    ]
+
+
+def denial_message(tool_name: str, mode: OperatingMode | str | None = None) -> str:
+    """Return the execution denial text for a mode-blocked tool."""
+    active = parse_operating_mode(mode) if mode is not None else active_operating_mode()
+    required = tool_required_mode(tool_name)
+    return (
+        f"Tool '{tool_name}' requires {required.value} operating mode; "
+        f"active mode is {active.value}."
+    )
+
+
+def required_mode_reason(required: OperatingMode) -> str:
+    """Return the structured server-info reason for an unavailable tool."""
+    return f"Requires {required.value} operating mode."
+
+
+def _category_names_for_tool(tool_name: str) -> set[str]:
+    return {
+        category_name
+        for category_name, category in TOOL_CATEGORIES.items()
+        if tool_name in category["tools"]
+    }
+
+
+def _is_experimental_tool(tool_name: str) -> bool:
+    categories = _category_names_for_tool(tool_name)
+    return (
+        tool_name in EXPERIMENTAL_TOOL_NAMES
+        or "routing" in categories
+        or tool_name.startswith(("route_", "tune_"))
+    )
+
+
+def _is_manufacturing_tool(tool_name: str) -> bool:
+    categories = _category_names_for_tool(tool_name)
+    return (
+        tool_name in _MANUFACTURING_TOOL_NAMES
+        or "manufacturing" in categories
+        or "release_export" in categories
+        or tool_name.startswith("mfg_")
+    )
+
+
+def _is_write_tool(tool_name: str) -> bool:
+    categories = _category_names_for_tool(tool_name)
+    return (
+        tool_name in _WRITE_TOOL_NAMES
+        or "pcb_write" in categories
+        or tool_name.startswith(_WRITE_PREFIXES)
+    )

--- a/packages/mcp-server/src/kicad_mcp/server.py
+++ b/packages/mcp-server/src/kicad_mcp/server.py
@@ -54,6 +54,13 @@ from .diagnostics import (
 from .discovery import ensure_studio_project_watcher, find_kicad_version
 from .i18n import SERVER_DESCRIPTION, localize, option_help
 from .ipc.capabilities import KiCadIpcCapabilityState, get_ipc_capability_state
+from .operating_modes import (
+    OperatingMode,
+    active_operating_mode,
+    denial_message,
+    filter_tools_for_mode,
+    is_tool_allowed_in_mode,
+)
 from .tools import router
 from .tools.fixers import validate_callable_imports
 from .tools.metadata import get_tool_metadata, infer_tool_annotations
@@ -262,6 +269,8 @@ def _clean_tool_error(exc: BaseException) -> str:
 
 def _tool_error_code(message: str, *, tool_name: str = "") -> str:
     lowered = message.casefold()
+    if "operating mode" in lowered and "requires" in lowered:
+        return "MODE_FORBIDDEN"
     if "timed out" in lowered or "timeout" in lowered:
         return "CLI_TIMEOUT"
     if "kicad-cli" in lowered:
@@ -281,6 +290,11 @@ def _tool_error_code(message: str, *, tool_name: str = "") -> str:
 
 def _tool_error_hint(message: str) -> str:
     lowered = message.casefold()
+    if "operating mode" in lowered and "requires" in lowered:
+        return (
+            "Start kicad-mcp-pro with --mode write, --mode manufacturing, "
+            "or --mode experimental as appropriate."
+        )
     if "no pcb file" in lowered or "no schematic file" in lowered:
         return "Call kicad_set_project() or set the relevant KICAD_MCP_*_FILE variable."
     if "kicad-cli" in lowered:
@@ -504,6 +518,7 @@ class KiCadFastMCP(FastMCP):
     allow_experimental_tools: bool = False
     allowed_tool_names: set[str] | None = None
     filter_runtime_tools: bool = True
+    operating_mode: OperatingMode = OperatingMode.READONLY
     _lazy_registration: Callable[[], None] | None = None
     _lazy_registration_complete: bool = False
     _lazy_registration_error: BaseException | None = None
@@ -600,8 +615,12 @@ class KiCadFastMCP(FastMCP):
         allowed_tool_names = getattr(self, "allowed_tool_names", None)
         if allowed_tool_names is not None:
             tools = [tool for tool in tools if tool.name in allowed_tool_names]
+        mode = getattr(self, "operating_mode", active_operating_mode())
+        tools = filter_tools_for_mode(tools, mode)
         if getattr(self, "filter_runtime_tools", True):
             tools = _filter_ipc_runtime_tools(tools)
+        if mode is OperatingMode.EXPERIMENTAL:
+            return tools
         if (
             getattr(self, "allow_experimental_tools", False)
             or get_config().enable_experimental_tools
@@ -731,6 +750,14 @@ class KiCadFastMCP(FastMCP):
         with otel.tool_span(name) as span:
             try:
                 await self._ensure_registered_async()
+                mode = getattr(self, "operating_mode", active_operating_mode())
+                if not is_tool_allowed_in_mode(name, mode):
+                    result = _structured_tool_error_from_message(
+                        denial_message(name, mode),
+                        tool_name=name,
+                    )
+                    status, error_code = _status_from_result(result)
+                    return result
                 if limiter is None:
                     result = await super().call_tool(name, arguments)
                 else:
@@ -1266,6 +1293,7 @@ def build_server(profile: str | None = None, *, defer_registration: bool = False
     otel.ensure_telemetry_configured(cfg)
     cfg._validate_http_transport_security()
     selected_profile = profile or cfg.profile
+    operating_mode = active_operating_mode(cfg)
     enabled = set(categories_for_profile(selected_profile))
     token_verifier = _StaticTokenVerifier(cfg.auth_token) if cfg.auth_token else None
     auth = None
@@ -1295,7 +1323,8 @@ def build_server(profile: str | None = None, *, defer_registration: bool = False
         auth=auth,
         token_verifier=token_verifier,
     )
-    server.allow_experimental_tools = selected_profile == "agent_full"
+    server.operating_mode = operating_mode
+    server.allow_experimental_tools = operating_mode is OperatingMode.EXPERIMENTAL
     server.allowed_tool_names = {
         tool_name for category in enabled for tool_name in router.TOOL_CATEGORIES[category]["tools"]
     }
@@ -1384,6 +1413,7 @@ def _print_startup_diagnostics(cfg: KiCadMCPConfig, *, probe_runtime: bool = Tru
     logger.info(
         "startup_diagnostics",
         profile=cfg.profile,
+        operating_mode=active_operating_mode(cfg).value,
         kicad_cli=str(cfg.kicad_cli),
         kicad_version=kicad_version or "unknown",
         project_dir=str(cfg.project_dir) if cfg.project_dir else None,
@@ -1401,6 +1431,7 @@ def _apply_cli_env(
     log_format: str | None = None,
     log_file: str | None = None,
     profile: str | None = None,
+    operating_mode: str | None = None,
     experimental: bool | None = None,
     telemetry: bool | None = None,
 ) -> None:
@@ -1414,6 +1445,7 @@ def _apply_cli_env(
         "KICAD_MCP_LOG_FORMAT": log_format,
         "KICAD_MCP_LOG_FILE": log_file,
         "KICAD_MCP_PROFILE": profile,
+        "KICAD_MCP_OPERATING_MODE": operating_mode,
         "KICAD_MCP_PROJECT_DIR": project_dir,
     }
     for key, value in cli_env.items():
@@ -1421,6 +1453,8 @@ def _apply_cli_env(
             os.environ[key] = value
     if experimental is not None and not isinstance(experimental, OptionInfo):
         os.environ["KICAD_MCP_ENABLE_EXPERIMENTAL_TOOLS"] = "true" if experimental else "false"
+        if experimental and operating_mode is None:
+            os.environ["KICAD_MCP_OPERATING_MODE"] = "experimental"
     if telemetry is not None and not isinstance(telemetry, OptionInfo):
         os.environ["KICAD_MCP_TELEMETRY_ENABLED"] = "true" if telemetry else "false"
 
@@ -1435,6 +1469,7 @@ def _run_server_from_options(
     log_format: str | None = None,
     log_file: str | None = None,
     profile: str | None = None,
+    operating_mode: str | None = None,
     experimental: bool | None = None,
     telemetry: bool | None = None,
 ) -> None:
@@ -1448,6 +1483,7 @@ def _run_server_from_options(
         log_format=log_format,
         log_file=log_file,
         profile=profile,
+        operating_mode=operating_mode,
         experimental=experimental,
         telemetry=telemetry,
     )
@@ -1486,6 +1522,7 @@ def _run_server_from_options(
             version=__version__,
             transport=selected_transport,
             profile=cfg.profile,
+            operating_mode=active_operating_mode(cfg).value,
         )
 
     if selected_transport == "stdio":
@@ -1516,6 +1553,11 @@ def main_callback(
     profile: str | None = typer.Option(
         None, help=f"Server profile: {', '.join(available_profiles())}"
     ),
+    operating_mode: str | None = typer.Option(
+        None,
+        "--mode",
+        help=option_help("Operating mode: readonly, write, manufacturing, experimental"),
+    ),
     experimental: bool | None = typer.Option(None, help=option_help("Enable experimental tools")),
     telemetry: bool | None = typer.Option(
         None, "--telemetry/--no-telemetry", help=option_help("Enable OpenTelemetry export")
@@ -1531,6 +1573,7 @@ def main_callback(
         log_format=log_format,
         log_file=log_file,
         profile=profile,
+        operating_mode=operating_mode,
         experimental=experimental,
         telemetry=telemetry,
     )
@@ -1556,6 +1599,11 @@ def serve(
     profile: str | None = typer.Option(
         None, help=f"Server profile: {', '.join(available_profiles())}"
     ),
+    operating_mode: str | None = typer.Option(
+        None,
+        "--mode",
+        help=option_help("Operating mode: readonly, write, manufacturing, experimental"),
+    ),
     experimental: bool | None = typer.Option(None, help=option_help("Enable experimental tools")),
     telemetry: bool | None = typer.Option(
         None, "--telemetry/--no-telemetry", help=option_help("Enable OpenTelemetry export")
@@ -1571,6 +1619,7 @@ def serve(
         log_format=log_format,
         log_file=log_file,
         profile=profile,
+        operating_mode=operating_mode,
         experimental=experimental,
         telemetry=telemetry,
     )
@@ -1716,12 +1765,29 @@ def list_tools_command(
     profile: str | None = typer.Option(
         None, help=f"Server profile: {', '.join(available_profiles())}"
     ),
+    operating_mode: str | None = typer.Option(
+        None,
+        "--mode",
+        help=option_help("Operating mode: readonly, write, manufacturing, experimental"),
+    ),
 ) -> None:
     """List MCP tools available for the selected profile."""
     if profile is not None and profile not in available_profiles():
         raise typer.BadParameter(f"Unsupported profile: {profile}")
+    previous_mode = os.environ.get("KICAD_MCP_OPERATING_MODE")
+    if operating_mode is not None:
+        os.environ["KICAD_MCP_OPERATING_MODE"] = operating_mode
+        reset_config()
     with contextlib.redirect_stdout(io.StringIO()):
-        server = build_server(profile, defer_registration=False)
+        try:
+            server = build_server(profile, defer_registration=False)
+        finally:
+            if operating_mode is not None:
+                if previous_mode is None:
+                    os.environ.pop("KICAD_MCP_OPERATING_MODE", None)
+                else:
+                    os.environ["KICAD_MCP_OPERATING_MODE"] = previous_mode
+                reset_config()
     sync_list = getattr(server, "list_tools_sync", None)
     if not callable(sync_list):
         raise typer.Exit(2)
@@ -1800,7 +1866,11 @@ def version_command(
         cfg = get_config()
     payload = {
         "package": {"name": "kicad-mcp-pro", "version": __version__},
-        "mcp": {"transport_default": cfg.transport, "profile": cfg.profile},
+        "mcp": {
+            "transport_default": cfg.transport,
+            "profile": cfg.profile,
+            "operating_mode": active_operating_mode(cfg).value,
+        },
         "python": {"version": sys.version.split()[0]},
     }
     typer.echo(json.dumps(payload, indent=2) if json_output else __version__)

--- a/packages/mcp-server/src/kicad_mcp/server_info.py
+++ b/packages/mcp-server/src/kicad_mcp/server_info.py
@@ -15,8 +15,9 @@ from .discovery import CliCapabilities, get_cli_capabilities
 from .i18n import SERVER_DESCRIPTION, localize, localized_message_variants
 from .ipc.capabilities import get_ipc_capability_state
 from .ipc.client import KiCadIpcClient
+from .operating_modes import operating_mode_contract
 
-SERVER_INFO_SCHEMA_VERSION = "1.1.0"
+SERVER_INFO_SCHEMA_VERSION = "1.2.0"
 _BIND_ALL_HOSTS = {"0.0.0.0", "::"}  # noqa: S104 - bind-all sentinel, not a socket bind.
 _SEMVER_NUMBER_RE = re.compile(r"\d+")
 TransportType = Literal["stdio", "streamable-http", "sse"]
@@ -67,6 +68,7 @@ def get_server_info_contract(*, probe_live_context: bool = True) -> dict[str, ob
             "livePcbContext": ipc_state.live_pcb_context,
             "liveSchematicContext": ipc_state.live_schematic_context,
         },
+        "operatingMode": operating_mode_contract(cfg),
         "capabilities": {
             "fileBackedDrc": cli.found,
             "fileBackedErc": cli.found,

--- a/packages/mcp-server/tests/conftest.py
+++ b/packages/mcp-server/tests/conftest.py
@@ -16,6 +16,26 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    """Register local markers even when pytest is launched from the monorepo root."""
+    config.addinivalue_line(
+        "markers",
+        "benchmark: lightweight performance regression checks with committed baselines",
+    )
+    config.addinivalue_line(
+        "markers",
+        "gui: real KiCad GUI smoke tests for scheduled/manual environments",
+    )
+    config.addinivalue_line(
+        "markers",
+        "mcp_mode(mode): run the test with an explicit KiCad MCP operating mode",
+    )
+    config.addinivalue_line(
+        "markers",
+        "slow: tests that are useful for scheduled/full validation but skipped by fast loops",
+    )
+
+
 def tool_text(result: object) -> str:
     """Extract text from a FastMCP tool result."""
     if hasattr(result, "isError") and hasattr(result, "content"):
@@ -110,6 +130,7 @@ def reset_globals(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.delenv("KICAD_MCP_LOG_MAX_BYTES", raising=False)
     monkeypatch.delenv("KICAD_MCP_LOG_BACKUP_COUNT", raising=False)
     monkeypatch.delenv("KICAD_MCP_PROFILE", raising=False)
+    monkeypatch.delenv("KICAD_MCP_OPERATING_MODE", raising=False)
     monkeypatch.delenv("KICAD_MCP_ENABLE_EXPERIMENTAL_TOOLS", raising=False)
     monkeypatch.delenv("KICAD_MCP_TELEMETRY_ENABLED", raising=False)
     monkeypatch.delenv("KICAD_MCP_OTEL_ENDPOINT", raising=False)
@@ -122,6 +143,29 @@ def reset_globals(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
     yield
     reset_telemetry(shutdown_managed=True)
+
+
+@pytest.fixture(autouse=True)
+def legacy_mutating_suite_mode(
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest, reset_globals: None
+) -> None:
+    """Run tests that exercise mutating tool surfaces with an explicit mode."""
+    marker = request.node.get_closest_marker("mcp_mode")
+    if marker is not None:
+        mode = str(marker.args[0])
+    else:
+        mode = ""
+
+    path_parts = set(Path(str(request.node.path)).parts)
+    if not mode and {"integration", "e2e"}.isdisjoint(path_parts):
+        return
+    if not mode:
+        mode = "experimental"
+
+    from kicad_mcp.config import reset_config
+
+    monkeypatch.setenv("KICAD_MCP_OPERATING_MODE", mode)
+    reset_config()
 
 
 @pytest.fixture

--- a/packages/mcp-server/tests/e2e/test_stdio_startup.py
+++ b/packages/mcp-server/tests/e2e/test_stdio_startup.py
@@ -18,6 +18,7 @@ def test_stdio_initialize_does_not_require_client_warmup() -> None:
     env["KICAD_MCP_LOG_LEVEL"] = "ERROR"
     env["KICAD_MCP_LOG_FORMAT"] = "json"
     env["KICAD_MCP_KICAD_CLI"] = "kicad-cli-missing-for-stdio-startup-test"
+    env["KICAD_MCP_OPERATING_MODE"] = "experimental"
     env["KICAD_MCP_TRANSPORT"] = "stdio"
 
     started = time.perf_counter()

--- a/packages/mcp-server/tests/unit/test_kicad10_parity_tools.py
+++ b/packages/mcp-server/tests/unit/test_kicad10_parity_tools.py
@@ -7,6 +7,8 @@ import pytest
 from kicad_mcp.server import build_server
 from tests.conftest import call_tool_text
 
+pytestmark = pytest.mark.mcp_mode("experimental")
+
 
 @pytest.mark.anyio
 async def test_sch_set_hop_over_updates_project_file(sample_project) -> None:

--- a/packages/mcp-server/tests/unit/test_operating_modes.py
+++ b/packages/mcp-server/tests/unit/test_operating_modes.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from kicad_mcp.config import reset_config
+from kicad_mcp.operating_modes import (
+    OperatingMode,
+    active_operating_mode,
+    is_tool_allowed_in_mode,
+    tool_required_mode,
+)
+from kicad_mcp.server import KiCadFastMCP, _apply_cli_env, build_server
+
+
+def _tool_names_for_mode(mode: str, *, profile: str = "full") -> set[str]:
+    os.environ["KICAD_MCP_OPERATING_MODE"] = mode
+    reset_config()
+    server = build_server(profile)
+    assert isinstance(server, KiCadFastMCP)
+    server.filter_runtime_tools = False
+    return {tool.name for tool in server.list_tools_sync()}
+
+
+def test_operating_mode_policy_matches_required_risk_levels() -> None:
+    assert active_operating_mode().value == "readonly"
+
+    assert tool_required_mode("kicad_get_version") is OperatingMode.READONLY
+    assert is_tool_allowed_in_mode("kicad_get_version", OperatingMode.READONLY) is True
+    assert tool_required_mode("pcb_placement_quality_gate") is OperatingMode.READONLY
+    assert is_tool_allowed_in_mode("pcb_placement_quality_gate", OperatingMode.READONLY) is True
+    assert tool_required_mode("pcb_placement_quality_report") is OperatingMode.READONLY
+
+    assert tool_required_mode("pcb_add_track") is OperatingMode.WRITE
+    assert is_tool_allowed_in_mode("pcb_add_track", OperatingMode.READONLY) is False
+    assert tool_required_mode("pcb_place_component") is OperatingMode.WRITE
+    assert is_tool_allowed_in_mode("pcb_place_component", OperatingMode.READONLY) is False
+    assert is_tool_allowed_in_mode("pcb_add_track", OperatingMode.WRITE) is True
+    assert is_tool_allowed_in_mode("pcb_add_track", OperatingMode.MANUFACTURING) is False
+
+    assert tool_required_mode("export_manufacturing_package") is OperatingMode.MANUFACTURING
+    assert is_tool_allowed_in_mode("export_manufacturing_package", OperatingMode.WRITE) is False
+    assert (
+        is_tool_allowed_in_mode("export_manufacturing_package", OperatingMode.MANUFACTURING) is True
+    )
+
+    assert tool_required_mode("route_tune_length") is OperatingMode.EXPERIMENTAL
+    assert is_tool_allowed_in_mode("route_tune_length", OperatingMode.WRITE) is False
+    assert is_tool_allowed_in_mode("route_tune_length", OperatingMode.EXPERIMENTAL) is True
+
+
+def test_default_readonly_mode_filters_mutating_and_high_risk_tools(sample_project) -> None:
+    _ = sample_project
+
+    tool_names = _tool_names_for_mode("readonly")
+
+    assert {
+        "kicad_get_version",
+        "run_drc",
+        "run_erc",
+        "export_bom",
+        "sch_get_symbols",
+    } <= tool_names
+    assert "pcb_add_track" not in tool_names
+    assert "sch_add_symbol" not in tool_names
+    assert "export_manufacturing_package" not in tool_names
+    assert "route_single_track" not in tool_names
+    assert "sch_swap_pins" not in tool_names
+
+
+def test_write_mode_allows_controlled_source_changes(sample_project) -> None:
+    _ = sample_project
+
+    tool_names = _tool_names_for_mode("write")
+
+    assert {"kicad_get_version", "pcb_add_track", "pcb_save", "sch_add_symbol"} <= tool_names
+    assert "export_manufacturing_package" not in tool_names
+    assert "route_tune_length" not in tool_names
+    assert "sch_swap_pins" not in tool_names
+
+
+def test_manufacturing_mode_exposes_release_exports_without_general_write_tools(
+    sample_project,
+) -> None:
+    _ = sample_project
+
+    tool_names = _tool_names_for_mode("manufacturing")
+
+    assert {
+        "kicad_get_version",
+        "export_gerber",
+        "export_bom",
+        "export_manufacturing_package",
+        "mfg_generate_release_manifest",
+    } <= tool_names
+    assert "pcb_add_track" not in tool_names
+    assert "sch_add_symbol" not in tool_names
+    assert "route_tune_length" not in tool_names
+
+
+def test_experimental_mode_requires_explicit_opt_in_for_routing_and_unstable_tools(
+    sample_project,
+) -> None:
+    _ = sample_project
+
+    tool_names = _tool_names_for_mode("experimental")
+
+    assert {
+        "pcb_add_track",
+        "export_manufacturing_package",
+        "route_single_track",
+        "route_tune_length",
+        "sch_swap_pins",
+    } <= tool_names
+
+
+@pytest.mark.anyio
+async def test_readonly_mode_rejects_write_tool_execution(monkeypatch) -> None:
+    monkeypatch.setenv("KICAD_MCP_OPERATING_MODE", "readonly")
+    reset_config()
+    server = KiCadFastMCP(name="kicad-mcp-pro-test")
+    called = False
+
+    @server.tool(name="pcb_add_track")
+    def pcb_add_track() -> str:
+        nonlocal called
+        called = True
+        return "mutated"
+
+    result = await server.call_tool("pcb_add_track", {})
+
+    assert called is False
+    assert result.isError is True
+    assert result.structuredContent == {
+        "error_code": "MODE_FORBIDDEN",
+        "message": ("Tool 'pcb_add_track' requires write operating mode; active mode is readonly."),
+        "hint": (
+            "Start kicad-mcp-pro with --mode write, --mode manufacturing, "
+            "or --mode experimental as appropriate."
+        ),
+    }
+
+
+def test_experimental_cli_flag_is_explicit_mode_opt_in(monkeypatch) -> None:
+    monkeypatch.delenv("KICAD_MCP_OPERATING_MODE", raising=False)
+    monkeypatch.delenv("KICAD_MCP_ENABLE_EXPERIMENTAL_TOOLS", raising=False)
+
+    _apply_cli_env(experimental=True)
+
+    assert os.environ["KICAD_MCP_ENABLE_EXPERIMENTAL_TOOLS"] == "true"
+    assert os.environ["KICAD_MCP_OPERATING_MODE"] == "experimental"

--- a/packages/mcp-server/tests/unit/test_profile_matrix.py
+++ b/packages/mcp-server/tests/unit/test_profile_matrix.py
@@ -2,8 +2,16 @@ from __future__ import annotations
 
 import pytest
 
+from kicad_mcp.operating_modes import OperatingMode, is_tool_allowed_in_mode
 from kicad_mcp.server import build_server
 from kicad_mcp.tools.router import EXPERIMENTAL_TOOL_NAMES, PROFILE_CATEGORIES, TOOL_CATEGORIES
+
+
+def _default_mode_expected_tools(profile_name: str, expected: list[str]) -> set[str]:
+    names = set(expected)
+    if profile_name != "agent_full":
+        names -= EXPERIMENTAL_TOOL_NAMES
+    return {name for name in names if is_tool_allowed_in_mode(name, OperatingMode.READONLY)}
 
 
 @pytest.mark.anyio
@@ -24,10 +32,7 @@ async def test_profile_tool_matrix_matches_declared_categories(
 
         assert len(listed) == len(listed_set)
         assert listed_set.issubset(set(expected))
-        if profile_name == "agent_full":
-            assert listed_set == set(expected)
-        else:
-            assert listed_set == (set(expected) - EXPERIMENTAL_TOOL_NAMES)
+        assert listed_set == _default_mode_expected_tools(profile_name, expected)
 
 
 class _AvailableIpcState:

--- a/packages/mcp-server/tests/unit/test_release_hardening.py
+++ b/packages/mcp-server/tests/unit/test_release_hardening.py
@@ -489,6 +489,7 @@ async def test_export_gerber_sends_progress_notifications(
 
 
 @pytest.mark.anyio
+@pytest.mark.mcp_mode("manufacturing")
 async def test_manufacturing_gate_block_returns_structured_validation_error(
     sample_project: Path,
     monkeypatch,
@@ -829,6 +830,7 @@ def test_docs_workflow_deploys_only_from_canonical_repo() -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.mcp_mode("write")
 async def test_project_generate_design_prompt_uses_design_intent(sample_project: Path) -> None:
     server = build_server("full")
     await call_tool_text(server, "kicad_set_project", {"project_dir": str(sample_project)})
@@ -863,6 +865,7 @@ async def test_project_generate_design_prompt_uses_design_intent(sample_project:
 
 
 @pytest.mark.anyio
+@pytest.mark.mcp_mode("experimental")
 async def test_export_manufacturing_package_accepts_explicit_variant(
     sample_project: Path,
     monkeypatch,

--- a/packages/mcp-server/tests/unit/test_router_profiles.py
+++ b/packages/mcp-server/tests/unit/test_router_profiles.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from kicad_mcp.operating_modes import OperatingMode, is_tool_allowed_in_mode
 from kicad_mcp.server import build_server, create_server
 from kicad_mcp.tools.router import (
     EXPERIMENTAL_TOOL_NAMES,
@@ -105,6 +106,7 @@ async def test_tool_category_output_shows_runtime_metadata() -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.mcp_mode("manufacturing")
 async def test_manufacturing_profile_exposes_release_exports_only() -> None:
     server = build_server("manufacturing")
     tool_names = {tool.name for tool in await server.list_tools()}
@@ -140,7 +142,12 @@ async def test_tool_categories_have_no_phantom_or_undeclared_tools(
     for category in TOOL_CATEGORIES.values():
         declared.update(category["tools"])
 
-    assert registered == (declared - EXPERIMENTAL_TOOL_NAMES)
+    expected = {
+        name
+        for name in declared - EXPERIMENTAL_TOOL_NAMES
+        if is_tool_allowed_in_mode(name, OperatingMode.READONLY)
+    }
+    assert registered == expected
 
 
 class _AvailableIpcState:

--- a/packages/mcp-server/tests/unit/test_server_info_contract.py
+++ b/packages/mcp-server/tests/unit/test_server_info_contract.py
@@ -51,7 +51,7 @@ def test_server_info_contract_matches_protocol_schema(monkeypatch, sample_projec
     payload = get_server_info_contract()
 
     _validate_contract(payload)
-    assert payload["schemaVersion"] == "1.1.0"
+    assert payload["schemaVersion"] == "1.2.0"
     assert payload["server"] == "kicad-mcp-pro"
     assert payload["description"] == "KiCad MCP Pro server for PCB and schematic workflows."
     assert payload["localizedDescriptions"] == {
@@ -90,6 +90,36 @@ def test_server_info_contract_matches_protocol_schema(monkeypatch, sample_projec
         "ipcEndpointSource": "default",
         "livePcbContext": True,
         "liveSchematicContext": False,
+    }
+    operating_mode = payload["operatingMode"]
+    assert operating_mode["active"] == "readonly"
+    assert operating_mode["default"] == "readonly"
+    assert operating_mode["available"] == [
+        "readonly",
+        "write",
+        "manufacturing",
+        "experimental",
+    ]
+    assert operating_mode["experimentalEnabled"] is False
+    assert operating_mode["toolAvailability"]["kicad_get_version"] == {
+        "available": True,
+        "requiredMode": "readonly",
+        "reason": None,
+    }
+    assert operating_mode["toolAvailability"]["pcb_add_track"] == {
+        "available": False,
+        "requiredMode": "write",
+        "reason": "Requires write operating mode.",
+    }
+    assert operating_mode["toolAvailability"]["export_manufacturing_package"] == {
+        "available": False,
+        "requiredMode": "manufacturing",
+        "reason": "Requires manufacturing operating mode.",
+    }
+    assert operating_mode["toolAvailability"]["route_tune_length"] == {
+        "available": False,
+        "requiredMode": "experimental",
+        "reason": "Requires experimental operating mode.",
     }
     capabilities = payload["capabilities"]
     assert capabilities == {

--- a/packages/mcp-server/tests/unit/test_tool_metadata_lint.py
+++ b/packages/mcp-server/tests/unit/test_tool_metadata_lint.py
@@ -8,6 +8,8 @@ from kicad_mcp.server import build_server
 from kicad_mcp.tools.metadata import infer_tool_annotations
 from kicad_mcp.tools.router import TOOL_CATEGORIES
 
+TESTS_ROOT = Path(__file__).resolve().parents[1]
+
 
 def test_every_declared_tool_can_be_normalized_into_annotations() -> None:
     declared_tools = {
@@ -36,7 +38,7 @@ async def test_every_declared_tool_has_static_test_reference() -> None:
         tool_name for category in TOOL_CATEGORIES.values() for tool_name in category["tools"]
     }
     test_blob = "\n".join(
-        path.read_text(encoding="utf-8", errors="ignore") for path in Path("tests").rglob("*.py")
+        path.read_text(encoding="utf-8", errors="ignore") for path in TESTS_ROOT.rglob("*.py")
     )
     missing = sorted(tool_name for tool_name in declared_tools if tool_name not in test_blob)
 

--- a/packages/mcp-server/tests/unit/test_variant_diff.py
+++ b/packages/mcp-server/tests/unit/test_variant_diff.py
@@ -9,6 +9,8 @@ from kicad_mcp.server import create_server
 from kicad_mcp.tools.schematic import place_symbol_block
 from tests.conftest import call_tool_text
 
+pytestmark = pytest.mark.mcp_mode("write")
+
 
 def _write_variant_schematic(sample_project) -> None:
     schematic = sample_project / "demo.kicad_sch"

--- a/packages/protocol-schemas/schemas/kicad-mcp-server-info.schema.json
+++ b/packages/protocol-schemas/schemas/kicad-mcp-server-info.schema.json
@@ -14,6 +14,7 @@
     "compatibilityRange",
     "transport",
     "kicad",
+    "operatingMode",
     "capabilities",
     "diagnostics"
   ],
@@ -150,6 +151,42 @@
         }
       }
     },
+    "operatingMode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "active",
+        "default",
+        "available",
+        "experimentalEnabled",
+        "toolAvailability"
+      ],
+      "properties": {
+        "active": {
+          "$ref": "#/$defs/operatingMode"
+        },
+        "default": {
+          "$ref": "#/$defs/operatingMode"
+        },
+        "available": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/operatingMode"
+          },
+          "uniqueItems": true,
+          "minItems": 4
+        },
+        "experimentalEnabled": {
+          "type": "boolean"
+        },
+        "toolAvailability": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/toolOperatingModeAvailability"
+          }
+        }
+      }
+    },
     "capabilities": {
       "type": "object",
       "additionalProperties": false,
@@ -253,6 +290,25 @@
     }
   },
   "$defs": {
+    "operatingMode": {
+      "enum": ["readonly", "write", "manufacturing", "experimental"]
+    },
+    "toolOperatingModeAvailability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available", "requiredMode", "reason"],
+      "properties": {
+        "available": {
+          "type": "boolean"
+        },
+        "requiredMode": {
+          "$ref": "#/$defs/operatingMode"
+        },
+        "reason": {
+          "type": ["string", "null"]
+        }
+      }
+    },
     "liveEditingTool": {
       "type": "object",
       "additionalProperties": false,

--- a/packages/protocol-schemas/src/index.ts
+++ b/packages/protocol-schemas/src/index.ts
@@ -53,6 +53,18 @@ export interface McpServerInfoCompatibilityRange {
   };
 }
 
+export type McpOperatingMode =
+  | "readonly"
+  | "write"
+  | "manufacturing"
+  | "experimental";
+
+export interface McpToolOperatingModeAvailability {
+  available: boolean;
+  requiredMode: McpOperatingMode;
+  reason: string | null;
+}
+
 export interface McpServerInfoContract {
   schemaVersion: string;
   server: "kicad-mcp-pro";
@@ -81,6 +93,13 @@ export interface McpServerInfoContract {
     ipcEndpointSource: "config" | "environment" | "default";
     livePcbContext: boolean;
     liveSchematicContext: boolean;
+  };
+  operatingMode: {
+    active: McpOperatingMode;
+    default: McpOperatingMode;
+    available: McpOperatingMode[];
+    experimentalEnabled: boolean;
+    toolAvailability: Record<string, McpToolOperatingModeAvailability>;
   };
   capabilities: {
     fileBackedDrc: boolean;

--- a/packages/protocol-schemas/test/index.test.ts
+++ b/packages/protocol-schemas/test/index.test.ts
@@ -199,7 +199,7 @@ test("validates shared protocol payload families", () => {
 
 function serverInfoFixture() {
   return {
-    schemaVersion: "1.1.0",
+    schemaVersion: "1.2.0",
     server: "kicad-mcp-pro",
     description: "KiCad MCP Pro server for PCB and schematic workflows.",
     localizedDescriptions: {
@@ -239,6 +239,34 @@ function serverInfoFixture() {
       ipcEndpointSource: "default",
       livePcbContext: true,
       liveSchematicContext: false,
+    },
+    operatingMode: {
+      active: "readonly",
+      default: "readonly",
+      available: ["readonly", "write", "manufacturing", "experimental"],
+      experimentalEnabled: false,
+      toolAvailability: {
+        kicad_get_version: {
+          available: true,
+          requiredMode: "readonly",
+          reason: null,
+        },
+        pcb_add_track: {
+          available: false,
+          requiredMode: "write",
+          reason: "Requires write operating mode.",
+        },
+        export_manufacturing_package: {
+          available: false,
+          requiredMode: "manufacturing",
+          reason: "Requires manufacturing operating mode.",
+        },
+        route_tune_length: {
+          available: false,
+          requiredMode: "experimental",
+          reason: "Requires experimental operating mode.",
+        },
+      },
     },
     capabilities: {
       fileBackedDrc: true,


### PR DESCRIPTION
## Summary
- add explicit readonly, write, manufacturing, and experimental operating-mode policy for kicad-mcp-pro discovery and execution
- expose operating-mode metadata in server-info/protocol schemas and logs/CLI/configuration
- gate VS Code extension actions and LM tools from server operating-mode context
- document configuration and update legacy tests to opt into mutating modes explicitly

## Validation
- corepack pnpm install --frozen-lockfile
- corepack pnpm run format:check
- corepack pnpm run lint
- corepack pnpm run typecheck
- corepack pnpm run test
- corepack pnpm run build
- corepack pnpm run verify:dist
- uv sync --project packages/mcp-server --all-extras
- uv run --project packages/mcp-server --all-extras pytest
- uvx pre-commit run --all-files
- git diff --check
- corepack pnpm audit --audit-level high
- corepack pnpm run docs:lint

## Notes
- Repo-root uv sync is not applicable because the monorepo root has no pyproject.toml; the package-scoped uv sync/pytest path above passed.
- No release, tag, or publish was performed.

Linear: https://linear.app/oaslananka/issue/OASLANA-72/add-read-only-write-manufacturing-and-experimental-modes-to-kicad-mcp
Closes #73