### PR TITLE
fix(kicad-studio): align Codex provider support

### DIFF
--- a/apps/vscode-extension/docs/AI_PROVIDERS.md
+++ b/apps/vscode-extension/docs/AI_PROVIDERS.md
@@ -2,7 +2,7 @@
 
 ## Supported Providers
 
-KiCad Studio supports seven direct AI provider paths:
+KiCad Studio supports six direct AI provider paths:
 
 - Claude
 - OpenAI
@@ -10,7 +10,6 @@ KiCad Studio supports seven direct AI provider paths:
 - GitHub Copilot
 - Gemini
 - local OpenAI-compatible endpoints
-- Codex through the VS Code Language Model API
 
 For compatible VS Code builds, KiCad Studio can also contribute:
 
@@ -43,14 +42,6 @@ For compatible VS Code builds, KiCad Studio can also contribute:
 - Requires a VS Code environment where the Language Model API exposes Copilot models.
 - No separate API key is stored by KiCad Studio.
 
-## Codex
-
-- Set `kicadstudio.ai.provider` to `codex`.
-- Requires a VS Code environment where the Language Model API exposes compatible models.
-- No separate API key is stored by KiCad Studio.
-- This provider is a direct KiCad Studio extension provider. It does not start the Codex CLI, read `~/.codex/config.toml`, or configure Codex as an external MCP client.
-- For Codex CLI or Codex IDE extension MCP setup, use [`docs/agents/codex-support.md`](../../../docs/agents/codex-support.md) and [`examples/mcp-clients/codex.config.example.toml`](../../../examples/mcp-clients/codex.config.example.toml).
-
 ## Gemini
 
 - Set `kicadstudio.ai.provider` to `gemini`.
@@ -63,6 +54,17 @@ For compatible VS Code builds, KiCad Studio can also contribute:
 - Set `kicadstudio.ai.localEndpoint` to the base URL of a local OpenAI-compatible chat endpoint, for example one that exposes `/v1/chat/completions`.
 - Set `kicadstudio.ai.model` to the model ID expected by that endpoint.
 - KiCad Studio does not store or send an API key for the local provider. Without a configured local endpoint, provider selection falls back to an unconfigured state.
+
+## Codex
+
+Codex is supported as an external MCP client workflow, not as a direct KiCad Studio
+extension AI provider. Use [`docs/agents/codex-support.md`](../../../docs/agents/codex-support.md)
+and [`examples/mcp-clients/codex.config.example.toml`](../../../examples/mcp-clients/codex.config.example.toml)
+to connect Codex CLI or the Codex IDE extension to `kicad-mcp-pro`.
+
+Legacy settings that still contain `kicadstudio.ai.provider=codex` are migrated to
+`copilot`, which preserves the previous VS Code Language Model API behavior without
+presenting Codex as a separate direct provider.
 
 ## Response Language
 

--- a/apps/vscode-extension/docs/ARCHITECTURE.md
+++ b/apps/vscode-extension/docs/ARCHITECTURE.md
@@ -37,7 +37,8 @@ The extension is activated from KiCad project, schematic, PCB, jobset, or DRC ru
 - `AIProviderRegistry` resolves the configured provider and model selection.
 - Claude, OpenAI, OpenRouter, and Gemini providers call their remote APIs from the extension host only.
 - The local provider routes to an explicitly configured OpenAI-compatible endpoint without a stored API key.
-- Copilot and Codex providers use the VS Code Language Model API when available.
+- The Copilot provider uses the VS Code Language Model API when available.
+- Codex is supported as an external MCP client workflow rather than a direct extension AI provider.
 - `KiCadChatPanel` is the multi-turn chat UI and can render MCP tool suggestions embedded in assistant replies.
 - Prompt construction in `src/ai/prompts.ts` is KiCad 10-aware and injects active variant / MCP context when available.
 - `src/lm/languageModelTools.ts` registers agent-callable KiCad tools for supported VS Code hosts.

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1402,8 +1402,7 @@
             "openrouter",
             "copilot",
             "gemini",
