### PR TITLE
ci(repo): install Playwright browsers in nightly gates

### DIFF
--- a/.github/workflows/nightly-quality-gates.yml
+++ b/.github/workflows/nightly-quality-gates.yml
@@ -32,6 +32,7 @@ jobs:
           version-file: packages/mcp-server/uv.toml
       - run: corepack enable
       - run: corepack pnpm install --frozen-lockfile
+      - run: corepack pnpm --filter kicadstudio exec playwright install --with-deps chromium
       - run: uv sync --all-extras --frozen --project packages/mcp-server
       - run: corepack pnpm run check
       - run: corepack pnpm run test:contract


### PR DESCRIPTION
## Problem
Nightly Quality Gates now reaches the monorepo check after PR #192 fixed Python setup, but run 26461417720 fails in `apps/vscode-extension` a11y tests before assertions execute because Playwright cannot find Chromium headless shell on the hosted runner.

## Solution
Install Playwright Chromium and Linux browser dependencies in `.github/workflows/nightly-quality-gates.yml` immediately after pnpm dependencies are installed and before `corepack pnpm run check` runs the extension a11y suite.

## Validation
- `corepack pnpm run check:ci-lanes`
- `corepack pnpm --filter kicadstudio run workflows:lint`
- `corepack pnpm --filter kicadstudio exec playwright install --with-deps chromium --dry-run`
- `pre-commit run --all-files`
- `gitleaks detect --source . --redact --no-banner`

Local note: a real Chromium download timed out on this Windows host after 10 minutes, so the post-merge manual Nightly dispatch on Linux is the acceptance validation for the actual install.

Closes #187