### PR TITLE
test(kicad-mcp-pro): add KiCad CLI contract matrix

### DIFF
--- a/.github/workflows/kicad-canary.yml
+++ b/.github/workflows/kicad-canary.yml
@@ -1,6 +1,15 @@
 name: KiCad Canary
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/kicad-canary.yml"
+      - "compatibility.yaml"
+      - "packages/kicad-fixtures/**"
+      - "packages/mcp-server/scripts/kicad_canary.py"
+      - "packages/mcp-server/tests/unit/test_kicad_canary.py"
+      - "packages/mcp-server/tests/integration/test_kicad_cli_smoke.py"
+      - "docs/testing-strategy.md"
   workflow_dispatch:
     inputs:
       include-manual-lanes:
@@ -35,18 +44,23 @@ jobs:
       - name: Build KiCad canary matrix
         id: lanes
         env:
+          EVENT_NAME: ${{ github.event_name }}
           INCLUDE_MANUAL_LANES: ${{ inputs['include-manual-lanes'] || 'false' }}
         run: |
           args=()
           if [ "$INCLUDE_MANUAL_LANES" = "true" ]; then
             args+=(--include-manual)
           fi
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            args+=(--required-only)
+          fi
           matrix="$(uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/kicad_canary.py matrix "${args[@]}")"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   cli:
     needs: matrix
-    runs-on: ubuntu-24.04
+    name: ${{ matrix.id }}
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.continue_on_error }}
     permissions:
       contents: read
@@ -64,7 +78,8 @@ jobs:
           enable-cache: true
           version-file: packages/mcp-server/uv.toml
       - run: uv sync --all-extras --frozen --project packages/mcp-server
-      - name: Install KiCad lane
+      - name: Install KiCad Linux lane
+        if: matrix.install == 'apt-ppa'
         env:
           KICAD_PACKAGE: ${{ matrix.package }}
           KICAD_PPA: ${{ matrix.ppa }}
@@ -74,6 +89,21 @@ jobs:
           sudo add-apt-repository --yes "$KICAD_PPA"
           sudo apt-get update
           sudo apt-get install --yes "$KICAD_PACKAGE"
+      - name: Install KiCad Windows primary lane
+        if: matrix.install == 'choco'
+        shell: pwsh
+        env:
+          KICAD_VERSION: ${{ matrix.version }}
+        run: |
+          choco install kicad --version="$env:KICAD_VERSION" --yes --no-progress
+          $kicadBin = "C:\Program Files\KiCad\10.0\bin"
+          $kicadCli = Join-Path $kicadBin "kicad-cli.exe"
+          if (!(Test-Path $kicadCli)) {
+            throw "KiCad CLI was not found: $kicadCli"
+          }
+          $kicadBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "KICAD_CANARY_KICAD_CLI=$kicadCli" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Run KiCad CLI canary
         env:
           KICAD_CANARY_RANGE: ${{ matrix.range }}
@@ -90,7 +120,7 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
       - name: Open or update compatibility issue
-        if: failure()
+        if: failure() && github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           KICAD_CANARY_CI: ${{ matrix.ci }}

--- a/.github/workflows/kicad-canary.yml
+++ b/.github/workflows/kicad-canary.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Run KiCad CLI canary
         env:
           KICAD_CANARY_RANGE: ${{ matrix.range }}
+        shell: bash
         run: |
           uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/kicad_canary.py run \
             --artifacts "artifacts/kicad-canary/${{ matrix.id }}" \

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage/
 htmlcov/
 coverage.xml
 performance-results/
+artifacts/
 .pytest-tmp*/
 *.vsix
 *.whl

--- a/docs/changelog/kicad-mcp-pro.md
+++ b/docs/changelog/kicad-mcp-pro.md
@@ -6,6 +6,9 @@ Source: `packages/mcp-server/CHANGELOG.md`
 
 - Add `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
   setup troubleshooting.
+- Add real KiCad CLI contract canaries with shared fixtures, Windows primary
+  KiCad 10.0.3 smoke coverage, scheduled 9.x/10.x lanes, and structured
+  unsupported-feature artifacts.
 
 ## [1.0.0]
 

--- a/docs/kicad-fixture-corpus.md
+++ b/docs/kicad-fixture-corpus.md
@@ -57,6 +57,19 @@ The root repository check also runs this gate:
 corepack pnpm run check
 ```
 
+Real KiCad CLI contract lanes consume the same corpus and write their runtime
+artifacts outside the package:
+
+```bash
+corepack pnpm run test:kicad-cli-contract
+```
+
+The contract command requires a real `kicad-cli` on `PATH` or one of
+`KICAD_CANARY_KICAD_CLI`, `KICAD_MCP_KICAD_CLI`, or `KICAD_CLI_PATH`. When the
+CLI is missing, the harness writes `summary.json` and `failing-fixtures.txt`
+with a structured environment failure instead of crashing before artifacts are
+created.
+
 ## Fixture Coverage
 
 The corpus includes these required semantic fixtures:

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -219,12 +219,34 @@ from `compatibility.yaml` every week and on manual dispatch. Required and
 scheduled lanes run by default; manual dispatch can opt into deprecated lanes
 that remain documented but should not block normal scheduled canaries.
 
