### PR TITLE
docs(kicad-studio/kicad-mcp-pro): add agent MCP onboarding pack

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,41 @@
+# GitHub Copilot Instructions
+
+Follow `AGENTS.md` for repository-wide rules.
+
+## Project Shape
+
+- `apps/vscode-extension` contains the VS Code extension.
+- `packages/mcp-server` contains the Python `kicad-mcp-pro` MCP server.
+- `packages/mcp-npm` contains the npm launcher wrapper.
+- `packages/test-harness` contains private shared test helpers.
+
+## Coding Rules
+
+- Keep pull requests scoped to one issue.
+- Prefer existing helpers, schemas, fixtures, and validation scripts over new parallel
+  patterns.
+- Update docs when user-visible behavior, commands, settings, or MCP config changes.
+- Do not add release, tag, or publish behavior unless the issue is explicitly a release
+  task.
+- Do not commit secrets, local credential files, or machine-specific production paths.
+
+## Validation
+
+Run the narrowest relevant test first, then the root gates when the change is ready:
+
+```bash
+corepack pnpm install --frozen-lockfile
+corepack pnpm run lint
+corepack pnpm run typecheck
+corepack pnpm run test
+corepack pnpm run build
+corepack pnpm run verify:dist
+```
+
+For MCP server or Python changes, also run the Python validation documented in
+`AGENTS.md`.
+
+## MCP Defaults
+
+Use `examples/mcp-clients/` for copyable client setup. Keep examples in
+`readonly` operating mode by default and use a focused profile such as `analysis`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - run: corepack pnpm run check:compatibility
       - run: corepack pnpm run check:governance