-            "local",
-            "codex"
+            "local"
           ],
           "description": "%kicadstudio.contributes.configuration.properties.kicadstudio.ai.provider.description%"
         },

--- a/apps/vscode-extension/src/ai/aiProvider.ts
+++ b/apps/vscode-extension/src/ai/aiProvider.ts
@@ -9,7 +9,7 @@ import {
   type AiSecretProvider
 } from '../utils/secrets';
 import { ClaudeProvider } from './claudeProvider';
-import { CodexProvider, CopilotProvider } from './copilotProvider';
+import { CopilotProvider } from './copilotProvider';
 import { GeminiProvider } from './geminiProvider';
 import { LocalProvider } from './localProvider';
 import { getDefaultModel } from './modelCatalog';
@@ -52,10 +52,6 @@ export class AIProviderRegistry {
 
     if (selected === 'copilot') {
       return new CopilotProvider();
-    }
-
-    if (selected === 'codex') {
-      return new CodexProvider();
     }
 
     if (selected === 'local') {
@@ -134,8 +130,7 @@ export class AIProviderRegistry {
       provider === 'openrouter' ||
       provider === 'copilot' ||
       provider === 'gemini' ||
-      provider === 'local' ||
-      provider === 'codex'
+      provider === 'local'
       ? getDefaultModel(provider)
       : '';
   }

--- a/apps/vscode-extension/src/ai/chatHtml.ts
+++ b/apps/vscode-extension/src/ai/chatHtml.ts
@@ -339,7 +339,6 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
         <option value="openai">OpenAI</option>
         <option value="copilot">Copilot</option>
         <option value="gemini">Gemini</option>
-        <option value="codex">Codex (VS Code)</option>
       </select>
       <input id="model" type="text" aria-label="Model" placeholder="Model override">
       <button id="settings" class="icon" type="button" title="Open KiCad Studio settings" aria-label="Open settings">&#9881;</button>

--- a/apps/vscode-extension/src/ai/copilotProvider.ts
+++ b/apps/vscode-extension/src/ai/copilotProvider.ts
@@ -135,23 +135,3 @@ export class CopilotProvider extends BaseLanguageModelProvider {
     { vendor: 'copilot' }
   ];
 }
-
-/**
- * VS Code Codex provider — uses the VS Code Language Model API to route
- * requests through GitHub Copilot or other LM extensions installed in VS Code.
- *
- * Selector list is ordered from most-preferred to least-preferred.  We try
- * newer GPT-4.x / Claude families first so the provider still works in 2025+
- * where the legacy "codex" family ID is no longer registered by Copilot.
- */
-export class CodexProvider extends BaseLanguageModelProvider {
-  readonly name = 'VS Code Codex';
-  protected readonly selectors = [
-    { vendor: 'copilot', family: 'gpt-4.1' },
-    { vendor: 'copilot', family: 'gpt-4o' },
-    { vendor: 'copilot', family: 'claude-sonnet' },
-    { vendor: 'copilot', family: 'o3' },
-    { vendor: 'copilot', family: 'gpt-4' },
-    { vendor: 'copilot' }
-  ];
-}

--- a/apps/vscode-extension/src/ai/modelCatalog.ts
+++ b/apps/vscode-extension/src/ai/modelCatalog.ts
@@ -4,8 +4,7 @@ export type AiProviderId =
   | 'openrouter'
   | 'copilot'
   | 'gemini'
-  | 'local'
-  | 'codex';
+  | 'local';
 
 export interface ModelInfo {
   id: string;
@@ -197,19 +196,6 @@ export const COPILOT_MODELS: AiModelInfo[] = [
   }
 ];
 
-export const CODEX_MODELS: AiModelInfo[] = [
-  {
-    id: 'codex/default',
-    provider: 'codex',
-    label: 'VS Code Codex (Best available)',
-    maxTokens: 4096,
-    supportsStreaming: true,
-    contextWindow: 128000,
-    recommended: true,
-    default: true
-  }
-];
-
 export const LOCAL_MODELS: AiModelInfo[] = [];
 
 export const MODEL_CATALOG: Record<AiProviderId, AiModelInfo[]> = {
@@ -218,26 +204,26 @@ export const MODEL_CATALOG: Record<AiProviderId, AiModelInfo[]> = {
   openrouter: OPENROUTER_MODELS,
   gemini: GEMINI_MODELS,
   copilot: COPILOT_MODELS,
-  local: LOCAL_MODELS,
-  codex: CODEX_MODELS
+  local: LOCAL_MODELS
 };
 
 export const AI_MODEL_CATALOG = MODEL_CATALOG;
 
 export function getProviderModels(provider: AiProviderId): AiModelInfo[] {
-  return MODEL_CATALOG[provider];
+  const models = MODEL_CATALOG[provider];
+  if (!models) {
+    throw new Error(`Unsupported AI provider: ${String(provider)}`);
+  }
+  return models;
 }
 
 export function getDefaultModel(provider: AiProviderId): string {
-  return (
-    MODEL_CATALOG[provider].find((model) => model.default)?.id ??
-    MODEL_CATALOG[provider][0]?.id ??
-    ''
-  );
+  const models = getProviderModels(provider);
+  return models.find((model) => model.default)?.id ?? models[0]?.id ?? '';
 }
 
 export function getRecommendedModel(
   provider: AiProviderId
 ): AiModelInfo | undefined {
-  return MODEL_CATALOG[provider].find((model) => model.recommended);
+  return getProviderModels(provider).find((model) => model.recommended);
 }

--- a/apps/vscode-extension/src/settings/settingsHtml.ts
+++ b/apps/vscode-extension/src/settings/settingsHtml.ts
@@ -217,7 +217,6 @@ export function buildSettingsHtml(options: SettingsHtmlOptions): string {
             <option value="copilot">GitHub Copilot</option>
             <option value="gemini">Gemini</option>
             <option value="local">Local OpenAI-compatible</option>
-            <option value="codex">Codex (VS Code)</option>
           </select>
         </div>
         <div class="field">

--- a/apps/vscode-extension/src/settings/settingsMigrations.ts
+++ b/apps/vscode-extension/src/settings/settingsMigrations.ts
@@ -136,6 +136,52 @@ export function createRenameSettingMigration(args: {
   };
 }
 
+export function createReplaceSettingValueMigration(args: {
+  readonly schemaVersion: number;
+  readonly setting: string;
+  readonly fromValue: unknown;
+  readonly toValue: unknown;
+  readonly description?: string;
+}): SettingMigration {
+  return {
+    schemaVersion: args.schemaVersion,
+    id: `replace-${args.setting}-${String(args.fromValue)}-with-${String(
+      args.toValue
+    )}`,
+    destructive: true,
+    describe: () =>
+      args.description ??
+      `Replace deprecated ${args.setting} value ${String(
+        args.fromValue
+      )} with ${String(args.toValue)}.`,
+    async apply(context) {
+      const inspection = context.config.inspect<unknown>(args.setting);
+      if (!inspection) {
+        context.logger.debug(
+          `Settings migration v${args.schemaVersion}: ${args.setting} has no configured values.`
+        );
+        return { changed: false, destructive: false };
+      }
+
+      let changed = false;
+      for (const scope of CONFIGURATION_SCOPES) {
+        if (inspection[scope.valueKey] !== args.fromValue) {
+          continue;
+        }
+        await context.config.update(args.setting, args.toValue, scope.target);
+        context.logger.info(
+          `Settings migration v${args.schemaVersion}: replaced ${args.setting}=${String(
+            args.fromValue
+          )} with ${String(args.toValue)} at ${scope.label} scope.`
+        );
+        changed = true;
+      }
+
+      return { changed, destructive: changed };
+    }
+  };
+}
+
 export const DEFAULT_SETTINGS_MIGRATIONS: readonly SettingMigration[] = [
   createNoopSettingsMigration(1),
   createRenameSettingMigration({
@@ -143,6 +189,13 @@ export const DEFAULT_SETTINGS_MIGRATIONS: readonly SettingMigration[] = [
     from: 'kicadstudio.viewerTheme',
     to: SETTINGS.viewerTheme,
     description: `Rename legacy kicadstudio.viewerTheme to ${SETTINGS.viewerTheme}.`
+  }),
+  createReplaceSettingValueMigration({
+    schemaVersion: 3,
+    setting: SETTINGS.aiProvider,
+    fromValue: 'codex',
+    toValue: 'copilot',
+    description: `Migrate ${SETTINGS.aiProvider}=codex to the equivalent GitHub Copilot VS Code Language Model provider.`
   })
 ];
 

--- a/apps/vscode-extension/src/webviewI18n.ts
+++ b/apps/vscode-extension/src/webviewI18n.ts
@@ -14,7 +14,6 @@ export const WEBVIEW_MESSAGES = [
   'Provider',
   'Disabled',
   'Local OpenAI-compatible',
-  'Codex (VS Code)',
   'Model',
   'Provider default',
   'Local endpoint',

--- a/apps/vscode-extension/test/unit/aiProviders.test.ts
+++ b/apps/vscode-extension/test/unit/aiProviders.test.ts
@@ -1,7 +1,8 @@
 import { ClaudeProvider } from '../../src/ai/claudeProvider';
+import { AIProviderRegistry } from '../../src/ai/aiProvider';
 import { CopilotProvider } from '../../src/ai/copilotProvider';
 import { OpenAIProvider } from '../../src/ai/openaiProvider';
-import { lm } from './vscodeMock';
+import { createExtensionContextMock, lm } from './vscodeMock';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -115,6 +116,18 @@ describe('AI providers', () => {
         content: expect.stringContaining('Context:\ncontext')
       })
     ]);
+  });
+
+  it('does not expose Codex as a direct extension provider', async () => {
+    const registry = new AIProviderRegistry(
+      createExtensionContextMock() as never
+    );
+
+    await expect(
+      registry.getProviderForSelection('codex')
+    ).resolves.toBeUndefined();
+    expect(registry.getDefaultModel('codex')).toBe('');
+    expect(registry.isKeyedProvider('codex')).toBe(false);
   });
 });
 

