### PR TITLE
test(kicad-studio): add VS Code integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,10 @@ jobs:
       - run: corepack pnpm --filter kicadstudio run test:webview
       - run: corepack pnpm --filter kicadstudio run test:a11y
       - run: corepack pnpm --filter kicadstudio run build
+      - if: runner.os == 'Linux'
+        run: xvfb-run -a corepack pnpm --filter kicadstudio run test:integration
+      - if: runner.os != 'Linux'
+        run: corepack pnpm --filter kicadstudio run test:integration
       - run: corepack pnpm --filter kicadstudio run package
       - name: Verify extension package and no VS Code Web target
         run: corepack pnpm --filter kicadstudio run package:validate

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1010,72 +1010,124 @@
       ],
       "commandPalette": [
         {
-          "command": "kicadstudio.exportGerbers",
+          "command": "kicadstudio.openSchematic",
+          "when": "kicadstudio.schematicOpen"
+        },
+        {
+          "command": "kicadstudio.openPCB",
           "when": "kicadstudio.pcbOpen"
+        },
+        {
+          "command": "kicadstudio.openInKiCad",
+          "when": "kicadstudio.workspaceTrusted && resourceExtname =~ /\\.kicad_(sch|pcb|sym|mod|pro|jobset|dru)/"
+        },
+        {
+          "command": "kicadstudio.detectCli",
+          "when": "kicadstudio.workspaceTrusted"
+        },
+        {
+          "command": "kicadstudio.exportGerbers",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
+        },
+        {
+          "command": "kicadstudio.exportGerbersWithDrill",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
+        },
+        {
+          "command": "kicadstudio.exportPCBPDF",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
+        },
+        {
+          "command": "kicadstudio.exportSVG",
+          "when": "kicadstudio.workspaceTrusted && (kicadstudio.schematicOpen || kicadstudio.pcbOpen)"
         },
         {
           "command": "kicadstudio.exportIPC2581",
-          "when": "kicadstudio.pcbOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
+        },
+        {
+          "command": "kicadstudio.exportODB",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
         },
         {
           "command": "kicadstudio.export3DGLB",
-          "when": "kicadstudio.pcbOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
         },
         {
           "command": "kicadstudio.export3DBREP",
-          "when": "kicadstudio.pcbOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
         },
         {
           "command": "kicadstudio.export3DPLY",
-          "when": "kicadstudio.pcbOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
         },
         {
           "command": "kicadstudio.export3DPdf",
-          "when": "kicadstudio.pcbOpen && kicadstudio.kicad10Plus"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen && kicadstudio.kicad10Plus"
         },
         {
           "command": "kicadstudio.exportGenCAD",
-          "when": "kicadstudio.pcbOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
         },
         {
           "command": "kicadstudio.exportIPCD356",
-          "when": "kicadstudio.pcbOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
         },
         {
-          "command": "kicadstudio.exportDXF"
+          "command": "kicadstudio.exportDXF",
+          "when": "kicadstudio.workspaceTrusted && (kicadstudio.schematicOpen || kicadstudio.pcbOpen)"
         },
         {
           "command": "kicadstudio.exportPickAndPlace",
-          "when": "kicadstudio.pcbOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
         },
         {
           "command": "kicadstudio.exportManufacturingPackage",
-          "when": "kicadstudio.pcbOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
         },
         {
-          "command": "kicadstudio.exportFootprintSVG"
+          "command": "kicadstudio.exportFootprintSVG",
+          "when": "kicadstudio.workspaceTrusted && resourceExtname == .kicad_mod"
         },
         {
-          "command": "kicadstudio.exportSymbolSVG"
+          "command": "kicadstudio.exportSymbolSVG",
+          "when": "kicadstudio.workspaceTrusted && resourceExtname == .kicad_sym"
         },
         {
-          "command": "kicadstudio.runJobset"
+          "command": "kicadstudio.runJobset",
+          "when": "kicadstudio.workspaceTrusted && resourceExtname == .kicad_jobset"
         },
         {
           "command": "kicadstudio.runDRC",
-          "when": "kicadstudio.pcbOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
         },
         {
           "command": "kicadstudio.runERC",
-          "when": "kicadstudio.schematicOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.schematicOpen"
         },
         {
           "command": "kicadstudio.exportPDF",
-          "when": "kicadstudio.schematicOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.schematicOpen"
         },
         {
           "command": "kicadstudio.exportBOMCSV",
-          "when": "kicadstudio.schematicOpen"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.schematicOpen"
+        },
+        {
+          "command": "kicadstudio.exportBOMXLSX",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.schematicOpen"
+        },
+        {
+          "command": "kicadstudio.exportNetlist",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.schematicOpen"
+        },
+        {
+          "command": "kicadstudio.exportInteractiveBOM",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.schematicOpen"
+        },
+        {
+          "command": "kicadstudio.exportViewerSvg",
+          "when": "kicadstudio.workspaceTrusted && (activeCustomEditorId == kicadstudio.schematicViewer || activeCustomEditorId == kicadstudio.pcbViewer)"
         },
         {
           "command": "kicadstudio.aiAnalyzeError",
@@ -1094,13 +1146,24 @@
           "when": "kicadstudio.aiEnabled"
         },
         {
+          "command": "kicadstudio.searchComponent"
+        },
+        {
+          "command": "kicadstudio.showDiff",
+          "when": "kicadstudio.hasProject"
+        },
+        {
+          "command": "kicadstudio.refreshProjectTree"
+        },
+        {
           "command": "kicadstudio.openSettings"
         },
         {
           "command": "kicadstudio.sendFeedback"
         },
         {
-          "command": "kicadstudio.setupMcpIntegration"
+          "command": "kicadstudio.setupMcpIntegration",
+          "when": "kicadstudio.workspaceTrusted"
         },
         {
           "command": "kicadstudio.mcp.launchHttp",
@@ -1112,6 +1175,9 @@
         },
         {
           "command": "kicadstudio.mcp.retry"
+        },
+        {
+          "command": "kicadstudio.mcp.openUpgradeGuide"
         },
         {
           "command": "kicadstudio.mcp.pickProfile",
@@ -1128,7 +1194,18 @@
         },
         {
           "command": "kicadstudio.qualityGate.runAll",
-          "when": "kicadstudio.mcpConnected && kicadstudio.hasProject"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.mcpConnected && kicadstudio.hasProject"
+        },
+        {
+          "command": "kicadstudio.qualityGate.runThis",
+          "when": "false"
+        },
+        {
+          "command": "kicadstudio.qualityGate.showRaw",
+          "when": "false"
+        },
+        {
+          "command": "kicadstudio.qualityGate.openDocs"
         },
         {
           "command": "kicadstudio.manufacturing.release",
@@ -1141,11 +1218,36 @@
           "command": "kicadstudio.clearAiKey"
         },
         {
+          "command": "kicadstudio.setOctopartApiKey"
+        },
+        {
+          "command": "kicadstudio.setAiApiKey"
+        },
+        {
+          "command": "kicadstudio.clearSecrets"
+        },
+        {
           "command": "kicadstudio.manageChatProvider"
         },
         {
           "command": "kicadstudio.openDesignIntent",
-          "when": "kicadstudio.mcpConnected"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.mcpConnected"
+        },
+        {
+          "command": "kicadstudio.refreshFixQueue",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.mcpConnected"
+        },
+        {
+          "command": "kicadstudio.applyFixQueueItem",
+          "when": "false"
+        },
+        {
+          "command": "kicadstudio.fixQueue.apply",
+          "when": "false"
+        },
+        {
+          "command": "kicadstudio.fixQueue.applyAll",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.mcpConnected"
         },
         {
           "command": "kicadstudio.drcRule.addWithMcp",
@@ -1160,16 +1262,24 @@
           "when": "kicadstudio.workspaceTrusted"
         },
         {
+          "command": "kicadstudio.drcRule.reveal",
+          "when": "false"
+        },
+        {
           "command": "kicadstudio.variant.create",
-          "when": "kicadstudio.kicad10Plus"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject && kicadstudio.kicad10Plus"
         },
         {
           "command": "kicadstudio.variant.setActive",
-          "when": "kicadstudio.hasVariants"
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasVariants"
         },
         {
           "command": "kicadstudio.variant.diffBom",
           "when": "kicadstudio.hasVariants"
+        },
+        {
+          "command": "kicadstudio.variant.refresh",
+          "when": "kicadstudio.kicad10Plus"
         },
         {
           "command": "kicadstudio.testAiConnection",
@@ -1207,19 +1317,47 @@
           "when": "kicadstudio.workspaceTrusted"
         },
         {
+          "command": "kicadstudio.saveExportPreset",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
+        },
+        {
+          "command": "kicadstudio.runExportPreset",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
+        },
+        {
           "command": "kicadstudio.showStatusMenu"
         },
         {
-          "command": "kicadstudio.importPads"
+          "command": "kicadstudio.importPads",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
         },
         {
-          "command": "kicadstudio.importAltium"
+          "command": "kicadstudio.importAltium",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
         },
         {
-          "command": "kicadstudio.importEagle"
+          "command": "kicadstudio.importEagle",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
         },
         {
-          "command": "kicadstudio.importGeda"
+          "command": "kicadstudio.importCadstar",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
+        },
+        {
+          "command": "kicadstudio.importFabmaster",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
+        },
+        {
+          "command": "kicadstudio.importPcad",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
+        },
+        {
+          "command": "kicadstudio.importSolidworks",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
+        },
+        {
+          "command": "kicadstudio.importGeda",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
         }
       ]
     },