+      - run: corepack pnpm run check:agent-configs
 
   vscode-extension:
     needs: ci-lanes

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -2,11 +2,12 @@
   "servers": {
     "kicad": {
       "type": "stdio",
-      "command": "kicad-mcp-pro",
-      "args": [],
+      "command": "uvx",
+      "args": ["kicad-mcp-pro"],
       "env": {
-        "KICAD_MCP_PROJECT_DIR": "${workspaceFolder}/test/fixtures/sample_project",
-        "KICAD_MCP_PROFILE": "full"
+        "KICAD_MCP_WORKSPACE_ROOT": "${workspaceFolder}",
+        "KICAD_MCP_PROFILE": "analysis",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       }
     }
   }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,14 +22,15 @@
     {
       "label": "Start kicad-mcp-pro (HTTP)",
       "type": "shell",
-      "command": "kicad-mcp-pro",
-      "args": ["--transport", "http", "--port", "27185"],
+      "command": "uvx",
+      "args": ["kicad-mcp-pro", "--transport", "http", "--port", "27185"],
       "isBackground": true,
       "problemMatcher": [],
       "options": {
         "env": {
-          "KICAD_MCP_PROJECT_DIR": "${workspaceFolder}/test/fixtures/sample_project",
-          "KICAD_MCP_PROFILE": "full"
+          "KICAD_MCP_WORKSPACE_ROOT": "${workspaceFolder}",
+          "KICAD_MCP_PROFILE": "analysis",
+          "KICAD_MCP_OPERATING_MODE": "readonly"
         }
       },
       "presentation": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# KiCad Studio Kit Agent Instructions
+
+This file is the repository-local contract for coding agents. Follow higher-priority
+system and operator instructions first, then these repo rules.
+
+## Repository Boundaries
+
+- Canonical repo: `oaslananka/kicad-studio-kit`.
+- Product surfaces:
+  - `apps/vscode-extension`: KiCad Studio VS Code extension.
+  - `packages/mcp-server`: `kicad-mcp-pro` Python MCP server.
+  - `packages/mcp-npm`: npm launcher wrapper.
+  - `packages/test-harness`: private shared test utilities.
+- Do not introduce another canonical repository or release root.
+- Keep issue scope narrow. Do not mix unrelated Linear/GitHub issues in one branch or PR.
+
+## Required First Reads
+
+Before changing behavior, read the relevant source, tests, docs, manifests, and workflow
+files. For repo-wide orientation, start with:
+
+- `README.md`
+- `docs/architecture/repo-structure.md`
+- `docs/architecture/product-boundaries.md`
+- `docs/testing-strategy.md`
+- `packages/mcp-server/docs/client-configuration.md`
+- `docs/agents/client-configs.md`
+- `docs/agents/codex-support.md`
+
+## Local Commands
+
+Use the repository package managers and lockfiles. From the repo root:
+
+```bash
+corepack pnpm install --frozen-lockfile
+corepack pnpm run lint
+corepack pnpm run typecheck
+corepack pnpm run test
+corepack pnpm run build
+corepack pnpm run verify:dist
+```
+
+When Python or MCP server code changes, also run:
+
+```bash
+uv sync --all-extras --frozen --project packages/mcp-server
+uv run --project packages/mcp-server --all-extras pytest
+```
+
+Repo-policy checks that are often relevant:
+
+```bash
+corepack pnpm run check:agent-configs
+corepack pnpm run check:ci-lanes
+corepack pnpm run docs:lint
+corepack pnpm run docs:links
+```
+
+## MCP Safety Defaults
+
+- Default external MCP examples to `KICAD_MCP_OPERATING_MODE=readonly`.
+- Prefer focused profiles such as `analysis`, `pcb_only`, `schematic_only`, or
+  `manufacturing` instead of `full`.
+- Use `write`, `manufacturing`, or `experimental` only when the task explicitly needs that
+  tool surface and the PR documents the reason.
+- Do not commit machine-specific production paths, fixture paths as defaults, tokens, API
+  keys, cookies, or private credentials.
+- Client setup examples live in `examples/mcp-clients/`; keep them parseable and
+  copy-pastable after replacing `/absolute/path/to/your/kicad-project`.
+
+## GitHub And PR Rules
+
+- Branch format for Linear work: `codex/OASLANA-<id>-<slug>`.
+- Link PRs to the corresponding Linear issue and GitHub issue when one exists.
+- PR #16 is the release bot PR; do not modify or merge it unless the explicit task is a
+  release-bot maintenance task.
+- Do not tag, publish, or run release workflows unless the task is explicitly a release.
+- After pushing a PR branch, watch required checks to a terminal state and fix failures.
+
+## Documentation Rules
+
+- User-facing behavior changes need docs updates.
+- Generated docs under `docs/extension/*.md` are refreshed with
+  `corepack pnpm run docs:generate`; do not hand-edit generated content.
+- New Markdown files under `docs/` must have exactly one H1 and valid internal links.
+
+## Secrets
+
+Never read, print, summarize, commit, or paste secret-bearing files such as `.env`,
+credential JSON, private keys, token stores, cookies, or local auth state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# Claude Repository Guide
+
+Claude Code and Claude Desktop users should treat `AGENTS.md` as the canonical
+repository instructions, then apply the Claude-specific notes below.
+
+## Working In This Repo
+
+- Keep changes scoped to one issue and one PR.
+- Read the relevant source, tests, docs, and manifests before editing.
+- Use `rg` for searches and the root validation commands documented in `AGENTS.md`.
+- Do not modify release PR #16 unless explicitly assigned a release-bot maintenance task.
+- Do not commit secrets or local machine paths.
+
+## Claude MCP Setup
+
+Use the checked-in examples under `examples/mcp-clients/`:
+
+- `claude-code.mcp.example.json` for project-scoped Claude Code setup.
+- `claude-desktop.config.example.json` for Claude Desktop.
+
+Replace `/absolute/path/to/your/kicad-project` with the target KiCad project path before
+copying a config into a real client location.
+
+Recommended local server:
+
+```bash
+claude mcp add --transport stdio --scope project \
+  --env KICAD_MCP_PROJECT_DIR=/absolute/path/to/your/kicad-project \
+  --env KICAD_MCP_PROFILE=analysis \
+  --env KICAD_MCP_OPERATING_MODE=readonly \
+  kicad -- uvx kicad-mcp-pro
+```
+
+Use broader MCP operating modes only for tasks that explicitly require write,
+manufacturing, or experimental tools.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ and best-effort KiCad CLI support for root checks and MCP tests.
 - [Dev container](docs/devcontainer.md)
 - [KiCad fixture corpus](docs/kicad-fixture-corpus.md)
 - [Integration model](docs/integration/kicad-studio-mcp.md)
+- [Agent onboarding](docs/agents/index.md)
+- [MCP client config examples](examples/mcp-clients/README.md)
 
 ## Examples
 

--- a/apps/vscode-extension/docs/AI_PROVIDERS.md
+++ b/apps/vscode-extension/docs/AI_PROVIDERS.md
@@ -2,7 +2,7 @@
 
 ## Supported Providers
 
-KiCad Studio supports six direct AI provider paths:
+KiCad Studio supports seven direct AI provider paths:
 
 - Claude
 - OpenAI
@@ -10,6 +10,7 @@ KiCad Studio supports six direct AI provider paths:
 - GitHub Copilot
 - Gemini
 - local OpenAI-compatible endpoints
+- Codex through the VS Code Language Model API
 
 For compatible VS Code builds, KiCad Studio can also contribute:
 
@@ -41,6 +42,14 @@ For compatible VS Code builds, KiCad Studio can also contribute:
 - Set `kicadstudio.ai.provider` to `copilot`.
 - Requires a VS Code environment where the Language Model API exposes Copilot models.
 - No separate API key is stored by KiCad Studio.
+
+## Codex
+
+- Set `kicadstudio.ai.provider` to `codex`.
+- Requires a VS Code environment where the Language Model API exposes compatible models.
+- No separate API key is stored by KiCad Studio.
+- This provider is a direct KiCad Studio extension provider. It does not start the Codex CLI, read `~/.codex/config.toml`, or configure Codex as an external MCP client.
+- For Codex CLI or Codex IDE extension MCP setup, use [`docs/agents/codex-support.md`](../../../docs/agents/codex-support.md) and [`examples/mcp-clients/codex.config.example.toml`](../../../examples/mcp-clients/codex.config.example.toml).
 
 ## Gemini
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -32,6 +32,7 @@ export default defineConfig({
       { text: "Install", link: "/install" },
       { text: "Extension", link: "/extension/" },
       { text: "MCP", link: "/mcp/" },
+      { text: "Agents", link: "/agents/" },
       { text: "Architecture", link: "/architecture/" },
       { text: "Support Matrix", link: "/support-matrix" },
       { text: "Changelog", link: "/changelog/" },
@@ -68,6 +69,14 @@ export default defineConfig({
           { text: "API Reference", link: "/mcp/api-reference" },
           { text: "Docker", link: "/deployment/docker" },
           { text: "Integration", link: "/integration/kicad-studio-mcp" },
+        ],
+      },
+      {
+        text: "Agents",
+        items: [
+          { text: "Overview", link: "/agents/" },
+          { text: "Client Configurations", link: "/agents/client-configs" },
+          { text: "Codex Support", link: "/agents/codex-support" },
         ],
       },
       {

--- a/docs/adr/0007-agent-onboarding-config-pack.md
+++ b/docs/adr/0007-agent-onboarding-config-pack.md
@@ -1,0 +1,61 @@
+# ADR 0007: Agent Onboarding And MCP Config Pack
+
+Status: Accepted
+
+Date: 2026-05-26
+
+## Context
+
+KiCad Studio Kit is used by repository-level coding agents and by MCP-capable clients such
+as VS Code/GitHub Copilot, Codex, Claude, Cursor, and Gemini CLI. Before this decision,
+the repo had product docs and MCP client examples, but it did not have a single onboarding
+layer that told agents where the product boundaries, validation commands, safety modes, and
+client config examples live.
+
+Current MCP client documentation checked on 2026-05-26 supports:
+
+- VS Code workspace/user `mcp.json` with top-level `servers`.
+- Codex shared MCP setup through the Codex CLI/IDE config.
+- Claude Code project-scoped `.mcp.json`.
+- Cursor `mcp.json` setup.
+- Gemini CLI `settings.json` with top-level `mcpServers`.
+- MCP stdio and Streamable HTTP transports.
+
+## Decision
+
+Ship repository-local agent onboarding and a checked-in MCP client config pack now:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `.github/copilot-instructions.md`
+- `docs/agents/`
+- `examples/mcp-clients/`
+
+Default the examples to `KICAD_MCP_OPERATING_MODE=readonly` and
+`KICAD_MCP_PROFILE=analysis`. Keep checked-in workspace config free of fixture paths and
+machine-specific production paths.
+
+Do not add Codex skills or a packaged plugin in this change. Skills should be added only
+after a workflow is stable enough to encode as a reusable procedure. Plugin distribution
+should be revisited only after repeated external reuse proves that repo-local docs and MCP
+server configuration are insufficient.
+
+## Consequences
+
+- Agents can start from root instructions instead of discovering scattered docs.
+- Client examples are parseable and copyable after replacing the project path placeholder.
+- The root VS Code MCP config is a safe developer default, not a fixture shortcut.
+- Codex is documented as both a VS Code extension provider enum and as an external MCP
+  client, with a clear boundary between those meanings.
+- CI must validate the agent docs and client examples so stale or unsafe defaults fail
+  before merge.
+
+## Future Revisit
+
+Reconsider repo-scoped skills or plugin packaging only when at least one workflow has all
+of the following:
+
+- repeated use across multiple issues,
+- stable commands and acceptance criteria,
+- dedicated validation coverage,
+- an owner for keeping the packaged instructions current.

--- a/docs/agents/client-configs.md
+++ b/docs/agents/client-configs.md
@@ -1,0 +1,64 @@
+# Agent MCP Client Configurations
+
+KiCad MCP Pro supports local stdio and Streamable HTTP MCP transports. The canonical
+copyable examples live under `examples/mcp-clients/`.
+
+Replace `/absolute/path/to/your/kicad-project` with the target KiCad project directory.
+Use an absolute path unless the client-specific documentation says workspace variables are
+expanded in MCP config files.
+
+## Setup Matrix
+
+| Client                     | Config file                                      | Transport       | Example                                                   | Notes                                                                                |
+| -------------------------- | ------------------------------------------------ | --------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| VS Code and GitHub Copilot | `.vscode/mcp.json` or user profile MCP config    | stdio           | `examples/mcp-clients/vscode.mcp.example.json`            | VS Code uses top-level `servers`. Copilot Agent mode uses the same MCP server setup. |
+| Codex CLI / IDE extension  | `~/.codex/config.toml` or trusted project config | stdio           | `examples/mcp-clients/codex.config.example.toml`          | This is Codex as an external MCP client, not the VS Code extension provider enum.    |
+| Claude Code                | `.mcp.json`                                      | stdio           | `examples/mcp-clients/claude-code.mcp.example.json`       | Project-scoped config is shareable after replacing paths.                            |
+| Claude Desktop             | `claude_desktop_config.json`                     | stdio           | `examples/mcp-clients/claude-desktop.config.example.json` | Keep user-local credentials out of this repo.                                        |
+| Cursor                     | `.cursor/mcp.json` or `~/.cursor/mcp.json`       | stdio           | `examples/mcp-clients/cursor.mcp.example.json`            | Cursor reads MCP config from `mcp.json` locations.                                   |
+| Gemini CLI                 | `~/.gemini/settings.json`                        | stdio           | `examples/mcp-clients/gemini.settings.example.json`       | The example leaves `trust` false so tools still require confirmation.                |
+| Generic stdio client       | Client-specific                                  | stdio           | `examples/mcp-clients/generic-stdio.mcp.example.json`     | Use this for clients that accept the common `mcpServers` shape.                      |
+| Generic HTTP client        | Client-specific                                  | Streamable HTTP | `examples/mcp-clients/generic-http.mcp.example.json`      | Start the local HTTP server separately on `127.0.0.1`.                               |
+
+## Recommended Environment
+
+```text
+KICAD_MCP_PROJECT_DIR=/absolute/path/to/your/kicad-project
+KICAD_MCP_PROFILE=analysis
+KICAD_MCP_OPERATING_MODE=readonly
+```
+
+`KICAD_MCP_PROFILE` narrows the tool categories. `KICAD_MCP_OPERATING_MODE` is the risk
+gate applied after the profile. Keep onboarding configs in `readonly`; switch modes only
+when the workflow explicitly needs a broader tool surface.
+
+## HTTP Startup
+
+For HTTP clients, start the server outside the client:
+
+```bash
+KICAD_MCP_PROJECT_DIR=/absolute/path/to/your/kicad-project \
+KICAD_MCP_PROFILE=analysis \
+KICAD_MCP_OPERATING_MODE=readonly \
+kicad-mcp-pro --transport http --host 127.0.0.1 --port 3334
+```
+
+Then configure the client URL as:
+
+```text
+http://127.0.0.1:3334/mcp
+```
+
+Do not bind local MCP HTTP to `0.0.0.0` as an onboarding default. If a remote deployment is
+needed, document the network boundary, authentication model, and operating mode in the PR.
+
+## Source References
+
+The config shapes were checked against the current client documentation on 2026-05-26:
+
+- VS Code MCP configuration reference: <https://code.vscode.dev/docs/copilot/customization/mcp-servers>
+- OpenAI Docs MCP Codex setup: <https://developers.openai.com/learn/docs-mcp>
+- Claude Code MCP configuration: <https://docs.anthropic.com/en/docs/claude-code/mcp>
+- Cursor MCP documentation: <https://docs.cursor.com/context/mcp>
+- Gemini CLI MCP server documentation: <https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md>
+- MCP transport specification: <https://modelcontextprotocol.io/specification/2025-06-18/basic/transports>

--- a/docs/agents/codex-support.md
+++ b/docs/agents/codex-support.md
@@ -1,0 +1,42 @@
+# Codex Support
+
+KiCad Studio Kit has two distinct Codex-related surfaces.
+
+## VS Code Extension Provider
+
+Inside the VS Code extension, `kicadstudio.ai.provider=codex` is implemented as a direct
+extension provider. It routes through the VS Code Language Model API using the local VS Code
+host and available language-model extensions. It does not read Codex CLI config, does not
+start the Codex CLI, and does not require a separate Codex API key in KiCad Studio.
+
+Related implementation and docs:
+
+- `apps/vscode-extension/src/ai/aiProvider.ts`
+- `apps/vscode-extension/src/ai/copilotProvider.ts`
+- `apps/vscode-extension/docs/AI_PROVIDERS.md`
+- [`docs/extension/settings.md`](../extension/settings.md)
+
+## External Codex MCP Client
+
+OpenAI Codex CLI and Codex IDE extension can connect to `kicad-mcp-pro` as MCP clients.
+Use `examples/mcp-clients/codex.config.example.toml` as the `~/.codex/config.toml`
+starting point, or use the CLI form below:
+
+```bash
+codex mcp add kicad \
+  --env KICAD_MCP_PROJECT_DIR=/absolute/path/to/your/kicad-project \
+  --env KICAD_MCP_PROFILE=analysis \
+  --env KICAD_MCP_OPERATING_MODE=readonly \
+  -- uvx kicad-mcp-pro
+```
+
+This external-client path gives Codex access to KiCad MCP tools. It is separate from the
+VS Code extension's `codex` provider enum.
+
+## Rule Of Thumb
+
+- Use `kicadstudio.ai.provider=codex` when working inside KiCad Studio's chat UI in VS
+  Code.
+- Use Codex MCP config when Codex is the coding agent or IDE agent connecting to
+  `kicad-mcp-pro`.
+- Do not describe the extension provider enum as the Codex CLI integration.

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -1,0 +1,18 @@
+# Agent Onboarding
+
+This section centralizes the instructions and client configuration surfaces used by
+coding agents and MCP-capable clients that work with KiCad Studio Kit.
+
+## Start Here
+
+- Repository agent rules: `AGENTS.md`
+- Claude-specific guide: `CLAUDE.md`
+- GitHub Copilot instructions: `.github/copilot-instructions.md`
+- MCP client setup matrix: [Client Configurations](client-configs.md)
+- Codex support model: [Codex Support](codex-support.md)
+
+## Default Safety Model
+
+Use `readonly` MCP operating mode and a focused profile such as `analysis` for onboarding,
+triage, review, and code-agent workflows. Broader tool surfaces are opt-in and should be
+documented in the PR when used.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,4 +38,7 @@ features:
   - title: Architecture and contribution flow
     details: Product boundaries, ownership, branch protection, test strategy, and contributor expectations are reachable from the architecture section.
     link: /architecture/
+  - title: Agent onboarding
+    details: Root agent instructions, MCP client setup examples, and Codex support boundaries are documented for repeatable coding-agent workflows.
+    link: /agents/
 ---

--- a/examples/mcp-clients/README.md
+++ b/examples/mcp-clients/README.md
@@ -1,0 +1,54 @@
+# MCP Client Config Examples
+
+These examples are the canonical copyable MCP client setup pack for KiCad Studio Kit.
+They are safe defaults for local development and external coding-agent workflows.
+
+Replace `/absolute/path/to/your/kicad-project` with the KiCad project directory you want
+the client to inspect. Keep the path absolute unless the target client explicitly supports
+workspace variables for MCP configuration.
+
+## Defaults
+
+All stdio examples use:
+
+- command: `uvx`
+- args: `["kicad-mcp-pro"]`
+- profile: `analysis`
+- operating mode: `readonly`
+
+`KICAD_MCP_PROFILE` narrows the tool categories. `KICAD_MCP_OPERATING_MODE` is the risk
+gate applied on top of that profile. Switch to `write`, `manufacturing`, or
+`experimental` only when the task explicitly requires that surface.
+
+## Example Files
+
+| Client                         | File                                 | Install location                                 |
+| ------------------------------ | ------------------------------------ | ------------------------------------------------ |
+| VS Code and GitHub Copilot     | `vscode.mcp.example.json`            | `.vscode/mcp.json` or user profile MCP config    |
+| Codex CLI / IDE extension      | `codex.config.example.toml`          | `~/.codex/config.toml` or trusted project config |
+| Claude Code                    | `claude-code.mcp.example.json`       | `.mcp.json`                                      |
+| Claude Desktop                 | `claude-desktop.config.example.json` | `claude_desktop_config.json`                     |
+| Cursor                         | `cursor.mcp.example.json`            | `.cursor/mcp.json` or `~/.cursor/mcp.json`       |
+| Gemini CLI                     | `gemini.settings.example.json`       | `~/.gemini/settings.json`                        |
+| Generic stdio MCP client       | `generic-stdio.mcp.example.json`     | Client-specific MCP config                       |
+| Generic Streamable HTTP client | `generic-http.mcp.example.json`      | Client-specific MCP config                       |
+
+## Streamable HTTP
+
+For HTTP clients, start the server separately:
+
+```bash
+KICAD_MCP_PROJECT_DIR=/absolute/path/to/your/kicad-project \
+KICAD_MCP_PROFILE=analysis \
+KICAD_MCP_OPERATING_MODE=readonly \
+kicad-mcp-pro --transport http --host 127.0.0.1 --port 3334
+```
+
+Then point the client at:
+
+```text
+http://127.0.0.1:3334/mcp
+```
+
+Do not bind the HTTP server to `0.0.0.0` unless you have added an explicit network and
+authentication design for that environment.

--- a/examples/mcp-clients/claude-code.mcp.example.json
+++ b/examples/mcp-clients/claude-code.mcp.example.json
@@ -1,14 +1,14 @@
 {
   "mcpServers": {
     "kicad": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_PROFILE": "analysis",
         "KICAD_MCP_OPERATING_MODE": "readonly"
-      },
-      "timeout": 120000
+      }
     }
   }
 }

--- a/examples/mcp-clients/claude-desktop.config.example.json
+++ b/examples/mcp-clients/claude-desktop.config.example.json
@@ -5,10 +5,9 @@
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_PROFILE": "analysis",
         "KICAD_MCP_OPERATING_MODE": "readonly"
-      },
-      "timeout": 120000
+      }
     }
   }
 }