--- a/apps/vscode-extension/test/unit/modelCatalog.test.ts
+++ b/apps/vscode-extension/test/unit/modelCatalog.test.ts
@@ -1,4 +1,5 @@
 import {
+  MODEL_CATALOG,
   getDefaultModel,
   getProviderModels,
   getRecommendedModel
@@ -26,5 +27,10 @@ describe('AI model catalog', () => {
         })
       ])
     );
+  });
+
+  it('does not advertise Codex as a direct extension model provider', () => {
+    expect(Object.keys(MODEL_CATALOG)).not.toContain('codex');
+    expect(() => getProviderModels('codex' as never)).toThrow();
   });
 });

--- a/apps/vscode-extension/test/unit/settingsMigrations.test.ts
+++ b/apps/vscode-extension/test/unit/settingsMigrations.test.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import {
   createNoopSettingsMigration,
   createRenameSettingMigration,
+  createReplaceSettingValueMigration,
   CURRENT_SETTINGS_SCHEMA_VERSION,
   DEFAULT_SETTINGS_MIGRATIONS,
   runSettingsMigrations,
@@ -219,13 +220,72 @@ describe('settings migrations', () => {
     );
   });
 
+  it('migrates legacy Codex provider selections to the Copilot provider per scope', async () => {
+    const context = createExtensionContextMock();
+    const logger = createLoggerMock();
+    const updates: Array<[string, unknown, vscode.ConfigurationTarget]> = [];
+    const config = {
+      inspect: jest.fn((key: string) => {
+        if (key === SETTINGS.aiProvider) {
+          return {
+            globalValue: 'codex',
+            workspaceValue: 'openai',
+            workspaceFolderValue: 'codex'
+          };
+        }
+        return undefined;
+      }),
+      update: jest.fn(
+        async (
+          key: string,
+          value: unknown,
+          target: vscode.ConfigurationTarget
+        ) => {
+          updates.push([key, value, target]);
+        }
+      )
+    };
+
+    const result = await runSettingsMigrations(
+      context as never,
+      logger,
+      [
+        createReplaceSettingValueMigration({
+          schemaVersion: 1,
+          setting: SETTINGS.aiProvider,
+          fromValue: 'codex',
+          toValue: 'copilot',
+          description:
+            'Migrate the removed Codex direct provider setting to GitHub Copilot.'
+        })
+      ],
+      config as never
+    );
+
+    expect(updates).toEqual([
+      [SETTINGS.aiProvider, 'copilot', vscode.ConfigurationTarget.Global],
+      [
+        SETTINGS.aiProvider,
+        'copilot',
+        vscode.ConfigurationTarget.WorkspaceFolder
+      ]
+    ]);
+    expect(result.destructiveChanges).toBe(true);
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('KiCad Studio updated deprecated settings')
+    );
+  });
+
   it('declares initial seed and template rename migrations', () => {
     expect(
       DEFAULT_SETTINGS_MIGRATIONS.map((migration) => migration.schemaVersion)
-    ).toEqual([1, 2]);
-    expect(CURRENT_SETTINGS_SCHEMA_VERSION).toBe(2);
+    ).toEqual([1, 2, 3]);
+    expect(CURRENT_SETTINGS_SCHEMA_VERSION).toBe(3);
     expect(DEFAULT_SETTINGS_MIGRATIONS[1]?.describe()).toContain(
       SETTINGS.viewerTheme
+    );
+    expect(DEFAULT_SETTINGS_MIGRATIONS[2]?.describe()).toContain(
+      SETTINGS.aiProvider
     );
   });
 });