@@ -1228,19 +1366,19 @@
         "command": "kicadstudio.runDRC",
         "key": "ctrl+shift+d",
         "mac": "cmd+shift+d",
-        "when": "kicadstudio.pcbOpen"
+        "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
       },
       {
         "command": "kicadstudio.runERC",
         "key": "ctrl+shift+e",
         "mac": "cmd+shift+e",
-        "when": "kicadstudio.schematicOpen"
+        "when": "kicadstudio.workspaceTrusted && kicadstudio.schematicOpen"
       },
       {
         "command": "kicadstudio.exportGerbers",
         "key": "ctrl+shift+g",
         "mac": "cmd+shift+g",
-        "when": "kicadstudio.pcbOpen"
+        "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
       },
       {
         "command": "kicadstudio.searchLibrarySymbol",
@@ -2060,7 +2198,7 @@
     "test:security": "pnpm run build:protocol-schemas && jest --config jest.config.js --runInBand --coverage=false --testMatch \"<rootDir>/test/security/**/*.test.ts\"",
     "test:a11y": "pnpm run build:protocol-schemas && jest --config jest.config.js --runInBand --coverage=false --testMatch \"<rootDir>/test/a11y/**/*.test.ts\"",
     "test:perf": "pnpm run build:protocol-schemas && jest --config jest.config.js --runInBand --coverage=false --testMatch \"<rootDir>/test/performance/**/*.test.ts\"",
-    "test:integration": "pnpm run compile-tests && node ./out/test/runTest.js",
+    "test:integration": "pnpm run build && pnpm run compile-tests && node ./out/test/runTest.js",
     "test:integration:real": "pnpm run compile-tests && node ./out/test/integration/realServer/quickstart.flow.test.js && node ./out/test/integration/realServer/qualityGate.flow.test.js && node ./out/test/integration/realServer/contextBridge.flow.test.js && node ./out/test/integration/realServer/compatibility.flow.test.js",
     "test:integration:real:host": "pnpm run build && pnpm run compile-tests && node ./out/test/runRealPairHostTest.js",
     "test:e2e": "playwright test test/e2e/",

--- a/apps/vscode-extension/src/commands/exportCommands.ts
+++ b/apps/vscode-extension/src/commands/exportCommands.ts
@@ -136,8 +136,10 @@ export function registerExportCommands(
       (resource?: vscode.Uri) => services.exportService.exportSVG(resource),
       'Export Viewer SVG'
     ),
-    vscode.commands.registerCommand(COMMANDS.saveExportPreset, () =>
-      services.exportService.savePreset()
+    registerTrustedCommand(
+      COMMANDS.saveExportPreset,
+      () => services.exportService.savePreset(),
+      'Save Export Preset'
     ),
     registerTrustedCommand(
       COMMANDS.runExportPreset,

--- a/apps/vscode-extension/src/commands/viewerCommands.ts
+++ b/apps/vscode-extension/src/commands/viewerCommands.ts
@@ -16,7 +16,7 @@ import { resolveKiCadExecutable, launchDetached } from './kicadLauncher';
 import { buildStatusMenuItems } from './viewerStatusMenu';
 import type { CommandServices } from './types';
 import { findFirstWorkspaceFile, getWorkspaceRoot } from '../utils/pathUtils';
-import type { ProjectContext, ProjectTreeNode } from '../types';
+import type { KiCadVariant, ProjectContext, ProjectTreeNode } from '../types';
 import { unwrapPcmPackage } from '../library/pcmLibraryProvider';
 import type { PcmPackage } from '../library/pcmService';
 
@@ -258,19 +258,24 @@ export function registerViewerCommands(
       'Uninstall PCM package'
     ),
 
-    vscode.commands.registerCommand(COMMANDS.createVariant, async () => {
-      await services.variantProvider.createVariant();
-      await services.refreshContexts();
-      await services.pushStudioContext();
-    }),
+    registerTrustedCommand(
+      COMMANDS.createVariant,
+      async () => {
+        await services.variantProvider.createVariant();
+        await services.refreshContexts();
+        await services.pushStudioContext();
+      },
+      'Create Variant'
+    ),
 
-    vscode.commands.registerCommand(
+    registerTrustedCommand(
       COMMANDS.setActiveVariant,
-      async (variant) => {
+      async (variant: KiCadVariant) => {
         await services.variantProvider.setActive(variant);
         await services.refreshContexts();
         await services.pushStudioContext();
-      }
+      },
+      'Set Active Variant'
     ),
 
     vscode.commands.registerCommand(COMMANDS.diffVariantBom, () =>

--- a/apps/vscode-extension/src/language/diagnosticsAggregator.ts
+++ b/apps/vscode-extension/src/language/diagnosticsAggregator.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-type DiagnosticBucket = 'syntax' | 'drc' | 'erc' | 'other';
+export type DiagnosticBucket = 'syntax' | 'drc' | 'erc' | 'other';
 
 export class KiCadDiagnosticsAggregator implements vscode.DiagnosticCollection {
   private readonly buckets = new Map<
@@ -50,6 +50,25 @@ export class KiCadDiagnosticsAggregator implements vscode.DiagnosticCollection {
     }
     this.uris.set(key, uri);
     const bucket = inferBucket(uri, diagnostics);
+    const current =
+      this.buckets.get(key) ??
+      new Map<DiagnosticBucket, readonly vscode.Diagnostic[]>();
+    current.set(bucket, diagnostics);
+    this.buckets.set(key, current);
+    this.flush(uri);
+  }
+
+  setForSource(
+    uri: vscode.Uri,
+    bucket: DiagnosticBucket,
+    diagnostics: readonly vscode.Diagnostic[]
+  ): void {
+    const key = keyForUri(uri);
+    const previousUri = this.uris.get(key);
+    if (previousUri && previousUri.toString() !== uri.toString()) {
+      this.backing.delete(previousUri);
+    }
+    this.uris.set(key, uri);
     const current =
       this.buckets.get(key) ??
       new Map<DiagnosticBucket, readonly vscode.Diagnostic[]>();

--- a/apps/vscode-extension/src/language/diagnosticsProvider.ts
+++ b/apps/vscode-extension/src/language/diagnosticsProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { KICAD_S_EXPRESSION_LANGUAGES } from '../constants';
+import type { DiagnosticBucket } from './diagnosticsAggregator';
 import { KEYWORD_DESCRIPTIONS } from './kicadSchemas';
 import { SExpressionParser, type SNode } from './sExpressionParser';
 
@@ -38,19 +39,15 @@ export class KiCadDiagnosticsProvider {
         (KEYWORD_DESCRIPTIONS[document.languageId] ?? new Map()).keys()
       );
       this.collectUnknownTags(ast, issues, schema);
-      this.diagnostics.set(document.uri, issues);
+      setDiagnosticsForSource(this.diagnostics, document.uri, 'syntax', issues);
     } catch (error) {
       const message =
         error instanceof Error
           ? error.message
           : 'Unable to analyze this KiCad file. Try saving again or checking the file for malformed S-expressions.';
       const range = new vscode.Range(0, 0, 0, 1);
-      this.diagnostics.set(document.uri, [
-        createSyntaxDiagnostic(
-          range,
-          message,
-          vscode.DiagnosticSeverity.Warning
-        )
+      setDiagnosticsForSource(this.diagnostics, document.uri, 'syntax', [
+        createSyntaxDiagnostic(range, message, vscode.DiagnosticSeverity.Warning)
       ]);
     }
   }
@@ -102,6 +99,26 @@ export class KiCadDiagnosticsProvider {
       tag.startsWith('${')
     );
   }
+}
+
+function setDiagnosticsForSource(
+  collection: vscode.DiagnosticCollection,
+  uri: vscode.Uri,
+  bucket: DiagnosticBucket,
+  diagnostics: readonly vscode.Diagnostic[]
+): void {
+  const bucketed = collection as vscode.DiagnosticCollection & {
+    setForSource?: (
+      uri: vscode.Uri,
+      bucket: DiagnosticBucket,
+      diagnostics: readonly vscode.Diagnostic[]
+    ) => void;
+  };
+  if (typeof bucketed.setForSource === 'function') {
+    bucketed.setForSource(uri, bucket, diagnostics);
+    return;
+  }
+  collection.set(uri, diagnostics);
 }
 
 function createSyntaxDiagnostic(

--- a/apps/vscode-extension/test/integration/extension.test.ts
+++ b/apps/vscode-extension/test/integration/extension.test.ts
@@ -1,107 +1,338 @@
 import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { KiCadProjectTreeProvider } from '../../src/providers/projectTreeProvider';
+import { KiCadStatusBar } from '../../src/statusbar/kicadStatusBar';
+import type { ProjectTreeNode } from '../../src/types';
+
+type CommandContribution = {
+  command?: string;
+};
+
+type CommandPaletteContribution = {
+  command?: string;
+  when?: string;
+};
+
+type ViewContribution = {
+  id?: string;
+  when?: string;
+};
+
+type ViewWelcomeContribution = {
+  view?: string;
+  when?: string;
+};
 
 suite('Extension Integration', () => {
-  test('activates when .kicad_pro workspace opened', async () => {
-    const extension = vscode.extensions.getExtension('oaslananka.kicadstudio');
-    assert.ok(extension);
-    await extension?.activate();
-    assert.strictEqual(extension?.isActive, true);
+  let extension: vscode.Extension<unknown>;
+  let workspaceRoot: string;
+
+  suiteSetup(() => {
+    const loadedExtension = vscode.extensions.getExtension(
+      'oaslananka.kicadstudio'
+    );
+    assert.ok(loadedExtension, 'Expected KiCad Studio extension to load.');
+    extension = loadedExtension;
+
+    const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    assert.ok(root, 'Expected test workspace root to be available.');
+    workspaceRoot = root;
   });
 
-  test('registers all commands', async () => {
+  test('activates when .kicad_pro workspace opened', async () => {
+    await extension.activate();
+    assert.strictEqual(extension.isActive, true);
+  });
+
+  test('registers every package.json command at runtime', async () => {
+    await extension.activate();
     const commands = await vscode.commands.getCommands(true);
+    const contributedCommands = getContributedCommands(extension);
+    const missing = contributedCommands.filter(
+      (command) => !commands.includes(command)
+    );
+
+    assert.deepStrictEqual(missing, []);
+  });
+
+  test('declares activation, empty-workspace welcome, and Workspace Trust contracts', () => {
+    const activationEvents = new Set(
+      extension.packageJSON?.activationEvents ?? []
+    );
+    for (const extensionGlob of [
+      '.kicad_pro',
+      '.kicad_sch',
+      '.kicad_pcb',
+      '.kicad_dru',
+      '.kicad_jobset'
+    ]) {
+      assert.ok(
+        activationEvents.has(`workspaceContains:**/*${extensionGlob}`),
+        `Missing activation event for ${extensionGlob}`
+      );
+    }
+
+    const trust =
+      extension.packageJSON?.capabilities?.untrustedWorkspaces ?? {};
+    assert.strictEqual(trust.supported, 'limited');
+    for (const restrictedConfiguration of [
+      'kicadstudio.kicadCliPath',
+      'kicadstudio.kicadPath',
+      'kicadstudio.defaultOutputDir',
+      'kicadstudio.cli.defineVars',
+      'kicadstudio.mcp.endpoint',
+      'kicadstudio.mcp.pushContext'
+    ]) {
+      assert.ok(
+        trust.restrictedConfigurations?.includes(restrictedConfiguration),
+        `Missing restricted Workspace Trust configuration ${restrictedConfiguration}`
+      );
+    }
+
+    const welcome =
+      (extension.packageJSON?.contributes
+        ?.viewsWelcome as ViewWelcomeContribution[]) ?? [];
+    for (const view of [
+      'kicadstudio.validation',
+      'kicadstudio.bomView',
+      'kicadstudio.netlistView',
+      'kicadstudio.drcRules'
+    ]) {
+      assert.ok(
+        welcome.some(
+          (item) =>
+            item.view === view && String(item.when ?? '').includes('!kicadstudio.hasProject')
+        ),
+        `Missing empty-workspace welcome contribution for ${view}`
+      );
+    }
+  });
+
+  test('gates command palette commands by file state and Workspace Trust', () => {
+    const commandPalette = getCommandPalettePolicies(extension);
+    const commandsMissingPolicy = getContributedCommands(extension).filter(
+      (command) => !commandPalette.has(command)
+    );
+
+    assert.deepStrictEqual(commandsMissingPolicy, []);
+
+    for (const [command, expectedContexts] of [
+      ['kicadstudio.openSchematic', ['kicadstudio.schematicOpen']],
+      ['kicadstudio.openPCB', ['kicadstudio.pcbOpen']],
+      [
+        'kicadstudio.openInKiCad',
+        ['kicadstudio.workspaceTrusted', 'resourceExtname']
+      ],
+      ['kicadstudio.detectCli', ['kicadstudio.workspaceTrusted']],
+      [
+        'kicadstudio.exportGerbers',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.exportGerbersWithDrill',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.exportPCBPDF',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.exportIPC2581',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.exportODB',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.export3DGLB',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.export3DBREP',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.export3DPLY',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.export3DPdf',
+        [
+          'kicadstudio.workspaceTrusted',
+          'kicadstudio.pcbOpen',
+          'kicadstudio.kicad10Plus'
+        ]
+      ],
+      [
+        'kicadstudio.exportGenCAD',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.exportIPCD356',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.exportPickAndPlace',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.exportManufacturingPackage',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.exportSVG',
+        [
+          'kicadstudio.workspaceTrusted',
+          'kicadstudio.schematicOpen',
+          'kicadstudio.pcbOpen'
+        ]
+      ],
+      [
+        'kicadstudio.exportDXF',
+        [
+          'kicadstudio.workspaceTrusted',
+          'kicadstudio.schematicOpen',
+          'kicadstudio.pcbOpen'
+        ]
+      ],
+      [
+        'kicadstudio.exportPDF',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.schematicOpen']
+      ],
+      [
+        'kicadstudio.exportBOMCSV',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.schematicOpen']
+      ],
+      [
+        'kicadstudio.exportBOMXLSX',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.schematicOpen']
+      ],
+      [
+        'kicadstudio.exportNetlist',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.schematicOpen']
+      ],
+      [
+        'kicadstudio.exportInteractiveBOM',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.schematicOpen']
+      ],
+      [
+        'kicadstudio.runDRC',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.pcbOpen']
+      ],
+      [
+        'kicadstudio.runERC',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.schematicOpen']
+      ],
+      [
+        'kicadstudio.exportViewerSvg',
+        ['kicadstudio.workspaceTrusted', 'activeCustomEditorId']
+      ],
+      [
+        'kicadstudio.exportFootprintSVG',
+        ['kicadstudio.workspaceTrusted', 'resourceExtname == .kicad_mod']
+      ],
+      [
+        'kicadstudio.exportSymbolSVG',
+        ['kicadstudio.workspaceTrusted', 'resourceExtname == .kicad_sym']
+      ],
+      [
+        'kicadstudio.runJobset',
+        ['kicadstudio.workspaceTrusted', 'resourceExtname == .kicad_jobset']
+      ],
+      [
+        'kicadstudio.saveExportPreset',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
+      ],
+      [
+        'kicadstudio.runExportPreset',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
+      ],
+      [
+        'kicadstudio.setupMcpIntegration',
+        ['kicadstudio.workspaceTrusted']
+      ],
+      [
+        'kicadstudio.qualityGate.runAll',
+        [
+          'kicadstudio.workspaceTrusted',
+          'kicadstudio.mcpConnected',
+          'kicadstudio.hasProject'
+        ]
+      ],
+      [
+        'kicadstudio.openDesignIntent',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.mcpConnected']
+      ],
+      [
+        'kicadstudio.variant.create',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.kicad10Plus']
+      ],
+      [
+        'kicadstudio.variant.setActive',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.hasVariants']
+      ],
+      [
+        'kicadstudio.variant.diffBom',
+        ['kicadstudio.hasVariants']
+      ],
+      [
+        'kicadstudio.importPads',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
+      ],
+      [
+        'kicadstudio.importAltium',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
+      ],
+      [
+        'kicadstudio.importEagle',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
+      ],
+      [
+        'kicadstudio.importCadstar',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
+      ],
+      [
+        'kicadstudio.importFabmaster',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
+      ],
+      [
+        'kicadstudio.importPcad',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
+      ],
+      [
+        'kicadstudio.importSolidworks',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
+      ],
+      [
+        'kicadstudio.importGeda',
+        ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
+      ]
+    ] as Array<[string, string[]]>) {
+      assertCommandPaletteWhen(commandPalette, command, expectedContexts);
+    }
+
     for (const command of [
-      'kicadstudio.openSchematic',
-      'kicadstudio.openPCB',
-      'kicadstudio.openInKiCad',
-      'kicadstudio.showStatusMenu',
-      'kicadstudio.detectCli',
-      'kicadstudio.exportGerbers',
-      'kicadstudio.exportGerbersWithDrill',
-      'kicadstudio.exportPDF',
-      'kicadstudio.exportPCBPDF',
-      'kicadstudio.exportSVG',
-      'kicadstudio.exportIPC2581',
-      'kicadstudio.exportODB',
-      'kicadstudio.export3DGLB',
-      'kicadstudio.export3DBREP',
-      'kicadstudio.export3DPLY',
-      'kicadstudio.exportGenCAD',
-      'kicadstudio.exportIPCD356',
-      'kicadstudio.exportDXF',
-      'kicadstudio.exportPickAndPlace',
-      'kicadstudio.exportFootprintSVG',
-      'kicadstudio.exportSymbolSVG',
-      'kicadstudio.exportManufacturingPackage',
-      'kicadstudio.exportBOMCSV',
-      'kicadstudio.exportBOMXLSX',
-      'kicadstudio.exportNetlist',
-      'kicadstudio.runJobset',
-      'kicadstudio.exportInteractiveBOM',
-      'kicadstudio.runDRC',
-      'kicadstudio.runERC',
-      'kicadstudio.searchComponent',
-      'kicadstudio.showDiff',
-      'kicadstudio.openAiChat',
-      'kicadstudio.aiAnalyzeError',
-      'kicadstudio.aiProactiveDRC',
-      'kicadstudio.aiExplainCircuit',
-      'kicadstudio.testAiConnection',
-      'kicadstudio.searchLibrarySymbol',
-      'kicadstudio.searchLibraryFootprint',
-      'kicadstudio.reindexLibraries',
-      'kicadstudio.saveExportPreset',
-      'kicadstudio.runExportPreset',
-      'kicadstudio.setOctopartApiKey',
-      'kicadstudio.setAiApiKey',
-      'kicadstudio.clearSecrets',
-      'kicadstudio.showStoredSecrets',
-      'kicadstudio.manageChatProvider',
-      'kicadstudio.export3DPdf',
-      'kicadstudio.setupMcpIntegration',
-      'kicadstudio.mcp.install',
-      'kicadstudio.mcp.retry',
-      'kicadstudio.mcp.openUpgradeGuide',
-      'kicadstudio.mcp.pickProfile',
-      'kicadstudio.mcp.openLog',
-      'kicadstudio.mcp.saveLog',
-      'kicadstudio.mcp.clearLog',
-      'kicadstudio.openDesignIntent',
-      'kicadstudio.refreshFixQueue',
       'kicadstudio.applyFixQueueItem',
       'kicadstudio.fixQueue.apply',
-      'kicadstudio.fixQueue.applyAll',
-      'kicadstudio.qualityGate.runAll',
       'kicadstudio.qualityGate.runThis',
       'kicadstudio.qualityGate.showRaw',
-      'kicadstudio.qualityGate.openDocs',
-      'kicadstudio.manufacturing.release',
-      'kicadstudio.variant.create',
-      'kicadstudio.variant.setActive',
-      'kicadstudio.variant.diffBom',
-      'kicadstudio.variant.refresh',
-      'kicadstudio.drcRule.reveal',
-      'kicadstudio.drcRule.createDefault',
-      'kicadstudio.drcRule.importTemplate',
-      'kicadstudio.drcRule.addWithMcp',
-      'kicadstudio.exportViewerSvg',
-      'kicadstudio.importPads',
-      'kicadstudio.importAltium',
-      'kicadstudio.importEagle',
-      'kicadstudio.importCadstar',
-      'kicadstudio.importFabmaster',
-      'kicadstudio.importPcad',
-      'kicadstudio.importSolidworks'
+      'kicadstudio.drcRule.reveal'
     ]) {
-      assert.ok(commands.includes(command), `Missing command ${command}`);
+      assert.strictEqual(
+        commandPalette.get(command),
+        'false',
+        `${command} should be hidden from the Command Palette because it requires a tree item argument.`
+      );
     }
   });
 
   test('registers all custom editors', async () => {
-    const extension = vscode.extensions.getExtension('oaslananka.kicadstudio');
     const customEditors =
-      extension?.packageJSON?.contributes?.customEditors ?? [];
+      extension.packageJSON?.contributes?.customEditors ?? [];
     assert.ok(
       customEditors.some(
         (item: any) => item.viewType === 'kicadstudio.schematicViewer'
@@ -118,4 +349,260 @@ suite('Extension Integration', () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(commands.includes('kicadstudio.showStatusMenu'));
   });
+
+  test('renders project tree fixture files with unique rows and role tooltips', async () => {
+    const provider = new KiCadProjectTreeProvider();
+    const [root] = await provider.getChildren();
+    assert.ok(root, 'Expected project tree root to load from fixture workspace.');
+    assert.strictEqual(root.label, path.basename(workspaceRoot));
+
+    assertUniqueTreeRow(root, 'Project Files', 'sample.kicad_pro');
+    const schematic = assertUniqueTreeRow(
+      root,
+      'Schematic Sheets',
+      'sample.kicad_sch'
+    );
+    assertUniqueTreeRow(root, 'PCB', 'sample.kicad_pcb');
+
+    const collection = vscode.languages.createDiagnosticCollection(
+      'kicadstudio-integration-tree'
+    );
+    try {
+      assert.ok(schematic.uri, 'Expected sample schematic URI.');
+      collection.set(schematic.uri, [
+        new vscode.Diagnostic(
+          new vscode.Range(0, 0, 0, 1),
+          'Fixture warning',
+          vscode.DiagnosticSeverity.Warning
+        )
+      ]);
+
+      const treeItem = provider.getTreeItem(schematic);
+      assert.ok(
+        String(treeItem.description ?? '').includes('Schematic sheet'),
+        'Expected schematic tree row to describe its file role.'
+      );
+      assert.ok(
+        String(treeItem.tooltip ?? '').includes('Schematic sheet'),
+        'Expected schematic tree tooltip to explain its file role.'
+      );
+      assert.ok(
+        String(treeItem.tooltip ?? '').includes('1 warning'),
+        'Expected schematic tree tooltip to summarize diagnostics.'
+      );
+    } finally {
+      collection.dispose();
+    }
+  });
+
+  test('renders status bar validation counters and stale validation state', () => {
+    const statusBar = new KiCadStatusBar({
+      subscriptions: []
+    } as unknown as vscode.ExtensionContext);
+
+    try {
+      statusBar.update({
+        drc: {
+          file: 'sample.kicad_pcb',
+          errors: 2,
+          warnings: 0,
+          infos: 0,
+          source: 'drc',
+          freshness: 'stale',
+          origin: 'kicad-cli',
+          capturedAt: '2026-05-26T00:00:00.000Z',
+          staleReason: 'Fixture board changed after validation.'
+        },
+        erc: {
+          file: 'sample.kicad_sch',
+          errors: 0,
+          warnings: 0,
+          infos: 0,
+          source: 'erc',
+          freshness: 'fresh-clean',
+          origin: 'kicad-cli',
+          capturedAt: '2026-05-26T00:00:00.000Z'
+        }
+      });
+
+      const items = statusBar as unknown as {
+        drcItem: vscode.StatusBarItem;
+        ercItem: vscode.StatusBarItem;
+      };
+      assert.ok(
+        items.drcItem.text.includes('stale'),
+        'Expected stale DRC results to be marked stale instead of current failures.'
+      );
+      assert.ok(
+        String(items.drcItem.tooltip ?? '').includes('Fixture board changed'),
+        'Expected stale DRC tooltip to explain the stale reason.'
+      );
+      assert.ok(
+        items.ercItem.text.includes('pass'),
+        'Expected clean ERC results to render as a passing counter.'
+      );
+    } finally {
+      statusBar.dispose();
+    }
+  });
+
+  test('keeps #21 #22 #29 #33 regression surfaces wired in the Extension Development Host', () => {
+    const sidebarViews =
+      (extension.packageJSON?.contributes?.views?.[
+        'kicadstudio-sidebar'
+      ] as ViewContribution[] | undefined) ?? [];
+    for (const viewId of [
+      'kicadstudio.projectTree',
+      'kicadstudio.netlistView',
+      'kicadstudio.validation'
+    ]) {
+      assert.ok(
+        sidebarViews.some((view) => view.id === viewId),
+        `Missing sidebar view ${viewId}`
+      );
+    }
+
+    const commandPalette = getCommandPalettePolicies(extension);
+    assertCommandPaletteWhen(commandPalette, 'kicadstudio.showStatusMenu', []);
+    assertCommandPaletteWhen(commandPalette, 'kicadstudio.runDRC', [
+      'kicadstudio.pcbOpen'
+    ]);
+    assertCommandPaletteWhen(commandPalette, 'kicadstudio.runERC', [
+      'kicadstudio.schematicOpen'
+    ]);
+  });
+
+  test('scopes Problems diagnostics to exact URIs and clears stale diagnostics after a clean save', async () => {
+    await extension.activate();
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kicadstudio-diagnostics-')
+    );
+    const dirtyUri = vscode.Uri.file(path.join(tempDir, 'dirty.kicad_sch'));
+    const cleanUri = vscode.Uri.file(path.join(tempDir, 'clean.kicad_sch'));
+
+    try {
+      fs.writeFileSync(dirtyUri.fsPath, '(kicad_sch (unknown_node))', 'utf8');
+      fs.writeFileSync(cleanUri.fsPath, '(kicad_sch)', 'utf8');
+
+      const dirtyDocument = await vscode.workspace.openTextDocument(dirtyUri);
+      await vscode.window.showTextDocument(dirtyDocument);
+
+      const dirtyDiagnostics = await waitForDiagnostics(
+        dirtyUri,
+        (diagnostics) => diagnostics.length > 0
+      );
+      assert.ok(
+        dirtyDiagnostics.some((diagnostic) =>
+          diagnostic.message.includes('unknown_node')
+        ),
+        'Expected dirty schematic diagnostics to mention the unknown node.'
+      );
+      assert.deepStrictEqual(vscode.languages.getDiagnostics(cleanUri), []);
+
+      const edit = new vscode.WorkspaceEdit();
+      edit.replace(
+        dirtyUri,
+        new vscode.Range(
+          dirtyDocument.positionAt(0),
+          dirtyDocument.positionAt(dirtyDocument.getText().length)
+        ),
+        '(kicad_sch)'
+      );
+      assert.strictEqual(await vscode.workspace.applyEdit(edit), true);
+      assert.strictEqual(await dirtyDocument.save(), true);
+
+      await waitForDiagnostics(
+        dirtyUri,
+        (diagnostics) => diagnostics.length === 0
+      );
+      assert.deepStrictEqual(vscode.languages.getDiagnostics(cleanUri), []);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });
+
+function getContributedCommands(
+  extension: vscode.Extension<unknown>
+): string[] {
+  const commands =
+    (extension.packageJSON?.contributes
+      ?.commands as CommandContribution[]) ?? [];
+  return commands
+    .map((item) => item.command)
+    .filter((command): command is string => Boolean(command));
+}
+
+function getCommandPalettePolicies(
+  extension: vscode.Extension<unknown>
+): Map<string, string> {
+  const entries =
+    (extension.packageJSON?.contributes?.menus
+      ?.commandPalette as CommandPaletteContribution[]) ?? [];
+  return new Map(
+    entries
+      .filter((item) => item.command)
+      .map((item) => [item.command as string, item.when ?? ''])
+  );
+}
+
+function assertCommandPaletteWhen(
+  commandPalette: ReadonlyMap<string, string>,
+  command: string,
+  expectedContexts: readonly string[]
+): void {
+  assert.ok(
+    commandPalette.has(command),
+    `${command} is missing an explicit commandPalette visibility policy.`
+  );
+  const when = commandPalette.get(command) ?? '';
+  for (const context of expectedContexts) {
+    assert.ok(
+      when.includes(context),
+      `${command} commandPalette when-clause "${when}" must include "${context}".`
+    );
+  }
+}
+
+function childrenFor(
+  root: ProjectTreeNode | undefined,
+  label: string
+): ProjectTreeNode[] {
+  return root?.children?.find((node) => node.label === label)?.children ?? [];
+}
+
+function assertUniqueTreeRow(
+  root: ProjectTreeNode,
+  groupLabel: string,
+  rowLabel: string
+): ProjectTreeNode {
+  const matches = childrenFor(root, groupLabel).filter(
+    (node) => node.label === rowLabel
+  );
+  assert.strictEqual(
+    matches.length,
+    1,
+    `Expected exactly one ${rowLabel} row under ${groupLabel}.`
+  );
+  return matches[0]!;
+}
+
+async function waitForDiagnostics(
+  uri: vscode.Uri,
+  predicate: (diagnostics: vscode.Diagnostic[]) => boolean
+): Promise<vscode.Diagnostic[]> {
+  const timeoutAt = Date.now() + 10000;
+  let latest: vscode.Diagnostic[] = [];
+
+  while (Date.now() < timeoutAt) {
+    latest = vscode.languages.getDiagnostics(uri);
+    if (predicate(latest)) {
+      return latest;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error(
+    `Timed out waiting for diagnostics for ${uri.toString()}: ${latest.map((diagnostic) => diagnostic.message).join('; ')}`
+  );
+}

--- a/apps/vscode-extension/test/unit/diagnosticsAggregator.test.ts
+++ b/apps/vscode-extension/test/unit/diagnosticsAggregator.test.ts
@@ -43,6 +43,33 @@ describe('KiCadDiagnosticsAggregator', () => {
     ).toEqual(['Unknown node', 'Clearance']);
   });
 
+  it('clears syntax diagnostics without erasing clean CLI state for the same schematic', () => {
+    const backing = createBackingCollection();
+    const aggregator = new KiCadDiagnosticsAggregator(backing);
+    const uri = vscode.Uri.file('/workspace/schematic.kicad_sch');
+    const syntax = new vscode.Diagnostic(
+      new vscode.Range(0, 0, 0, 1),
+      'Unknown node',
+      2
+    );
+    syntax.source = 'kicad-studio:syntax';
+    const erc = new vscode.Diagnostic(
+      new vscode.Range(1, 0, 1, 1),
+      'ERC warning',
+      1
+    );
+    erc.source = 'kicad-cli:erc';
+
+    aggregator.setForSource(uri, 'syntax', [syntax]);
+    aggregator.set(uri, [erc]);
+    aggregator.setForSource(uri, 'syntax', []);
+
+    expect(
+      aggregator.get(uri)?.map((diagnostic) => diagnostic.message)
+    ).toEqual(['ERC warning']);
+    expect(backing.set).toHaveBeenLastCalledWith(uri, [erc]);
+  });
+
   it('replaces only diagnostics from the same source', () => {
     const backing = createBackingCollection();
     const aggregator = new KiCadDiagnosticsAggregator(backing);


### PR DESCRIPTION
## Summary
- Expand VS Code Extension Development Host integration tests for activation, command registration, command palette context policies, Workspace Trust contracts, custom editors, diagnostics URI scoping, project tree rows/tooltips, status bar validation states, and regression surfaces for #21/#22/#29/#33.
- Fix diagnostics source bucketing so syntax diagnostics can clear without erasing DRC/ERC diagnostics for the same URI.
- Gate unsafe command palette entries and runtime command handlers with Workspace Trust/file-state policies, and run `test:integration` headlessly in CI.

## Linear
- OASLANA-39: https://linear.app/oaslananka/issue/OASLANA-39/add-vs-code-extension-integration-tests-for-activation-commands

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist`
- `corepack pnpm --filter kicadstudio run format:check`
- `corepack pnpm --filter kicadstudio run check:workspace-trust`
- `corepack pnpm --dir packages/mcp-server run workflows:lint`
- `corepack pnpm --dir packages/mcp-server run workflows:security`
- workflow deprecated-runtime/command grep: no matches

## Notes
- Root MCP pytest emitted existing `ResourceWarning: unclosed database` warnings from untouched `packages/mcp-server`/third-party frames; no deprecation warnings were introduced by this change.
- `corepack pnpm run build` emitted the existing `packages/mcp-npm` message about the unpublished matching PyPI package, guarded by that package script and exiting 0.

Fixes #40