--- a/examples/mcp-clients/codex.config.example.toml
+++ b/examples/mcp-clients/codex.config.example.toml
@@ -6,5 +6,5 @@ tool_timeout_sec = 120
 
 [mcp_servers.kicad.env]
 KICAD_MCP_PROJECT_DIR = "/absolute/path/to/your/kicad-project"
-KICAD_MCP_PROFILE = "pcb_only"
+KICAD_MCP_PROFILE = "analysis"
 KICAD_MCP_OPERATING_MODE = "readonly"

--- a/examples/mcp-clients/cursor.mcp.example.json
+++ b/examples/mcp-clients/cursor.mcp.example.json
@@ -1,14 +1,14 @@
 {
   "mcpServers": {
     "kicad": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_PROFILE": "analysis",
         "KICAD_MCP_OPERATING_MODE": "readonly"
-      },
-      "timeout": 120000
+      }
     }
   }
 }

--- a/examples/mcp-clients/gemini.settings.example.json
+++ b/examples/mcp-clients/gemini.settings.example.json
@@ -5,10 +5,11 @@
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_PROFILE": "analysis",
         "KICAD_MCP_OPERATING_MODE": "readonly"
       },
-      "timeout": 120000
+      "timeout": 120000,
+      "trust": false
     }
   }
 }