--- a/apps/vscode-extension/test/unit/settingsPanel.test.ts
+++ b/apps/vscode-extension/test/unit/settingsPanel.test.ts
@@ -96,6 +96,8 @@ describe('settings webview', () => {
     expect(html).not.toContain('https://cdn');
     expect(html).not.toMatch(/\son[a-z]+=/i);
     expect(html).toContain('data-setting="kicadstudio.ai.provider"');
+    expect(html).toContain('<option value="copilot">GitHub Copilot</option>');
+    expect(html).not.toContain('<option value="codex">');
     expect(html).toContain("type: 'requestApiKeyStatus'");
   });
 

--- a/docs/agents/codex-support.md
+++ b/docs/agents/codex-support.md
@@ -1,18 +1,17 @@
 # Codex Support
 
-KiCad Studio Kit has two distinct Codex-related surfaces.
+KiCad Studio Kit supports Codex through the external MCP client path.
 
-## VS Code Extension Provider
+## Extension Provider Status
 
-Inside the VS Code extension, `kicadstudio.ai.provider=codex` is implemented as a direct
-extension provider. It routes through the VS Code Language Model API using the local VS Code
-host and available language-model extensions. It does not read Codex CLI config, does not
-start the Codex CLI, and does not require a separate Codex API key in KiCad Studio.
+`kicadstudio.ai.provider=codex` is a legacy setting value, not a current direct KiCad
+Studio extension provider. KiCad Studio migrates that legacy value to `copilot` because the
+old implementation used the VS Code Language Model API and Copilot-compatible models.
 
 Related implementation and docs:
 
 - `apps/vscode-extension/src/ai/aiProvider.ts`
