### PR TITLE
docs(kicad-studio): note Codex support model

### DIFF
--- a/apps/vscode-extension/CHANGELOG.md
+++ b/apps/vscode-extension/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Clarify Codex support as an external MCP client workflow, remove it from the
+  direct extension provider settings, and migrate legacy
+  `kicadstudio.ai.provider=codex` selections to GitHub Copilot.
 - Add explicit KiCanvas/CLI SVG fallback/metadata-only viewer engine state,
   toolbar engine badges, unsupported-control disabling, and regression coverage
   for fallback diagnostics.

--- a/docs/changelog/kicad-studio.md
+++ b/docs/changelog/kicad-studio.md
@@ -4,6 +4,9 @@ Source: `apps/vscode-extension/CHANGELOG.md`
 
 ## [Unreleased]
 
+- Clarify Codex support as an external MCP client workflow, remove it from the
+  direct extension provider settings, and migrate legacy
+  `kicadstudio.ai.provider=codex` selections to GitHub Copilot.
 - Add explicit KiCanvas/CLI SVG fallback/metadata-only viewer engine state,
   toolbar engine badges, unsupported-control disabling, and regression coverage
   for fallback diagnostics.

--- a/scripts/check-agent-configs.mjs
+++ b/scripts/check-agent-configs.mjs
@@ -223,6 +223,10 @@ const requiredReferences = {
     "examples/mcp-clients/codex.config.example.toml",
     "docs/agents/codex-support.md",
   ],
+  "apps/vscode-extension/CHANGELOG.md": [
+    "Clarify Codex support as an external MCP client workflow",
+    "kicadstudio.ai.provider=codex",
+  ],
   "packages/mcp-server/docs/client-configuration.md": [
     "KICAD_MCP_OPERATING_MODE=readonly",
     "KICAD_MCP_PROFILE=pcb_only",


### PR DESCRIPTION
## Summary
- Add an Unreleased KiCad Studio changelog entry for the clarified Codex support model.
- Regenerate the docs changelog copy from the extension changelog.
- Extend `check:agent-configs` so the Codex support model release note stays present.

## Linear
- OASLANA-133: https://linear.app/oaslananka/issue/OASLANA-133/clarify-codex-support-model-direct-ai-provider-versus-external-mcp

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run format:check`
- `corepack pnpm run check:agent-configs`
- `corepack pnpm run docs:lint`
- `corepack pnpm run docs:links`
- `corepack pnpm run docs:check-generated`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist`
- `git diff --check`

Note: `pnpm test` still prints pre-existing MCP server `ResourceWarning: unclosed database` warnings in unrelated Python tests; this PR only changes changelog/docs validation text.