--- a/examples/mcp-clients/generic-http.mcp.example.json
+++ b/examples/mcp-clients/generic-http.mcp.example.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "kicad": {
+      "type": "streamable-http",
+      "url": "http://127.0.0.1:3334/mcp"
+    }
+  }
+}

--- a/examples/mcp-clients/generic-stdio.mcp.example.json
+++ b/examples/mcp-clients/generic-stdio.mcp.example.json
@@ -1,14 +1,14 @@
 {
   "mcpServers": {
     "kicad": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_PROFILE": "analysis",
         "KICAD_MCP_OPERATING_MODE": "readonly"
-      },
-      "timeout": 120000
+      }
     }
   }
 }

--- a/examples/mcp-clients/vscode.mcp.example.json
+++ b/examples/mcp-clients/vscode.mcp.example.json
@@ -1,14 +1,14 @@
 {
-  "mcpServers": {
+  "servers": {
     "kicad": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_PROFILE": "analysis",
         "KICAD_MCP_OPERATING_MODE": "readonly"
-      },
-      "timeout": 120000
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "check:performance-budgets": "node scripts/check-performance-budgets.mjs && node --test scripts/check-performance-budgets.test.mjs",
     "test:beta-program": "node --test scripts/check-beta-program.test.mjs",
     "check:beta-program": "node scripts/check-beta-program.mjs && pnpm run test:beta-program",
+    "test:agent-configs": "node --test scripts/check-agent-configs.test.mjs",
+    "check:agent-configs": "node scripts/check-agent-configs.mjs && node --test scripts/check-agent-configs.test.mjs",
     "check:examples": "node scripts/check-examples.mjs && node --test scripts/check-examples.test.mjs",
     "docs:generate": "node scripts/generate-docs-site.mjs",
     "docs:lint": "node scripts/check-docs-site.mjs --markdown",
@@ -77,7 +79,7 @@
     "check:docs-site": "pnpm --dir packages/mcp-server run docs:tools:check && pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "check:publish": "node scripts/check-publish-preflight.mjs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.0",

--- a/packages/mcp-server/docs/client-configuration.md
+++ b/packages/mcp-server/docs/client-configuration.md
@@ -70,6 +70,7 @@ CLI setup:
 codex mcp add kicad \
   --env KICAD_MCP_PROJECT_DIR=/absolute/path/to/your/kicad-project \
   --env KICAD_MCP_PROFILE=pcb_only \
+  --env KICAD_MCP_OPERATING_MODE=readonly \
   -- uvx kicad-mcp-pro
 ```
 
@@ -85,6 +86,7 @@ tool_timeout_sec = 120
 [mcp_servers.kicad.env]
 KICAD_MCP_PROJECT_DIR = "/absolute/path/to/your/kicad-project"
 KICAD_MCP_PROFILE = "pcb_only"
+KICAD_MCP_OPERATING_MODE = "readonly"
 ```
 
 ## Claude Desktop
@@ -99,7 +101,8 @@ Add the server to `claude_desktop_config.json`:
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only"
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       }
     }
   }
@@ -122,7 +125,8 @@ Project-scoped `.mcp.json`:
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only"
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       }
     }
   }
