### PR TITLE
feat(repo): harden KiCad 11 IPC readiness

### DIFF
--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -20,6 +20,99 @@ kicad:
       notes: "File-level read and migration support only; removal requires a release note."
   dropped: []
 
+kicadIpcReadiness:
+  reviewed: "2026-05-26"
+  sources:
+    pcbnewDeprecation: "https://dev-docs.kicad.org/en/apis-and-binding/pcbnew/"
+    commandLine: "https://docs.kicad.org/master/en/cli/cli.html"
+    nightlies: "https://www.kicad.org/help/nightlies-and-rcs/"
+  directPcbnewImports:
+    policy: "forbidden-in-production"
+    allowedPaths:
+      - "packages/mcp-server/scripts/check_no_pcbnew.py"
+      - "packages/mcp-server/tests/**"
+  manualCanary:
+    currentNightlyRange: "10.99.x"
+    releaseCandidateRange: "11.0.x"
+    currentNightlyCommand: "corepack pnpm run test:kicad-cli-contract:nightly"
+    releaseCandidateCommand: "corepack pnpm run test:kicad-cli-contract:future"
+  ipcApi:
+    requiredFor:
+      projectDiscovery:
+        tools: ["kicad_get_project_info", "kicad_set_project"]
+        canaryProbes:
+          [
+            "version",
+            "path-with-spaces-board-stats",
+            "unicode-path-board-stats",
+          ]
+        evidence:
+          - "packages/mcp-server/tests/integration/test_project_library_surface.py"
+          - "packages/mcp-server/tests/unit/test_discovery.py"
+      pcbRead:
+        tools:
+          [
+            "pcb_get_board_summary",
+            "pcb_get_tracks",
+            "pcb_get_footprints",
+            "pcb_get_nets",
+          ]
+        canaryProbes:
+          [
+            "board-stats",
+            "path-with-spaces-board-stats",
+            "unicode-path-board-stats",
+          ]
+        evidence:
+          - "packages/mcp-server/tests/integration/test_pcb_tools.py"
+          - "packages/mcp-server/tests/gui/test_kicad_gui_live_context.py"
+      schematicRead:
+        tools: ["sch_get_symbols", "sch_get_sheet_info", "sch_get_net_names"]
+        canaryProbes: ["clean-erc", "schematic-pdf", "bom", "netlist"]
+        evidence:
+          - "packages/mcp-server/tests/integration/test_schematic_tools.py"
+          - "packages/mcp-server/tests/integration/test_project_library_surface.py"
+      drc:
+        tools: ["run_drc", "validate_design", "check_design_for_manufacture"]
+        canaryProbes: ["clean-drc", "dirty-drc"]
+        evidence:
+          - "packages/mcp-server/tests/integration/test_export_tools.py"
+          - "packages/mcp-server/tests/integration/test_pcb_export_validation_surface.py"
+      erc:
+        tools: ["run_erc", "validate_design", "schematic_quality_gate"]
+        canaryProbes: ["clean-erc", "dirty-erc"]
+        evidence:
+          - "packages/mcp-server/tests/integration/test_export_tools.py"
+          - "packages/mcp-server/tests/integration/test_schematic_connectivity_gate.py"
+      export:
+        tools:
+          [
+            "export_gerber",
+            "export_drill",
+            "export_manufacturing_package",
+            "export_bom",
+            "export_netlist",
+          ]
+        canaryProbes:
+          [
+            "schematic-pdf",
+            "pcb-pdf",
+            "pcb-svg",
+            "pcb-dxf",
+            "gerbers",
+            "drill",
+            "step",
+          ]
+        evidence:
+          - "packages/mcp-server/tests/integration/test_export_tools.py"
+          - "packages/mcp-server/tests/unit/test_kicad_canary.py"
+      diagnostics:
+        tools: ["kicad_get_version", "kicad_get_server_info", "kicad_help"]
+        canaryProbes: ["version", "read-only-output-failure"]
+        evidence:
+          - "packages/mcp-server/tests/unit/test_server_info_contract.py"
+          - "packages/mcp-server/tests/unit/test_cli_diagnostics.py"
+
 vscode:
   minimum: "1.120.0"
   enginesRange: "^1.120.0"

