### PR TITLE
fix(kicad-mcp-pro): use shared GUI smoke fixture

### DIFF
--- a/packages/mcp-server/tests/gui/test_kicad_gui_live_context.py
+++ b/packages/mcp-server/tests/gui/test_kicad_gui_live_context.py
@@ -26,9 +26,8 @@ from tests.conftest import call_tool_text
 pytestmark = [pytest.mark.anyio, pytest.mark.gui, pytest.mark.slow]
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
-FIXTURE_ROOT = (
-    REPO_ROOT / "apps" / "vscode-extension" / "test" / "fixtures" / "kicad" / "clean-led-kicad10"
-)
+GUI_SMOKE_FIXTURE_ID = "clean-led-kicad10"
+FIXTURE_ROOT = REPO_ROOT / "packages" / "kicad-fixtures" / "fixtures" / GUI_SMOKE_FIXTURE_ID
 SMOKE_TOOLS = (
     "pcb_get_board_summary",
     "pcb_get_tracks",
@@ -98,7 +97,7 @@ def _copy_fixture(tmp_path: Path, name: str) -> Path:
 
 
 def _configure_project(monkeypatch: pytest.MonkeyPatch, project_dir: Path) -> dict[str, str]:
-    stem = "clean-led-kicad10"
+    stem = GUI_SMOKE_FIXTURE_ID
     env = {
         "KICAD_MCP_PROJECT_DIR": str(project_dir),
         "KICAD_MCP_PROJECT_FILE": str(project_dir / f"{stem}.kicad_pro"),

--- a/packages/mcp-server/tests/unit/test_gui_smoke_fixture_path.py
+++ b/packages/mcp-server/tests/unit/test_gui_smoke_fixture_path.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_gui_smoke_module() -> ModuleType:
+    module_path = Path(__file__).resolve().parents[1] / "gui" / "test_kicad_gui_live_context.py"
+    spec = importlib.util.spec_from_file_location("test_kicad_gui_live_context", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load GUI smoke test module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_issue_186_gui_smoke_uses_shared_fixture_corpus() -> None:
+    gui_smoke = _load_gui_smoke_module()
+    expected_root = (
+        gui_smoke.REPO_ROOT
+        / "packages"
+        / "kicad-fixtures"
+        / "fixtures"
+        / gui_smoke.GUI_SMOKE_FIXTURE_ID
+    )
+
+    assert gui_smoke.FIXTURE_ROOT == expected_root
+    assert gui_smoke.FIXTURE_ROOT.is_dir()
+    assert (gui_smoke.FIXTURE_ROOT / "clean-led-kicad10.kicad_pro").is_file()


### PR DESCRIPTION
## Summary

Fixes the KiCad GUI smoke suite after the shared fixture corpus move by loading `clean-led-kicad10` from `packages/kicad-fixtures/fixtures` instead of the removed extension-local fixture path.

Adds a unit regression test so the GUI smoke fixture path fails in the fast Python unit lane if it drifts again.

## Linked issue

Closes #186

## Type of change

- [x] type:bug
- [ ] type:feature
- [ ] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `uv sync --all-extras --frozen --project packages/mcp-server` passed.
- `uv run --project packages/mcp-server --all-extras ruff format packages/mcp-server/tests/gui/test_kicad_gui_live_context.py packages/mcp-server/tests/unit/test_gui_smoke_fixture_path.py` passed.
- `uv run --project packages/mcp-server --all-extras ruff check packages/mcp-server/tests/gui/test_kicad_gui_live_context.py packages/mcp-server/tests/unit/test_gui_smoke_fixture_path.py` passed.
- `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_gui_smoke_fixture_path.py -q` passed.
- `corepack pnpm install --frozen-lockfile` passed after repairing a local concurrent pnpm install collision.
- `corepack pnpm run check:kicad-gui-smoke` passed.
- `corepack pnpm run test:kicad-gui-smoke` passed locally with 2 expected skips because `KICAD_MCP_ENABLE_GUI_SMOKE=1` is not set.
- `corepack pnpm --dir packages/mcp-server run check:lint` passed.
- `corepack pnpm --dir packages/mcp-server run check:type` passed.
- `corepack pnpm --dir packages/mcp-server run test:unit` passed.
- `corepack pnpm --dir packages/mcp-server run check:build` passed.
- `corepack pnpm --dir packages/mcp-server run security:bandit` passed.
- `corepack pnpm --dir packages/mcp-server run security:audit` passed.
- `corepack pnpm --dir packages/mcp-server run check:meta` passed.
- `corepack pnpm --filter kicadstudio run workflows:lint` passed.
- `corepack pnpm --dir packages/mcp-server run workflows:security` passed.
- `corepack pnpm --dir packages/mcp-server run check:release` passed; existing PyPI reachability warning remained non-fatal.
- `pre-commit run --all-files` passed.

Regression test: `test_issue_186_gui_smoke_uses_shared_fixture_corpus`.

## Protocol / MCP impact

Complete this section when the PR changes MCP tool names, tool schemas,
capability metadata, transport behavior, server-info payloads, compatibility
metadata, or extension adapter behavior. For non-protocol PRs, mark it not
applicable and state why.

Checklist reference: `docs/architecture/protocol-change-checklist.md`

- [x] Not applicable; reason: test fixture path only, no MCP protocol surface changed.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [ ] Docs updated
- [ ] Release notes considered for both products
- [ ] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [ ] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [ ] CHANGELOG entry (if user-visible)
- [ ] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts