### PR TITLE
feat(kicad-studio): surface KiCad support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ All release surfaces are pinned to `1.0.0`:
 - npm wrapper: `@oaslananka/kicad-mcp-pro`
 - MCP Registry name: `io.github.oaslananka/kicad-mcp-pro`
 
+## KiCad Compatibility
+
+KiCad Studio Kit treats KiCad `10.0.x` as the primary tested line, keeps KiCad
+`9.x` as a supported previous line, and keeps KiCad `8.x` as deprecated
+file-level compatibility. The canonical matrix, tested patch versions, CI
+coverage level, and feature gates are maintained in
+[docs/support-matrix.md](docs/support-matrix.md) and `compatibility.yaml`.
+
 ## Local Validation
 
 ```powershell

--- a/apps/vscode-extension/CHANGELOG.md
+++ b/apps/vscode-extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Surface KiCad 8.x, 9.x, and 10.0.x compatibility state in the status
+  bar/menu with feature-level capability probe results.
 - Clarify Codex support as an external MCP client workflow, remove it from the
   direct extension provider settings, and migrate legacy
   `kicadstudio.ai.provider=codex` selections to GitHub Copilot.

--- a/apps/vscode-extension/src/cli/exportCommands.ts
+++ b/apps/vscode-extension/src/cli/exportCommands.ts
@@ -101,7 +101,7 @@ export function buildCliExportCommands(
           outputDir,
           '--layers',
           layers.join(','),
-          ...(versionMajor >= 9 ? ['--precision', precision] : []),
+          ...(versionMajor >= 8 ? ['--precision', precision] : []),
           file
         ]
       ];
@@ -430,9 +430,21 @@ export class KiCadExportService {
   async export3DPdf(resource?: vscode.Uri): Promise<void> {
     const detected = await this.detector.detect(true);
     const versionMajor = Number(detected?.version.split('.')[0] ?? '0');
-    if (versionMajor < 10 || !(await this.detector.hasCapability('pdf3d'))) {
+    if (!detected) {
       void vscode.window.showWarningMessage(
-        '3D PDF export requires KiCad 10 or later.'
+        '3D PDF export requires a detected KiCad 10+ kicad-cli.'
+      );
+      return;
+    }
+    if (versionMajor < 10) {
+      void vscode.window.showWarningMessage(
+        `3D PDF export requires KiCad 10 or later; detected ${detected.versionLabel}.`
+      );
+      return;
+    }
+    if (!(await this.detector.hasCapability('pdf3d'))) {
+      void vscode.window.showWarningMessage(
+        `${detected.versionLabel} does not expose kicad-cli pcb export 3dpdf.`
       );
       return;
     }
@@ -944,7 +956,11 @@ export class KiCadExportService {
         ? inferOutputPath(file, outputDir, '-bom', '.csv')
         : inferOutputPath(file, outputDir, '-bom', '.xlsx');
     const uri = vscode.Uri.file(file);
-    this.exportState?.begin('bom', uri, `Exporting BOM ${format.toUpperCase()}.`);
+    this.exportState?.begin(
+      'bom',
+      uri,
+      `Exporting BOM ${format.toUpperCase()}.`
+    );
     try {
       if (format === 'csv') {
         await this.bomExporter.exportCsv(entries, outputFile);

--- a/apps/vscode-extension/src/cli/exportCommands.ts
+++ b/apps/vscode-extension/src/cli/exportCommands.ts
@@ -429,13 +429,13 @@ export class KiCadExportService {
 
   async export3DPdf(resource?: vscode.Uri): Promise<void> {
     const detected = await this.detector.detect(true);
-    const versionMajor = Number(detected?.version.split('.')[0] ?? '0');
     if (!detected) {
       void vscode.window.showWarningMessage(
         '3D PDF export requires a detected KiCad 10+ kicad-cli.'
       );
       return;
     }
+    const versionMajor = Number(detected.version.split('.')[0] ?? '0');
     if (versionMajor < 10) {
       void vscode.window.showWarningMessage(
         `3D PDF export requires KiCad 10 or later; detected ${detected.versionLabel}.`

--- a/apps/vscode-extension/src/cli/kicadCliDetector.ts
+++ b/apps/vscode-extension/src/cli/kicadCliDetector.ts
@@ -9,6 +9,24 @@ import { normalizeUserPath } from '../utils/pathUtils';
 
 const SYNC_PROBE_TIMEOUT_MS = 5_000;
 const SYNC_PROBE_MAX_BUFFER = 1024 * 1024;
+const STATUS_MENU_CAPABILITY_COMMANDS = [
+  'drc',
+  'erc',
+  'bom',
+  'netlist',
+  'gerbers',
+  'drill',
+  'jobset',
+  'pdf3d',
+  'odb'
+] as const satisfies ReadonlyArray<keyof typeof CLI_CAPABILITY_COMMANDS>;
+
+export type KiCadCliCapabilityName = keyof typeof CLI_CAPABILITY_COMMANDS;
+export type KiCadCliCapabilitySnapshot = Partial<
+  Record<KiCadCliCapabilityName, boolean>
+> & {
+  variantOption?: boolean;
+};
 
 export function getCliCandidates(
   platform = process.platform,
@@ -227,6 +245,25 @@ export class KiCadCliDetector {
     const normalized = supported ? help : undefined;
     this.helpCache.set(key, normalized);
     return normalized;
+  }
+
+  async getCapabilitySnapshot(): Promise<
+    KiCadCliCapabilitySnapshot | undefined
+  > {
+    const detected = await this.detect();
+    if (!detected) {
+      return undefined;
+    }
+
+    const capabilities: KiCadCliCapabilitySnapshot = {};
+    for (const command of STATUS_MENU_CAPABILITY_COMMANDS) {
+      capabilities[command] = await this.hasCapability(command);
+    }
+    capabilities.variantOption = await this.commandHelpIncludes(
+      ['sch', 'export', 'pdf'],
+      /--variant\b/
+    );
+    return capabilities;
   }
 
   private async validateCandidate(

--- a/apps/vscode-extension/src/cli/kicadCliDetector.ts
+++ b/apps/vscode-extension/src/cli/kicadCliDetector.ts
@@ -255,15 +255,19 @@ export class KiCadCliDetector {
       return undefined;
     }
 
-    const capabilities: KiCadCliCapabilitySnapshot = {};
-    for (const command of STATUS_MENU_CAPABILITY_COMMANDS) {
-      capabilities[command] = await this.hasCapability(command);
-    }
-    capabilities.variantOption = await this.commandHelpIncludes(
-      ['sch', 'export', 'pdf'],
-      /--variant\b/
-    );
-    return capabilities;
+    const [commandResults, variantOption] = await Promise.all([
+      Promise.all(
+        STATUS_MENU_CAPABILITY_COMMANDS.map(
+          async (command) =>
+            [command, await this.hasCapability(command)] as const
+        )
+      ),
+      this.commandHelpIncludes(['sch', 'export', 'pdf'], /--variant\b/)
+    ]);
+    return {
+      ...(Object.fromEntries(commandResults) as KiCadCliCapabilitySnapshot),
+      variantOption
+    };
   }
 
   private async validateCandidate(

--- a/apps/vscode-extension/src/cli/kicadCliSupport.ts
+++ b/apps/vscode-extension/src/cli/kicadCliSupport.ts
@@ -51,11 +51,19 @@ export function describeKiCadSupportLine(
   cli: Pick<DetectedKiCadCli, 'version' | 'versionLabel'> | undefined
 ): KiCadSupportLine {
   const major = parseKiCadMajor(cli);
-  if (!cli || typeof major === 'undefined') {
+  if (!cli) {
     return {
       state: 'unknown',
       label: 'KiCad CLI not detected',
       detail: 'Install KiCad or configure kicadstudio.kicadCliPath.'
+    };
+  }
+  if (typeof major === 'undefined') {
+    return {
+      state: 'unknown',
+      label: `${cli.versionLabel} unknown`,
+      detail:
+        'Detected kicad-cli did not report a parseable KiCad major version.'
     };
   }
   if (major >= 10) {

--- a/apps/vscode-extension/src/cli/kicadCliSupport.ts
+++ b/apps/vscode-extension/src/cli/kicadCliSupport.ts
@@ -1,0 +1,228 @@
+import type { DetectedKiCadCli } from '../types';
+import { COMPATIBILITY_MATRIX } from '../mcp/compatibilityMatrix';
+import type { KiCadCliCapabilitySnapshot } from './kicadCliDetector';
+
+export type KiCadSupportState =
+  | 'primary'
+  | 'supported'
+  | 'deprecated'
+  | 'unsupported'
+  | 'unknown';
+
+export type KiCadFeatureState = 'available' | 'unsupported' | 'unknown';
+
+export interface KiCadSupportLine {
+  state: KiCadSupportState;
+  label: string;
+  detail: string;
+}
+
+export interface KiCadFeatureSupport {
+  id:
+    | 'core-validation'
+    | 'manufacturing-exports'
+    | 'jobsets'
+    | 'variants'
+    | 'odb-export'
+    | 'three-d-pdf-export';
+  label: string;
+  state: KiCadFeatureState;
+  summary: string;
+  reason: string;
+}
+
+const KI_CAD_PRIMARY_RANGE = COMPATIBILITY_MATRIX.kicad.primary;
+
+export function parseKiCadMajor(
+  cli: Pick<DetectedKiCadCli, 'version'> | undefined
+): number | undefined {
+  if (!cli) {
+    return undefined;
+  }
+  const match = cli.version.match(/^(\d+)/);
+  if (!match) {
+    return undefined;
+  }
+  const major = Number.parseInt(match[1]!, 10);
+  return Number.isFinite(major) ? major : undefined;
+}
+
+export function describeKiCadSupportLine(
+  cli: Pick<DetectedKiCadCli, 'version' | 'versionLabel'> | undefined
+): KiCadSupportLine {
+  const major = parseKiCadMajor(cli);
+  if (!cli || typeof major === 'undefined') {
+    return {
+      state: 'unknown',
+      label: 'KiCad CLI not detected',
+      detail: 'Install KiCad or configure kicadstudio.kicadCliPath.'
+    };
+  }
+  if (major >= 10) {
+    return {
+      state: 'primary',
+      label: `${cli.versionLabel} primary`,
+      detail: `Primary release-blocking KiCad line: ${KI_CAD_PRIMARY_RANGE}.`
+    };
+  }
+  if (major === 9) {
+    return {
+      state: 'supported',
+      label: `${cli.versionLabel} supported`,
+      detail:
+        'Supported previous KiCad line; covered by scheduled compatibility checks.'
+    };
+  }
+  if (major === 8) {
+    return {
+      state: 'deprecated',
+      label: `${cli.versionLabel} deprecated`,
+      detail:
+        'Deprecated compatibility line; file-level read and migration support only.'
+    };
+  }
+  return {
+    state: 'unsupported',
+    label: `${cli.versionLabel} unsupported`,
+    detail: 'KiCad Studio supports KiCad 8.x, 9.x, and 10.0.x only.'
+  };
+}
+
+export function buildKiCadFeatureSupport(options: {
+  cli?: DetectedKiCadCli | undefined;
+  capabilities?: KiCadCliCapabilitySnapshot | undefined;
+}): KiCadFeatureSupport[] {
+  const major = parseKiCadMajor(options.cli);
+  const capabilities = options.capabilities;
+
+  return [
+    feature({
+      id: 'core-validation',
+      label: 'DRC, ERC, BOM, netlist, Gerbers',
+      major,
+      minimumMajor: 8,
+      capabilityKeys: ['drc', 'erc', 'bom', 'netlist', 'gerbers'],
+      capabilities,
+      supportedReason:
+        'Core validation and standard fabrication commands are supported for KiCad 8, 9, and 10 when the CLI help probes pass.',
+      unsupportedReason:
+        'Core validation requires a detected KiCad 8+ kicad-cli with DRC, ERC, BOM, netlist, and Gerber commands.'
+    }),
+    feature({
+      id: 'manufacturing-exports',
+      label: 'Manufacturing package exports',
+      major,
+      minimumMajor: 9,
+      capabilityKeys: ['drill', 'gerbers'],
+      capabilities,
+      supportedReason:
+        'Manufacturing export workflows are supported for KiCad 9 and 10 after drill and Gerber command probes pass.',
+      unsupportedReason:
+        'Manufacturing package exports require KiCad 9+ plus drill and Gerber CLI command support.'
+    }),
+    feature({
+      id: 'jobsets',
+      label: 'Jobset runner',
+      major,
+      minimumMajor: 9,
+      capabilityKeys: ['jobset'],
+      capabilities,
+      supportedReason:
+        'Jobset execution is available for KiCad 9 and 10 when `kicad-cli jobset run --help` succeeds.',
+      unsupportedReason:
+        'Jobsets require KiCad 9+ and a kicad-cli build that exposes `jobset run`.'
+    }),
+    feature({
+      id: 'variants',
+      label: 'Design variants',
+      major,
+      minimumMajor: 10,
+      capabilityKeys: ['variantOption'],
+      capabilities,
+      supportedReason:
+        'Variant-aware exports are enabled for KiCad 10 when command help exposes `--variant`.',
+      unsupportedReason:
+        'Design variant export switching requires KiCad 10+ and `--variant` support in CLI export help.'
+    }),
+    feature({
+      id: 'odb-export',
+      label: 'ODB++ export',
+      major,
+      minimumMajor: 9,
+      capabilityKeys: ['odb'],
+      capabilities,
+      supportedReason:
+        'ODB++ export is available for KiCad 9 and 10 when the `pcb export odb` command probe passes.',
+      unsupportedReason:
+        'ODB++ export requires KiCad 9+ and a kicad-cli build that exposes `pcb export odb`.'
+    }),
+    feature({
+      id: 'three-d-pdf-export',
+      label: '3D PDF export',
+      major,
+      minimumMajor: 10,
+      capabilityKeys: ['pdf3d'],
+      capabilities,
+      supportedReason:
+        '3D PDF export is enabled for KiCad 10 when the `pcb export 3dpdf` command probe passes.',
+      unsupportedReason:
+        '3D PDF export requires KiCad 10+ and a kicad-cli build that exposes `pcb export 3dpdf`.'
+    })
+  ];
+}
+
+function feature(options: {
+  id: KiCadFeatureSupport['id'];
+  label: string;
+  major: number | undefined;
+  minimumMajor: number;
+  capabilityKeys: Array<keyof KiCadCliCapabilitySnapshot>;
+  capabilities: KiCadCliCapabilitySnapshot | undefined;
+  supportedReason: string;
+  unsupportedReason: string;
+}): KiCadFeatureSupport {
+  if (typeof options.major === 'undefined') {
+    return {
+      id: options.id,
+      label: options.label,
+      state: 'unknown',
+      summary: 'unknown',
+      reason: 'Run KiCad: Detect kicad-cli to evaluate this feature.'
+    };
+  }
+  if (options.major < options.minimumMajor) {
+    return {
+      id: options.id,
+      label: options.label,
+      state: 'unsupported',
+      summary: `requires KiCad ${options.minimumMajor}+`,
+      reason: options.unsupportedReason
+    };
+  }
+
+  const failedProbe = options.capabilityKeys.find(
+    (key) => options.capabilities?.[key] === false
+  );
+  if (failedProbe) {
+    return {
+      id: options.id,
+      label: options.label,
+      state: 'unsupported',
+      summary: `missing ${String(failedProbe)}`,
+      reason: `${options.unsupportedReason} The ${String(failedProbe)} capability probe failed.`
+    };
+  }
+
+  const pendingProbe = options.capabilityKeys.some(
+    (key) => typeof options.capabilities?.[key] === 'undefined'
+  );
+  return {
+    id: options.id,
+    label: options.label,
+    state: pendingProbe ? 'unknown' : 'available',
+    summary: pendingProbe ? 'probe pending' : 'available',
+    reason: pendingProbe
+      ? `${options.supportedReason} This status menu has not run all probes yet.`
+      : options.supportedReason
+  };
+}

--- a/apps/vscode-extension/src/commands/viewerCommands.ts
+++ b/apps/vscode-extension/src/commands/viewerCommands.ts
@@ -32,12 +32,15 @@ export function registerViewerCommands(
       const cli = trusted
         ? await services.cliDetector.detect(false)
         : undefined;
+      const capabilities = cli
+        ? await services.cliDetector.getCapabilitySnapshot()
+        : undefined;
       if (cli) {
         services.statusBar.update({ cli });
       }
       const snapshot = services.statusBar.getSnapshot();
       const picked = await vscode.window.showQuickPick(
-        buildStatusMenuItems({ trusted, cli, snapshot }),
+        buildStatusMenuItems({ trusted, cli, capabilities, snapshot }),
         { title: 'KiCad Studio Commands' }
       );
       if (picked?.command) {

--- a/apps/vscode-extension/src/commands/viewerStatusMenu.ts
+++ b/apps/vscode-extension/src/commands/viewerStatusMenu.ts
@@ -1,5 +1,10 @@
 import { COMMANDS, SETTINGS } from '../constants';
 import type { DetectedKiCadCli, DiagnosticSummary } from '../types';
+import type { KiCadCliCapabilitySnapshot } from '../cli/kicadCliDetector';
+import {
+  buildKiCadFeatureSupport,
+  describeKiCadSupportLine
+} from '../cli/kicadCliSupport';
 
 export interface StatusBarSnapshot {
   drc?: DiagnosticSummary | undefined;
@@ -20,9 +25,18 @@ const QUICK_PICK_SEPARATOR = -1;
 export function buildStatusMenuItems(options: {
   trusted: boolean;
   cli?: DetectedKiCadCli | undefined;
+  capabilities?: KiCadCliCapabilitySnapshot | undefined;
   snapshot: StatusBarSnapshot;
 }): StatusMenuItem[] {
-  const { trusted, cli, snapshot } = options;
+  const { trusted, cli, capabilities, snapshot } = options;
+  const supportLine = describeKiCadSupportLine(cli);
+  const featureItems = trusted
+    ? buildKiCadFeatureSupport({ cli, capabilities }).map((feature) => ({
+        label: `${featureIcon(feature.state)} ${feature.label}`,
+        description: feature.summary,
+        detail: feature.reason
+      }))
+    : [];
   const drcDetail = snapshot.drc
     ? `${snapshot.drc.errors} errors, ${snapshot.drc.warnings} warnings, ${snapshot.drc.infos} info - ${formatTimestamp(snapshot.drc.capturedAt)}`
     : 'No DRC result yet';
@@ -34,8 +48,8 @@ export function buildStatusMenuItems(options: {
     ? cli
       ? {
           label: '$(circuit-board) KiCad detected',
-          description: cli.versionLabel,
-          detail: `${cli.path} (${cli.source})`
+          description: supportLine.label,
+          detail: `${cli.path} (${cli.source})\n${supportLine.detail}`
         }
       : {
           label: '$(warning) kicad-cli not detected',
@@ -52,6 +66,7 @@ export function buildStatusMenuItems(options: {
   const items: StatusMenuItem[] = [
     separator('Status'),
     statusItem,
+    ...(trusted ? [separator('Compatibility'), ...featureItems] : []),
     separator('Validate'),
     {
       label: '$(beaker) Run board DRC',
@@ -115,6 +130,16 @@ export function buildStatusMenuItems(options: {
   ];
 
   return items;
+}
+
+function featureIcon(state: 'available' | 'unsupported' | 'unknown'): string {
+  if (state === 'available') {
+    return '$(pass)';
+  }
+  if (state === 'unsupported') {
+    return '$(warning)';
+  }
+  return '$(question)';
 }
 
 function separator(label: string): StatusMenuItem {

--- a/apps/vscode-extension/src/statusbar/kicadStatusBar.ts
+++ b/apps/vscode-extension/src/statusbar/kicadStatusBar.ts
@@ -7,6 +7,7 @@ import type {
   McpCompatStatus,
   McpConnectionKind
 } from '../types';
+import { describeKiCadSupportLine } from '../cli/kicadCliSupport';
 
 // Priority decreases left-to-right within Left-aligned items.
 // Higher number = further left.
@@ -186,9 +187,13 @@ export class KiCadStatusBar implements vscode.Disposable {
         'statusBarItem.warningBackground'
       );
     } else {
+      const support = describeKiCadSupportLine(this.cli);
       this.kicadItem.text = `$(circuit-board) ${this.cli.versionLabel}`;
-      this.kicadItem.tooltip = `KiCad CLI: ${this.cli.path}\nClick to open settings`;
-      this.kicadItem.backgroundColor = undefined;
+      this.kicadItem.tooltip = `KiCad CLI: ${this.cli.path}\nSupport: ${support.label}\n${support.detail}\nClick to open settings`;
+      this.kicadItem.backgroundColor =
+        support.state === 'deprecated' || support.state === 'unsupported'
+          ? new vscode.ThemeColor('statusBarItem.warningBackground')
+          : undefined;
     }
     this.kicadItem.command = COMMANDS.showStatusMenu;
   }

--- a/apps/vscode-extension/src/statusbar/kicadStatusBar.ts
+++ b/apps/vscode-extension/src/statusbar/kicadStatusBar.ts
@@ -191,7 +191,9 @@ export class KiCadStatusBar implements vscode.Disposable {
       this.kicadItem.text = `$(circuit-board) ${this.cli.versionLabel}`;
       this.kicadItem.tooltip = `KiCad CLI: ${this.cli.path}\nSupport: ${support.label}\n${support.detail}\nClick to open settings`;
       this.kicadItem.backgroundColor =
-        support.state === 'deprecated' || support.state === 'unsupported'
+        support.state === 'deprecated' ||
+        support.state === 'unsupported' ||
+        support.state === 'unknown'
           ? new vscode.ThemeColor('statusBarItem.warningBackground')
           : undefined;
     }

--- a/apps/vscode-extension/test/unit/exportCommands.test.ts
+++ b/apps/vscode-extension/test/unit/exportCommands.test.ts
@@ -41,18 +41,61 @@ describe('buildCliExportCommands', () => {
     ).toContain('ipcd356');
   });
 
-  it('builds gerber precision only for KiCad 9 and newer', () => {
+  it('builds Gerber precision for the supported KiCad 8, 9, and 10 lines', () => {
     const pcb = '/project/board.kicad_pcb';
+    for (const versionMajor of [8, 9, 10]) {
+      expect(
+        buildCliExportCommands('export-gerbers', pcb, '/project/fab', {
+          versionMajor
+        })[0]
+      ).toEqual(expect.arrayContaining(['--precision', '6']));
+    }
     expect(
       buildCliExportCommands('export-gerbers', pcb, '/project/fab', {
-        versionMajor: 9
-      })[0]
-    ).toEqual(expect.arrayContaining(['--precision', '6']));
-    expect(
-      buildCliExportCommands('export-gerbers', pcb, '/project/fab', {
-        versionMajor: 6
+        versionMajor: 7
       })[0]
     ).not.toContain('--precision');
+  });
+
+  it('validates command construction across the KiCad support matrix', () => {
+    const pcb = '/project/board.kicad_pcb';
+    const schematic = '/project/design.kicad_sch';
+
+    for (const versionMajor of [8, 9, 10]) {
+      expect(
+        buildCliExportCommands('export-gerbers', pcb, '/project/fab', {
+          versionMajor
+        })[0]
+      ).toEqual(
+        expect.arrayContaining([
+          'pcb',
+          'export',
+          'gerbers',
+          '--output',
+          '/project/fab',
+          pcb
+        ])
+      );
+      expect(
+        buildCliExportCommands('export-pdf-sch', schematic, '/project/fab', {
+          versionMajor
+        })[0]
+      ).toEqual(expect.arrayContaining(['sch', 'export', 'pdf', schematic]));
+      expect(
+        buildCliExportCommands('export-netlist', schematic, '/project/fab', {
+          versionMajor
+        })[0]
+      ).toEqual(
+        expect.arrayContaining([
+          'sch',
+          'export',
+          'netlist',
+          '--format',
+          'kicadsexpr',
+          schematic
+        ])
+      );
+    }
   });
 
   it('discovers active Gerber layers from the board stackup', async () => {

--- a/apps/vscode-extension/test/unit/kicadCliDetector.test.ts
+++ b/apps/vscode-extension/test/unit/kicadCliDetector.test.ts
@@ -287,6 +287,36 @@ describe('KiCadCliDetector', () => {
     await expect(detector.hasCapability('bom')).resolves.toBe(false);
   });
 
+  it('builds a status-menu capability snapshot from CLI help probes', async () => {
+    const detector = new KiCadCliDetector() as any;
+    detector.detect = jest.fn().mockResolvedValue({
+      path: '/usr/bin/kicad-cli',
+      version: '10.0.3',
+      versionLabel: 'KiCad 10.0.3',
+      source: 'path'
+    });
+    detector.hasCapability = jest
+      .fn()
+      .mockImplementation(async (command: string) => command !== 'odb');
+    detector.commandHelpIncludes = jest.fn().mockResolvedValue(true);
+
+    await expect(detector.getCapabilitySnapshot()).resolves.toEqual(
+      expect.objectContaining({
+        drc: true,
+        erc: true,
+        gerbers: true,
+        pdf3d: true,
+        odb: false,
+        variantOption: true
+      })
+    );
+    expect(detector.hasCapability).toHaveBeenCalledWith('jobset');
+    expect(detector.commandHelpIncludes).toHaveBeenCalledWith(
+      ['sch', 'export', 'pdf'],
+      /--variant\b/
+    );
+  });
+
   it('handles empty candidates, missing files, and failed PATH lookups', async () => {
     const detector = new KiCadCliDetector() as any;
     const existsSyncMock = fs.existsSync as unknown as jest.Mock;

--- a/apps/vscode-extension/test/unit/kicadCliSupport.test.ts
+++ b/apps/vscode-extension/test/unit/kicadCliSupport.test.ts
@@ -1,0 +1,171 @@
+import {
+  buildKiCadFeatureSupport,
+  describeKiCadSupportLine,
+  parseKiCadMajor
+} from '../../src/cli/kicadCliSupport';
+
+describe('kicadCliSupport', () => {
+  it('classifies the supported KiCad 8, 9, and 10 support lines', () => {
+    expect(parseKiCadMajor({ version: '10.0.3' })).toBe(10);
+    expect(
+      describeKiCadSupportLine({
+        version: '10.0.3',
+        versionLabel: 'KiCad 10.0.3'
+      }).state
+    ).toBe('primary');
+    expect(
+      describeKiCadSupportLine({
+        version: '9.0.9',
+        versionLabel: 'KiCad 9.0.9'
+      }).state
+    ).toBe('supported');
+    expect(
+      describeKiCadSupportLine({
+        version: '8.0.8',
+        versionLabel: 'KiCad 8.0.8'
+      }).state
+    ).toBe('deprecated');
+    expect(
+      describeKiCadSupportLine({
+        version: '7.0.11',
+        versionLabel: 'KiCad 7.0.11'
+      }).state
+    ).toBe('unsupported');
+  });
+
+  it('reports feature availability from version line plus capability probes', () => {
+    const features = buildKiCadFeatureSupport({
+      cli: {
+        path: '/usr/bin/kicad-cli',
+        version: '10.0.3',
+        versionLabel: 'KiCad 10.0.3',
+        source: 'path'
+      },
+      capabilities: {
+        drc: true,
+        erc: true,
+        bom: true,
+        netlist: true,
+        gerbers: true,
+        drill: true,
+        jobset: true,
+        pdf3d: true,
+        odb: true,
+        variantOption: true
+      }
+    });
+
+    expect(features).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'core-validation',
+          state: 'available'
+        }),
+        expect.objectContaining({
+          id: 'variants',
+          state: 'available'
+        }),
+        expect.objectContaining({
+          id: 'odb-export',
+          state: 'available'
+        }),
+        expect.objectContaining({
+          id: 'three-d-pdf-export',
+          state: 'available'
+        })
+      ])
+    );
+  });
+
+  it('keeps KiCad 8 core support while marking newer feature gates unsupported', () => {
+    const features = buildKiCadFeatureSupport({
+      cli: {
+        path: '/usr/bin/kicad-cli',
+        version: '8.0.8',
+        versionLabel: 'KiCad 8.0.8',
+        source: 'path'
+      },
+      capabilities: {
+        drc: true,
+        erc: true,
+        bom: true,
+        netlist: true,
+        gerbers: true
+      }
+    });
+
+    expect(features.find((item) => item.id === 'core-validation')).toEqual(
+      expect.objectContaining({ state: 'available' })
+    );
+    expect(features.find((item) => item.id === 'jobsets')).toEqual(
+      expect.objectContaining({ state: 'unsupported' })
+    );
+    expect(features.find((item) => item.id === 'variants')).toEqual(
+      expect.objectContaining({ state: 'unsupported' })
+    );
+    expect(features.find((item) => item.id === 'odb-export')).toEqual(
+      expect.objectContaining({ state: 'unsupported' })
+    );
+  });
+
+  it('keeps KiCad 9 ODB++ support while marking KiCad 10-only exports unsupported', () => {
+    const features = buildKiCadFeatureSupport({
+      cli: {
+        path: '/usr/bin/kicad-cli',
+        version: '9.0.9',
+        versionLabel: 'KiCad 9.0.9',
+        source: 'path'
+      },
+      capabilities: {
+        drc: true,
+        erc: true,
+        bom: true,
+        netlist: true,
+        gerbers: true,
+        drill: true,
+        jobset: true,
+        odb: true
+      }
+    });
+
+    expect(features.find((item) => item.id === 'odb-export')).toEqual(
+      expect.objectContaining({ state: 'available' })
+    );
+    expect(features.find((item) => item.id === 'variants')).toEqual(
+      expect.objectContaining({ state: 'unsupported' })
+    );
+    expect(features.find((item) => item.id === 'three-d-pdf-export')).toEqual(
+      expect.objectContaining({ state: 'unsupported' })
+    );
+  });
+
+  it('marks a feature unsupported when a detected CLI capability probe fails', () => {
+    const features = buildKiCadFeatureSupport({
+      cli: {
+        path: '/usr/bin/kicad-cli',
+        version: '10.0.3',
+        versionLabel: 'KiCad 10.0.3',
+        source: 'path'
+      },
+      capabilities: {
+        drc: true,
+        erc: true,
+        bom: true,
+        netlist: true,
+        gerbers: true,
+        drill: true,
+        jobset: true,
+        pdf3d: false,
+        odb: true,
+        variantOption: true
+      }
+    });
+
+    expect(features.find((item) => item.id === 'three-d-pdf-export')).toEqual(
+      expect.objectContaining({
+        state: 'unsupported',
+        summary: 'missing pdf3d'
+      })
+    );
+  });
+});

--- a/apps/vscode-extension/test/unit/kicadCliSupport.test.ts
+++ b/apps/vscode-extension/test/unit/kicadCliSupport.test.ts
@@ -31,6 +31,18 @@ describe('kicadCliSupport', () => {
         versionLabel: 'KiCad 7.0.11'
       }).state
     ).toBe('unsupported');
+    expect(
+      describeKiCadSupportLine({
+        version: 'nightly',
+        versionLabel: 'KiCad nightly'
+      })
+    ).toEqual(
+      expect.objectContaining({
+        state: 'unknown',
+        label: 'KiCad nightly unknown',
+        detail: expect.stringContaining('parseable KiCad major version')
+      })
+    );
   });
 
   it('reports feature availability from version line plus capability probes', () => {

--- a/apps/vscode-extension/test/unit/kicadStatusBar.test.ts
+++ b/apps/vscode-extension/test/unit/kicadStatusBar.test.ts
@@ -112,6 +112,21 @@ describe('KiCadStatusBar', () => {
       bar.dispose();
     });
 
+    it('warns when detected CLI reports an unparseable version', () => {
+      const bar = makeBar();
+      bar.update({
+        cli: {
+          path: '/usr/bin/kicad-cli',
+          version: 'nightly',
+          versionLabel: 'KiCad nightly',
+          source: 'path'
+        }
+      });
+      expect(item(0).tooltip).toContain('parseable KiCad major version');
+      expect(item(0).backgroundColor).toBeDefined();
+      bar.dispose();
+    });
+
     it('shows circuit-board icon when cli is detected', () => {
       const bar = makeBar();
       bar.update({

--- a/apps/vscode-extension/test/unit/viewerStatusMenu.test.ts
+++ b/apps/vscode-extension/test/unit/viewerStatusMenu.test.ts
@@ -25,6 +25,18 @@ describe('buildStatusMenuItems', () => {
         versionLabel: 'KiCad 10.0.1',
         source: 'settings'
       },
+      capabilities: {
+        drc: true,
+        erc: true,
+        bom: true,
+        netlist: true,
+        gerbers: true,
+        drill: true,
+        jobset: true,
+        pdf3d: true,
+        odb: false,
+        variantOption: true
+      },
       snapshot: {
         drc: {
           file: '/workspace/sample.kicad_pcb',
@@ -46,6 +58,7 @@ describe('buildStatusMenuItems', () => {
     expect(items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ label: 'Status', kind: -1 }),
+        expect.objectContaining({ label: 'Compatibility', kind: -1 }),
         expect.objectContaining({ label: 'Validate', kind: -1 }),
         expect.objectContaining({ label: 'Export', kind: -1 }),
         expect.objectContaining({ label: 'Libraries', kind: -1 }),
@@ -58,11 +71,28 @@ describe('buildStatusMenuItems', () => {
     );
     expect(detectedItem).toEqual(
       expect.objectContaining({
-        description: 'KiCad 10.0.1',
+        description: 'KiCad 10.0.1 primary',
         detail: expect.stringContaining('/opt/kicad/bin/kicad-cli')
       })
     );
     expect(detectedItem).not.toHaveProperty('command');
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: '$(pass) Design variants',
+          description: 'available'
+        }),
+        expect.objectContaining({
+          label: '$(warning) ODB++ export',
+          description: 'missing odb',
+          detail: expect.stringContaining('capability probe failed')
+        }),
+        expect.objectContaining({
+          label: '$(pass) 3D PDF export',
+          description: 'available'
+        })
+      ])
+    );
     expect(items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -104,6 +134,14 @@ describe('buildStatusMenuItems', () => {
         command: 'workbench.action.openSettings',
         args: [SETTINGS.cliPath]
       })
+    );
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: '$(question) DRC, ERC, BOM, netlist, Gerbers',
+          description: 'unknown'
+        })
+      ])
     );
   });
 });

--- a/docs/changelog/kicad-studio.md
+++ b/docs/changelog/kicad-studio.md
@@ -4,6 +4,8 @@ Source: `apps/vscode-extension/CHANGELOG.md`
 
 ## [Unreleased]
 
+- Surface KiCad 8.x, 9.x, and 10.0.x compatibility state in the status
+  bar/menu with feature-level capability probe results.
 - Clarify Codex support as an external MCP client workflow, remove it from the
   direct extension provider settings, and migrate legacy
   `kicadstudio.ai.provider=codex` selections to GitHub Copilot.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -47,6 +47,34 @@ Machine-maintained from `compatibility.yaml`. Refresh with
 
 <!-- docs-site:compatibility:end -->
 
+## Tested KiCad CLI Feature Matrix
+
+This matrix records the user-facing support boundary for `kicad-cli` driven
+extension features. The runtime checks intentionally probe CLI command help
+before running commands; a version line alone is not enough to enable advanced
+exports.
+
+| KiCad line | Tested patch | Support state | Required validation                         | Extension feature state                                                                                                                                                                     |
+| ---------- | ------------ | ------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 10.0.x     | 10.0.3       | Primary       | Required release gate and KiCad canary lane | Core DRC/ERC, BOM/netlist, Gerbers/drill, jobsets, design variants, 3D PDF, and ODB++ are supported when command probes pass.                                                               |
+| 9.x        | 9.0.9        | Supported     | Scheduled KiCad canary lane                 | Core DRC/ERC, BOM/netlist, Gerbers/drill, jobsets, ODB++, and manufacturing package workflows are supported when command probes pass; KiCad 10-only variants and 3D PDF remain unavailable. |
+| 8.x        | 8.0.x        | Deprecated    | Manual compatibility check                  | Core file-level read, migration, DRC/ERC, BOM/netlist, and Gerber workflows are best-effort when command probes pass; jobsets, variants, 3D PDF, and ODB++ remain unavailable.              |
+| <8         | none         | Unsupported   | None                                        | KiCad Studio reports the detected CLI as unsupported and does not claim feature compatibility.                                                                                              |
+
+Status surfaces:
+
+- The status bar shows the detected KiCad support line and warns on deprecated or unsupported CLIs.
+- The `KiCad Studio Commands` status menu lists feature-level availability with precise unsupported reasons.
+- Advanced commands such as ODB++ and 3D PDF export require both their documented KiCad line and a successful `kicad-cli` capability probe.
+
+Freshness sources checked on 2026-05-26:
+
+- KiCad 10.0.3 release notes: <https://www.kicad.org/blog/2026/05/KiCad-10.0.3-Release/>
+- KiCad 9.0.9 release notes: <https://www.kicad.org/blog/2026/04/KiCad-9.0.9-Release/>
+- KiCad 10.0 CLI reference: <https://docs.kicad.org/10.0/en/cli/cli.html>
+- KiCad 9.0 CLI reference: <https://docs.kicad.org/9.0/en/cli/cli.html>
+- KiCad 8.0 CLI reference: <https://docs.kicad.org/8.0/en/cli/cli.html>
+
 ## Lifecycle States
 
 | State      | Meaning                                                               |
@@ -58,14 +86,14 @@ Machine-maintained from `compatibility.yaml`. Refresh with
 
 ## Current Platform Policy
 
-| Surface      | Primary    | Supported             | Deprecated | Gate                                     |
-| ------------ | ---------- | --------------------- | ---------- | ---------------------------------------- |
-| KiCad        | 10.0.x     | 9.x                   | 8.x        | `compatibility.yaml` + release preflight |
-| VS Code      | current    | `engines.vscode` 1.120 | none      | extension manifest + VS Code canary      |
-| MCP protocol | 2025-11-25 | 2025-11-25            | older      | well-known server card + matrix          |
-| Node         | 24.x       | `>=24.11.0 <25`       | older      | root and extension package metadata      |
-| pnpm         | 11.x       | `>=11.0.0 <12`        | older      | root package metadata                    |
-| Python       | 3.13       | 3.13, 3.14            | older      | `pyproject.toml` and CI                  |
+| Surface      | Primary    | Supported              | Deprecated | Gate                                     |
+| ------------ | ---------- | ---------------------- | ---------- | ---------------------------------------- |
+| KiCad        | 10.0.x     | 9.x                    | 8.x        | `compatibility.yaml` + release preflight |
+| VS Code      | current    | `engines.vscode` 1.120 | none       | extension manifest + VS Code canary      |
+| MCP protocol | 2025-11-25 | 2025-11-25             | older      | well-known server card + matrix          |
+| Node         | 24.x       | `>=24.11.0 <25`        | older      | root and extension package metadata      |
+| pnpm         | 11.x       | `>=11.0.0 <12`         | older      | root package metadata                    |
+| Python       | 3.13       | 3.13, 3.14             | older      | `pyproject.toml` and CI                  |
 
 ## Minimum-Bump Policy
 


### PR DESCRIPTION
## Summary

- Added the KiCad 8.x / 9.x / 10.0.x support matrix to README/docs with official KiCad release and CLI references.
- Added extension-side support-line and feature capability state so the status bar/menu can report supported, deprecated, unsupported, or unknown KiCad installations with precise reasons.
- Added command construction and status-menu unit coverage for the supported KiCad version matrix.
- Addressed automated review feedback by parallelizing capability probes, distinguishing unparseable KiCad versions, and warning on unknown detected support state.

## Linked issue

Closes #31

Linear: OASLANA-30

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm exec prettier --ignore-unknown --write README.md docs/support-matrix.md apps/vscode-extension/src/cli/kicadCliSupport.ts apps/vscode-extension/src/cli/kicadCliDetector.ts apps/vscode-extension/src/commands/viewerCommands.ts apps/vscode-extension/src/commands/viewerStatusMenu.ts apps/vscode-extension/src/statusbar/kicadStatusBar.ts apps/vscode-extension/src/cli/exportCommands.ts apps/vscode-extension/test/unit/kicadCliDetector.test.ts apps/vscode-extension/test/unit/kicadCliSupport.test.ts apps/vscode-extension/test/unit/viewerStatusMenu.test.ts apps/vscode-extension/test/unit/exportCommands.test.ts`
- `corepack pnpm --dir apps/vscode-extension exec jest --runInBand --coverage=false test/unit/kicadCliSupport.test.ts test/unit/kicadCliDetector.test.ts test/unit/viewerStatusMenu.test.ts test/unit/exportCommands.test.ts test/unit/kicadStatusBar.test.ts test/unit/statusBar.test.ts`
- `corepack pnpm --filter kicadstudio run typecheck`
- `corepack pnpm run docs:lint`
- `corepack pnpm run docs:links`
- `corepack pnpm run docs:check-generated`
- `corepack pnpm run check:docs-site`
- `corepack pnpm run check:compatibility`
- `corepack pnpm run check:forbidden-refs`
- `corepack pnpm run format:check`
- `git diff --check`
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist`
- `uvx pre-commit run --all-files`

## Protocol / MCP impact

- [x] Not applicable; reason: this changes extension KiCad CLI capability probing and documentation only. MCP tool names, schemas, server implementation, server-info payloads, protocol metadata, and MCP compatibility metadata are unchanged.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean / opened ready after full local gates passed
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [ ] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [ ] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [x] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