--- a/docs/compatibility/kicad-10-to-11-migration.md
+++ b/docs/compatibility/kicad-10-to-11-migration.md
@@ -1,0 +1,118 @@
+# KiCad 10 to 11 Migration
+
+This guide keeps KiCad Studio and KiCad MCP Pro ready for the KiCad 11 line
+without changing the current supported baseline. KiCad 10.0.x remains the
+primary release-blocking target until a KiCad 11 stable or release-candidate
+canary has passed and the support matrix is updated in `compatibility.yaml`.
+
+## Compatibility Boundary
+
+| Surface                        | KiCad 10.0.x              | KiCad 11 readiness                          |
+| ------------------------------ | ------------------------- | ------------------------------------------- |
+| Primary support                | Required release gate     | Not primary yet                             |
+| Direct `pcbnew` / SWIG imports | Forbidden in production   | Forbidden in production                     |
+| Project discovery              | MCP and file-backed paths | Must remain IPC or CLI backed               |
+| Schematic and PCB reads        | MCP tests plus CLI canary | Same tool contracts, no SWIG fallback       |
+| DRC and ERC                    | `kicad-cli` contract      | Same command contract against nightly or RC |
+| Manufacturing exports          | `kicad-cli` contract      | Same command contract against nightly or RC |
+
+The executable contract lives in `compatibility.yaml` under
+`kicadIpcReadiness`. It records the direct `pcbnew` import policy, the minimal
+allowlist, the manual nightly/RC canary commands, and the IPC feature-parity
+matrix that maps user-facing MCP tools to tests and canary probes.
+
+## Direct `pcbnew` Policy
+
+Production code must not import or call the legacy SWIG Python `pcbnew` module.
+The only repository allowlist entries are:
+
+- `packages/mcp-server/scripts/check_no_pcbnew.py`, because it names the
+  forbidden API while enforcing the guard.
+- `packages/mcp-server/tests/**`, because tests may construct examples that
+  prove the guard fails.
+
+Run the guard locally:
+
+```bash
+uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/check_no_pcbnew.py
+```
+
+```powershell
+uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/check_no_pcbnew.py
+```
+
+## Manual KiCad 11 Smoke Path
+
+KiCad nightly builds use the development branch version before a release
+candidate and switch to the next major version during the RC window. As of
+2026-05-26, KiCad 10.0.x is the stable line, so the next-major readiness smoke
+has two manual paths:
+
+```bash
+KICAD_CANARY_KICAD_CLI=/absolute/path/to/kicad-cli \
+  corepack pnpm run test:kicad-cli-contract:nightly
+```
+
+```powershell
+$Env:KICAD_CANARY_KICAD_CLI = "C:\Program Files\KiCad Nightly\bin\kicad-cli.exe"
+corepack pnpm run test:kicad-cli-contract:nightly
+```
+
+Use the RC command once the installed prerelease reports `11.0.x`:
+
+```bash
+KICAD_CANARY_KICAD_CLI=/absolute/path/to/kicad-cli \
+  corepack pnpm run test:kicad-cli-contract:future
+```
+
+```powershell
+$Env:KICAD_CANARY_KICAD_CLI = "C:\Program Files\KiCad\11.0\bin\kicad-cli.exe"
+corepack pnpm run test:kicad-cli-contract:future
+```
+
+The canary writes logs, reports, manufacturing outputs, `summary.json`, and
+`failing-fixtures.txt` under `artifacts/kicad-cli-contract/`.
+
+## IPC Feature-Parity Matrix
+
+| Area              | Representative tools                                                                            | Required probes and tests                                                  |
+| ----------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Project discovery | `kicad_get_project_info`, `kicad_set_project`                                                   | Version, paths-with-spaces, Unicode paths, project-library tests           |
+| PCB read          | `pcb_get_board_summary`, `pcb_get_tracks`, `pcb_get_footprints`, `pcb_get_nets`                 | Board statistics probes, PCB integration tests, GUI smoke                  |
+| Schematic read    | `sch_get_symbols`, `sch_get_sheet_info`, `sch_get_net_names`                                    | ERC, schematic PDF, BOM, netlist, schematic integration tests              |
+| DRC               | `run_drc`, `validate_design`, `check_design_for_manufacture`                                    | Clean and dirty DRC probes, export validation tests                        |
+| ERC               | `run_erc`, `validate_design`, `schematic_quality_gate`                                          | Clean and dirty ERC probes, schematic connectivity tests                   |
+| Export            | `export_gerber`, `export_drill`, `export_manufacturing_package`, `export_bom`, `export_netlist` | PDF, SVG, DXF, Gerber, drill, STEP probes, export tests                    |
+| Diagnostics       | `kicad_get_version`, `kicad_get_server_info`, `kicad_help`                                      | Version and read-only-output probes, server-info and CLI diagnostics tests |
+
+The repository gate checks that every listed tool exists in the generated MCP
+tool reference and that every evidence path exists:
+
+```bash
+corepack pnpm run check:compatibility
+```
+
+```powershell
+corepack pnpm run check:compatibility
+```
+
+## Promotion Checklist
+
+- Update `compatibility.yaml` only after the KiCad 11 RC or stable canary passes.
+- Keep KiCad 10.0.x primary support unchanged until the support matrix and
+  product changelogs intentionally move the primary line.
+- Update [`../support-matrix.md`](../support-matrix.md) and
+  [`../testing-strategy.md`](../testing-strategy.md) with the new line state.
+- Attach the canary artifact summary to the tracking issue or PR.
+- Keep production code on IPC, `kicad-cli`, or file-backed adapters.
+
+## Source Verification
+
+Checked on 2026-05-26:
+
+- [KiCad PCB Python bindings](https://dev-docs.kicad.org/en/apis-and-binding/pcbnew/)
+  for the SWIG `pcbnew` deprecation and KiCad 11 removal plan.
+- [KiCad command-line interface](https://docs.kicad.org/master/en/cli/cli.html)
+  for the `api-server`, DRC, ERC, and export command surfaces.
+- [KiCad nightly builds and release candidates](https://www.kicad.org/help/nightlies-and-rcs/)
+  for nightly/RC version behavior and data-safety guidance.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -61,6 +61,22 @@ exports.
 | 8.x        | 8.0.x        | Deprecated    | Manual compatibility check                  | Core file-level read, migration, DRC/ERC, BOM/netlist, and Gerber workflows are best-effort when command probes pass; jobsets, variants, 3D PDF, and ODB++ remain unavailable.              |
 | <8         | none         | Unsupported   | None                                        | KiCad Studio reports the detected CLI as unsupported and does not claim feature compatibility.                                                                                              |
 
+## KiCad 11 Readiness
+
+KiCad 11 is not a primary support target yet. The readiness contract is tracked
+separately from the current KiCad 10.0.x support boundary so release gates keep
+protecting users on the stable line while maintainers test the next major line.
+
+| Readiness item         | Current contract                                                                                   |
+| ---------------------- | -------------------------------------------------------------------------------------------------- |
+| Stable baseline        | KiCad 10.0.x remains primary and release-blocking.                                                 |
+| Direct SWIG imports    | Production `pcbnew` imports are forbidden by `packages/mcp-server/scripts/check_no_pcbnew.py`.     |
+| Allowed `pcbnew` paths | Only the guard script and `packages/mcp-server/tests/**`.                                          |
+| IPC parity matrix      | `compatibility.yaml` `kicadIpcReadiness.ipcApi.requiredFor`.                                       |
+| Current nightly smoke  | `corepack pnpm run test:kicad-cli-contract:nightly` with a configured nightly `kicad-cli`.         |
+| KiCad 11 RC smoke      | `corepack pnpm run test:kicad-cli-contract:future` once the installed prerelease reports `11.0.x`. |
+| Migration guide        | [`docs/compatibility/kicad-10-to-11-migration.md`](compatibility/kicad-10-to-11-migration.md).     |
+
 Status surfaces:
 
 - The status bar shows the detected KiCad support line and warns on deprecated or unsupported CLIs.
@@ -72,6 +88,9 @@ Freshness sources checked on 2026-05-26:
 - KiCad 10.0.3 release notes: <https://www.kicad.org/blog/2026/05/KiCad-10.0.3-Release/>
 - KiCad 9.0.9 release notes: <https://www.kicad.org/blog/2026/04/KiCad-9.0.9-Release/>
 - KiCad 10.0 CLI reference: <https://docs.kicad.org/10.0/en/cli/cli.html>
+- KiCad nightly CLI reference: <https://docs.kicad.org/master/en/cli/cli.html>
+- KiCad PCB Python bindings deprecation notice: <https://dev-docs.kicad.org/en/apis-and-binding/pcbnew/>
+- KiCad nightly and release candidate guidance: <https://www.kicad.org/help/nightlies-and-rcs/>
 - KiCad 9.0 CLI reference: <https://docs.kicad.org/9.0/en/cli/cli.html>
 - KiCad 8.0 CLI reference: <https://docs.kicad.org/8.0/en/cli/cli.html>
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -227,6 +227,36 @@ Linux primary lane from the KiCad 10 release PPA. Scheduled and manual runs keep
 the heavier matrix: primary 10.0.x, supported 9.x, prerelease/nightly 10.x, and
 manual opt-in deprecated 8.x.
 
+KiCad 11 readiness is documented as a manual smoke path until a stable package
+or release candidate lane can be installed deterministically in CI. The current
+development-branch nightly command expects a nightly `kicad-cli` that reports
+the next-development version range:
+
+```bash
+KICAD_CANARY_KICAD_CLI=/absolute/path/to/kicad-cli \
+  corepack pnpm run test:kicad-cli-contract:nightly
+```
+
+```powershell
+$Env:KICAD_CANARY_KICAD_CLI = "C:\Program Files\KiCad Nightly\bin\kicad-cli.exe"
+corepack pnpm run test:kicad-cli-contract:nightly
+```
+
+When the installed prerelease reports `11.0.x`, use the future-line smoke:
+
+```bash
+KICAD_CANARY_KICAD_CLI=/absolute/path/to/kicad-cli \
+  corepack pnpm run test:kicad-cli-contract:future
+```
+
+```powershell
+$Env:KICAD_CANARY_KICAD_CLI = "C:\Program Files\KiCad\11.0\bin\kicad-cli.exe"
+corepack pnpm run test:kicad-cli-contract:future
+```
+
+The migration checklist and IPC parity matrix live in
+[`docs/compatibility/kicad-10-to-11-migration.md`](compatibility/kicad-10-to-11-migration.md).
+
 Each lane writes command logs, KiCad reports, manufacturing export outputs,
 `summary.json`, and `failing-fixtures.txt` into an artifact named after the
 lane. Manufacturing exports are enabled only when the matrix feature gate lists

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "test:kicad-mcp-pro": "pnpm --dir packages/mcp-server run test:unit",
     "test:contract": "pnpm --dir packages/mcp-server run test:transport-contract && pnpm run check:compatibility && pnpm --dir packages/mcp-server run mcp:manifest:check",
     "test:kicad-cli-contract": "uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/kicad_canary.py run --artifacts artifacts/kicad-cli-contract/local --kicad-range 10.0.x",
+    "test:kicad-cli-contract:nightly": "uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/kicad_canary.py run --artifacts artifacts/kicad-cli-contract/nightly --kicad-range 10.99.x",
+    "test:kicad-cli-contract:future": "uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/kicad_canary.py run --artifacts artifacts/kicad-cli-contract/kicad11 --kicad-range 11.0.x",
     "test:kicad-cli-contract:matrix": "uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/kicad_canary.py matrix",
     "test:perf": "pnpm --filter kicadstudio run test:perf && uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_benchmark_latency.py",
     "test:kicad-gui-smoke": "pnpm --dir packages/mcp-server run test:gui-smoke",

--- a/packages/mcp-server/docs/runtime-matrix.md
+++ b/packages/mcp-server/docs/runtime-matrix.md
@@ -5,48 +5,54 @@ operating systems, and execution modes.
 
 ## Support Tiers
 
-| Tier | Meaning |
-|---|---|
-| Tested | Tested and passing in CI |
-| Caveat | Works with known caveats |
+| Tier        | Meaning                      |
+| ----------- | ---------------------------- |
+| Tested      | Tested and passing in CI     |
+| Caveat      | Works with known caveats     |
 | Best effort | Not covered in the CI matrix |
-| Unsupported | Not supported |
+| Unsupported | Not supported                |
 
 ## KiCad Version and Feature Matrix
 
-| Capability | KiCad 9.x | KiCad 10.0.x | Notes |
-|---|---|---|---|
-| Project management | Tested | Tested | |
-| Schematic read (IPC) | Caveat | Tested | IPC API is still evolving in KiCad. |
-| Schematic write (IPC) | Best effort | Caveat | Round-trip parsing validation required. |
-| PCB inspection (IPC) | Caveat | Tested | |
-| PCB editing (IPC) | Best effort | Caveat | Retryable errors are environment-dependent. |
-| DRC/ERC (CLI) | Tested | Tested | CLI-backed; most stable path. |
-| BOM export (CLI) | Tested | Tested | Multi-sheet behavior needs explicit fixture verification. |
-| Gerber export (CLI) | Tested | Tested | |
-| STEP export (CLI) | Tested | Tested | |
-| FreeRouting | Best effort | Best effort | External binary; Specctra flow is install-dependent. |
-| ngspice simulation | Best effort | Best effort | External binary; smoke-level only. |
-| KiCad 10 Design Blocks | Unsupported | Tested | New in KiCad 10. |
-| KiCad 10 Time-Domain | Unsupported | Tested | New in KiCad 10. |
+| Capability             | KiCad 9.x   | KiCad 10.0.x | KiCad 11 readiness | Notes                                                     |
+| ---------------------- | ----------- | ------------ | ------------------ | --------------------------------------------------------- |
+| Project management     | Tested      | Tested       | Manual smoke       | Must stay IPC, CLI, or file backed.                       |
+| Schematic read (IPC)   | Caveat      | Tested       | Manual smoke       | IPC API is still evolving in KiCad.                       |
+| Schematic write (IPC)  | Best effort | Caveat       | Manual smoke       | Round-trip parsing validation required.                   |
+| PCB inspection (IPC)   | Caveat      | Tested       | Manual smoke       | Direct `pcbnew` fallback is forbidden.                    |
+| PCB editing (IPC)      | Best effort | Caveat       | Manual smoke       | Retryable errors are environment-dependent.               |
+| DRC/ERC (CLI)          | Tested      | Tested       | Manual smoke       | CLI-backed; most stable path.                             |
+| BOM export (CLI)       | Tested      | Tested       | Manual smoke       | Multi-sheet behavior needs explicit fixture verification. |
+| Gerber export (CLI)    | Tested      | Tested       | Manual smoke       |                                                           |
+| STEP export (CLI)      | Tested      | Tested       | Manual smoke       |                                                           |
+| FreeRouting            | Best effort | Best effort  | Best effort        | External binary; Specctra flow is install-dependent.      |
+| ngspice simulation     | Best effort | Best effort  | Best effort        | External binary; smoke-level only.                        |
+| KiCad 10 Design Blocks | Unsupported | Tested       | Manual smoke       | KiCad 10-specific behavior stays gated.                   |
+| KiCad 10 Time-Domain   | Unsupported | Tested       | Manual smoke       | KiCad 10-specific behavior stays gated.                   |
+
+KiCad 11 readiness is tracked in repository compatibility metadata rather than
+declared as supported runtime coverage. See `compatibility.yaml`
+`kicadIpcReadiness` and `docs/compatibility/kicad-10-to-11-migration.md` for the
+direct SWIG/`pcbnew` guard, manual nightly and RC smoke commands, and IPC
+feature-parity evidence.
 
 ## Operating System Matrix
 
-| OS | Tested | Notes |
-|---|---|---|
-| Ubuntu latest | Tested | Primary CI runner. |
-| macOS latest | Tested | CI runner; IPC socket path differs. |
-| Windows latest | Caveat | CI runner; path separators differ. |
+| OS             | Tested | Notes                               |
+| -------------- | ------ | ----------------------------------- |
+| Ubuntu latest  | Tested | Primary CI runner.                  |
+| macOS latest   | Tested | CI runner; IPC socket path differs. |
+| Windows latest | Caveat | CI runner; path separators differ.  |
 
 ## Execution Mode Matrix
 
-| Mode | KiCad Required | GUI Required | Notes |
-|---|---|---|---|
-| stdio default | Optional | No | Most tools degrade gracefully. |
-| Streamable HTTP | Optional | No | Requires the `http` extra. |
-| With KiCad open (IPC) | Yes | Yes | Full edit capability. |
-| CLI-only headless | Optional | No | Export and validation only. |
-| Docker | No, external mount | No | KiCad must be mounted or configured externally. |
+| Mode                  | KiCad Required     | GUI Required | Notes                                           |
+| --------------------- | ------------------ | ------------ | ----------------------------------------------- |
+| stdio default         | Optional           | No           | Most tools degrade gracefully.                  |
+| Streamable HTTP       | Optional           | No           | Requires the `http` extra.                      |
+| With KiCad open (IPC) | Yes                | Yes          | Full edit capability.                           |
+| CLI-only headless     | Optional           | No           | Export and validation only.                     |
+| Docker                | No, external mount | No           | KiCad must be mounted or configured externally. |
 
 ## Known Limitations
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -25,6 +25,8 @@
     "test:unit": "uv run --all-extras python scripts/run_pytest.py unit",
     "test:transport-contract": "uv run --all-extras python scripts/run_pytest.py transport-contract",
     "test:kicad-cli-contract": "uv run --all-extras python scripts/kicad_canary.py run --artifacts ../../artifacts/kicad-cli-contract/local --kicad-range 10.0.x",
+    "test:kicad-cli-contract:nightly": "uv run --all-extras python scripts/kicad_canary.py run --artifacts ../../artifacts/kicad-cli-contract/nightly --kicad-range 10.99.x",
+    "test:kicad-cli-contract:future": "uv run --all-extras python scripts/kicad_canary.py run --artifacts ../../artifacts/kicad-cli-contract/kicad11 --kicad-range 11.0.x",
     "test:kicad-cli-contract:matrix": "uv run --all-extras python scripts/kicad_canary.py matrix",
     "test:gui-smoke": "uv run --all-extras python scripts/run_pytest.py gui",
     "build": "uv build",

--- a/packages/mcp-server/scripts/check_compatibility_matrix.py
+++ b/packages/mcp-server/scripts/check_compatibility_matrix.py
@@ -14,6 +14,16 @@ import yaml
 
 MCP_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = MCP_ROOT.parents[1]
+PCBNEW_POLICY = "forbidden-in-production"
+REQUIRED_IPC_AREAS = (
+    "projectDiscovery",
+    "pcbRead",
+    "schematicRead",
+    "drc",
+    "erc",
+    "export",
+    "diagnostics",
+)
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -57,6 +67,91 @@ def _extension_protocol_from_ts() -> str:
 def _tool_names() -> set[str]:
     text = (MCP_ROOT / "docs/tools-reference.generated.md").read_text(encoding="utf-8")
     return set(re.findall(r"^\| `([^`]+)` \|", text, flags=re.MULTILINE))
+
+
+def _validate_repo_relative_path(value: Any, label: str) -> list[str]:
+    if not isinstance(value, str) or not value:
+        return [f"{label} must be a non-empty relative path"]
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts:
+        return [f"{label} must stay inside the repository: {value!r}"]
+    return []
+
+
+def _validate_pcbnew_policy(readiness: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    direct = readiness.get("directPcbnewImports")
+    if not isinstance(direct, dict):
+        return ["kicadIpcReadiness.directPcbnewImports must be a mapping"]
+    if direct.get("policy") != PCBNEW_POLICY:
+        errors.append(f"kicadIpcReadiness.directPcbnewImports.policy must be {PCBNEW_POLICY!r}")
+    allowed = direct.get("allowedPaths")
+    if not isinstance(allowed, list) or not allowed:
+        return [*errors, "kicadIpcReadiness.directPcbnewImports.allowedPaths must be a list"]
+    for index, value in enumerate(allowed):
+        errors.extend(
+            _validate_repo_relative_path(value, f"directPcbnewImports.allowedPaths[{index}]")
+        )
+    if "packages/mcp-server/tests/**" not in allowed:
+        errors.append("direct pcbnew allowlist must document test-only compatibility paths")
+    return errors
+
+
+def _validate_manual_canary(readiness: dict[str, Any]) -> list[str]:
+    manual = readiness.get("manualCanary")
+    if not isinstance(manual, dict):
+        return ["kicadIpcReadiness.manualCanary must be a mapping"]
+    errors: list[str] = []
+    for key in ("currentNightlyRange", "releaseCandidateRange"):
+        value = manual.get(key)
+        if not isinstance(value, str) or re.fullmatch(r"\d+(?:\.\d+)?\.x", value) is None:
+            errors.append(f"kicadIpcReadiness.manualCanary.{key} must be a KiCad range")
+    for key in ("currentNightlyCommand", "releaseCandidateCommand"):
+        if not isinstance(manual.get(key), str) or not manual[key]:
+            errors.append(f"kicadIpcReadiness.manualCanary.{key} must be a non-empty command")
+    return errors
+
+
+def _validate_ipc_area(
+    area: str,
+    detail: Any,
+    available_tools: set[str],
+) -> list[str]:
+    if not isinstance(detail, dict):
+        return [f"kicadIpcReadiness.ipcApi.requiredFor.{area} must be a mapping"]
+    errors: list[str] = []
+    for key in ("tools", "canaryProbes", "evidence"):
+        if not isinstance(detail.get(key), list) or not detail[key]:
+            errors.append(f"kicadIpcReadiness.ipcApi.requiredFor.{area}.{key} must be a list")
+    for tool_name in detail.get("tools", []):
+        if isinstance(tool_name, str) and tool_name not in available_tools:
+            errors.append(f"kicadIpcReadiness {area} references unknown tool {tool_name!r}")
+    for index, evidence in enumerate(detail.get("evidence", [])):
+        label = f"kicadIpcReadiness.ipcApi.requiredFor.{area}.evidence[{index}]"
+        errors.extend(_validate_repo_relative_path(evidence, label))
+        if isinstance(evidence, str) and not (REPO_ROOT / evidence).exists():
+            errors.append(f"{label} does not exist: {evidence!r}")
+    return errors
+
+
+def _validate_ipc_readiness(
+    matrix: dict[str, Any],
+    available_tools: set[str],
+) -> list[str]:
+    readiness = matrix.get("kicadIpcReadiness")
+    if not isinstance(readiness, dict):
+        return ["compatibility.yaml missing top-level 'kicadIpcReadiness'"]
+    errors = [*_validate_pcbnew_policy(readiness), *_validate_manual_canary(readiness)]
+    ipc_api = readiness.get("ipcApi")
+    required_for = ipc_api.get("requiredFor") if isinstance(ipc_api, dict) else None
+    if not isinstance(required_for, dict):
+        return [*errors, "kicadIpcReadiness.ipcApi.requiredFor must be a mapping"]
+    for area in REQUIRED_IPC_AREAS:
+        if area not in required_for:
+            errors.append(f"kicadIpcReadiness.ipcApi.requiredFor missing {area!r}")
+            continue
+        errors.extend(_validate_ipc_area(area, required_for[area], available_tools))
+    return errors
 
 
 def _validate_required_shape(matrix: dict[str, Any]) -> list[str]:
@@ -154,6 +249,7 @@ def validate_compatibility_matrix() -> list[str]:
         errors.append("well-known server card must embed compatibility_summary()")
 
     available_tools = _tool_names()
+    errors.extend(_validate_ipc_readiness(matrix, available_tools))
     for group in ("required", "optional"):
         for tool_name in matrix["mcpTools"][group]:
             if tool_name not in available_tools:

--- a/packages/mcp-server/scripts/check_no_pcbnew.py
+++ b/packages/mcp-server/scripts/check_no_pcbnew.py
@@ -9,16 +9,50 @@ supported IPC/CLI surfaces instead of adding new SWIG dependencies.
 from __future__ import annotations
 
 import ast
+import fnmatch
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-SCAN_DIRS = (ROOT / "src", ROOT / "tests", ROOT / "scripts")
-IGNORED_FILES = {Path(__file__).resolve()}
+import yaml
+
+MCP_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = MCP_ROOT.parents[1]
+MATRIX_PATH = REPO_ROOT / "compatibility.yaml"
+SCAN_DIRS = (REPO_ROOT / "apps", MCP_ROOT / "src", MCP_ROOT / "scripts", MCP_ROOT / "tests")
+DEFAULT_ALLOWED_PATHS = ("packages/mcp-server/scripts/check_no_pcbnew.py",)
 
 
 def _is_pcbnew_module(module_name: str | None) -> bool:
     return bool(module_name) and (module_name == "pcbnew" or module_name.startswith("pcbnew."))
+
+
+def _repo_relative(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def _allowed_path_patterns() -> tuple[str, ...]:
+    if not MATRIX_PATH.exists():
+        return DEFAULT_ALLOWED_PATHS
+    data = yaml.safe_load(MATRIX_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        return DEFAULT_ALLOWED_PATHS
+    readiness = data.get("kicadIpcReadiness")
+    if not isinstance(readiness, dict):
+        return DEFAULT_ALLOWED_PATHS
+    direct_imports = readiness.get("directPcbnewImports", {})
+    allowed = direct_imports.get("allowedPaths") if isinstance(direct_imports, dict) else None
+    if not isinstance(allowed, list):
+        return DEFAULT_ALLOWED_PATHS
+    return tuple(pattern for pattern in allowed if isinstance(pattern, str) and pattern)
+
+
+def _is_allowed(path: Path, patterns: tuple[str, ...]) -> bool:
+    relative = _repo_relative(path)
+    return any(fnmatch.fnmatchcase(relative, pattern) for pattern in patterns)
 
 
 def _violations(path: Path) -> list[str]:
@@ -44,11 +78,10 @@ def _violations(path: Path) -> list[str]:
 
 def _python_files() -> list[Path]:
     files: list[Path] = []
+    allowed = _allowed_path_patterns()
     for directory in SCAN_DIRS:
         if directory.exists():
-            files.extend(
-                path for path in directory.rglob("*.py") if path.resolve() not in IGNORED_FILES
-            )
+            files.extend(path for path in directory.rglob("*.py") if not _is_allowed(path, allowed))
     return sorted(files)
 
 

--- a/packages/mcp-server/tests/unit/test_compatibility_matrix.py
+++ b/packages/mcp-server/tests/unit/test_compatibility_matrix.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+import yaml
+
 from kicad_mcp.compatibility import COMPATIBILITY_MATRIX, MCP_PROTOCOL_VERSION
-from scripts.check_compatibility_matrix import validate_compatibility_matrix
+from scripts.check_compatibility_matrix import (
+    PCBNEW_POLICY,
+    REPO_ROOT,
+    REQUIRED_IPC_AREAS,
+    validate_compatibility_matrix,
+)
 
 
 def test_embedded_compatibility_metadata_declares_current_contract() -> None:
@@ -15,3 +22,19 @@ def test_embedded_compatibility_metadata_declares_current_contract() -> None:
 
 def test_repository_compatibility_matrix_has_no_drift() -> None:
     assert validate_compatibility_matrix() == []
+
+
+def test_kicad_ipc_readiness_contract_covers_pcbnew_and_parity() -> None:
+    matrix = yaml.safe_load((REPO_ROOT / "compatibility.yaml").read_text(encoding="utf-8"))
+    readiness = matrix["kicadIpcReadiness"]
+    direct_imports = readiness["directPcbnewImports"]
+    required_for = readiness["ipcApi"]["requiredFor"]
+
+    assert direct_imports["policy"] == PCBNEW_POLICY
+    assert direct_imports["allowedPaths"] == [
+        "packages/mcp-server/scripts/check_no_pcbnew.py",
+        "packages/mcp-server/tests/**",
+    ]
+    assert set(REQUIRED_IPC_AREAS).issubset(required_for)
+    assert readiness["manualCanary"]["currentNightlyRange"] == "10.99.x"
+    assert readiness["manualCanary"]["releaseCandidateRange"] == "11.0.x"

--- a/packages/mcp-server/tests/unit/test_release_preflight_guard.py
+++ b/packages/mcp-server/tests/unit/test_release_preflight_guard.py
@@ -101,9 +101,38 @@ def test_no_pcbnew_guard_detects_imports(tmp_path: Path, monkeypatch: pytest.Mon
     bad.write_text("import pcbnew\npcbnew.LoadBoard('board.kicad_pcb')\n", encoding="utf-8")
 
     monkeypatch.setattr(module, "SCAN_DIRS", (src_dir,))
-    monkeypatch.setattr(module, "IGNORED_FILES", set())
 
     assert module._violations(good) == []
+    assert module.main() == 1
+
+
+def test_no_pcbnew_guard_honors_matrix_allowlist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_script("check_no_pcbnew.py")
+    matrix = tmp_path / "compatibility.yaml"
+    matrix.write_text(
+        """
+kicadIpcReadiness:
+  directPcbnewImports:
+    allowedPaths:
+      - allowed/**
+""".lstrip(),
+        encoding="utf-8",
+    )
+    allowed_file = tmp_path / "allowed" / "fixture.py"
+    blocked_file = tmp_path / "src" / "blocked.py"
+    allowed_file.parent.mkdir()
+    blocked_file.parent.mkdir()
+    allowed_file.write_text("import pcbnew\n", encoding="utf-8")
+    blocked_file.write_text("import pcbnew\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "MATRIX_PATH", matrix)
+    monkeypatch.setattr(module, "SCAN_DIRS", (tmp_path,))
+
+    assert module._python_files() == [blocked_file]
     assert module.main() == 1
 
 


### PR DESCRIPTION
## Summary

- Added `compatibility.yaml` `kicadIpcReadiness` metadata for the direct `pcbnew`/SWIG policy, minimal allowlist, manual KiCad nightly/11 RC smoke commands, and IPC feature-parity evidence.
- Updated the compatibility validator and `check_no_pcbnew.py` so CI enforces the readiness metadata and blocks direct production `pcbnew` usage.
- Added a KiCad 10 to 11 migration guide and updated support, testing, and MCP runtime compatibility docs.

## Linked issue

Closes #182

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm install --frozen-lockfile` passed.
- `uv sync --all-extras --frozen --project packages/mcp-server` passed.
- `corepack pnpm run check:compatibility` passed.
- `corepack pnpm --dir packages/mcp-server run compat:check` passed.
- `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_compatibility_matrix.py packages/mcp-server/tests/unit/test_release_preflight_guard.py packages/mcp-server/tests/unit/test_kicad_canary.py -q` passed.
- `corepack pnpm run docs:check-generated`, `docs:lint`, and `docs:links` passed.
- `corepack pnpm run format:check`, `lint`, `typecheck`, and `test` passed.
- Product builds passed for the VS Code extension, MCP server, protocol schemas, KiCad fixtures, and test harness.
- `corepack pnpm run check:docs-site`, `check:devcontainer`, `check:performance-budgets`, `check:beta-program`, `check:agent-configs`, and `check:examples` passed.
- `corepack pnpm run release:dry-run` passed; existing Node DEP0190 warning is unrelated to touched files.
- `gitleaks detect --source . --redact --no-banner` passed.
- `corepack pnpm --dir packages/mcp-server run security` passed.
- `pre-commit run --all-files` passed.
- `corepack pnpm --filter kicadstudio run workflows:lint` and `corepack pnpm --dir packages/mcp-server run workflows:security` passed.

Known local Windows-only blockers outside this PR scope:
- `corepack pnpm run check` fails in `check:dev-doctor` and recursive workflow lint because Node/Python subprocesses cannot spawn the Windows Corepack shim directly.
- `corepack pnpm run build` fails only in `packages/mcp-npm` on Windows due the existing #191 wrapper smoke issue.

## Protocol / MCP impact

Checklist reference: `docs/architecture/protocol-change-checklist.md`

- [ ] Not applicable; reason:
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [x] Contract tests updated
- [x] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [ ] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts