### PR TITLE
ci(repo): set Python for nightly quality gates

### DIFF
--- a/.github/workflows/nightly-quality-gates.yml
+++ b/.github/workflows/nightly-quality-gates.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           node-version-file: .node-version
           package-manager-cache: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version-file: .python-version
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: true


### PR DESCRIPTION
## Problem
Fresh dispatches proved the original action archive download failures were transient: Stale downloaded and ran `actions/stale`, and Nightly downloaded checkout/setup-node/setup-uv. Nightly then failed later because `dev-doctor --strict` saw Ubuntu's default `Python 3.12.3`, while the repo requires Python `>=3.13`.

## Solution
- Add pinned `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405` to `.github/workflows/nightly-quality-gates.yml`.
- Use the root `.python-version` so the scheduled workflow installs the repository-supported Python line before `uv` and `dev-doctor` run.

Closes #187

## Verification
- `gh workflow run stale.yml --ref main` -> run `26460520393` succeeded
- `gh workflow run nightly-quality-gates.yml --ref main` -> run `26460520461` reproduced the later Python 3.12 dev-doctor failure after action archives downloaded successfully
- `gh api repos/actions/setup-python/releases/latest` -> `v6.2.0`
- `gh api repos/actions/setup-python/git/ref/tags/v6.2.0` -> commit `a309ff8b426b58ec0e2a45f0f869d46889d02405`
- `actions/setup-python` action metadata at that commit uses `node24`
- `corepack pnpm install --frozen-lockfile`
- workflow uses/deprecation scan: no deprecated workflow markers
- `corepack pnpm run check:ci-lanes`
- `corepack pnpm --filter kicadstudio run workflows:lint`
- `corepack pnpm --dir packages/mcp-server run workflows:security`
- `corepack pnpm run check:version`
- `pre-commit run --all-files`
- `gitleaks detect --source . --redact --no-banner`

Known unrelated local blocker: `corepack pnpm run check:dev-doctor` on this Windows host fails because `scripts/dev-doctor.mjs` cannot spawn `corepack`; issue #191 tracks the related Windows build/preflight portability class.