-- `apps/vscode-extension/src/ai/copilotProvider.ts`
+- `apps/vscode-extension/src/settings/settingsMigrations.ts`
 - `apps/vscode-extension/docs/AI_PROVIDERS.md`
 - [`docs/extension/settings.md`](../extension/settings.md)
 
@@ -31,12 +30,12 @@ codex mcp add kicad \
 ```
 
 This external-client path gives Codex access to KiCad MCP tools. It is separate from the
-VS Code extension's `codex` provider enum.
+VS Code extension's direct AI provider setting.
 
 ## Rule Of Thumb
 
-- Use `kicadstudio.ai.provider=codex` when working inside KiCad Studio's chat UI in VS
-  Code.
+- Use `kicadstudio.ai.provider=copilot` when you want KiCad Studio's chat UI to route
+  through the VS Code Language Model API.
 - Use Codex MCP config when Codex is the coding agent or IDE agent connecting to
   `kicad-mcp-pro`.
-- Do not describe the extension provider enum as the Codex CLI integration.
+- Do not describe the extension provider setting as the Codex CLI integration.

--- a/docs/extension/settings.md
+++ b/docs/extension/settings.md
@@ -27,7 +27,7 @@ Total settings: 45.
 | `kicadstudio.pcm.repositoryUrls` | array | `["https://repository.kicad.org/repository.json"]` |  | PCM repository JSON feed URLs. The default points at KiCad's official add-on repository; add community repository.json feeds here. |
 | `kicadstudio.pcm.configDir` | string | `` |  | Optional KiCad user configuration directory for PCM metadata such as installed_packages.json. Leave empty for platform defaults. |
 | `kicadstudio.pcm.thirdPartyDir` | string | `` |  | Optional KiCad third-party content directory used by PCM installs. Leave empty for KiCad environment variables or the KiCad Studio fallback. |
-| `kicadstudio.ai.provider` | string | `none` | `none`, `claude`, `openai`, `openrouter`, `copilot`, `gemini`, `local`, `codex` | AI provider for circuit analysis and error explanation. |
+| `kicadstudio.ai.provider` | string | `none` | `none`, `claude`, `openai`, `openrouter`, `copilot`, `gemini`, `local` | AI provider for circuit analysis and error explanation. |
 | `kicadstudio.ai.model` | string | `` |  | Optional AI model override. Leave empty to use the provider default when the provider has one. |
 | `kicadstudio.ai.localEndpoint` | string | `` |  | OpenAI-compatible local chat endpoint base URL. KiCad Studio enables the local provider only after this endpoint is configured. |
 | `kicadstudio.ai.openaiApiMode` | string | `responses` | `responses`, `chat-completions` | OpenAI API mode. Responses is the default for new work; Chat Completions is retained for compatibility. |

--- a/scripts/check-agent-configs.mjs
+++ b/scripts/check-agent-configs.mjs
@@ -217,9 +217,10 @@ const requiredReferences = {
     "profile: `pcb_only`",
   ],
   "apps/vscode-extension/docs/AI_PROVIDERS.md": [
-    "seven direct AI provider paths",
+    "six direct AI provider paths",
     "## Codex",
-    "~/.codex/config.toml",
+    "not as a direct KiCad Studio",
+    "examples/mcp-clients/codex.config.example.toml",
     "docs/agents/codex-support.md",
   ],
   "packages/mcp-server/docs/client-configuration.md": [


### PR DESCRIPTION
## Summary
- Remove Codex from the direct KiCad Studio extension provider enum, chat/settings UI, model catalog, registry, and webview strings.
- Preserve legacy behavior by migrating `kicadstudio.ai.provider=codex` to `copilot`, matching the previous VS Code Language Model API routing.
- Update Codex docs and agent config checks to describe Codex as an external MCP client workflow.

## Linear
- OASLANA-137: https://linear.app/oaslananka/issue/OASLANA-137/align-codex-support-between-settings-docs-and-implementation

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run format:check`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist`
- `corepack pnpm run check:agent-configs`
- `corepack pnpm run docs:lint`
- `corepack pnpm run docs:links`
- `corepack pnpm run docs:check-generated`
- `git diff --check`