### PR TITLE
feat(kicad-studio): add diagnostic freshness model

### DIFF
--- a/apps/vscode-extension/src/cli/checkCommands.ts
+++ b/apps/vscode-extension/src/cli/checkCommands.ts
@@ -63,6 +63,7 @@ export class KiCadCheckService {
           ];
 
     try {
+      const detected = await this.runner.detectCli(false);
       await this.runner.runWithProgress<string>({
         command,
         cwd: path.dirname(file),
@@ -72,7 +73,11 @@ export class KiCadCheckService {
       const diagnostics = this.parseDiagnostics(raw, file, kind);
       return {
         diagnostics,
-        summary: this.summarize(file, kind, diagnostics)
+        summary: this.summarize(file, kind, diagnostics, {
+          commandArgs: command,
+          reportPath: tmpJsonFile,
+          kicadVersion: detected?.version
+        })
       };
     } catch (error) {
       this.logger.error(`Failed to run ${kind.toUpperCase()}`, error);
@@ -85,7 +90,12 @@ export class KiCadCheckService {
   private summarize(
     file: string,
     source: 'drc' | 'erc',
-    diagnostics: vscode.Diagnostic[]
+    diagnostics: vscode.Diagnostic[],
+    metadata: {
+      commandArgs: string[];
+      reportPath: string;
+      kicadVersion: string | undefined;
+    }
   ): DiagnosticSummary {
     let errors = 0;
     let warnings = 0;
@@ -105,7 +115,12 @@ export class KiCadCheckService {
       errors,
       warnings,
       infos,
-      capturedAt: new Date().toISOString()
+      capturedAt: new Date().toISOString(),
+      freshness: diagnostics.length > 0 ? 'fresh-dirty' : 'fresh-clean',
+      origin: 'kicad-cli',
+      commandArgs: metadata.commandArgs,
+      reportPath: metadata.reportPath,
+      kicadVersion: metadata.kicadVersion
     };
   }
 

--- a/apps/vscode-extension/src/cli/kicadCliRunner.ts
+++ b/apps/vscode-extension/src/cli/kicadCliRunner.ts
@@ -95,6 +95,12 @@ export class KiCadCliRunner {
     this.controllers.clear();
   }
 
+  async detectCli(
+    notifyOnMissing = false
+  ): Promise<DetectedKiCadCli | undefined> {
+    return this.detector.detect(notifyOnMissing);
+  }
+
   private async executeCommand(
     options: CliRunOptions,
     detected: DetectedKiCadCli,

--- a/apps/vscode-extension/src/commands/checkCommands.ts
+++ b/apps/vscode-extension/src/commands/checkCommands.ts
@@ -3,6 +3,7 @@ import { COMMANDS } from '../constants';
 import { resolveTargetFile } from '../utils/workspaceUtils';
 import { registerTrustedCommand } from '../utils/workspaceTrust';
 import type { CommandServices } from './types';
+import type { DiagnosticSummary } from '../types';
 
 /**
  * Register DRC and ERC check commands.
@@ -48,6 +49,7 @@ export function registerCheckCommands(
           }
           await services.pushStudioContext();
         } catch (error) {
+          recordValidationFailure(services, 'drc', file, error);
           void vscode.window.showErrorMessage(
             error instanceof Error
               ? error.message
@@ -76,6 +78,7 @@ export function registerCheckCommands(
             );
           }
         } catch (error) {
+          recordValidationFailure(services, 'erc', file, error);
           void vscode.window.showErrorMessage(
             error instanceof Error
               ? error.message
@@ -120,5 +123,34 @@ function applyValidationResult(
     result.summary.source === 'drc'
       ? { drc: result.summary }
       : { erc: result.summary }
+  );
+}
+
+function recordValidationFailure(
+  services: CommandServices,
+  source: 'drc' | 'erc',
+  file: string,
+  error: unknown
+): void {
+  const uri = vscode.Uri.file(file);
+  if (services.diagnosticState) {
+    services.diagnosticState.recordValidationFailure(source, uri, error, {
+      project: services.projectState.findProjectForResource(uri)
+    });
+    return;
+  }
+  const summary: DiagnosticSummary = {
+    file,
+    source,
+    errors: 0,
+    warnings: 0,
+    infos: 0,
+    capturedAt: new Date().toISOString(),
+    freshness: 'failed',
+    origin: 'kicad-cli',
+    failureMessage: error instanceof Error ? error.message : String(error)
+  };
+  services.statusBar.update(
+    source === 'drc' ? { drc: summary } : { erc: summary }
   );
 }

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -159,6 +159,16 @@ export async function activate(
     diagnosticsCollection
   );
   const checkService = new KiCadCheckService(cliRunner, parser, logger);
+  const markViewerDiagnosticsStale = (
+    resource: vscode.Uri,
+    project: ProjectContext | undefined
+  ): void => {
+    diagnosticState.markStaleForResource(
+      resource,
+      'Viewer reloaded after source file changed.',
+      { project }
+    );
+  };
   const treeProvider = new KiCadProjectTreeProvider();
   const validationViewProvider = new ValidationViewProvider(diagnosticState);
   const bomViewProvider = new BomViewProvider(context, parser, exportState);
@@ -173,13 +183,15 @@ export async function activate(
     context,
     async (resource) => exportService.renderViewerSvg(resource),
     viewerState,
-    (resource) => projectState.findProjectForResource(resource)
+    (resource) => projectState.findProjectForResource(resource),
+    markViewerDiagnosticsStale
   );
   const pcbEditorProvider = new PcbEditorProvider(
     context,
     async (resource) => exportService.renderViewerSvg(resource),
     viewerState,
-    (resource) => projectState.findProjectForResource(resource)
+    (resource) => projectState.findProjectForResource(resource),
+    markViewerDiagnosticsStale
   );
   const gitDiffDetector = new GitDiffDetector(parser);
   const diffEditorProvider = new DiffEditorProvider(context, gitDiffDetector);
@@ -694,6 +706,14 @@ export async function activate(
         await vscode.commands.executeCommand('workbench.actions.view.problems');
       }
     } catch (error) {
+      diagnosticState.recordValidationFailure(
+        shouldRunDrc ? 'drc' : 'erc',
+        vscode.Uri.file(document.fileName),
+        error,
+        {
+          project: projectState.findProjectForResource(document.fileName)
+        }
+      );
       logger.error('Auto DRC/ERC on save failed', error);
       void vscode.window.showErrorMessage(
         error instanceof Error

--- a/apps/vscode-extension/src/lm/languageModelTools.ts
+++ b/apps/vscode-extension/src/lm/languageModelTools.ts
@@ -186,22 +186,27 @@ function createRunDrcTool(
         );
       }
 
-      const result = await services.checkService.runDRC(file);
-      applyValidationResult(services, file, result);
-      services.setLatestDrcRun({
-        file,
-        diagnostics: result.diagnostics,
-        summary: result.summary
-      });
-
-      return buildToolResult(
-        `DRC completed for ${path.basename(file)}: ${formatSummary(result.summary)}.`,
-        {
+      try {
+        const result = await services.checkService.runDRC(file);
+        applyValidationResult(services, file, result);
+        services.setLatestDrcRun({
           file,
-          summary: result.summary,
-          diagnostics: result.diagnostics.map(serializeDiagnostic)
-        }
-      );
+          diagnostics: result.diagnostics,
+          summary: result.summary
+        });
+
+        return buildToolResult(
+          `DRC completed for ${path.basename(file)}: ${formatSummary(result.summary)}.`,
+          {
+            file,
+            summary: result.summary,
+            diagnostics: result.diagnostics.map(serializeDiagnostic)
+          }
+        );
+      } catch (error) {
+        recordValidationFailure(services, 'drc', file, error);
+        throw error;
+      }
     }
   };
 }
@@ -227,17 +232,22 @@ function createRunErcTool(
         );
       }
 
-      const result = await services.checkService.runERC(file);
-      applyValidationResult(services, file, result);
+      try {
+        const result = await services.checkService.runERC(file);
+        applyValidationResult(services, file, result);
 
-      return buildToolResult(
-        `ERC completed for ${path.basename(file)}: ${formatSummary(result.summary)}.`,
-        {
-          file,
-          summary: result.summary,
-          diagnostics: result.diagnostics.map(serializeDiagnostic)
-        }
-      );
+        return buildToolResult(
+          `ERC completed for ${path.basename(file)}: ${formatSummary(result.summary)}.`,
+          {
+            file,
+            summary: result.summary,
+            diagnostics: result.diagnostics.map(serializeDiagnostic)
+          }
+        );
+      } catch (error) {
+        recordValidationFailure(services, 'erc', file, error);
+        throw error;
+      }
     }
   };
 }
@@ -263,6 +273,22 @@ function applyValidationResult(
     return;
   }
   services.diagnosticsCollection.set(uri, result.diagnostics);
+}
+
+function recordValidationFailure(
+  services: LanguageModelToolServices,
+  source: 'drc' | 'erc',
+  file: string,
+  error: unknown
+): void {
+  services.diagnosticState?.recordValidationFailure(
+    source,
+    vscode.Uri.file(file),
+    error,
+    {
+      project: services.projectState?.findProjectForResource(file)
+    }
+  );
 }
 
 function createExportGerbersTool(
@@ -626,7 +652,8 @@ function collectProjectFiles(
     currentPath !== rootPath &&
     entries.some(
       (entry) =>
-        entry.isFile() && path.extname(entry.name).toLowerCase() === '.kicad_pro'
+        entry.isFile() &&
+        path.extname(entry.name).toLowerCase() === '.kicad_pro'
     )
   ) {
     return [];
@@ -647,7 +674,10 @@ function collectProjectFiles(
 }
 
 function isWithinDirectory(rootPath: string, filePath: string): boolean {
-  const relative = path.relative(path.resolve(rootPath), path.resolve(filePath));
+  const relative = path.relative(
+    path.resolve(rootPath),
+    path.resolve(filePath)
+  );
   return !relative.startsWith('..') && !path.isAbsolute(relative);
 }
 

--- a/apps/vscode-extension/src/providers/baseKiCanvasEditorProvider.ts
+++ b/apps/vscode-extension/src/providers/baseKiCanvasEditorProvider.ts
@@ -62,6 +62,10 @@ type ViewerSvgFallbackProvider = (
   uri: vscode.Uri
 ) => Promise<string | undefined>;
 type ViewerProjectResolver = (uri: vscode.Uri) => ProjectContext | undefined;
+type ViewerReloadObserver = (
+  uri: vscode.Uri,
+  project: ProjectContext | undefined
+) => void;
 
 /**
  * Shared custom editor provider for KiCanvas-backed viewers.
@@ -90,7 +94,8 @@ export abstract class BaseKiCanvasEditorProvider
     protected readonly context: vscode.ExtensionContext,
     private readonly svgFallbackProvider?: ViewerSvgFallbackProvider,
     private readonly viewerState = new ViewerStateStore(),
-    private readonly resolveProject?: ViewerProjectResolver
+    private readonly resolveProject?: ViewerProjectResolver,
+    private readonly onViewerReload?: ViewerReloadObserver
   ) {
     this.disposables.push(
       vscode.workspace.onDidSaveTextDocument((document) => {
@@ -331,9 +336,9 @@ export abstract class BaseKiCanvasEditorProvider
       return;
     }
 
-    this.viewerState.beginReload(uri, {
-      project: this.resolveProject?.(uri)
-    });
+    const project = this.resolveProject?.(uri);
+    this.viewerState.beginReload(uri, { project });
+    this.onViewerReload?.(uri, project);
     try {
       const payload = await this.buildViewerPayload(uri);
       for (const panel of visiblePanels) {

--- a/apps/vscode-extension/src/providers/validationViewProvider.ts
+++ b/apps/vscode-extension/src/providers/validationViewProvider.ts
@@ -74,6 +74,29 @@ function tooltip(row: ValidationRow): string {
       status: statusFor(row.summary)
     }),
     row.summary.file,
+    ...(row.summary.fileUri ? [`URI: ${row.summary.fileUri}`] : []),
+    ...(row.summary.projectName || row.summary.projectId
+      ? [`Project: ${row.summary.projectName ?? row.summary.projectId}`]
+      : []),
+    `Freshness: ${row.summary.freshness ?? 'not recorded'}`,
+    `Origin: ${row.summary.origin ?? 'not recorded'}`,
+    ...(row.summary.capturedAt ? [`Last run: ${row.summary.capturedAt}`] : []),
+    ...(row.summary.kicadVersion
+      ? [`KiCad CLI: ${row.summary.kicadVersion}`]
+      : []),
+    ...(row.summary.reportPath ? [`Report: ${row.summary.reportPath}`] : []),
+    ...(row.summary.commandArgs?.length
+      ? [`Command: kicad-cli ${row.summary.commandArgs.join(' ')}`]
+      : []),
+    ...(row.summary.staleReason
+      ? [`Stale reason: ${row.summary.staleReason}`]
+      : []),
+    ...(row.summary.failureMessage
+      ? [`Failure: ${row.summary.failureMessage}`]
+      : []),
+    ...(row.summary.lastGoodCapturedAt
+      ? [`Last good result: ${row.summary.lastGoodCapturedAt}`]
+      : []),
     localize('diagnosticErrors', { count: row.summary.errors }),
     localize('diagnosticWarnings', { count: row.summary.warnings }),
     localize('diagnosticInfos', { count: row.summary.infos })
@@ -88,16 +111,44 @@ function iconFor(summary: DiagnosticSummary | undefined): string {
       return 'warning';
     case 'PASS':
       return 'pass';
+    case 'STALE':
+      return 'history';
+    case 'FAILED':
+      return 'error';
+    case 'RUNNING':
+      return 'sync';
     case 'PENDING':
       return 'play-circle';
   }
 }
 
-function statusFor(
-  summary: DiagnosticSummary | undefined
-): 'PENDING' | 'PASS' | 'WARN' | 'FAIL' {
+type ValidationStatus =
+  | 'PENDING'
+  | 'PASS'
+  | 'WARN'
+  | 'FAIL'
+  | 'STALE'
+  | 'FAILED'
+  | 'RUNNING';
+
+function statusFor(summary: DiagnosticSummary | undefined): ValidationStatus {
   if (!summary) {
     return 'PENDING';
+  }
+  if (summary.freshness === 'stale') {
+    return 'STALE';
+  }
+  if (summary.freshness === 'failed') {
+    return 'FAILED';
+  }
+  if (summary.freshness === 'running') {
+    return 'RUNNING';
+  }
+  if (summary.freshness === 'never-run') {
+    return 'PENDING';
+  }
+  if (summary.freshness === 'fresh-clean') {
+    return 'PASS';
   }
   if (summary.errors > 0) {
     return 'FAIL';

--- a/apps/vscode-extension/src/state/stateStores.ts
+++ b/apps/vscode-extension/src/state/stateStores.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import type {
+  DiagnosticFreshness,
   DiagnosticSummary,
   McpCapabilityCard,
   McpConnectionState,
@@ -106,16 +107,21 @@ export interface DiagnosticStateSnapshot {
   }>;
 }
 
-interface LatestDrcRun {
+type ValidationSource = Extract<DiagnosticSummary['source'], 'drc' | 'erc'>;
+
+interface LatestValidationRun {
   file: string;
   diagnostics: vscode.Diagnostic[];
   summary: DiagnosticSummary;
 }
 
+type LatestDrcRun = LatestValidationRun;
+
 interface ProjectDiagnostics {
   drc: DiagnosticSummary | undefined;
   erc: DiagnosticSummary | undefined;
   latestDrcRun: LatestDrcRun | undefined;
+  latestErcRun: LatestValidationRun | undefined;
 }
 
 export class DiagnosticStateStore implements vscode.Disposable {
@@ -125,6 +131,7 @@ export class DiagnosticStateStore implements vscode.Disposable {
   private drc: DiagnosticSummary | undefined;
   private erc: DiagnosticSummary | undefined;
   private latestDrcRun: LatestDrcRun | undefined;
+  private latestErcRun: LatestValidationRun | undefined;
   private activeProjectId: string | undefined;
   private readonly projectDiagnostics = new Map<string, ProjectDiagnostics>();
 
@@ -144,38 +151,133 @@ export class DiagnosticStateStore implements vscode.Disposable {
     options: { project?: ProjectContext | undefined; projectId?: string } = {}
   ): DiagnosticStateSnapshot {
     this.diagnostics.set(uri, diagnostics);
-    const nextSummary = cloneSummary(summary);
     const projectId = options.project?.id ?? options.projectId;
-    const projectState = projectId
-      ? (this.projectDiagnostics.get(projectId) ?? {
-          drc: undefined,
-          erc: undefined,
-          latestDrcRun: undefined
-        })
-      : undefined;
+    const projectState = this.getOrCreateProjectDiagnostics(projectId);
+    const nextSummary = normalizeDiagnosticSummary(summary, {
+      uri,
+      project: options.project,
+      projectId
+    });
 
-    if (summary.source === 'drc') {
+    if (nextSummary.source === 'drc') {
       this.drc = nextSummary;
       this.latestDrcRun = {
-        file: summary.file,
+        file: nextSummary.file,
         diagnostics: [...diagnostics],
         summary: nextSummary
       };
       if (projectState) {
         projectState.drc = nextSummary;
         projectState.latestDrcRun = {
-          file: summary.file,
+          file: nextSummary.file,
           diagnostics: [...diagnostics],
           summary: nextSummary
         };
       }
     }
-    if (summary.source === 'erc') {
+    if (nextSummary.source === 'erc') {
       this.erc = nextSummary;
+      this.latestErcRun = {
+        file: nextSummary.file,
+        diagnostics: [...diagnostics],
+        summary: nextSummary
+      };
       if (projectState) {
         projectState.erc = nextSummary;
+        projectState.latestErcRun = {
+          file: nextSummary.file,
+          diagnostics: [...diagnostics],
+          summary: nextSummary
+        };
       }
     }
+    if (projectId && projectState) {
+      this.projectDiagnostics.set(projectId, projectState);
+    }
+    const snapshot = this.getSnapshot();
+    this.onDidChangeEmitter.fire(snapshot);
+    return snapshot;
+  }
+
+  recordValidationFailure(
+    source: ValidationSource,
+    uri: vscode.Uri,
+    error: unknown,
+    options: { project?: ProjectContext | undefined; projectId?: string } = {}
+  ): DiagnosticStateSnapshot {
+    const projectId = options.project?.id ?? options.projectId;
+    const projectState = this.getOrCreateProjectDiagnostics(projectId);
+    const previous =
+      this.getSummaryForSource(source, projectState) ??
+      this.getSummaryForSource(source);
+    const nextSummary = normalizeDiagnosticSummary(
+      {
+        ...(previous ?? {
+          file: uri.fsPath,
+          errors: 0,
+          warnings: 0,
+          infos: 0,
+          source
+        }),
+        file: previous?.file ?? uri.fsPath,
+        source,
+        freshness: 'failed',
+        failureMessage: formatErrorMessage(error),
+        lastGoodCapturedAt: lastGoodTimestamp(previous),
+        capturedAt: new Date().toISOString()
+      },
+      { uri, project: options.project, projectId }
+    );
+
+    this.setSummaryForSource(source, nextSummary, projectState);
+    if (projectId && projectState) {
+      this.projectDiagnostics.set(projectId, projectState);
+    }
+    const snapshot = this.getSnapshot();
+    this.onDidChangeEmitter.fire(snapshot);
+    return snapshot;
+  }
+
+  markStaleForResource(
+    uri: vscode.Uri,
+    reason: string,
+    options: { project?: ProjectContext | undefined; projectId?: string } = {}
+  ): DiagnosticStateSnapshot {
+    const source = validationSourceForUri(uri);
+    if (!source) {
+      return this.getSnapshot();
+    }
+    return this.markValidationStale(source, uri, reason, options);
+  }
+
+  markValidationStale(
+    source: ValidationSource,
+    uri: vscode.Uri,
+    reason: string,
+    options: { project?: ProjectContext | undefined; projectId?: string } = {}
+  ): DiagnosticStateSnapshot {
+    const projectId = options.project?.id ?? options.projectId;
+    const projectState = this.getOrCreateProjectDiagnostics(projectId);
+    const previous =
+      this.getSummaryForSource(source, projectState) ??
+      this.getSummaryForSource(source);
+    if (!previous) {
+      return this.getSnapshot();
+    }
+
+    const nextSummary = normalizeDiagnosticSummary(
+      {
+        ...previous,
+        file: previous.file || uri.fsPath,
+        source,
+        freshness: 'stale',
+        staleReason: reason,
+        lastGoodCapturedAt: lastGoodTimestamp(previous)
+      },
+      { uri, project: options.project, projectId }
+    );
+    this.setSummaryForSource(source, nextSummary, projectState);
+    this.markProblemsDiagnosticsStale(source, uri, reason, projectState);
     if (projectId && projectState) {
       this.projectDiagnostics.set(projectId, projectState);
     }
@@ -214,15 +316,15 @@ export class DiagnosticStateStore implements vscode.Disposable {
         : useProjectScope
           ? undefined
           : this.drc
-          ? cloneSummary(this.drc)
-          : undefined,
+            ? cloneSummary(this.drc)
+            : undefined,
       erc: projectState?.erc
         ? cloneSummary(projectState.erc)
         : useProjectScope
           ? undefined
           : this.erc
-          ? cloneSummary(this.erc)
-          : undefined,
+            ? cloneSummary(this.erc)
+            : undefined,
       activeProjectId: this.activeProjectId,
       projects: [...this.projectDiagnostics.entries()].map(
         ([entryProjectId, state]) => ({
@@ -240,6 +342,75 @@ export class DiagnosticStateStore implements vscode.Disposable {
 
   dispose(): void {
     this.onDidChangeEmitter.dispose();
+  }
+
+  private getOrCreateProjectDiagnostics(
+    projectId: string | undefined
+  ): ProjectDiagnostics | undefined {
+    return projectId
+      ? (this.projectDiagnostics.get(projectId) ?? {
+          drc: undefined,
+          erc: undefined,
+          latestDrcRun: undefined,
+          latestErcRun: undefined
+        })
+      : undefined;
+  }
+
+  private getSummaryForSource(
+    source: ValidationSource,
+    projectState?: ProjectDiagnostics | undefined
+  ): DiagnosticSummary | undefined {
+    if (projectState) {
+      return source === 'drc' ? projectState.drc : projectState.erc;
+    }
+    return source === 'drc' ? this.drc : this.erc;
+  }
+
+  private setSummaryForSource(
+    source: ValidationSource,
+    summary: DiagnosticSummary,
+    projectState?: ProjectDiagnostics | undefined
+  ): void {
+    if (source === 'drc') {
+      this.drc = summary;
+      if (projectState) {
+        projectState.drc = summary;
+      }
+      return;
+    }
+    this.erc = summary;
+    if (projectState) {
+      projectState.erc = summary;
+    }
+  }
+
+  private getLatestRunForSource(
+    source: ValidationSource,
+    projectState?: ProjectDiagnostics | undefined
+  ): LatestValidationRun | undefined {
+    if (source === 'drc') {
+      return projectState?.latestDrcRun ?? this.latestDrcRun;
+    }
+    return projectState?.latestErcRun ?? this.latestErcRun;
+  }
+
+  private markProblemsDiagnosticsStale(
+    source: ValidationSource,
+    uri: vscode.Uri,
+    reason: string,
+    projectState?: ProjectDiagnostics | undefined
+  ): void {
+    const latest = this.getLatestRunForSource(source, projectState);
+    if (!latest?.diagnostics.length) {
+      return;
+    }
+    this.diagnostics.set(
+      uri,
+      latest.diagnostics.map((diagnostic) =>
+        cloneStaleDiagnostic(diagnostic, source, reason)
+      )
+    );
   }
 }
 
@@ -314,7 +485,9 @@ export class ViewerStateStore implements vscode.Disposable {
     return {
       viewers: [...this.viewers.values()].map((viewer) => ({
         uri: viewer.uri.toString(),
-        project: viewer.project ? cloneProjectContext(viewer.project) : undefined,
+        project: viewer.project
+          ? cloneProjectContext(viewer.project)
+          : undefined,
         state: viewer.state ? cloneViewerState(viewer.state) : undefined,
         error: viewer.error,
         status: viewer.status
@@ -389,8 +562,8 @@ export class McpStateStore implements vscode.Disposable {
             ...snapshot.server,
             capabilities: {
               ...snapshot.server.capabilities,
-              diagnostics: snapshot.server.capabilities.diagnostics?.map((value) =>
-                redactSensitiveText(value)
+              diagnostics: snapshot.server.capabilities.diagnostics?.map(
+                (value) => redactSensitiveText(value)
               ),
               serverInfo: snapshot.server.capabilities.serverInfo
                 ? {
@@ -526,7 +699,95 @@ export class ExportStateStore implements vscode.Disposable {
 }
 
 function cloneSummary(summary: DiagnosticSummary): DiagnosticSummary {
-  return { ...summary };
+  return {
+    ...summary,
+    commandArgs: summary.commandArgs ? [...summary.commandArgs] : undefined
+  };
+}
+
+function normalizeDiagnosticSummary(
+  summary: DiagnosticSummary,
+  context: {
+    uri?: vscode.Uri | undefined;
+    project?: ProjectContext | undefined;
+    projectId?: string | undefined;
+  } = {}
+): DiagnosticSummary {
+  const next = cloneSummary(summary);
+  next.fileUri = next.fileUri ?? context.uri?.toString();
+  next.projectId = next.projectId ?? context.project?.id ?? context.projectId;
+  next.projectName = next.projectName ?? context.project?.name;
+  next.origin = next.origin ?? defaultDiagnosticOrigin(next.source);
+  next.freshness = next.freshness ?? inferDiagnosticFreshness(next);
+  return next;
+}
+
+function inferDiagnosticFreshness(
+  summary: DiagnosticSummary
+): DiagnosticFreshness {
+  return summary.errors + summary.warnings + summary.infos > 0
+    ? 'fresh-dirty'
+    : 'fresh-clean';
+}
+
+function defaultDiagnosticOrigin(
+  source: DiagnosticSummary['source']
+): NonNullable<DiagnosticSummary['origin']> {
+  return source === 'syntax' ? 'syntax' : 'kicad-cli';
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function lastGoodTimestamp(
+  summary: DiagnosticSummary | undefined
+): string | undefined {
+  if (!summary) {
+    return undefined;
+  }
+  if (
+    summary.freshness === 'fresh-clean' ||
+    summary.freshness === 'fresh-dirty' ||
+    !summary.freshness
+  ) {
+    return summary.capturedAt;
+  }
+  return summary.lastGoodCapturedAt;
+}
+
+function validationSourceForUri(uri: vscode.Uri): ValidationSource | undefined {
+  const filePath = uri.fsPath.toLowerCase();
+  if (filePath.endsWith('.kicad_pcb')) {
+    return 'drc';
+  }
+  if (filePath.endsWith('.kicad_sch')) {
+    return 'erc';
+  }
+  return undefined;
+}
+
+function cloneStaleDiagnostic(
+  diagnostic: vscode.Diagnostic,
+  source: ValidationSource,
+  reason: string
+): vscode.Diagnostic {
+  const stale = new vscode.Diagnostic(
+    diagnostic.range,
+    `[stale] ${diagnostic.message} (${reason})`,
+    diagnostic.severity
+  );
+  stale.source = `${diagnostic.source ?? `kicad-cli:${source}`}:stale`;
+  if (typeof diagnostic.code !== 'undefined') {
+    stale.code = diagnostic.code;
+  }
+  if (diagnostic.relatedInformation) {
+    stale.relatedInformation = [...diagnostic.relatedInformation];
+  }
+  if (diagnostic.tags) {
+    stale.tags = [...diagnostic.tags];
+  }
+  return stale;
 }
 
 function cloneViewerState(state: ViewerState): ViewerState {
@@ -538,7 +799,9 @@ function cloneViewerState(state: ViewerState): ViewerState {
   };
 }
 
-function cloneMcpConnectionState(state: McpConnectionState): McpConnectionState {
+function cloneMcpConnectionState(
+  state: McpConnectionState
+): McpConnectionState {
   return {
     ...state,
     install: cloneInstall(state.install),

--- a/apps/vscode-extension/src/statusbar/kicadStatusBar.ts
+++ b/apps/vscode-extension/src/statusbar/kicadStatusBar.ts
@@ -194,55 +194,11 @@ export class KiCadStatusBar implements vscode.Disposable {
   }
 
   private renderDrc(): void {
-    if (!this.drc) {
-      this.drcItem.hide();
-      this.drcItem.backgroundColor = undefined;
-      return;
-    }
-    this.drcItem.show();
-    if (this.drc.errors > 0) {
-      this.drcItem.text = `$(error) DRC: ${this.drc.errors}`;
-      this.drcItem.tooltip = this.diagnosticTooltip('DRC', this.drc);
-      this.drcItem.backgroundColor = new vscode.ThemeColor(
-        'statusBarItem.errorBackground'
-      );
-    } else if (this.drc.warnings > 0) {
-      this.drcItem.text = `$(warning) DRC: ${this.drc.warnings}`;
-      this.drcItem.tooltip = this.diagnosticTooltip('DRC', this.drc);
-      this.drcItem.backgroundColor = new vscode.ThemeColor(
-        'statusBarItem.warningBackground'
-      );
-    } else {
-      this.drcItem.text = '$(pass) DRC';
-      this.drcItem.tooltip = this.diagnosticTooltip('DRC', this.drc);
-      this.drcItem.backgroundColor = undefined;
-    }
+    this.renderDiagnosticItem(this.drcItem, 'DRC', this.drc);
   }
 
   private renderErc(): void {
-    if (!this.erc) {
-      this.ercItem.hide();
-      this.ercItem.backgroundColor = undefined;
-      return;
-    }
-    this.ercItem.show();
-    if (this.erc.errors > 0) {
-      this.ercItem.text = `$(error) ERC: ${this.erc.errors}`;
-      this.ercItem.tooltip = this.diagnosticTooltip('ERC', this.erc);
-      this.ercItem.backgroundColor = new vscode.ThemeColor(
-        'statusBarItem.errorBackground'
-      );
-    } else if (this.erc.warnings > 0) {
-      this.ercItem.text = `$(warning) ERC: ${this.erc.warnings}`;
-      this.ercItem.tooltip = this.diagnosticTooltip('ERC', this.erc);
-      this.ercItem.backgroundColor = new vscode.ThemeColor(
-        'statusBarItem.warningBackground'
-      );
-    } else {
-      this.ercItem.text = '$(pass) ERC';
-      this.ercItem.tooltip = this.diagnosticTooltip('ERC', this.erc);
-      this.ercItem.backgroundColor = undefined;
-    }
+    this.renderDiagnosticItem(this.ercItem, 'ERC', this.erc);
   }
 
   private renderValidationSeparator(): void {
@@ -384,12 +340,74 @@ export class KiCadStatusBar implements vscode.Disposable {
     label: 'DRC' | 'ERC',
     summary: DiagnosticSummary
   ): string {
-    return [
+    const lines = [
       `${label}: ${summary.errors} error(s), ${summary.warnings} warning(s), ${summary.infos} info.`,
+      `Freshness: ${summary.freshness ?? 'not recorded'}`,
+      `Origin: ${summary.origin ?? 'not recorded'}`,
       `Source: ${summary.file}`,
+      ...(summary.fileUri ? [`URI: ${summary.fileUri}`] : []),
+      ...(summary.projectName || summary.projectId
+        ? [`Project: ${summary.projectName ?? summary.projectId}`]
+        : []),
       `Updated: ${formatTimestamp(summary.capturedAt)}`,
+      ...(summary.kicadVersion ? [`KiCad CLI: ${summary.kicadVersion}`] : []),
+      ...(summary.reportPath ? [`Report: ${summary.reportPath}`] : []),
+      ...(summary.commandArgs?.length
+        ? [`Command: kicad-cli ${summary.commandArgs.join(' ')}`]
+        : []),
+      ...(summary.staleReason ? [`Stale reason: ${summary.staleReason}`] : []),
+      ...(summary.failureMessage ? [`Failure: ${summary.failureMessage}`] : []),
+      ...(summary.lastGoodCapturedAt
+        ? [`Last good result: ${formatTimestamp(summary.lastGoodCapturedAt)}`]
+        : []),
       'Click to re-run and refresh Problems.'
-    ].join('\n');
+    ];
+    return lines.join('\n');
+  }
+
+  private renderDiagnosticItem(
+    item: vscode.StatusBarItem,
+    label: 'DRC' | 'ERC',
+    summary: DiagnosticSummary | undefined
+  ): void {
+    if (!summary) {
+      item.hide();
+      item.backgroundColor = undefined;
+      return;
+    }
+    item.show();
+    item.tooltip = this.diagnosticTooltip(label, summary);
+    if (summary.freshness === 'stale') {
+      item.text = `$(history) ${label} stale`;
+      item.backgroundColor = undefined;
+      return;
+    }
+    if (summary.freshness === 'failed') {
+      item.text = `$(error) ${label} failed`;
+      item.backgroundColor = new vscode.ThemeColor(
+        'statusBarItem.warningBackground'
+      );
+      return;
+    }
+    if (summary.freshness === 'running') {
+      item.text = `$(sync~spin) ${label}`;
+      item.backgroundColor = undefined;
+      return;
+    }
+    if (summary.errors > 0) {
+      item.text = `$(error) ${label}: ${summary.errors}`;
+      item.backgroundColor = new vscode.ThemeColor(
+        'statusBarItem.errorBackground'
+      );
+    } else if (summary.warnings > 0) {
+      item.text = `$(warning) ${label}: ${summary.warnings}`;
+      item.backgroundColor = new vscode.ThemeColor(
+        'statusBarItem.warningBackground'
+      );
+    } else {
+      item.text = `$(pass) ${label}`;
+      item.backgroundColor = undefined;
+    }
   }
 }
 

--- a/apps/vscode-extension/src/types.ts
+++ b/apps/vscode-extension/src/types.ts
@@ -4,10 +4,7 @@ import type {
   McpServerInfoContract
 } from '@oaslananka/kicad-protocol-schemas';
 
-export type {
-  McpServerInfoCompatibilityRange,
-  McpServerInfoContract
-};
+export type { McpServerInfoCompatibilityRange, McpServerInfoContract };
 
 export interface FileReference {
   uri: vscode.Uri;
@@ -236,6 +233,21 @@ export interface AIProviderCapabilities {
   supportsStreaming: boolean;
 }
 
+export type DiagnosticFreshness =
+  | 'never-run'
+  | 'running'
+  | 'fresh-clean'
+  | 'fresh-dirty'
+  | 'stale'
+  | 'failed';
+
+export type DiagnosticOrigin =
+  | 'kicad-cli'
+  | 'mcp'
+  | 'cached-report'
+  | 'manual-import'
+  | 'syntax';
+
 export interface DiagnosticSummary {
   file: string;
   errors: number;
@@ -243,6 +255,17 @@ export interface DiagnosticSummary {
   infos: number;
   source: 'drc' | 'erc' | 'syntax';
   capturedAt?: string | undefined;
+  fileUri?: string | undefined;
+  projectId?: string | undefined;
+  projectName?: string | undefined;
+  freshness?: DiagnosticFreshness | undefined;
+  origin?: DiagnosticOrigin | undefined;
+  kicadVersion?: string | undefined;
+  reportPath?: string | undefined;
+  commandArgs?: string[] | undefined;
+  staleReason?: string | undefined;
+  failureMessage?: string | undefined;
+  lastGoodCapturedAt?: string | undefined;
 }
 
 export interface ProjectContext {

--- a/apps/vscode-extension/test/unit/kicadStatusBar.test.ts
+++ b/apps/vscode-extension/test/unit/kicadStatusBar.test.ts
@@ -172,6 +172,23 @@ describe('KiCadStatusBar', () => {
       expect(item(1).backgroundColor).toBeUndefined();
       bar.dispose();
     });
+
+    it('does not render stale DRC errors as current failures', () => {
+      const bar = makeBar();
+      const staleDrc = {
+        ...makeDrc({ errors: 5, warnings: 2 }),
+        freshness: 'stale',
+        staleReason: 'Viewer reloaded after source file changed.'
+      } as DiagnosticSummary;
+
+      bar.update({ drc: staleDrc });
+
+      expect(item(1).text).toContain('stale');
+      expect(item(1).text).not.toContain('5');
+      expect(item(1).backgroundColor).toBeUndefined();
+      expect(item(1).tooltip).toContain('Viewer reloaded');
+      bar.dispose();
+    });
   });
 
   describe('ERC item (index 2)', () => {

--- a/apps/vscode-extension/test/unit/stateStores.test.ts
+++ b/apps/vscode-extension/test/unit/stateStores.test.ts
@@ -62,20 +62,125 @@ describe('extension state stores', () => {
     expect(store.getSnapshot()).toMatchObject({
       drc: {
         file: boardUri.fsPath,
-        errors: 0
+        errors: 0,
+        freshness: 'fresh-clean',
+        origin: 'kicad-cli'
       },
       erc: undefined
     });
     expect(store.getLatestDrcRun()).toEqual({
       file: boardUri.fsPath,
       diagnostics: [],
-      summary: expect.objectContaining({ errors: 0, source: 'drc' })
+      summary: expect.objectContaining({
+        errors: 0,
+        source: 'drc',
+        freshness: 'fresh-clean',
+        origin: 'kicad-cli'
+      })
     });
     expect(store.getDiagnosticBundleSnapshot()).toEqual({
-      drc: expect.objectContaining({ errors: 0, source: 'drc' }),
+      drc: expect.objectContaining({
+        errors: 0,
+        source: 'drc',
+        freshness: 'fresh-clean',
+        origin: 'kicad-cli'
+      }),
       erc: undefined,
       activeProjectId: undefined,
       projects: []
+    });
+  });
+
+  it('marks dirty validation results as fresh-dirty', () => {
+    const collection = createDiagnosticsCollection();
+    const store = new DiagnosticStateStore(collection);
+    const boardUri = vscode.Uri.file('/workspace/demo.kicad_pcb');
+    const violation = createDiagnostic('Clearance violation');
+
+    store.applyValidationResult(boardUri, [violation], {
+      file: boardUri.fsPath,
+      errors: 1,
+      warnings: 0,
+      infos: 0,
+      source: 'drc'
+    });
+
+    expect(store.getSnapshot().drc).toMatchObject({
+      errors: 1,
+      freshness: 'fresh-dirty',
+      origin: 'kicad-cli'
+    });
+  });
+
+  it('records failed validation without replacing the last known good Problems entries', () => {
+    const collection = createDiagnosticsCollection();
+    const store = new DiagnosticStateStore(collection);
+    const boardUri = vscode.Uri.file('/workspace/demo.kicad_pcb');
+
+    store.applyValidationResult(boardUri, [], {
+      file: boardUri.fsPath,
+      errors: 0,
+      warnings: 0,
+      infos: 0,
+      source: 'drc',
+      capturedAt: '2026-05-25T08:00:00.000Z'
+    });
+
+    (
+      store as DiagnosticStateStore & {
+        recordValidationFailure(
+          source: 'drc' | 'erc',
+          uri: vscode.Uri,
+          error: unknown,
+          options?: { projectId?: string }
+        ): void;
+      }
+    ).recordValidationFailure(
+      'drc',
+      boardUri,
+      new Error('kicad-cli exited with code 1')
+    );
+
+    expect(collection.set).toHaveBeenCalledTimes(1);
+    expect(store.getSnapshot().drc).toMatchObject({
+      file: boardUri.fsPath,
+      errors: 0,
+      freshness: 'failed',
+      failureMessage: 'kicad-cli exited with code 1',
+      lastGoodCapturedAt: '2026-05-25T08:00:00.000Z'
+    });
+  });
+
+  it('marks viewer-reloaded validation diagnostics as stale in state and Problems', () => {
+    const collection = createDiagnosticsCollection();
+    const store = new DiagnosticStateStore(collection);
+    const boardUri = vscode.Uri.file('/workspace/demo.kicad_pcb');
+    const violation = createDiagnostic('Clearance violation');
+
+    store.applyValidationResult(boardUri, [violation], {
+      file: boardUri.fsPath,
+      errors: 1,
+      warnings: 0,
+      infos: 0,
+      source: 'drc',
+      capturedAt: '2026-05-25T08:00:00.000Z'
+    });
+
+    store.markStaleForResource(
+      boardUri,
+      'Viewer reloaded after source file changed.'
+    );
+
+    expect(collection.set).toHaveBeenLastCalledWith(boardUri, [
+      expect.objectContaining({
+        message: expect.stringContaining('[stale] Clearance violation'),
+        source: 'kicad-cli:drc:stale'
+      })
+    ]);
+    expect(store.getSnapshot().drc).toMatchObject({
+      freshness: 'stale',
+      staleReason: 'Viewer reloaded after source file changed.',
+      lastGoodCapturedAt: '2026-05-25T08:00:00.000Z'
     });
   });
 
@@ -165,7 +270,8 @@ describe('extension state stores', () => {
       'sk-mcp-secret'
     );
     expect(
-      mcp.getDiagnosticBundleSnapshot().server?.capabilities.serverInfo?.diagnostics
+      mcp.getDiagnosticBundleSnapshot().server?.capabilities.serverInfo
+        ?.diagnostics
     ).toEqual(['password=***']);
     expect(exports.getDiagnosticBundleSnapshot()).toEqual({
       surfaces: [

--- a/apps/vscode-extension/test/unit/validationViewProvider.test.ts
+++ b/apps/vscode-extension/test/unit/validationViewProvider.test.ts
@@ -49,8 +49,32 @@ describe('ValidationViewProvider', () => {
     expect(rows.map((row) => row.label)).toEqual(['DRC', 'ERC']);
     expect(provider.getTreeItem(rows[0]!).description).toContain('PASS');
     expect(provider.getTreeItem(rows[1]!).description).toContain('WARN');
-    expect(provider.getTreeItem(rows[1]!).tooltip).toContain(
-      schematic.fsPath
-    );
+    expect(provider.getTreeItem(rows[1]!).tooltip).toContain(schematic.fsPath);
+  });
+
+  it('shows stale validation freshness instead of treating cached errors as current', () => {
+    const diagnostics = new DiagnosticStateStore(createDiagnosticsCollection());
+    const provider = new ValidationViewProvider(diagnostics);
+    const board = vscode.Uri.file('/workspace/demo.kicad_pcb');
+
+    diagnostics.applyValidationResult(board, [], {
+      file: board.fsPath,
+      errors: 5,
+      warnings: 2,
+      infos: 0,
+      source: 'drc',
+      capturedAt: '2026-05-21T05:00:00.000Z',
+      freshness: 'stale',
+      staleReason: 'Viewer reloaded after source file changed.',
+      origin: 'kicad-cli'
+    } as never);
+
+    const [row] = provider.getChildren();
+    const item = provider.getTreeItem(row!);
+
+    expect(item.description).toContain('STALE');
+    expect(item.description).not.toContain('FAIL');
+    expect(item.tooltip).toContain('Viewer reloaded');
+    expect(item.tooltip).toContain('kicad-cli');
   });
 });

--- a/apps/vscode-extension/test/unit/viewerProviders.test.ts
+++ b/apps/vscode-extension/test/unit/viewerProviders.test.ts
@@ -147,6 +147,40 @@ describe.each([
     );
   });
 
+  it('notifies diagnostics when a visible viewer reloads', async () => {
+    const onViewerReload = jest.fn();
+    const provider = new (ContextProvider as never as {
+      new (
+        context: vscode.ExtensionContext,
+        svgFallbackProvider: undefined,
+        viewerState: ViewerStateStore,
+        resolveProject: undefined,
+        onViewerReload: (uri: vscode.Uri) => void
+      ): InstanceType<typeof ContextProvider>;
+    })(
+      {
+        extensionUri: vscode.Uri.file('/extension')
+      } as vscode.ExtensionContext,
+      undefined,
+      new ViewerStateStore(),
+      undefined,
+      onViewerReload
+    );
+    const panel = createPanel();
+    const document = {
+      uri: vscode.Uri.file(tempFile)
+    } as vscode.CustomDocument;
+
+    await provider.resolveCustomEditor(
+      document,
+      panel as unknown as vscode.WebviewPanel
+    );
+
+    await (provider as any).refreshDocument(document.uri);
+
+    expect(onViewerReload).toHaveBeenCalledWith(document.uri, undefined);
+  });
+
   it('keeps hidden viewers out of loading state until refresh becomes visible', async () => {
     const viewerState = new ViewerStateStore();
     const provider = new (ContextProvider as never as {


### PR DESCRIPTION
## Summary
- add explicit diagnostic freshness/origin metadata for DRC/ERC summaries
- mark failed validations without replacing the last known Problems diagnostics
- mark viewer reloads as stale and surface freshness in the status bar and validation tree
- include KiCad CLI version, report path, command args, file URI, and project metadata on validation summaries

## Validation
- corepack pnpm install --frozen-lockfile
- corepack pnpm run format:check
- corepack pnpm run lint
- corepack pnpm run typecheck
- corepack pnpm run test
- corepack pnpm run build
- corepack pnpm run verify:dist
- corepack pnpm --filter kicadstudio run audit:ci
- uvx pre-commit run --all-files

Closes #70
Linear: https://linear.app/oaslananka/issue/OASLANA-69/add-diagnostic-freshness-model-across-problems-status-bar-and