+Pull requests that touch the KiCad contract harness, compatibility metadata, or
+fixture corpus run the required KiCad contract smoke lanes only. The PR smoke
+matrix covers the primary KiCad 10.0.x line on Windows with the Chocolatey
+KiCad 10.0.3 install path under `C:\Program Files\KiCad\10.0\bin`, plus the
+Linux primary lane from the KiCad 10 release PPA. Scheduled and manual runs keep
+the heavier matrix: primary 10.0.x, supported 9.x, prerelease/nightly 10.x, and
+manual opt-in deprecated 8.x.
+
 Each lane writes command logs, KiCad reports, manufacturing export outputs,
 `summary.json`, and `failing-fixtures.txt` into an artifact named after the
 lane. Manufacturing exports are enabled only when the matrix feature gate lists
 that KiCad range. Primary-lane failures fail the workflow and create or update a
 compatibility issue with the `release-blocker` label; prerelease and deprecated
 lanes report artifacts and issue comments without blocking the default branch.
+
+Run the same primary contract locally after installing KiCad or setting
+`KICAD_CANARY_KICAD_CLI`, `KICAD_MCP_KICAD_CLI`, or `KICAD_CLI_PATH`:
+
+```bash
+corepack pnpm run test:kicad-cli-contract
+```
+
+The contract uses the shared fixture corpus in `packages/kicad-fixtures/` and
+validates `kicad-cli version`, ERC, DRC, schematic PDF export, PCB PDF/SVG/DXF
+export, Gerber and drill export, BOM, netlist, board statistics, STEP export,
+paths containing spaces, Unicode paths, missing CLI reporting, read-only output
+failure reporting, and structured skipped results for feature gates that are not
+supported by a KiCad line.
 
 ## VS Code Canary
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "test:kicad-studio": "pnpm --filter kicadstudio run test",
     "test:kicad-mcp-pro": "pnpm --dir packages/mcp-server run test:unit",
     "test:contract": "pnpm --dir packages/mcp-server run test:transport-contract && pnpm run check:compatibility && pnpm --dir packages/mcp-server run mcp:manifest:check",