@@ -136,6 +140,7 @@ claude mcp add kicad \
   --scope project \
   --env KICAD_MCP_PROJECT_DIR=/absolute/path/to/your/kicad-project \
   --env KICAD_MCP_PROFILE=pcb_only \
+  --env KICAD_MCP_OPERATING_MODE=readonly \
   -- uvx kicad-mcp-pro
 ```
 
@@ -153,7 +158,8 @@ configuration:
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only"
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       }
     }
   }
@@ -172,7 +178,8 @@ Add the server to `~/.gemini/settings.json`:
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only"
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       },
       "timeout": 120000
     }
@@ -193,7 +200,8 @@ If your client accepts the common `mcpServers` JSON shape, use this as the start
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only"
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       }
     }
   }
@@ -208,6 +216,9 @@ setup below.
 Start KiCad MCP Pro as an HTTP server:
 
 ```bash
+KICAD_MCP_PROJECT_DIR=/absolute/path/to/your/kicad-project \
+KICAD_MCP_PROFILE=pcb_only \
+KICAD_MCP_OPERATING_MODE=readonly \
 kicad-mcp-pro --transport http --host 127.0.0.1 --port 3334
 ```
 
@@ -253,8 +264,9 @@ Gemini CLI HTTP example:
 
 ## References
 
+- Agent onboarding and examples: ../../../docs/agents/client-configs.md
 - VS Code MCP configuration: https://code.vscode.dev/docs/copilot/customization/mcp-servers
-- Codex MCP configuration: https://developers.openai.com/codex/mcp
+- Codex MCP configuration: https://developers.openai.com/learn/docs-mcp
 - Claude Code MCP configuration: https://docs.anthropic.com/en/docs/claude-code/mcp
 - Anthropic MCP overview: https://docs.anthropic.com/en/docs/mcp
 - Cursor MCP configuration: https://docs.cursor.com/en/context/mcp

--- a/packages/mcp-server/docs/examples/clients/claude-code.mcp.json
+++ b/packages/mcp-server/docs/examples/clients/claude-code.mcp.json
@@ -5,7 +5,8 @@
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only"
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       }
     }
   }

--- a/packages/mcp-server/docs/examples/clients/claude-desktop.json
+++ b/packages/mcp-server/docs/examples/clients/claude-desktop.json
@@ -5,7 +5,8 @@
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only"
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       }
     }
   }

--- a/packages/mcp-server/docs/examples/clients/cursor.mcp.json
+++ b/packages/mcp-server/docs/examples/clients/cursor.mcp.json
@@ -6,7 +6,8 @@
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only"
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       }
     }
   }

--- a/packages/mcp-server/docs/examples/clients/generic-mcp-client.json
+++ b/packages/mcp-server/docs/examples/clients/generic-mcp-client.json
@@ -6,7 +6,8 @@
       "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only"
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       }
     }
   }

--- a/packages/mcp-server/docs/examples/clients/vscode.mcp.json
+++ b/packages/mcp-server/docs/examples/clients/vscode.mcp.json
@@ -3,12 +3,11 @@
     "kicad": {
       "type": "stdio",
       "command": "uvx",
-      "args": [
-        "kicad-mcp-pro"
-      ],
+      "args": ["kicad-mcp-pro"],
       "env": {
         "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
-        "KICAD_MCP_PROFILE": "pcb_only"
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
       }
     }
   }

--- a/scripts/check-agent-configs.mjs
+++ b/scripts/check-agent-configs.mjs
@@ -1,0 +1,583 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = path.resolve(SCRIPT_ROOT, "..");
+const PROJECT_PLACEHOLDER = "/absolute/path/to/your/kicad-project";
+
+const requiredMarkdownFiles = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  ".github/copilot-instructions.md",
+  "docs/agents/index.md",
+  "docs/agents/client-configs.md",
+  "docs/agents/codex-support.md",
+  "docs/adr/0007-agent-onboarding-config-pack.md",
+  "examples/mcp-clients/README.md",
+];
+
+const requiredRootExamples = [
+  {
+    file: "examples/mcp-clients/vscode.mcp.example.json",
+    format: "json",
+    rootKey: "servers",
+    type: "stdio",
+    profile: "analysis",
+  },
+  {
+    file: "examples/mcp-clients/codex.config.example.toml",
+    format: "toml",
+    rootKey: "mcp_servers",
+    type: "stdio",
+    profile: "analysis",
+  },
+  {
+    file: "examples/mcp-clients/claude-code.mcp.example.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "stdio",
+    profile: "analysis",
+  },
+  {
+    file: "examples/mcp-clients/claude-desktop.config.example.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "stdio",
+    profile: "analysis",
+  },
+  {
+    file: "examples/mcp-clients/cursor.mcp.example.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "stdio",
+    profile: "analysis",
+  },
+  {
+    file: "examples/mcp-clients/gemini.settings.example.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "stdio",
+    profile: "analysis",
+  },
+  {
+    file: "examples/mcp-clients/generic-stdio.mcp.example.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "stdio",
+    profile: "analysis",
+  },
+  {
+    file: "examples/mcp-clients/generic-http.mcp.example.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "http",
+  },
+];
+
+const requiredPackageExamples = [
+  {
+    file: "packages/mcp-server/docs/examples/clients/vscode.mcp.json",
+    format: "json",
+    rootKey: "servers",
+    type: "stdio",
+    profile: "pcb_only",
+  },
+  {
+    file: "packages/mcp-server/docs/examples/clients/codex-config.toml",
+    format: "toml",
+    rootKey: "mcp_servers",
+    type: "stdio",
+    profile: "pcb_only",
+  },
+  {
+    file: "packages/mcp-server/docs/examples/clients/claude-code.mcp.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "stdio",
+    profile: "pcb_only",
+  },
+  {
+    file: "packages/mcp-server/docs/examples/clients/claude-desktop.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "stdio",
+    profile: "pcb_only",
+  },
+  {
+    file: "packages/mcp-server/docs/examples/clients/cursor.mcp.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "stdio",
+    profile: "pcb_only",
+  },
+  {
+    file: "packages/mcp-server/docs/examples/clients/gemini-settings.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "stdio",
+    profile: "pcb_only",
+  },
+  {
+    file: "packages/mcp-server/docs/examples/clients/generic-mcp-client.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "stdio",
+    profile: "pcb_only",
+  },
+  {
+    file: "packages/mcp-server/docs/examples/clients/vscode-http.mcp.json",
+    format: "json",
+    rootKey: "servers",
+    type: "http",
+  },
+  {
+    file: "packages/mcp-server/docs/examples/clients/codex-http-config.toml",
+    format: "toml",
+    rootKey: "mcp_servers",
+    type: "http",
+  },
+  {
+    file: "packages/mcp-server/docs/examples/clients/gemini-http-settings.json",
+    format: "json",
+    rootKey: "mcpServers",
+    type: "http",
+  },
+];
+
+const requiredReferences = {
+  "AGENTS.md": [
+    "apps/vscode-extension",
+    "packages/mcp-server",
+    "packages/mcp-npm",
+    "corepack pnpm run lint",
+    "corepack pnpm run typecheck",
+    "corepack pnpm run test",
+    "corepack pnpm run build",
+    "corepack pnpm run verify:dist",
+    "KICAD_MCP_OPERATING_MODE=readonly",
+    "PR #16",
+  ],
+  "CLAUDE.md": [
+    "AGENTS.md",
+    "claude-code.mcp.example.json",
+    "KICAD_MCP_OPERATING_MODE=readonly",
+  ],
+  ".github/copilot-instructions.md": [
+    "AGENTS.md",
+    "corepack pnpm run verify:dist",
+    "examples/mcp-clients/",
+  ],
+  "README.md": ["docs/agents/index.md", "examples/mcp-clients/README.md"],
+  "docs/agents/index.md": [
+    "AGENTS.md",
+    "client-configs.md",
+    "codex-support.md",
+  ],
+  "docs/agents/client-configs.md": [
+    "vscode.mcp.example.json",
+    "codex.config.example.toml",
+    "claude-code.mcp.example.json",
+    "generic-http.mcp.example.json",
+    "https://code.vscode.dev/docs/copilot/customization/mcp-servers",
+    "https://developers.openai.com/learn/docs-mcp",
+    "https://modelcontextprotocol.io/specification/2025-06-18/basic/transports",
+  ],
+  "docs/agents/codex-support.md": [
+    "kicadstudio.ai.provider=codex",
+    "~/.codex/config.toml",
+    "codex mcp add kicad",
+    "examples/mcp-clients/codex.config.example.toml",
+  ],
+  "docs/adr/0007-agent-onboarding-config-pack.md": [
+    "Do not add Codex skills or a packaged plugin in this change.",
+    "KICAD_MCP_OPERATING_MODE=readonly",
+  ],
+  "examples/mcp-clients/README.md": [
+    "/absolute/path/to/your/kicad-project",
+    "vscode.mcp.example.json",
+    "codex.config.example.toml",
+    "generic-http.mcp.example.json",
+    "KICAD_MCP_OPERATING_MODE",
+  ],
+  "apps/vscode-extension/docs/AI_PROVIDERS.md": [
+    "seven direct AI provider paths",
+    "## Codex",
+    "~/.codex/config.toml",
+    "docs/agents/codex-support.md",
+  ],
+  "packages/mcp-server/docs/client-configuration.md": [
+    "KICAD_MCP_OPERATING_MODE=readonly",
+    "../../../docs/agents/client-configs.md",
+    "https://developers.openai.com/learn/docs-mcp",
+  ],
+  "docs/.vitepress/config.mts": ["/agents/", "/agents/client-configs"],
+};
+
+const forbiddenContent = [
+  {
+    pattern: /test\/fixtures\/sample_project/u,
+    message: "must not point onboarding configs at the fixture project",
+  },
+  {
+    pattern: /\$\{workspaceFolder\}\/test\/fixtures/u,
+    message: "must not use workspace fixture paths as developer defaults",
+  },
+  {
+    pattern: /Authorization:\s*Bearer\s+(?!\[REDACTED\]|your-token|YOUR_)/iu,
+    message: "must not include bearer tokens",
+  },
+  {
+    pattern: /client_secret\s*=\s*["'][^"']+["']/iu,
+    message: "must not include client secrets",
+  },
+];
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function readText(repoRoot, relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function readJson(repoRoot, relativePath, errors) {
+  try {
+    return JSON.parse(readText(repoRoot, relativePath));
+  } catch (error) {
+    errors.push(`${relativePath}: invalid JSON: ${error.message}`);
+    return undefined;
+  }
+}
+
+function setNestedValue(root, tablePath, key, value) {
+  let target = root;
+  for (const part of tablePath) {
+    target[part] ??= {};
+    target = target[part];
+  }
+  target[key] = value;
+}
+
+function parseTomlValue(rawValue, sourceName, lineNumber) {
+  const value = rawValue.trim();
+  if (/^"[^"]*"$/u.test(value)) {
+    return value.slice(1, -1);
+  }
+  if (/^\d+$/u.test(value)) {
+    return Number(value);
+  }
+  if (value.startsWith("[") && value.endsWith("]")) {
+    const entries = value
+      .slice(1, -1)
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    return entries.map((entry) => {
+      if (!/^"[^"]*"$/u.test(entry)) {
+        throw new Error(
+          `${sourceName}:${lineNumber}: only string arrays are supported`,
+        );
+      }
+      return entry.slice(1, -1);
+    });
+  }
+  throw new Error(`${sourceName}:${lineNumber}: unsupported TOML value`);
+}
+
+export function parseTomlSubset(text, sourceName = "config.toml") {
+  const root = {};
+  let currentTable = [];
+
+  text.split(/\r?\n/u).forEach((rawLine, index) => {
+    const lineNumber = index + 1;
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      return;
+    }
+
+    const table = line.match(/^\[([A-Za-z0-9_.-]+)\]$/u);
+    if (table) {
+      currentTable = table[1].split(".");
+      return;
+    }
+
+    const assignment = line.match(/^([A-Za-z0-9_-]+)\s*=\s*(.+)$/u);
+    if (!assignment) {
+      throw new Error(`${sourceName}:${lineNumber}: invalid TOML line`);
+    }
+    setNestedValue(
+      root,
+      currentTable,
+      assignment[1],
+      parseTomlValue(assignment[2], sourceName, lineNumber),
+    );
+  });
+
+  return root;
+}
+
+export function collectForbiddenContentErrors(relativePath, text) {
+  return forbiddenContent
+    .filter(({ pattern }) => pattern.test(text))
+    .map(({ message }) => `${relativePath}: ${message}`);
+}
+
+function assertFile(repoRoot, relativePath, errors) {
+  const fullPath = path.join(repoRoot, relativePath);
+  if (!fs.existsSync(fullPath) || !fs.statSync(fullPath).isFile()) {
+    errors.push(`${relativePath}: missing required file`);
+    return false;
+  }
+  return true;
+}
+
+function validateRequiredReferences(repoRoot, errors) {
+  for (const [relativePath, phrases] of Object.entries(requiredReferences)) {
+    if (!assertFile(repoRoot, relativePath, errors)) {
+      continue;
+    }
+    const text = readText(repoRoot, relativePath);
+    for (const error of collectForbiddenContentErrors(relativePath, text)) {
+      errors.push(error);
+    }
+    for (const phrase of phrases) {
+      if (!text.includes(phrase)) {
+        errors.push(`${relativePath}: missing required reference: ${phrase}`);
+      }
+    }
+  }
+}
+
+function expectArray(value, expected, label, errors) {
+  if (
+    !Array.isArray(value) ||
+    value.length !== expected.length ||
+    value.some((item, index) => item !== expected[index])
+  ) {
+    errors.push(`${label}: expected ${JSON.stringify(expected)}`);
+  }
+}
+
+export function validateStdioServer(server, options) {
+  const errors = [];
+  const { file, expectedProfile, requireProjectDir = true } = options;
+  if (server.command !== "uvx") {
+    errors.push(`${file}: stdio command must be uvx`);
+  }
+  expectArray(server.args, ["kicad-mcp-pro"], `${file}: stdio args`, errors);
+
+  const env = server.env;
+  if (!env || typeof env !== "object" || Array.isArray(env)) {
+    errors.push(`${file}: stdio server must define env`);
+    return errors;
+  }
+
+  if (requireProjectDir && env.KICAD_MCP_PROJECT_DIR !== PROJECT_PLACEHOLDER) {
+    errors.push(
+      `${file}: KICAD_MCP_PROJECT_DIR must use the project placeholder`,
+    );
+  }
+  if (!requireProjectDir && "KICAD_MCP_PROJECT_DIR" in env) {
+    errors.push(
+      `${file}: developer default must not set KICAD_MCP_PROJECT_DIR`,
+    );
+  }
+  if (env.KICAD_MCP_PROFILE !== expectedProfile) {
+    errors.push(`${file}: KICAD_MCP_PROFILE must be ${expectedProfile}`);
+  }
+  if (env.KICAD_MCP_OPERATING_MODE !== "readonly") {
+    errors.push(`${file}: KICAD_MCP_OPERATING_MODE must be readonly`);
+  }
+
+  return errors;
+}
+
+function validateHttpServer(server, file, errors) {
+  const url = server.url ?? server.httpUrl;
+  if (url !== "http://127.0.0.1:3334/mcp") {
+    errors.push(`${file}: HTTP example must use http://127.0.0.1:3334/mcp`);
+  }
+}
+
+function getServer(config, descriptor, errors) {
+  const group = config?.[descriptor.rootKey];
+  if (!group || typeof group !== "object" || Array.isArray(group)) {
+    errors.push(`${descriptor.file}: missing ${descriptor.rootKey}`);
+    return undefined;
+  }
+  const server = group.kicad;
+  if (!server || typeof server !== "object" || Array.isArray(server)) {
+    errors.push(`${descriptor.file}: missing kicad server`);
+    return undefined;
+  }
+  return server;
+}
+
+function validateDescriptor(repoRoot, descriptor, errors) {
+  if (!assertFile(repoRoot, descriptor.file, errors)) {
+    return;
+  }
+  const text = readText(repoRoot, descriptor.file);
+  for (const error of collectForbiddenContentErrors(descriptor.file, text)) {
+    errors.push(error);
+  }
+  if (!text.endsWith("\n")) {
+    errors.push(`${descriptor.file}: missing final newline`);
+  }
+
+  let config;
+  if (descriptor.format === "json") {
+    config = readJson(repoRoot, descriptor.file, errors);
+  } else {
+    try {
+      config = parseTomlSubset(text, descriptor.file);
+    } catch (error) {
+      errors.push(error.message);
+    }
+  }
+  if (!config) {
+    return;
+  }
+
+  const server = getServer(config, descriptor, errors);
+  if (!server) {
+    return;
+  }
+
+  if (descriptor.type === "stdio") {
+    errors.push(
+      ...validateStdioServer(server, {
+        file: descriptor.file,
+        expectedProfile: descriptor.profile,
+      }),
+    );
+  } else {
+    validateHttpServer(server, descriptor.file, errors);
+  }
+
+  if (
+    descriptor.file.includes("gemini") &&
+    server.trust !== undefined &&
+    server.trust !== false
+  ) {
+    errors.push(
+      `${descriptor.file}: Gemini trust must remain false when present`,
+    );
+  }
+}
+
+function validateWorkspaceDefaults(repoRoot, errors) {
+  const mcp = readJson(repoRoot, ".vscode/mcp.json", errors);
+  const server = mcp?.servers?.kicad;
+  if (server) {
+    errors.push(
+      ...validateStdioServer(server, {
+        file: ".vscode/mcp.json",
+        expectedProfile: "analysis",
+        requireProjectDir: false,
+      }),
+    );
+    if (server.env?.KICAD_MCP_WORKSPACE_ROOT !== "${workspaceFolder}") {
+      errors.push(".vscode/mcp.json: must set KICAD_MCP_WORKSPACE_ROOT");
+    }
+  }
+
+  const tasks = readJson(repoRoot, ".vscode/tasks.json", errors);
+  const taskText = fs.existsSync(path.join(repoRoot, ".vscode/tasks.json"))
+    ? readText(repoRoot, ".vscode/tasks.json")
+    : "";
+  for (const error of collectForbiddenContentErrors(
+    ".vscode/tasks.json",
+    taskText,
+  )) {
+    errors.push(error);
+  }
+  const httpTask = tasks?.tasks?.find(
+    (task) => task.label === "Start kicad-mcp-pro (HTTP)",
+  );
+  if (!httpTask) {
+    errors.push(".vscode/tasks.json: missing Start kicad-mcp-pro (HTTP) task");
+    return;
+  }
+  if (httpTask.command !== "uvx") {
+    errors.push(".vscode/tasks.json: HTTP dev task command must be uvx");
+  }
+  expectArray(
+    httpTask.args,
+    ["kicad-mcp-pro", "--transport", "http", "--port", "27185"],
+    ".vscode/tasks.json: HTTP dev task args",
+    errors,
+  );
+  const env = httpTask.options?.env;
+  if (env?.KICAD_MCP_PROJECT_DIR) {
+    errors.push(
+      ".vscode/tasks.json: HTTP dev task must not set KICAD_MCP_PROJECT_DIR",
+    );
+  }
+  if (env?.KICAD_MCP_WORKSPACE_ROOT !== "${workspaceFolder}") {
+    errors.push(
+      ".vscode/tasks.json: HTTP dev task must set KICAD_MCP_WORKSPACE_ROOT",
+    );
+  }
+  if (env?.KICAD_MCP_PROFILE !== "analysis") {
+    errors.push(".vscode/tasks.json: HTTP dev task profile must be analysis");
+  }
+  if (env?.KICAD_MCP_OPERATING_MODE !== "readonly") {
+    errors.push(".vscode/tasks.json: HTTP dev task mode must be readonly");
+  }
+}
+
+function validateScriptWiring(repoRoot, errors) {
+  const packageJson = readJson(repoRoot, "package.json", errors);
+  const checkAgentConfigs = packageJson?.scripts?.["check:agent-configs"];
+  if (
+    checkAgentConfigs !==
+    "node scripts/check-agent-configs.mjs && node --test scripts/check-agent-configs.test.mjs"
+  ) {
+    errors.push("package.json: check:agent-configs script is missing or stale");
+  }
+  if (!packageJson?.scripts?.check?.includes("pnpm run check:agent-configs")) {
+    errors.push("package.json: root check must run check:agent-configs");
+  }
+
+  const ci = readText(repoRoot, ".github/workflows/ci.yml");
+  if (!ci.includes("corepack pnpm run check:agent-configs")) {
+    errors.push(
+      ".github/workflows/ci.yml: metadata job must run check:agent-configs",
+    );
+  }
+}
+
+export function validateAgentConfigs(options = {}) {
+  const repoRoot = options.repoRoot ?? DEFAULT_REPO_ROOT;
+  const errors = [];
+
+  for (const file of requiredMarkdownFiles) {
+    assertFile(repoRoot, file, errors);
+  }
+  validateRequiredReferences(repoRoot, errors);
+  for (const descriptor of requiredRootExamples) {
+    validateDescriptor(repoRoot, descriptor, errors);
+  }
+  for (const descriptor of requiredPackageExamples) {
+    validateDescriptor(repoRoot, descriptor, errors);
+  }
+  validateWorkspaceDefaults(repoRoot, errors);
+  validateScriptWiring(repoRoot, errors);
+
+  return errors.map((error) => toPosixPath(error));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const errors = validateAgentConfigs();
+  if (errors.length > 0) {
+    console.error("Agent config validation failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-agent-configs.test.mjs
+++ b/scripts/check-agent-configs.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  collectForbiddenContentErrors,
+  parseTomlSubset,
+  validateAgentConfigs,
+  validateStdioServer,
+} from "./check-agent-configs.mjs";
+
+test("agent onboarding configs validate in the repository", () => {
+  assert.deepEqual(validateAgentConfigs(), []);
+});
+
+test("TOML parser handles nested MCP server tables", () => {
+  const parsed = parseTomlSubset(`
+[mcp_servers.kicad]
+command = "uvx"
+args = ["kicad-mcp-pro"]
+startup_timeout_sec = 20
+
+[mcp_servers.kicad.env]
+KICAD_MCP_PROJECT_DIR = "/absolute/path/to/your/kicad-project"
+KICAD_MCP_PROFILE = "analysis"
+KICAD_MCP_OPERATING_MODE = "readonly"
+`);
+
+  assert.equal(parsed.mcp_servers.kicad.command, "uvx");
+  assert.deepEqual(parsed.mcp_servers.kicad.args, ["kicad-mcp-pro"]);
+  assert.equal(parsed.mcp_servers.kicad.startup_timeout_sec, 20);
+  assert.equal(
+    parsed.mcp_servers.kicad.env.KICAD_MCP_OPERATING_MODE,
+    "readonly",
+  );
+});
+
+test("stdio validator rejects unsafe profile and mode drift", () => {
+  const errors = validateStdioServer(
+    {
+      command: "kicad-mcp-pro",
+      args: [],
+      env: {
+        KICAD_MCP_PROJECT_DIR: "/absolute/path/to/your/kicad-project",
+        KICAD_MCP_PROFILE: "full",
+        KICAD_MCP_OPERATING_MODE: "write",
+      },
+    },
+    { file: "example.json", expectedProfile: "analysis" },
+  );
+
+  assert.match(errors.join("\n"), /stdio command must be uvx/u);
+  assert.match(errors.join("\n"), /KICAD_MCP_PROFILE must be analysis/u);
+  assert.match(errors.join("\n"), /KICAD_MCP_OPERATING_MODE must be readonly/u);
+});
+
+test("forbidden content scanner catches fixture defaults and secrets", () => {
+  const errors = collectForbiddenContentErrors(
+    ".vscode/mcp.json",
+    'Authorization: Bearer live-token\n"${workspaceFolder}/test/fixtures/sample_project"',
+  );
+
+  assert.equal(errors.length, 3);
+  assert.match(errors[0], /fixture/u);
+  assert.match(errors[1], /workspace fixture/u);
+  assert.match(errors[2], /bearer tokens/u);
+});

--- a/scripts/check-ci-lanes.mjs
+++ b/scripts/check-ci-lanes.mjs
@@ -76,7 +76,15 @@ const SHARED_PREFIXES = [
   "packages/test-harness/",
 ];
 const CI_POLICY_PREFIXES = ["scripts/", ".github/"];
-const DOC_PREFIXES = ["docs/", "README.md", "CONTRIBUTING.md"];
+const DOC_PREFIXES = [
+  "docs/",
+  "README.md",
+  "CONTRIBUTING.md",
+  "AGENTS.md",
+  "CLAUDE.md",
+  ".github/copilot-instructions.md",
+  "examples/mcp-clients/",
+];
 
 const EXTENSION_INTEGRATION_PREFIXES = [
   "apps/vscode-extension/src/mcp/",

--- a/scripts/check-ci-lanes.test.mjs
+++ b/scripts/check-ci-lanes.test.mjs
@@ -83,12 +83,18 @@ test("root toolchain and CI workflow changes run all lanes", () => {
 });
 
 test("docs-only changes keep product lanes skipped while metadata still runs", () => {
-  const report = classifyChangedFiles(["docs/testing-strategy.md"]);
+  const report = classifyChangedFiles([
+    "docs/testing-strategy.md",
+    "AGENTS.md",
+    ".github/copilot-instructions.md",
+    "examples/mcp-clients/vscode.mcp.example.json",
+  ]);
 
   assert.equal(report.lanes.metadata, true);
   assert.equal(report.lanes.vscodeExtension, false);
   assert.equal(report.lanes.mcpServer, false);
   assert.equal(report.lanes.sharedPackages, false);
+  assert.equal(report.lanes.integrationContracts, false);
 });
 
 test("manual and scheduled contexts can force all lanes", () => {


### PR DESCRIPTION
## Summary
- Adds root agent onboarding for Codex/Claude/Copilot-style coding agents.
- Adds canonical MCP client config examples for VS Code/Copilot, Codex, Claude, Cursor, Gemini, generic stdio, and generic HTTP clients.
- Normalizes checked-in VS Code MCP config away from fixture paths and adds CI validation for agent docs/config examples.

Linear: OASLANA-127 https://linear.app/oaslananka/issue/OASLANA-127/add-canonical-agent-onboarding-and-mcp-client-config-pack-for-codex

## Validation
- corepack pnpm install --frozen-lockfile
- corepack pnpm run format
- corepack pnpm exec prettier --ignore-unknown --check AGENTS.md CLAUDE.md README.md .github/copilot-instructions.md .github/workflows/ci.yml .vscode/mcp.json .vscode/tasks.json docs/.vitepress/config.mts docs/index.md docs/agents/index.md docs/agents/client-configs.md docs/agents/codex-support.md docs/adr/0007-agent-onboarding-config-pack.md examples/mcp-clients/README.md examples/mcp-clients/*.json scripts/check-agent-configs.mjs scripts/check-agent-configs.test.mjs scripts/check-ci-lanes.mjs scripts/check-ci-lanes.test.mjs package.json packages/mcp-server/docs/client-configuration.md packages/mcp-server/docs/examples/clients/*.json
- corepack pnpm run check:agent-configs
- corepack pnpm run check:ci-lanes
- corepack pnpm run docs:lint
- corepack pnpm run docs:links
- corepack pnpm run format:check
- corepack pnpm --filter kicadstudio run workflows:lint
- uvx yamllint .github/workflows
- corepack pnpm run lint
- corepack pnpm run typecheck
- corepack pnpm run test
- corepack pnpm run build
- corepack pnpm run verify:dist
- corepack pnpm run check:docs-site
- corepack pnpm --filter kicadstudio run audit:ci
- corepack pnpm --filter kicadstudio run package:validate
- uvx pre-commit run --all-files
- /tmp/a2a-warp-gitleaks-8.30.1/gitleaks detect --source . --redact --verbose
- git diff --check

## Freshness / deprecation checks
- Checked current official VS Code MCP, OpenAI Codex MCP, Claude Code MCP, Cursor MCP, Gemini CLI MCP, MCP transport, and GitHub Actions runtime docs.
- Scanned workflow files for deprecated commands and node12/node16/node20 runtime references.
- Fetched action metadata for every external workflow action reference; all JavaScript actions report node24, composite, or docker runtimes.