### PR TITLE
docs(repo): document main ruleset bypass policy

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -2,6 +2,13 @@
   "name": "main-protection",
   "target": "branch",
   "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ],
   "conditions": {
     "ref_name": {
       "include": ["~DEFAULT_BRANCH"],

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -54,7 +54,8 @@ Enable CODEOWNERS review. Path ownership is declared in `.github/CODEOWNERS`:
 - Require branches to be up to date before merge when required checks are enabled.
 - Require signed commits if the account policy supports it.
 - Disallow force pushes and branch deletion for `main`.
-- Restrict who can bypass required pull requests and required checks.
+- Restrict bypass to repository administrators and only for pull request merges.
+  Direct pushes to `main` remain blocked.
 
 The strict up-to-date rule currently favors a current green `main` integration
 point over merge throughput. Re-evaluate it with the required-check set if the


### PR DESCRIPTION
## Problem
The repository documented a `main` protection ruleset, but live GitHub state had no active ruleset and `main` was not protected.

## Solution
- Created the live `main-protection` repository ruleset from `.github/rulesets/main.json`.
- Kept required PRs, CODEOWNERS review, signed commits, non-fast-forward/deletion protection, and required status checks active.
- Added a PR-only administrator bypass actor to the importable ruleset and documented that direct pushes to `main` remain blocked.

Closes #64

## Verification
- `gh api repos/oaslananka/kicad-studio-kit/rulesets/16883353`
- `gh api repos/oaslananka/kicad-studio-kit/branches/main --jq '{name,protected,protection_url}'`
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run docs:lint`
- `corepack pnpm run docs:links`
- `corepack pnpm run check:ci-lanes`
- `corepack pnpm run check:agent-configs`
- `corepack pnpm run format:check`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run verify:dist`
- `pre-commit run --all-files`
- `gitleaks detect --source . --redact --no-banner`

Known unrelated local blocker: `corepack pnpm run build` currently fails on Windows in `packages/mcp-npm` because its existing build script relies on `|| true` while the matching Python package is unpublished; a separate canonical packaging issue will track that after the REST API limit resets.