+    "test:kicad-cli-contract": "uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/kicad_canary.py run --artifacts artifacts/kicad-cli-contract/local --kicad-range 10.0.x",
+    "test:kicad-cli-contract:matrix": "uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/kicad_canary.py matrix",
     "test:perf": "pnpm --filter kicadstudio run test:perf && uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_benchmark_latency.py",
     "test:kicad-gui-smoke": "pnpm --dir packages/mcp-server run test:gui-smoke",
     "fixtures:kicad:generate": "node scripts/generate-kicad-fixture-corpus.mjs --write",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Add `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
   setup troubleshooting.
+- Add real KiCad CLI contract canaries with shared fixtures, Windows primary
+  KiCad 10.0.3 smoke coverage, scheduled 9.x/10.x lanes, and structured
+  unsupported-feature artifacts.
 
 ## [1.0.0]
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -24,6 +24,8 @@
     "test": "uv run --all-extras python scripts/run_pytest.py full",
     "test:unit": "uv run --all-extras python scripts/run_pytest.py unit",
     "test:transport-contract": "uv run --all-extras python scripts/run_pytest.py transport-contract",
+    "test:kicad-cli-contract": "uv run --all-extras python scripts/kicad_canary.py run --artifacts ../../artifacts/kicad-cli-contract/local --kicad-range 10.0.x",
+    "test:kicad-cli-contract:matrix": "uv run --all-extras python scripts/kicad_canary.py matrix",
     "test:gui-smoke": "uv run --all-extras python scripts/run_pytest.py gui",
     "build": "uv build",
     "package:check": "uv build && uv run --all-extras python scripts/check_package_metadata.py",

--- a/packages/mcp-server/scripts/kicad_canary.py
+++ b/packages/mcp-server/scripts/kicad_canary.py
@@ -19,9 +19,11 @@ import yaml
 
 MCP_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = MCP_ROOT.parents[1]
-FIXTURE_ROOT = REPO_ROOT / "apps" / "vscode-extension" / "test" / "fixtures" / "kicad"
+FIXTURE_ROOT = REPO_ROOT / "packages" / "kicad-fixtures" / "fixtures"
 DEFAULT_TIMEOUT_SECONDS = 180
 KICAD_VIOLATION_EXIT_CODE = 5
+WINDOWS_PRIMARY_RUNNER = "windows-2025-vs2026"
+WINDOWS_PRIMARY_KICAD_VERSION = "10.0.3"
 
 INSTALLERS = {
     "10.0.x": {
@@ -46,9 +48,12 @@ class CanaryStep:
 
     name: str
     fixture: str
-    args: tuple[str, ...]
+    args: tuple[str, ...] = ()
     outputs: tuple[Path, ...] = ()
     expects_violations: bool = False
+    expects_failure: bool = False
+    skip_reason: str | None = None
+    readonly_dirs: tuple[Path, ...] = ()
 
 
 def _read_compatibility_matrix() -> dict[str, Any]:
@@ -79,7 +84,7 @@ def _expected_major(kicad_range: str) -> int:
     return int(match.group("major"))
 
 
-def _release_lane(entry: object) -> dict[str, object]:
+def _linux_release_lane(entry: object) -> dict[str, object]:
     kicad_range = _entry_value(entry, "range")
     state = _entry_value(entry, "state")
     ci_mode = _entry_value(entry, "ci")
@@ -87,13 +92,35 @@ def _release_lane(entry: object) -> dict[str, object]:
     if installer is None:
         raise ValueError(f"No canary installer metadata for KiCad range {kicad_range!r}")
     return {
-        "id": _lane_id(kicad_range, state),
+        "id": f"{_lane_id(kicad_range, state)}-linux",
         "range": kicad_range,
         "state": state,
         "ci": ci_mode,
+        "os": "ubuntu-24.04",
+        "install": "apt-ppa",
         "ppa": installer["release_ppa"],
         "package": installer["package"],
         "continue_on_error": state == "deprecated",
+    }
+
+
+def _windows_primary_lane(entry: object, compatibility: dict[str, Any]) -> dict[str, object]:
+    kicad_range = _entry_value(entry, "range")
+    state = _entry_value(entry, "state")
+    ci_mode = _entry_value(entry, "ci")
+    kicad = compatibility.get("kicad")
+    latest_verified = WINDOWS_PRIMARY_KICAD_VERSION
+    if isinstance(kicad, dict) and isinstance(kicad.get("latestVerified"), str):
+        latest_verified = str(kicad["latestVerified"])
+    return {
+        "id": f"{_lane_id(kicad_range, state)}-windows",
+        "range": kicad_range,
+        "state": state,
+        "ci": ci_mode,
+        "os": WINDOWS_PRIMARY_RUNNER,
+        "install": "choco",
+        "version": latest_verified,
+        "continue_on_error": False,
     }
 
 
@@ -102,10 +129,12 @@ def _nightly_lane(primary_range: str) -> dict[str, object]:
     if installer is None or "nightly_ppa" not in installer:
         raise ValueError(f"No nightly canary installer metadata for {primary_range!r}")
     return {
-        "id": f"kicad-{_expected_major(primary_range)}-nightly",
+        "id": f"kicad-{_expected_major(primary_range)}-nightly-linux",
         "range": primary_range,
         "state": "prerelease",
         "ci": "scheduled",
+        "os": "ubuntu-24.04",
+        "install": "apt-ppa",
         "ppa": installer["nightly_ppa"],
         "package": installer["package"],
         "continue_on_error": True,
@@ -116,6 +145,7 @@ def build_canary_matrix(
     compatibility: dict[str, Any],
     *,
     include_manual: bool,
+    required_only: bool = False,
 ) -> dict[str, list[dict[str, object]]]:
     """Return GitHub Actions matrix lanes derived from compatibility metadata."""
     kicad = compatibility.get("kicad")
@@ -125,17 +155,25 @@ def build_canary_matrix(
     if not isinstance(entries, list):
         raise ValueError("compatibility metadata missing kicad.supported list")
 
-    lanes = [
-        _release_lane(entry)
-        for entry in entries
-        if (ci_mode := _entry_value(entry, "ci")) in {"required", "scheduled"}
-        or include_manual
-        and ci_mode == "manual"
-    ]
     primary = kicad.get("primary")
     if not isinstance(primary, str) or not primary:
         raise ValueError("compatibility metadata missing kicad.primary")
-    lanes.append(_nightly_lane(primary))
+
+    lanes: list[dict[str, object]] = []
+    for entry in entries:
+        ci_mode = _entry_value(entry, "ci")
+        if required_only and ci_mode != "required":
+            continue
+        if ci_mode not in {"required", "scheduled"} and not (
+            include_manual and ci_mode == "manual"
+        ):
+            continue
+        if _entry_value(entry, "range") == primary and _entry_value(entry, "state") == "primary":
+            lanes.append(_windows_primary_lane(entry, compatibility))
+        lanes.append(_linux_release_lane(entry))
+
+    if not required_only:
+        lanes.append(_nightly_lane(primary))
     return {"include": lanes}
 
 
@@ -155,8 +193,8 @@ def supports_feature_gate(
     return isinstance(ranges, list) and kicad_range in ranges
 
 
-def _project_file(fixture: str, suffix: str) -> Path:
-    matches = sorted((FIXTURE_ROOT / fixture).glob(f"*{suffix}"))
+def _fixture_file(root: Path, fixture: str, suffix: str) -> Path:
+    matches = sorted((root / fixture).glob(f"*{suffix}"))
     if len(matches) != 1:
         raise FileNotFoundError(
             f"Expected one {suffix} file in fixture {fixture!r}, found {len(matches)}"
@@ -164,18 +202,61 @@ def _project_file(fixture: str, suffix: str) -> Path:
     return matches[0]
 
 
+def _project_file(fixture: str, suffix: str) -> Path:
+    return _fixture_file(FIXTURE_ROOT, fixture, suffix)
+
+
+def _prepare_fixture_workspaces(artifacts: Path, fixtures: set[str]) -> Path:
+    workspace_root = artifacts / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    for fixture in sorted(fixtures):
+        source = FIXTURE_ROOT / fixture
+        target = workspace_root / fixture
+        if not source.is_dir():
+            raise FileNotFoundError(f"Unknown KiCad fixture: {fixture}")
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(source, target)
+    return workspace_root
+
+
+def _feature_skip_reason(
+    compatibility: dict[str, Any],
+    feature_name: str,
+    kicad_range: str,
+) -> str | None:
+    if supports_feature_gate(compatibility, feature_name, kicad_range):
+        return None
+    return f"{feature_name} is not enabled for KiCad {kicad_range}"
+
+
 def _command_plan(
     artifacts: Path,
     compatibility: dict[str, Any],
     kicad_range: str,
 ) -> list[CanaryStep]:
-    clean_schematic = _project_file("clean-led-kicad10", ".kicad_sch")
-    clean_board = _project_file("clean-led-kicad10", ".kicad_pcb")
-    dirty_erc = _project_file("erc-power-pin-error", ".kicad_sch")
-    dirty_drc = _project_file("drc-courtyard-error", ".kicad_pcb")
+    workspace_root = _prepare_fixture_workspaces(
+        artifacts,
+        {
+            "clean-led-kicad10",
+            "drc-courtyard-error",
+            "erc-power-pin-error",
+            "paths-with-spaces",
+            "unicode-path-çöğü",
+        },
+    )
+    clean_schematic = _fixture_file(workspace_root, "clean-led-kicad10", ".kicad_sch")
+    clean_board = _fixture_file(workspace_root, "clean-led-kicad10", ".kicad_pcb")
+    dirty_erc = _fixture_file(workspace_root, "erc-power-pin-error", ".kicad_sch")
+    dirty_drc = _fixture_file(workspace_root, "drc-courtyard-error", ".kicad_pcb")
+    path_with_spaces_board = _fixture_file(workspace_root, "paths-with-spaces", ".kicad_pcb")
+    unicode_path_board = _fixture_file(workspace_root, "unicode-path-çöğü", ".kicad_pcb")
 
     reports = artifacts / "reports"
     manufacturing = artifacts / "manufacturing"
+    graphics = artifacts / "graphics"
+    readonly_output = artifacts / "readonly-project"
+    manufacturing_skip = _feature_skip_reason(compatibility, "manufacturingExports", kicad_range)
     steps = [
         CanaryStep(name="version", fixture="compatibility", args=("version",)),
         CanaryStep(
@@ -243,6 +324,64 @@ def _command_plan(
             expects_violations=True,
         ),
         CanaryStep(
+            name="schematic-pdf",
+            fixture="clean-led-kicad10",
+            args=(
+                "sch",
+                "export",
+                "pdf",
+                "--output",
+                str(reports / "schematic.pdf"),
+                str(clean_schematic),
+            ),
+            outputs=(reports / "schematic.pdf",),
+        ),
+        CanaryStep(
+            name="pcb-pdf",
+            fixture="clean-led-kicad10",
+            args=(
+                "pcb",
+                "export",
+                "pdf",
+                "--output",
+                str(reports / "pcb.pdf"),
+                "--layers",
+                "F.Cu,B.Cu,Edge.Cuts",
+                str(clean_board),
+            ),
+            outputs=(reports / "pcb.pdf",),
+        ),
+        CanaryStep(
+            name="pcb-svg",
+            fixture="clean-led-kicad10",
+            args=(
+                "pcb",
+                "export",
+                "svg",
+                "--output",
+                str(graphics / "pcb-svg"),
+                "--layers",
+                "F.Cu,B.Cu,Edge.Cuts",
+                str(clean_board),
+            ),
+            outputs=(graphics / "pcb-svg",),
+        ),
+        CanaryStep(
+            name="pcb-dxf",
+            fixture="clean-led-kicad10",
+            args=(
+                "pcb",
+                "export",
+                "dxf",
+                "--output",
+                str(graphics / "pcb.dxf"),
+                "--layers",
+                "F.Cu,B.Cu,Edge.Cuts",
+                str(clean_board),
+            ),
+            outputs=(graphics / "pcb.dxf",),
+        ),
+        CanaryStep(
             name="bom",
             fixture="clean-led-kicad10",
             args=(
@@ -285,38 +424,95 @@ def _command_plan(
             ),
             outputs=(reports / "board-stats.txt",),
         ),
+        CanaryStep(
+            name="step",
+            fixture="clean-led-kicad10",
+            args=(
+                "pcb",
+                "export",
+                "step",
+                "--output",
+                str(graphics / "board.step"),
+                str(clean_board),
+            ),
+            outputs=(graphics / "board.step",),
+        ),
+        CanaryStep(
+            name="path-with-spaces-board-stats",
+            fixture="paths-with-spaces",
+            args=(
+                "pcb",
+                "export",
+                "stats",
+                "--output",
+                str(reports / "path-with-spaces-board-stats.txt"),
+                str(path_with_spaces_board),
+            ),
+            outputs=(reports / "path-with-spaces-board-stats.txt",),
+        ),
+        CanaryStep(
+            name="unicode-path-board-stats",
+            fixture="unicode-path-çöğü",
+            args=(
+                "pcb",
+                "export",
+                "stats",
+                "--output",
+                str(reports / "unicode-path-board-stats.txt"),
+                str(unicode_path_board),
+            ),
+            outputs=(reports / "unicode-path-board-stats.txt",),
+        ),
+        CanaryStep(
+            name="read-only-output-failure",
+            fixture="clean-led-kicad10",
+            args=(
+                "pcb",
+                "export",
+                "stats",
+                "--output",
+                str(readonly_output / "board-stats.txt"),
+                str(clean_board),
+            ),
+            expects_failure=True,
+            readonly_dirs=(readonly_output,),
+        ),
     ]
-    if supports_feature_gate(compatibility, "manufacturingExports", kicad_range):
-        steps.extend(
-            [
-                CanaryStep(
-                    name="gerbers",
-                    fixture="clean-led-kicad10",
-                    args=(
-                        "pcb",
-                        "export",
-                        "gerbers",
-                        "--layers",
-                        "F.Cu,B.Cu,F.Silkscreen,B.Silkscreen,F.Mask,B.Mask,Edge.Cuts",
-                        "--output",
-                        str(manufacturing / "gerbers"),
-                        str(clean_board),
-                    ),
+
+    steps.extend(
+        [
+            CanaryStep(
+                name="gerbers",
+                fixture="clean-led-kicad10",
+                args=(
+                    "pcb",
+                    "export",
+                    "gerbers",
+                    "--layers",
+                    "F.Cu,B.Cu,F.Silkscreen,B.Silkscreen,F.Mask,B.Mask,Edge.Cuts",
+                    "--output",
+                    str(manufacturing / "gerbers"),
+                    str(clean_board),
                 ),
-                CanaryStep(
-                    name="drill",
-                    fixture="clean-led-kicad10",
-                    args=(
-                        "pcb",
-                        "export",
-                        "drill",
-                        "--output",
-                        str(manufacturing / "drill"),
-                        str(clean_board),
-                    ),
+                outputs=(manufacturing / "gerbers",),
+                skip_reason=manufacturing_skip,
+            ),
+            CanaryStep(
+                name="drill",
+                fixture="clean-led-kicad10",
+                args=(
+                    "pcb",
+                    "export",
+                    "drill",
+                    "--output",
+                    str(manufacturing / "drill"),
+                    str(clean_board),
                 ),
-            ]
-        )
+                outputs=(manufacturing / "drill",),
+                skip_reason=manufacturing_skip,
+            ),
+        ]
+    )
     return steps
 
 
@@ -353,9 +549,58 @@ def _subprocess_output_text(value: object) -> str:
     return str(value)
 
 
+def _path_has_content(path: Path) -> bool:
+    if path.is_dir():
+        return any(path.iterdir())
+    return path.exists() and path.stat().st_size > 0
+
+
+def _make_readonly_dirs(paths: tuple[Path, ...]) -> list[Path]:
+    readonly_paths: list[Path] = []
+    for path in paths:
+        path.mkdir(parents=True, exist_ok=True)
+        path.chmod(0o555)
+        readonly_paths.append(path)
+    return readonly_paths
+
+
+def _restore_writable_dirs(paths: list[Path]) -> None:
+    for path in paths:
+        try:
+            path.chmod(0o755)
+        except OSError:
+            pass
+
+
 def _run_step(cli: Path, step: CanaryStep, artifacts: Path) -> dict[str, object]:
+    if step.skip_reason is not None:
+        return {
+            "name": step.name,
+            "fixture": step.fixture,
+            "returncode": None,
+            "expectsViolations": step.expects_violations,
+            "expectsFailure": step.expects_failure,
+            "outputs": [str(path.relative_to(artifacts)) for path in step.outputs],
+            "ok": True,
+            "skipped": True,
+            "reason": step.skip_reason,
+        }
+    if step.readonly_dirs and os.name == "nt":
+        return {
+            "name": step.name,
+            "fixture": step.fixture,
+            "returncode": None,
+            "expectsViolations": step.expects_violations,
+            "expectsFailure": step.expects_failure,
+            "outputs": [],
+            "ok": True,
+            "skipped": True,
+            "reason": "read-only directory permission checks are covered by Linux canary lanes",
+        }
+
     command = [str(cli), *step.args]
     error: str | None = None
+    readonly_dirs = _make_readonly_dirs(step.readonly_dirs)
     try:
         result = subprocess.run(
             command,
@@ -381,21 +626,27 @@ def _run_step(cli: Path, step: CanaryStep, artifacts: Path) -> dict[str, object]
         error = f"{type(exc).__name__}: {exc}"
         stderr = f"{error}\n"
         returncode = -1
+    finally:
+        _restore_writable_dirs(readonly_dirs)
 
     logs = artifacts / "logs"
     _write_text(logs / f"{step.name}.command.txt", shlex.join(command) + "\n")
     _write_text(logs / f"{step.name}.stdout.log", stdout)
     _write_text(logs / f"{step.name}.stderr.log", stderr)
 
-    outputs_exist = all(path.exists() and path.stat().st_size > 0 for path in step.outputs)
+    outputs_exist = all(_path_has_content(path) for path in step.outputs)
     command_ok = (
         returncode == KICAD_VIOLATION_EXIT_CODE if step.expects_violations else returncode == 0
     )
+    if step.expects_failure:
+        command_ok = returncode not in {0, None}
+        outputs_exist = True
     step_result: dict[str, object] = {
         "name": step.name,
         "fixture": step.fixture,
         "returncode": returncode,
         "expectsViolations": step.expects_violations,
+        "expectsFailure": step.expects_failure,
         "outputs": [str(path.relative_to(artifacts)) for path in step.outputs],
         "ok": command_ok and outputs_exist,
     }
@@ -440,8 +691,35 @@ def _assert_version_matches_range(version_result: dict[str, object], kicad_range
 def run_canary(artifacts: Path, kicad_range: str) -> int:
     """Run the KiCad CLI canary plan and write reports and logs to artifacts."""
     compatibility = _read_compatibility_matrix()
-    cli = _resolve_cli()
     artifacts.mkdir(parents=True, exist_ok=True)
+    try:
+        cli = _resolve_cli()
+    except FileNotFoundError as exc:
+        results: list[dict[str, object]] = [
+            {
+                "name": "resolve-cli",
+                "fixture": "environment",
+                "ok": False,
+                "error": str(exc),
+            }
+        ]
+        summary = {
+            "kicadRange": kicad_range,
+            "kicadCli": None,
+            "manufacturingExports": supports_feature_gate(
+                compatibility,
+                "manufacturingExports",
+                kicad_range,
+            ),
+            "results": results,
+            "failingFixtures": ["environment"],
+        }
+        _write_text(
+            artifacts / "summary.json", json.dumps(summary, indent=2, sort_keys=True) + "\n"
+        )
+        _write_text(artifacts / "failing-fixtures.txt", "environment\n")
+        print(str(exc), file=sys.stderr)
+        return 1
 
     steps = _command_plan(artifacts, compatibility, kicad_range)
     results = [_run_step(cli, step, artifacts) for step in steps]
@@ -477,8 +755,12 @@ def run_canary(artifacts: Path, kicad_range: str) -> int:
     return 0
 
 
-def _write_matrix(include_manual: bool) -> int:
-    matrix = build_canary_matrix(_read_compatibility_matrix(), include_manual=include_manual)
+def _write_matrix(include_manual: bool, required_only: bool) -> int:
+    matrix = build_canary_matrix(
+        _read_compatibility_matrix(),
+        include_manual=include_manual,
+        required_only=required_only,
+    )
     print(json.dumps(matrix, separators=(",", ":")))
     return 0
 
@@ -493,6 +775,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Include compatibility lanes marked manual.",
     )
+    matrix_parser.add_argument(
+        "--required-only",
+        action="store_true",
+        help="Only include required lanes for pull-request smoke checks.",
+    )
 
     run_parser = subcommands.add_parser("run", help="Run KiCad CLI canary commands.")
     run_parser.add_argument("--artifacts", type=Path, required=True)
@@ -500,7 +787,7 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
     if args.command == "matrix":
-        return _write_matrix(args.include_manual)
+        return _write_matrix(args.include_manual, args.required_only)
     if args.command == "run":
         return run_canary(args.artifacts, args.kicad_range)
     raise AssertionError(f"Unhandled command: {args.command}")

--- a/packages/mcp-server/tests/unit/test_kicad_canary.py
+++ b/packages/mcp-server/tests/unit/test_kicad_canary.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -43,28 +44,44 @@ def test_kicad_canary_matrix_uses_scheduled_compatibility_lanes() -> None:
     assert matrix == {
         "include": [
             {
-                "id": "kicad-10-primary",
+                "id": "kicad-10-primary-windows",
                 "range": "10.0.x",
                 "state": "primary",
                 "ci": "required",
+                "os": "windows-2025-vs2026",
+                "install": "choco",
+                "version": "10.0.3",
+                "continue_on_error": False,
+            },
+            {
+                "id": "kicad-10-primary-linux",
+                "range": "10.0.x",
+                "state": "primary",
+                "ci": "required",
+                "os": "ubuntu-24.04",
+                "install": "apt-ppa",
                 "ppa": "ppa:kicad/kicad-10.0-releases",
                 "package": "kicad",
                 "continue_on_error": False,
             },
             {
-                "id": "kicad-9-supported",
+                "id": "kicad-9-supported-linux",
                 "range": "9.x",
                 "state": "supported",
                 "ci": "scheduled",
+                "os": "ubuntu-24.04",
+                "install": "apt-ppa",
                 "ppa": "ppa:kicad/kicad-9.0-releases",
                 "package": "kicad",
                 "continue_on_error": False,
             },
             {
-                "id": "kicad-10-nightly",
+                "id": "kicad-10-nightly-linux",
                 "range": "10.0.x",
                 "state": "prerelease",
                 "ci": "scheduled",
+                "os": "ubuntu-24.04",
+                "install": "apt-ppa",
                 "ppa": "ppa:kicad/kicad-10.0-nightly",
                 "package": "kicad",
                 "continue_on_error": True,
@@ -73,19 +90,115 @@ def test_kicad_canary_matrix_uses_scheduled_compatibility_lanes() -> None:
     }
 
 
+def test_primary_matrix_includes_windows_10_0_3_contract_lane() -> None:
+    matrix = build_canary_matrix(_compatibility_matrix(), include_manual=False)
+
+    windows_primary = next(
+        lane for lane in matrix["include"] if lane["id"] == "kicad-10-primary-windows"
+    )
+
+    assert windows_primary == {
+        "id": "kicad-10-primary-windows",
+        "range": "10.0.x",
+        "state": "primary",
+        "ci": "required",
+        "os": "windows-2025-vs2026",
+        "install": "choco",
+        "version": "10.0.3",
+        "continue_on_error": False,
+    }
+
+
+def test_kicad_canary_matrix_can_limit_pull_requests_to_required_lanes() -> None:
+    matrix = build_canary_matrix(
+        _compatibility_matrix(),
+        include_manual=False,
+        required_only=True,
+    )
+
+    assert [lane["id"] for lane in matrix["include"]] == [
+        "kicad-10-primary-windows",
+        "kicad-10-primary-linux",
+    ]
+
+
 def test_kicad_canary_matrix_exposes_manual_deprecated_lane_on_dispatch() -> None:
     matrix = build_canary_matrix(_compatibility_matrix(), include_manual=True)
 
-    assert matrix["include"][2] == {
-        "id": "kicad-8-deprecated",
+    assert matrix["include"][3] == {
+        "id": "kicad-8-deprecated-linux",
         "range": "8.x",
         "state": "deprecated",
         "ci": "manual",
+        "os": "ubuntu-24.04",
+        "install": "apt-ppa",
         "ppa": "ppa:kicad/kicad-8.0-releases",
         "package": "kicad",
         "continue_on_error": True,
     }
-    assert matrix["include"][3]["id"] == "kicad-10-nightly"
+    assert matrix["include"][4]["id"] == "kicad-10-nightly-linux"
+
+
+def test_kicad_canary_uses_shared_fixture_corpus() -> None:
+    assert kicad_canary.FIXTURE_ROOT == (
+        kicad_canary.REPO_ROOT / "packages" / "kicad-fixtures" / "fixtures"
+    )
+    assert (
+        kicad_canary._project_file("clean-led-kicad10", ".kicad_pcb").name
+        == "clean-led-kicad10.kicad_pcb"
+    )
+
+
+def test_command_plan_covers_oaslana_38_export_surface(tmp_path: Path) -> None:
+    steps = {
+        step.name: step
+        for step in kicad_canary._command_plan(tmp_path, _compatibility_matrix(), "10.0.x")
+    }
+
+    for name in [
+        "version",
+        "clean-erc",
+        "dirty-erc",
+        "clean-drc",
+        "dirty-drc",
+        "schematic-pdf",
+        "pcb-pdf",
+        "pcb-svg",
+        "pcb-dxf",
+        "gerbers",
+        "drill",
+        "bom",
+        "netlist",
+        "board-stats",
+        "step",
+        "path-with-spaces-board-stats",
+        "unicode-path-board-stats",
+        "read-only-output-failure",
+    ]:
+        assert name in steps
+
+    assert steps["path-with-spaces-board-stats"].fixture == "paths-with-spaces"
+    assert steps["unicode-path-board-stats"].fixture == "unicode-path-çöğü"
+    assert steps["read-only-output-failure"].expects_failure is True
+    assert "--layers" in steps["pcb-pdf"].args
+    assert str(kicad_canary.FIXTURE_ROOT) not in " ".join(steps["clean-erc"].args)
+    assert str(tmp_path / "workspace" / "clean-led-kicad10") in " ".join(steps["clean-erc"].args)
+
+
+def test_unsupported_feature_steps_are_structured_skips(tmp_path: Path) -> None:
+    steps = {
+        step.name: step
+        for step in kicad_canary._command_plan(tmp_path, _compatibility_matrix(), "8.x")
+    }
+
+    assert steps["gerbers"].skip_reason == "manufacturingExports is not enabled for KiCad 8.x"
+    assert steps["drill"].skip_reason == "manufacturingExports is not enabled for KiCad 8.x"
+
+    result = kicad_canary._run_step(Path(sys.executable), steps["gerbers"], tmp_path)
+
+    assert result["ok"] is True
+    assert result["skipped"] is True
+    assert result["reason"] == "manufacturingExports is not enabled for KiCad 8.x"
 
 
 def test_kicad_canary_gates_manufacturing_exports_by_compatibility_range() -> None:
@@ -94,6 +207,28 @@ def test_kicad_canary_gates_manufacturing_exports_by_compatibility_range() -> No
     assert supports_feature_gate(compatibility, "manufacturingExports", "10.0.x")
     assert supports_feature_gate(compatibility, "manufacturingExports", "9.x")
     assert not supports_feature_gate(compatibility, "manufacturingExports", "8.x")
+
+
+def test_missing_cli_writes_structured_summary(tmp_path: Path, monkeypatch) -> None:
+    def raise_missing_cli() -> Path:
+        raise FileNotFoundError("kicad-cli not found in test")
+
+    monkeypatch.setattr(kicad_canary, "_resolve_cli", raise_missing_cli)
+
+    exit_code = kicad_canary.run_canary(tmp_path, "10.0.x")
+    summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+
+    assert exit_code == 1
+    assert summary["kicadRange"] == "10.0.x"
+    assert summary["failingFixtures"] == ["environment"]
+    assert summary["results"] == [
+        {
+            "name": "resolve-cli",
+            "fixture": "environment",
+            "ok": False,
+            "error": "kicad-cli not found in test",
+        }
+    ]
 
 
 def test_violation_step_only_accepts_documented_kicad_exit_code(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds real KiCad CLI contract coverage for OASLANA-38:
- expands the canary harness to run KiCad 10 CLI commands against shared fixture workspaces for version, ERC, DRC, PDF/SVG/DXF, Gerber, drill, BOM, netlist, board stats, STEP, path-with-spaces, Unicode paths, read-only output failure, missing CLI artifacts, and structured unsupported-feature skips
- wires a PR smoke matrix for required KiCad 10 lanes, including Windows KiCad 10.0.3 under C:\Program Files\KiCad\10.0\bin and Linux KiCad 10 release PPA
- keeps scheduled/manual lanes for Linux KiCad 9.x, 10.x nightly, and manual deprecated 8.x coverage
- documents local install/use and changelog entries

## Linked issue

Closes #39
Linear: OASLANA-38

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

Red tests first covered the missing Windows primary lane, stale fixture root, missing export/failure steps, missing structured unsupported skip, missing CLI summary artifact, and source-fixture runtime paths.

Passed locally:
- corepack pnpm install --frozen-lockfile
- corepack pnpm run lint
- corepack pnpm run typecheck
- corepack pnpm run test
- corepack pnpm run build
- corepack pnpm run verify:dist
- uv sync --all-extras && uv run --all-extras pytest (packages/mcp-server; 701 passed, 2 skipped)
- corepack pnpm run test:kicad-cli-contract:matrix
- corepack pnpm run test:kicad-cli-contract (local KiCad CLI 10.0.3)
- corepack pnpm run format:check
- corepack pnpm run check:testing-strategy
- corepack pnpm run check:ci-lanes
- corepack pnpm --dir packages/mcp-server run workflows:lint
- corepack pnpm --dir packages/mcp-server run workflows:security
- corepack pnpm run docs:check-generated
- corepack pnpm run docs:lint
- corepack pnpm run docs:links
- corepack pnpm run check:forbidden-refs
- corepack pnpm --dir packages/mcp-server run security
- uvx pre-commit run --all-files
- git diff --check
- PATH=packages/mcp-server/.venv/bin:$PATH corepack pnpm run check

Notes:
- root-level uv sync && uv run pytest cannot run because the repo root has no pyproject.toml; package-local plain uv sync && uv run pytest is not the repo test profile because it removes required extras. The repo-valid MCP profile above passed.
- local dev-doctor warns that standalone actionlint and cloudflared are absent; repository workflow lint/security commands passed and no publish workflow was triggered.

## Protocol / MCP impact

- [x] Not applicable; reason: this changes MCP test/CI harness coverage and docs, not MCP tool schemas, transport behavior, or server-info payloads.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [x] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [ ] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval: not a bug-fix PR; feature/test-harness coverage
- [x] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
