### PR TITLE
feat(kicad-studio/kicad-mcp-pro): add product release provenance evidence

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -28,7 +28,7 @@ jobs:
   package:
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
       id-token: write
       attestations: write
       artifact-metadata: write
@@ -79,29 +79,47 @@ jobs:
         run: corepack pnpm --filter kicadstudio run package
       - run: corepack pnpm --filter kicadstudio run package:validate
       - run: corepack pnpm --filter kicadstudio run release:assets
-      - name: Identify extension package
+      - name: Stage extension release evidence
+        id: stage-evidence
         shell: bash
         run: |
           set -euo pipefail
+          evidence_dir="release-assets/vscode-extension"
+          mkdir -p "$evidence_dir"
           VSIX_PATH="$(find apps/vscode-extension -maxdepth 2 -type f -name '*.vsix' | sort | tail -n1)"
           test -n "$VSIX_PATH"
           test -f "$VSIX_PATH"
-          echo "Packaged ${VSIX_PATH}"
+          cp "$VSIX_PATH" "$evidence_dir/"
+          cp apps/vscode-extension/SHA256SUMS.txt "$evidence_dir/"
+          cp apps/vscode-extension/sbom.cdx.json "$evidence_dir/"
+          (cd "$evidence_dir" && sha256sum --check SHA256SUMS.txt)
+          echo "vsix_name=$(basename "$VSIX_PATH")" >> "$GITHUB_OUTPUT"
       - name: Attest extension assets
+        id: attest-extension
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
-          subject-checksums: apps/vscode-extension/SHA256SUMS.txt
-          sbom-path: apps/vscode-extension/sbom.cdx.json
+          subject-checksums: release-assets/vscode-extension/SHA256SUMS.txt
+          sbom-path: release-assets/vscode-extension/sbom.cdx.json
       - name: Store extension release evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: extension-release-evidence
-          path: |
-            apps/vscode-extension/*.vsix
-            apps/vscode-extension/SHA256SUMS.txt
-            apps/vscode-extension/sbom.cdx.json
+          path: release-assets/vscode-extension
           if-no-files-found: error
           retention-days: 14
+      - name: Attach extension evidence to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release-policy.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          upload_dir="release-assets/upload/vscode-extension"
+          mkdir -p "$upload_dir"
+          cp release-assets/vscode-extension/*.vsix "$upload_dir/"
+          cp release-assets/vscode-extension/SHA256SUMS.txt "$upload_dir/vscode-extension-SHA256SUMS.txt"
+          cp release-assets/vscode-extension/sbom.cdx.json "$upload_dir/vscode-extension-sbom.cdx.json"
+          gh release upload "$RELEASE_TAG" "$upload_dir"/* --clobber
 
   publish_vscode:
     needs: package
@@ -125,14 +143,19 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: extension-release-evidence
-          path: release-assets/extension
+          path: release-assets/vscode-extension
+      - name: Verify extension checksums before Marketplace publish
+        shell: bash
+        run: |
+          set -euo pipefail
+          (cd release-assets/vscode-extension && sha256sum --check SHA256SUMS.txt)
       - name: Publish Visual Studio Marketplace
         shell: bash
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
           set -euo pipefail
-          VSIX_PATH="$(find release-assets/extension -type f -name '*.vsix' | sort | tail -n1)"
+          VSIX_PATH="$(find release-assets/vscode-extension -type f -name '*.vsix' | sort | tail -n1)"
           test -n "$VSIX_PATH"
           test -f "$VSIX_PATH"
           test -n "$VSCE_PAT"
@@ -148,6 +171,13 @@ jobs:
           fi
 
           corepack pnpm --filter kicadstudio exec vsce "${publish_args[@]}"
+      - name: Verify Visual Studio Marketplace publish status
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./apps/vscode-extension/package.json').version")"
+          corepack pnpm --filter kicadstudio exec vsce show oaslananka.kicadstudio --json > vscode-marketplace.json
+          VERSION="$version" node -e "const fs = require('node:fs'); const data = JSON.parse(fs.readFileSync('vscode-marketplace.json', 'utf8')); if (!JSON.stringify(data).includes(process.env.VERSION)) throw new Error('Visual Studio Marketplace version not visible: ' + process.env.VERSION);"
 
   publish_openvsx:
     needs: [package, publish_vscode]
@@ -172,7 +202,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: extension-release-evidence
-          path: release-assets/extension
+          path: release-assets/vscode-extension
+      - name: Verify extension checksums before Open VSX publish
+        shell: bash
+        run: |
+          set -euo pipefail
+          (cd release-assets/vscode-extension && sha256sum --check SHA256SUMS.txt)
       - name: Publish Open VSX
         shell: bash
         env:
@@ -182,7 +217,7 @@ jobs:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
           set -euo pipefail
-          VSIX_PATH="$(find release-assets/extension -type f -name '*.vsix' | sort | tail -n1)"
+          VSIX_PATH="$(find release-assets/vscode-extension -type f -name '*.vsix' | sort | tail -n1)"
           test -n "$VSIX_PATH"
           test -f "$VSIX_PATH"
           test -n "$OVSX_PAT"
@@ -202,3 +237,16 @@ jobs:
           fi
 
           corepack pnpm --filter kicadstudio exec ovsx "${publish_args[@]}"
+      - name: Verify Open VSX published digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./apps/vscode-extension/package.json').version")"
+          mkdir -p release-assets/openvsx-verify
+          corepack pnpm --filter kicadstudio exec ovsx get oaslananka.kicadstudio --metadata --versionRange "$version" > release-assets/openvsx-verify/metadata.json
+          corepack pnpm --filter kicadstudio exec ovsx get oaslananka.kicadstudio --versionRange "$version" --output release-assets/openvsx-verify
+          downloaded="$(find release-assets/openvsx-verify -type f -name '*.vsix' | sort | tail -n1)"
+          test -n "$downloaded"
+          expected="$(awk '{print $1}' release-assets/vscode-extension/SHA256SUMS.txt)"
+          actual="$(sha256sum "$downloaded" | awk '{print $1}')"
+          test "$expected" = "$actual"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,6 +13,11 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     environment: npm
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     defaults:
       run:
         working-directory: packages/mcp-npm
@@ -27,5 +32,66 @@ jobs:
           package-manager-cache: false
       - run: npm --version
       - run: npm ci --ignore-scripts=false
-      - run: npm pack --dry-run
-      - run: npm publish --access public --provenance
+      - name: Pack npm launcher and generate evidence
+        id: npm-evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm pack --json > npm-pack.json
+          tarball="$(node -e "const fs = require('node:fs'); const pack = JSON.parse(fs.readFileSync('npm-pack.json', 'utf8')); console.log(pack[0].filename);")"
+          test -f "$tarball"
+          evidence_dir="../../release-assets/mcp-npm"
+          mkdir -p "$evidence_dir"
+          cp "$tarball" "$evidence_dir/"
+          (
+            cd "$evidence_dir"
+            sha256sum "$(basename "$tarball")" > SHA256SUMS.txt
+          )
+          npm sbom --sbom-format cyclonedx --sbom-type application > "$evidence_dir/sbom.cdx.json"
+          (cd "$evidence_dir" && sha256sum --check SHA256SUMS.txt)
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+      - name: Attest npm launcher tarball
+        id: attest-npm
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        with:
+          subject-checksums: release-assets/mcp-npm/SHA256SUMS.txt
+          sbom-path: release-assets/mcp-npm/sbom.cdx.json
+      - name: Store npm release evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: npm-release-evidence
+          path: release-assets/mcp-npm
+          if-no-files-found: error
+          retention-days: 14
+      - name: Attach npm evidence to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          upload_dir="../../release-assets/upload/mcp-npm"
+          mkdir -p "$upload_dir"
+          cp ../../release-assets/mcp-npm/*.tgz "$upload_dir/"
+          cp ../../release-assets/mcp-npm/SHA256SUMS.txt "$upload_dir/mcp-npm-SHA256SUMS.txt"
+          cp ../../release-assets/mcp-npm/sbom.cdx.json "$upload_dir/mcp-npm-sbom.cdx.json"
+          gh release upload "$RELEASE_TAG" "$upload_dir"/* --clobber
+      - name: Verify npm checksums before publish
+        run: (cd ../../release-assets/mcp-npm && sha256sum --check SHA256SUMS.txt)
+      - run: npm publish "${{ steps.npm-evidence.outputs.tarball }}" --access public --provenance
+      - name: Verify npm published tarball digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          node ../../scripts/verify-npm-release.mjs \
+            --package kicad-mcp-pro \
+            --version "$version" \
+            --checksums ../../release-assets/mcp-npm/SHA256SUMS.txt \
+            --output-dir ../../release-assets/npm-verify
+      - name: Attach npm post-publish verification to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" ../../release-assets/npm-verify/npm-published-digest.json --clobber

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
       id-token: write
       attestations: write
       artifact-metadata: write
@@ -35,19 +35,24 @@ jobs:
         working-directory: packages/mcp-server
       - run: uv run --all-extras python scripts/check_package_metadata.py
         working-directory: packages/mcp-server
-      - name: Generate Python checksums
+      - name: Generate Python release evidence
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p packages/mcp-server/release-evidence
-          (
-            cd packages/mcp-server/dist
-            sha256sum -- *.whl *.tar.gz
-          ) > packages/mcp-server/release-evidence/SHA256SUMS.txt
+          uv run --all-extras python scripts/generate_release_evidence.py generate \
+            --dist-dir dist \
+            --output release-evidence
+          uv run --all-extras python scripts/generate_release_evidence.py verify-local \
+            --checksums release-evidence/SHA256SUMS.txt \
+            --artifacts dist
+          (cd dist && sha256sum --check ../release-evidence/SHA256SUMS.txt)
+        working-directory: packages/mcp-server
       - name: Attest Python distributions
+        id: attest-python
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-checksums: packages/mcp-server/release-evidence/SHA256SUMS.txt
+          sbom-path: packages/mcp-server/release-evidence/sbom.cdx.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: python-dist
@@ -57,7 +62,24 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: python-release-evidence
-          path: packages/mcp-server/release-evidence/SHA256SUMS.txt
+          path: packages/mcp-server/release-evidence
+      - name: Attach Python evidence to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          upload_dir="release-assets/upload/kicad-mcp-pro-python"
+          mkdir -p "$upload_dir"
+          cp packages/mcp-server/dist/*.whl "$upload_dir/"
+          cp packages/mcp-server/dist/*.tar.gz "$upload_dir/"
+          cp packages/mcp-server/release-evidence/SHA256SUMS.txt "$upload_dir/kicad-mcp-pro-python-SHA256SUMS.txt"
+          cp packages/mcp-server/release-evidence/sbom.cdx.json "$upload_dir/kicad-mcp-pro-python-sbom.cdx.json"
+          cp packages/mcp-server/release-evidence/release-evidence.json "$upload_dir/kicad-mcp-pro-python-release-evidence.json"
+          gh release upload "$RELEASE_TAG" \
+            "$upload_dir"/* \
+            --clobber
 
   publish-testpypi:
     if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
@@ -70,15 +92,34 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: python-dist
           path: dist
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: python-release-evidence
+          path: release-evidence
+      - name: Verify Python checksums before TestPyPI publish
+        run: |
+          python packages/mcp-server/scripts/generate_release_evidence.py verify-local --checksums release-evidence/SHA256SUMS.txt --artifacts dist
+          (cd dist && sha256sum --check ../release-evidence/SHA256SUMS.txt)
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           packages-dir: dist
           repository-url: https://test.pypi.org/legacy/
           attestations: true
+      - name: Verify TestPyPI published digests
+        run: |
+          version="$(python -c "import tomllib; print(tomllib.load(open('packages/mcp-server/pyproject.toml', 'rb'))['project']['version'])")"
+          python packages/mcp-server/scripts/generate_release_evidence.py verify-pypi \
+            --repository testpypi \
+            --package kicad-mcp-pro \
+            --version "$version" \
+            --checksums release-evidence/SHA256SUMS.txt
 
   publish-pypi:
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
@@ -91,11 +132,30 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: python-dist
           path: dist
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: python-release-evidence
+          path: release-evidence
+      - name: Verify Python checksums before PyPI publish
+        run: |
+          python packages/mcp-server/scripts/generate_release_evidence.py verify-local --checksums release-evidence/SHA256SUMS.txt --artifacts dist
+          (cd dist && sha256sum --check ../release-evidence/SHA256SUMS.txt)
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           packages-dir: dist
           attestations: true
+      - name: Verify PyPI published digests
+        run: |
+          version="$(python -c "import tomllib; print(tomllib.load(open('packages/mcp-server/pyproject.toml', 'rb'))['project']['version'])")"
+          python packages/mcp-server/scripts/generate_release_evidence.py verify-pypi \
+            --repository pypi \
+            --package kicad-mcp-pro \
+            --version "$version" \
+            --checksums release-evidence/SHA256SUMS.txt

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All release surfaces are pinned to `1.0.0`:
 
 - VS Code extension: `oaslananka.kicadstudio`
 - Python package: `kicad-mcp-pro`
-- npm wrapper: `@oaslananka/kicad-mcp-pro`
+- npm wrapper: `kicad-mcp-pro`
 - MCP Registry name: `io.github.oaslananka/kicad-mcp-pro`
 
 ## KiCad Compatibility

--- a/apps/vscode-extension/scripts/validate-package.js
+++ b/apps/vscode-extension/scripts/validate-package.js
@@ -554,11 +554,17 @@ function extractRegisteredCustomEditorConstants(sourceText) {
 }
 
 function runVsceList(root) {
-  const command = process.platform === 'win32' ? 'vsce.cmd' : 'vsce';
-  const result = spawnSync(command, ['ls', '--no-dependencies'], {
+  const invocation =
+    process.platform === 'win32'
+      ? {
+          command: process.env.ComSpec ?? 'cmd.exe',
+          args: ['/d', '/s', '/c', 'vsce ls --no-dependencies']
+        }
+      : { command: 'vsce', args: ['ls', '--no-dependencies'] };
+  const result = spawnSync(invocation.command, invocation.args, {
     cwd: root,
     encoding: 'utf8',
-    shell: process.platform === 'win32'
+    shell: false
   });
   if (result.error) {
     throw result.error;

--- a/docs/architecture/repo-structure.md
+++ b/docs/architecture/repo-structure.md
@@ -6,7 +6,7 @@ KiCad Studio Kit is one GitHub repository with three independently validated rel
 | ----------------------- | --------------------------------------------------- | ------------------------------------------------------ |
 | `apps/vscode-extension` | KiCad Studio VS Code and Open VSX extension         | `oaslananka.kicadstudio`                               |
 | `packages/mcp-server`   | KiCad MCP Pro Python server and MCP Registry source | `kicad-mcp-pro` / `io.github.oaslananka/kicad-mcp-pro` |
-| `packages/mcp-npm`      | Thin npm launcher for the Python server             | `@oaslananka/kicad-mcp-pro`                            |
+| `packages/mcp-npm`      | Thin npm launcher for the Python server             | `kicad-mcp-pro`                                        |
 | `packages/test-harness` | Private shared test utilities                       | Not published                                          |
 
 The folder names intentionally preserve the package roots used by the current publish workflows:

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@ KiCad Studio Kit has three install surfaces:
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | KiCad Studio VS Code extension | You want KiCad project navigation, viewers, validation, exports, component search, and MCP integration inside VS Code. | Install `oaslananka.kicadstudio` from the VS Code Marketplace or Open VSX once release publishing is enabled. |
 | kicad-mcp-pro Python server    | You want an MCP server that exposes KiCad workflows to MCP clients.                                                    | Install the Python package or run from this repository with `uv`.                                             |
-| npm launcher                   | You want a Node package that launches the Python MCP server consistently.                                              | Install `@oaslananka/kicad-mcp-pro` once npm publishing is enabled.                                           |
+| npm launcher                   | You want a Node package that launches the Python MCP server consistently.                                              | Install `kicad-mcp-pro` once npm publishing is enabled.                                                       |
 
 ## Local Repository Setup
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -5,12 +5,12 @@ Publishing is GitHub-only and uses the canonical repository `oaslananka/kicad-st
 ## Version Availability
 
 ```bash
-npm view @oaslananka/kicad-mcp-pro@1.0.0 version --json || true
+npm view kicad-mcp-pro@1.0.0 version --json || true
 python -m pip index versions kicad-mcp-pro || true
 ```
 
 ```powershell
-npm view '@oaslananka/kicad-mcp-pro@1.0.0' version --json
+npm view 'kicad-mcp-pro@1.0.0' version --json
 python -m pip index versions kicad-mcp-pro
 ```
 
@@ -78,15 +78,18 @@ TestPyPI:
 - provenance: `pypa/gh-action-pypi-publish` uploads PyPI attestations with
   `attestations: true`
 
-npm:
+Npm:
 
-- package: `@oaslananka/kicad-mcp-pro`
+- package: `kicad-mcp-pro`
 - provider: GitHub Actions
 - organization/user: `oaslananka`
 - repository: `kicad-studio-kit`
 - workflow filename: `publish-npm.yml`
 - environment: `npm`
 - runner: GitHub-hosted `ubuntu-24.04`
+- provenance: npm trusted publishing automatically emits provenance for public
+  packages from public GitHub repositories; the workflow keeps
+  `npm publish --provenance` as an explicit release guard.
 
 Open VSX:
 
@@ -151,3 +154,56 @@ corepack pnpm --filter kicadstudio run package
 ```
 
 The `ovsx publish --help` command is the safe Open VSX CLI smoke check for local preflight. Do not run `ovsx publish` with a token outside `.github/workflows/publish-extension.yml`.
+
+## Release Evidence
+
+GitHub Releases are the durable release evidence index. Each product publish
+workflow uploads product-scoped build artifacts, `SHA256SUMS.txt`,
+`sbom.cdx.json`, GitHub artifact attestations, and post-publish verification
+records when a GitHub Release triggers the workflow.
+
+| Product                | Release assets                                                                 | Publish verification                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| VSIX                   | `kicadstudio-<version>.vsix`, `vscode-extension-SHA256SUMS.txt`, SBOM evidence | Verify checksum before Marketplace/Open VSX publish; verify Marketplace version and Open VSX digest. |
+| Python wheel and sdist | wheel, sdist, `kicad-mcp-pro-python-SHA256SUMS.txt`, SBOM evidence             | Verify local checksums before publish; verify PyPI/TestPyPI SHA-256 digests after publish.           |
+| npm launcher tarball   | `kicad-mcp-pro-<version>.tgz`, `mcp-npm-SHA256SUMS.txt`, SBOM evidence         | Verify local checksum before publish; download npm tarball and verify SHA-256 after publish.         |
+
+Local release policy verification:
+
+```bash
+corepack pnpm run release:verify
+```
+
+Windows 11 PowerShell:
+
+```powershell
+corepack pnpm run release:verify
+```
+
+## Rollback and re-publish policy
+
+VS Code Marketplace and Open VSX:
+
+- Prefer publishing a fixed patch version. Do not delete or reuse a version.
+- If an extension must be hidden, unpublish it from the Marketplace or Open VSX
+  publisher console, then publish a new patch version with fresh evidence.
+- Keep the original GitHub Release evidence attached and add a maintainer note to
+  the replacement release explaining the superseded version.
+
+PyPI and TestPyPI:
+
+- Do not delete files to replace them with different bytes. PyPI versions are
+  immutable for practical release integrity.
+- If a published distribution is defective, yank it when appropriate and publish
+  a new patch version.
+- Verify the new wheel and source distribution against the GitHub Release
+  checksums and PyPI digest metadata before announcement.
+
+npm:
+
+- Do not unpublish stable versions except for the narrow windows and policy cases
+  allowed by npm.
+- Use `npm deprecate kicad-mcp-pro@<version> "<reason>"` for a bad release and
+  publish a fixed patch version.
+- Confirm `npm view kicad-mcp-pro@<version> dist.tarball --json` points to the
+  tarball whose SHA-256 matches the GitHub Release checksum.

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,13 +19,20 @@ The publish workflows keep release evidence product-scoped:
 - `publish-extension.yml` validates the VSIX, emits `SHA256SUMS.txt` and a
   CycloneDX SBOM, creates GitHub artifact attestations for the checksummed
   extension package, publishes the shared VSIX to the Visual Studio Marketplace,
-  and then publishes the same VSIX to Open VSX in a separate non-blocking job.
+  verifies the Marketplace version, and then publishes the same VSIX to Open VSX
+  in a separate non-blocking job that downloads the published VSIX and compares
+  its digest with the release checksum.
 - `publish-python.yml` validates the wheel and source distribution, emits
-  `packages/mcp-server/release-evidence/SHA256SUMS.txt`, uploads that checksum
-  as `python-release-evidence`, and creates GitHub artifact attestations for the
-  wheel and source distribution before PyPI trusted publishing. The `python-dist`
-  artifact intentionally contains only `*.whl` and `*.tar.gz` files.
-- `publish-npm.yml` uses npm provenance for the MCP launcher package.
+  `packages/mcp-server/release-evidence/SHA256SUMS.txt`, emits a CycloneDX SBOM,
+  uploads that evidence as `python-release-evidence`, and creates GitHub
+  artifact attestations for the Python wheel and source distribution before PyPI
+  trusted publishing. The publish jobs verify local checksums before upload and
+  verify PyPI/TestPyPI SHA-256 digests after upload. The `python-dist` artifact
+  intentionally contains only `*.whl` and `*.tar.gz` files.
+- `publish-npm.yml` packs the `kicad-mcp-pro` npm launcher tarball, emits
+  `SHA256SUMS.txt` and a CycloneDX SBOM, creates GitHub artifact attestations,
+  publishes with npm provenance, and downloads the published tarball to verify
+  its SHA-256 digest.
 - `publish-mcp-container.yml` validates the Docker image on pull requests and
   publishes signed multi-arch GHCR images with BuildKit SBOM/provenance for
   `mcp-server-v*` GitHub Releases.

--- a/docs/superpowers/plans/2026-05-20-monorepo-migration.md
+++ b/docs/superpowers/plans/2026-05-20-monorepo-migration.md
@@ -13,6 +13,7 @@
 ### Task 1: Build Target Topology
 
 **Files:**
+
 - Create directories: `apps/vscode-extension`, `packages/mcp-server`, `packages/mcp-npm`, `docs`, `scripts`, `.github/workflows`
 - Move/copy source: `kicad-studio-ide/*` to `apps/vscode-extension/*`
 - Move/copy source: `kicad-studio-mcp/*` to `packages/mcp-server/*`
@@ -25,6 +26,7 @@
 ### Task 2: Patch Root Workspace
 
 **Files:**
+
 - Create/modify: `package.json`, `pnpm-workspace.yaml`, `.node-version`, `.nvmrc`, `.python-version`, `.npmrc`, `uv.toml`, `.gitignore`, `.gitattributes`
 - Create/modify: `README.md`, `CHANGELOG.md`, `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`
 - Create/modify: `.release-please-manifest.json`, `release-please-config.json`, `renovate.json`, `Taskfile.yml`
@@ -36,6 +38,7 @@
 ### Task 3: Patch Package Metadata
 
 **Files:**
+
 - Modify: `apps/vscode-extension/package.json`
 - Modify: `packages/mcp-server/pyproject.toml`
 - Modify: `packages/mcp-server/src/kicad_mcp/__init__.py`
@@ -46,11 +49,12 @@
 
 - [ ] Set every package version to `1.0.0`.
 - [ ] Set repository, homepage, bugs, docs, and MCP identity fields to `oaslananka/kicad-studio-kit`.
-- [ ] Preserve public package identities: `kicadstudio`, `kicad-mcp-pro`, `@oaslananka/kicad-mcp-pro`, and `io.github.oaslananka/kicad-mcp-pro`.
+- [ ] Preserve public package identities: `kicadstudio`, `kicad-mcp-pro`, and `io.github.oaslananka/kicad-mcp-pro`.
 
 ### Task 4: Replace CI and Publish Workflows
 
 **Files:**
+
 - Create/modify: `.github/workflows/ci.yml`
 - Create/modify: `.github/workflows/release-please.yml`
 - Create/modify: `.github/workflows/publish-extension.yml`
@@ -73,6 +77,7 @@
 ### Task 5: Add Validation Scripts and Docs
 
 **Files:**
+
 - Create: `scripts/check-no-forbidden-refs.mjs`
 - Create: `scripts/check-version-consistency.mjs`
 - Create: `scripts/check-publish-preflight.mjs`
@@ -86,6 +91,7 @@
 ### Task 6: Validate and Report
 
 **Commands:**
+
 - `corepack pnpm install --frozen-lockfile`
 - `uv sync --all-extras --frozen --project packages/mcp-server`
 - `corepack pnpm run check:forbidden-refs`

--- a/package.json
+++ b/package.json
@@ -49,9 +49,11 @@
     "release:dry-run:kicad-studio": "pnpm --filter kicadstudio run package && pnpm --filter kicadstudio run package:validate && pnpm --filter kicadstudio run release:dry-run",
     "release:dry-run:kicad-mcp-pro": "pnpm --dir packages/mcp-server run release:dry-run && pnpm --dir packages/mcp-npm run check",
     "release:dry-run": "pnpm run release:dry-run:kicad-studio && pnpm run release:dry-run:kicad-mcp-pro",
+    "release:verify": "node scripts/check-release-provenance.mjs && pnpm run test:release-provenance",
     "check:forbidden-refs": "node scripts/check-no-forbidden-refs.mjs",
     "check:boundaries": "node scripts/check-boundaries.mjs",
     "test:release-please": "node --test scripts/check-release-please-monorepo.test.mjs",
+    "test:release-provenance": "node --test scripts/check-release-provenance.test.mjs scripts/verify-npm-release.test.mjs",
     "check:release-please": "node scripts/check-release-please-monorepo.mjs && pnpm run test:release-please",
     "check:version": "node scripts/check-version-consistency.mjs && pnpm run check:release-please",
     "check:compatibility": "uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/check_compatibility_matrix.py",
@@ -83,7 +85,7 @@
     "check:docs-site": "pnpm --dir packages/mcp-server run docs:tools:check && pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "check:publish": "node scripts/check-publish-preflight.mjs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:dry-run && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:dry-run && pnpm run release:verify && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.0",

--- a/packages/mcp-npm/README.md
+++ b/packages/mcp-npm/README.md
@@ -1,8 +1,8 @@
-# @oaslananka/kicad-mcp-pro
+# kicad-mcp-pro
 
 Thin npm launcher for the `kicad-mcp-pro` Python package.
 
-- npm package: `@oaslananka/kicad-mcp-pro`
+- npm package: `kicad-mcp-pro`
 - Python package: `kicad-mcp-pro`
 - MCP name: `io.github.oaslananka/kicad-mcp-pro`
 - Canonical repository: https://github.com/oaslananka/kicad-studio-kit/tree/main/packages/mcp-npm
@@ -10,5 +10,5 @@ Thin npm launcher for the `kicad-mcp-pro` Python package.
 The wrapper resolves the Python package version from `KICAD_MCP_PRO_PYPI_VERSION` or from this package version.
 
 ```bash
-npx @oaslananka/kicad-mcp-pro@1.0.0 --help
+npx kicad-mcp-pro@1.0.0 --help
 ```

--- a/packages/mcp-npm/package-lock.json
+++ b/packages/mcp-npm/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@oaslananka/kicad-mcp-pro",
+  "name": "kicad-mcp-pro",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@oaslananka/kicad-mcp-pro",
+      "name": "kicad-mcp-pro",
       "version": "1.0.0",
       "license": "MIT",
       "bin": {

--- a/packages/mcp-npm/package.json
+++ b/packages/mcp-npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@oaslananka/kicad-mcp-pro",
+  "name": "kicad-mcp-pro",
   "version": "1.0.0",
   "description": "npm wrapper for the KiCad MCP Pro Python package.",
   "license": "MIT",

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -5,7 +5,7 @@
 Canonical repository: https://github.com/oaslananka/kicad-studio-kit/tree/main/packages/mcp-server
 
 - PyPI: `kicad-mcp-pro`
-- npm wrapper: `@oaslananka/kicad-mcp-pro`
+- npm wrapper: `kicad-mcp-pro`
 - MCP Registry name: `io.github.oaslananka/kicad-mcp-pro`
 - Version: `1.0.0`
 
@@ -44,7 +44,7 @@ The deprecated HTTP+SSE fallback routes are disabled by default. Set
 ```bash
 corepack pnpm run dev:doctor -- --ci
 uvx kicad-mcp-pro@1.0.0 --help
-npx @oaslananka/kicad-mcp-pro@1.0.0 --help
+npx kicad-mcp-pro@1.0.0 --help
 ```
 
 For source checkouts, `corepack pnpm run dev:doctor` validates Node, pnpm,

--- a/packages/mcp-server/docs/publishing.md
+++ b/packages/mcp-server/docs/publishing.md
@@ -134,14 +134,14 @@ the Python package into the Scoop app directory at install time.
 The repository root `package.json` is private and exists only for hooks and CI
 scripts. It must not be published to npm.
 
-The optional npm wrapper lives under `npm-wrapper/`:
+The optional npm wrapper lives under `packages/mcp-npm/`:
 
 ```text
-npm-wrapper/package.json
-npm-wrapper/bin/kicad-mcp-pro.js
+packages/mcp-npm/package.json
+packages/mcp-npm/bin/kicad-mcp-pro.js
 ```
 
-The wrapper package name is `@oaslananka/kicad-mcp-pro`. It does not install
+The wrapper package name is `kicad-mcp-pro`. It does not install
 Python dependencies during the package-manager install lifecycle; at runtime it
 executes:
 
@@ -162,8 +162,9 @@ Required GitHub environment:
 Required GitHub secrets:
 
 - `PACKAGE_MANAGER_TOKEN`
-- `NPM_TOKEN` only if npm trusted publishing is not used for a future wrapper
-  publish workflow
+
+The npm wrapper uses trusted publishing through GitHub Actions OIDC. Do not add
+an `NPM_TOKEN` secret for the canonical npm publish workflow.
 
 Required GitHub variables:
 

--- a/packages/mcp-server/docs/security/release-integrity.md
+++ b/packages/mcp-server/docs/security/release-integrity.md
@@ -3,12 +3,12 @@
 Release integrity controls are emitted only from the canonical repository,
 `oaslananka/kicad-studio-kit`.
 
-## SBOM
+## Python SBOM
 
-The release workflow generates a CycloneDX SBOM as a release artifact:
+The Python publish workflow generates a CycloneDX SBOM as release evidence:
 
 ```text
-dist/bom.json
+packages/mcp-server/release-evidence/sbom.cdx.json
 ```
 
 Download it from the GitHub Release or the release workflow artifacts and keep
@@ -101,14 +101,14 @@ when the image is pushed.
 
 ## PyPI Trusted Publishing
 
-The release workflow is configured for PyPI Trusted Publishing through GitHub
-Actions OIDC. PyPI and TestPyPI project owners must configure trusted
-publishers for:
+The Python publish workflow is configured for PyPI Trusted Publishing through
+GitHub Actions OIDC. PyPI and TestPyPI project owners must configure trusted
+publishers for the package-index environments:
 
 - Owner: `oaslananka`
-- Repository: `kicad-mcp-pro`
-- Workflow: `release-please.yml`
-- Environment: `release`
+- Repository: `kicad-studio-kit`
+- Workflow: `publish-python.yml`
+- Environments: `pypi` and `testpypi`
 
 After the publisher is configured, long-lived package-index token secrets should
 not be used by CI.

--- a/packages/mcp-server/mcp.json
+++ b/packages/mcp-server/mcp.json
@@ -40,7 +40,7 @@
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "@oaslananka/kicad-mcp-pro",
+      "identifier": "kicad-mcp-pro",
       "version": "1.0.0",
       "runtimeHint": "npx",
       "transport": {

--- a/packages/mcp-server/scripts/check_submission_readiness.py
+++ b/packages/mcp-server/scripts/check_submission_readiness.py
@@ -138,7 +138,8 @@ def _runner_check() -> CheckResult:
             normalized = tuple(str(value).strip().strip("'\"") for value in values)
             if "self-hosted" in normalized:
                 hits.append(
-                    f"{path.relative_to(REPO_ROOT)} job {job_name}: self-hosted runner is not allowed"
+                    f"{path.relative_to(REPO_ROOT)} job {job_name}: "
+                    "self-hosted runner is not allowed"
                 )
     if hits:
         return CheckResult("runner regression", "FAIL", "; ".join(hits))
@@ -284,7 +285,7 @@ def _readme_check() -> CheckResult:
     required = {
         "canonical repository": "https://github.com/oaslananka/kicad-studio-kit/tree/main/packages/mcp-server",
         "PyPI package": "kicad-mcp-pro",
-        "npm wrapper": "@oaslananka/kicad-mcp-pro",
+        "npm wrapper": "kicad-mcp-pro",
         "MCP Registry name": "io.github.oaslananka/kicad-mcp-pro",
         "version": "1.0.0",
     }

--- a/packages/mcp-server/scripts/generate_release_evidence.py
+++ b/packages/mcp-server/scripts/generate_release_evidence.py
@@ -1,0 +1,251 @@
+"""Generate and verify release evidence for Python distribution artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import time
+import tomllib
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+PYPI_ENDPOINTS = {
+    "pypi": "https://pypi.org/pypi/{name}/{version}/json",
+    "testpypi": "https://test.pypi.org/pypi/{name}/{version}/json",
+}
+DEFAULT_PYPI_RETRIES = 6
+DEFAULT_PYPI_RETRY_DELAY = 10.0
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest for one artifact."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_project(pyproject_path: Path) -> dict[str, Any]:
+    """Load project metadata from pyproject.toml."""
+    with pyproject_path.open("rb") as handle:
+        return tomllib.load(handle)["project"]
+
+
+def _artifact_paths(dist_dir: Path, project: dict[str, Any]) -> list[Path]:
+    """Find the wheel and source distribution for the project version."""
+    prefix = str(project["name"]).replace("-", "_")
+    version = str(project["version"])
+    artifacts = sorted(
+        path
+        for path in dist_dir.iterdir()
+        if path.name.startswith(f"{prefix}-{version}")
+        and (path.suffix == ".whl" or path.suffixes[-2:] == [".tar", ".gz"])
+    )
+    kinds = {"wheel" if path.suffix == ".whl" else "sdist" for path in artifacts}
+    if kinds != {"wheel", "sdist"}:
+        raise SystemExit(f"Expected wheel and sdist in {dist_dir} for {project['name']} {version}.")
+    return artifacts
+
+
+def _dependency_name(requirement: str) -> str:
+    """Extract a package name from a PEP 508 dependency string."""
+    match = re.match(r"\s*([A-Za-z0-9_.-]+)", requirement)
+    if match is None:
+        raise ValueError(f"Could not parse dependency name from {requirement!r}.")
+    return match.group(1).replace("_", "-")
+
+
+def _bom_ref(name: str, version: str) -> str:
+    """Create a deterministic CycloneDX component reference."""
+    return f"pkg:pypi/{name}@{version}"
+
+
+def _cyclonedx_sbom(project: dict[str, Any], artifacts: list[Path]) -> dict[str, Any]:
+    """Build a minimal CycloneDX SBOM from pyproject metadata."""
+    name = str(project["name"])
+    version = str(project["version"])
+    dependency_components = [
+        {
+            "type": "library",
+            "name": _dependency_name(dependency),
+            "purl": f"pkg:pypi/{_dependency_name(dependency)}",
+        }
+        for dependency in project.get("dependencies", [])
+    ]
+    subject = "|".join(f"{path.name}:{_sha256(path)}" for path in artifacts)
+    serial = uuid.uuid5(uuid.NAMESPACE_URL, f"{name}:{version}:{subject}")
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "serialNumber": f"urn:uuid:{serial}",
+        "version": 1,
+        "metadata": {
+            "component": {
+                "type": "application",
+                "name": name,
+                "version": version,
+                "bom-ref": _bom_ref(name, version),
+            }
+        },
+        "components": dependency_components,
+    }
+
+
+def _write_checksum_file(artifacts: list[Path], output_dir: Path) -> Path:
+    """Write SHA256SUMS.txt for release artifacts."""
+    checksum_path = output_dir / "SHA256SUMS.txt"
+    lines = [f"{_sha256(path)}  {path.name}" for path in artifacts]
+    checksum_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return checksum_path
+
+
+def _read_checksums(checksum_file: Path) -> dict[str, str]:
+    """Read a SHA256SUMS file into a filename-to-digest mapping."""
+    checksums: dict[str, str] = {}
+    for line in checksum_file.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        digest, filename = line.split(maxsplit=1)
+        checksums[filename.strip()] = digest.strip()
+    return checksums
+
+
+def _write_evidence(
+    project: dict[str, Any], artifacts: list[Path], output_dir: Path, checksum_path: Path
+) -> None:
+    """Write machine-readable release evidence metadata."""
+    evidence = {
+        "product": "kicad-mcp-pro",
+        "surface": "python",
+        "package": project["name"],
+        "version": project["version"],
+        "checksums": checksum_path.name,
+        "sbom": "sbom.cdx.json",
+        "artifacts": [
+            {"name": path.name, "sha256": _sha256(path), "size": path.stat().st_size}
+            for path in artifacts
+        ],
+    }
+    (output_dir / "release-evidence.json").write_text(
+        json.dumps(evidence, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def generate(dist_dir: Path, output_dir: Path, pyproject_path: Path) -> None:
+    """Generate checksums, SBOM, and evidence JSON."""
+    project = _read_project(pyproject_path)
+    artifacts = _artifact_paths(dist_dir, project)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    checksum_path = _write_checksum_file(artifacts, output_dir)
+    sbom = _cyclonedx_sbom(project, artifacts)
+    (output_dir / "sbom.cdx.json").write_text(json.dumps(sbom, indent=2) + "\n", encoding="utf-8")
+    _write_evidence(project, artifacts, output_dir, checksum_path)
+
+
+def verify_local(checksum_file: Path, artifact_dir: Path) -> None:
+    """Verify local artifacts against SHA256SUMS.txt."""
+    failures = []
+    for filename, expected in _read_checksums(checksum_file).items():
+        artifact = artifact_dir / filename
+        if not artifact.exists():
+            failures.append(f"missing artifact: {artifact}")
+        elif _sha256(artifact) != expected:
+            failures.append(f"sha256 mismatch: {artifact}")
+    if failures:
+        raise SystemExit("Release evidence verification failed:\n- " + "\n- ".join(failures))
+
+
+def _published_pypi_digests(repository: str, package: str, version: str) -> dict[str, str]:
+    """Read published artifact digests from PyPI or TestPyPI."""
+    url = PYPI_ENDPOINTS[repository].format(name=package, version=version)
+    with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
+        payload = json.loads(response.read().decode("utf-8"))
+    return {
+        str(item["filename"]): str(item["digests"]["sha256"])
+        for item in payload.get("urls", [])
+        if "digests" in item and "sha256" in item["digests"]
+    }
+
+
+def _pypi_digest_failures(expected: dict[str, str], published: dict[str, str]) -> list[str]:
+    """Describe release artifacts that do not match published PyPI digests."""
+    return [
+        f"{filename}: expected {digest}, published {published.get(filename, '<missing>')}"
+        for filename, digest in expected.items()
+        if published.get(filename) != digest
+    ]
+
+
+def verify_pypi(
+    repository: str,
+    package: str,
+    version: str,
+    checksum_file: Path,
+    retries: int = DEFAULT_PYPI_RETRIES,
+    retry_delay: float = DEFAULT_PYPI_RETRY_DELAY,
+) -> None:
+    """Verify PyPI or TestPyPI published artifact digests."""
+    expected = _read_checksums(checksum_file)
+    last_error = "published metadata did not match release checksums"
+    for attempt in range(1, retries + 1):
+        try:
+            failures = _pypi_digest_failures(
+                expected, _published_pypi_digests(repository, package, version)
+            )
+            if not failures:
+                return
+            last_error = "\n- ".join(failures)
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+            last_error = str(exc)
+        if attempt < retries:
+            time.sleep(retry_delay)
+    raise SystemExit("Published PyPI digest verification failed:\n- " + last_error)
+
+
+def main() -> int:
+    """Run the release evidence CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate_parser = subparsers.add_parser("generate")
+    generate_parser.add_argument("--dist-dir", type=Path, default=Path("dist"))
+    generate_parser.add_argument("--output", type=Path, default=Path("release-evidence"))
+    generate_parser.add_argument("--pyproject", type=Path, default=Path("pyproject.toml"))
+
+    local_parser = subparsers.add_parser("verify-local")
+    local_parser.add_argument("--checksums", type=Path, required=True)
+    local_parser.add_argument("--artifacts", type=Path, required=True)
+
+    pypi_parser = subparsers.add_parser("verify-pypi")
+    pypi_parser.add_argument("--repository", choices=sorted(PYPI_ENDPOINTS), required=True)
+    pypi_parser.add_argument("--package", required=True)
+    pypi_parser.add_argument("--version", required=True)
+    pypi_parser.add_argument("--checksums", type=Path, required=True)
+    pypi_parser.add_argument("--retries", type=int, default=DEFAULT_PYPI_RETRIES)
+    pypi_parser.add_argument("--retry-delay", type=float, default=DEFAULT_PYPI_RETRY_DELAY)
+
+    args = parser.parse_args()
+    if args.command == "generate":
+        generate(args.dist_dir, args.output, args.pyproject)
+    elif args.command == "verify-local":
+        verify_local(args.checksums, args.artifacts)
+    elif args.command == "verify-pypi":
+        verify_pypi(
+            args.repository,
+            args.package,
+            args.version,
+            args.checksums,
+            retries=args.retries,
+            retry_delay=args.retry_delay,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/mcp-server/scripts/sync_mcp_metadata.py
+++ b/packages/mcp-server/scripts/sync_mcp_metadata.py
@@ -129,7 +129,7 @@ def _registry_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
             {
                 "registryType": "npm",
                 "registryBaseUrl": "https://registry.npmjs.org",
-                "identifier": "@oaslananka/kicad-mcp-pro",
+                "identifier": "kicad-mcp-pro",
                 "version": metadata["version"],
                 "runtimeHint": "npx",
                 "transport": {"type": "stdio"},
@@ -265,7 +265,8 @@ def main(argv: list[str] | None = None) -> int:
         if path.read_text(encoding="utf-8") != rendered:
             drift.append(path)
             if args.write:
-                path.write_text(rendered, encoding="utf-8")
+                with path.open("w", encoding="utf-8", newline="\n") as manifest:
+                    manifest.write(rendered)
 
     if drift and args.check:
         rel = ", ".join(

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -40,7 +40,7 @@
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "@oaslananka/kicad-mcp-pro",
+      "identifier": "kicad-mcp-pro",
       "version": "1.0.0",
       "runtimeHint": "npx",
       "transport": {

--- a/packages/mcp-server/tests/unit/test_npm_wrapper.py
+++ b/packages/mcp-server/tests/unit/test_npm_wrapper.py
@@ -18,7 +18,7 @@ def test_npm_wrapper_package_is_separate_from_private_root_package() -> None:
     wrapper_package = json.loads((WRAPPER_ROOT / "package.json").read_text(encoding="utf-8"))
 
     assert root_package["private"] is True
-    assert wrapper_package["name"] == "@oaslananka/kicad-mcp-pro"
+    assert wrapper_package["name"] == "kicad-mcp-pro"
     assert wrapper_package["bin"]["kicad-mcp-pro"] == "bin/kicad-mcp-pro.js"
     assert wrapper_package["mcpName"] == "io.github.oaslananka/kicad-mcp-pro"
 

--- a/packages/mcp-server/tests/unit/test_release_evidence.py
+++ b/packages/mcp-server/tests/unit/test_release_evidence.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType, TracebackType
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class _PypiResponse:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> _PypiResponse:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "generate_release_evidence",
+        ROOT / "scripts" / "generate_release_evidence.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_generate_release_evidence_writes_checksums_and_sbom(tmp_path: Path) -> None:
+    module = _load_script()
+    pyproject = tmp_path / "pyproject.toml"
+    dist = tmp_path / "dist"
+    output = tmp_path / "release-evidence"
+    dist.mkdir()
+    pyproject.write_text(
+        """
+[project]
+name = "kicad-mcp-pro"
+version = "1.2.3"
+dependencies = ["mcp>=1.27.1,<1.28", "typer>=0.12.0"]
+""".strip(),
+        encoding="utf-8",
+    )
+    (dist / "kicad_mcp_pro-1.2.3-py3-none-any.whl").write_bytes(b"wheel")
+    (dist / "kicad_mcp_pro-1.2.3.tar.gz").write_bytes(b"sdist")
+
+    module.generate(dist, output, pyproject)
+
+    checksums = (output / "SHA256SUMS.txt").read_text(encoding="utf-8")
+    sbom = json.loads((output / "sbom.cdx.json").read_text(encoding="utf-8"))
+    evidence = json.loads((output / "release-evidence.json").read_text(encoding="utf-8"))
+    assert "kicad_mcp_pro-1.2.3-py3-none-any.whl" in checksums
+    assert sbom["bomFormat"] == "CycloneDX"
+    assert {component["name"] for component in sbom["components"]} == {"mcp", "typer"}
+    assert evidence["surface"] == "python"
+
+
+def test_verify_local_rejects_checksum_mismatch(tmp_path: Path) -> None:
+    module = _load_script()
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    (artifacts / "artifact.whl").write_text("changed", encoding="utf-8")
+    checksums = tmp_path / "SHA256SUMS.txt"
+    checksums.write_text(f"{'0' * 64}  artifact.whl\n", encoding="utf-8")
+
+    try:
+        module.verify_local(checksums, artifacts)
+    except SystemExit as exc:
+        assert "sha256 mismatch" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("verify_local should reject mismatched checksums")
+
+
+def test_verify_pypi_accepts_matching_published_digests(tmp_path: Path, monkeypatch) -> None:
+    module = _load_script()
+    checksums = tmp_path / "SHA256SUMS.txt"
+    checksums.write_text(f"{'a' * 64}  artifact.whl\n", encoding="utf-8")
+
+    payload = b'{"urls":[{"filename":"artifact.whl","digests":{"sha256":"' + b"a" * 64 + b'"}}]}'
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _PypiResponse(payload),
+    )
+
+    module.verify_pypi("pypi", "kicad-mcp-pro", "1.0.0", checksums, retries=1, retry_delay=0)
+
+
+def test_verify_pypi_rejects_digest_mismatch(tmp_path: Path, monkeypatch) -> None:
+    module = _load_script()
+    checksums = tmp_path / "SHA256SUMS.txt"
+    checksums.write_text(f"{'0' * 64}  artifact.whl\n", encoding="utf-8")
+
+    payload = b'{"urls":[{"filename":"artifact.whl","digests":{"sha256":"' + b"1" * 64 + b'"}}]}'
+    monkeypatch.setattr(
+        module.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _PypiResponse(payload),
+    )
+
+    try:
+        module.verify_pypi("pypi", "kicad-mcp-pro", "1.0.0", checksums, retries=1, retry_delay=0)
+    except SystemExit as exc:
+        assert "Published PyPI digest verification failed" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("verify_pypi should reject mismatched checksums")

--- a/packages/mcp-server/tests/unit/test_release_hardening.py
+++ b/packages/mcp-server/tests/unit/test_release_hardening.py
@@ -622,7 +622,10 @@ def test_release_and_publish_workflows_are_monorepo_ready() -> None:
     assert "TEST_PYPI_TOKEN" not in publish_python
 
     assert "id-token: write" in publish_npm
-    assert "npm publish --access public --provenance" in publish_npm
+    assert (
+        'npm publish "${{ steps.npm-evidence.outputs.tarball }}" --access public --provenance'
+        in publish_npm
+    )
     assert "NPM_TOKEN" not in publish_npm
 
     assert "VSCE_PAT" in publish_extension
@@ -650,11 +653,11 @@ def test_security_and_publish_workflows_emit_supply_chain_evidence() -> None:
     assert "show-patched-versions: true" in security
 
     assert "corepack pnpm --filter kicadstudio run release:assets" in publish_extension
-    assert "apps/vscode-extension/SHA256SUMS.txt" in publish_extension
+    assert "release-assets/vscode-extension/SHA256SUMS.txt" in publish_extension
     assert "apps/vscode-extension/sbom.cdx.json" in publish_extension
-    assert "subject-checksums: apps/vscode-extension/SHA256SUMS.txt" in publish_extension
+    assert "subject-checksums: release-assets/vscode-extension/SHA256SUMS.txt" in publish_extension
 
-    assert "Generate Python checksums" in publish_python
+    assert "Generate Python release evidence" in publish_python
     assert "packages/mcp-server/release-evidence/SHA256SUMS.txt" in publish_python
     assert "packages/mcp-server/dist/SHA256SUMS.txt" not in publish_python
     assert (

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -70,7 +70,7 @@
     },
     "packages/mcp-npm": {
       "release-type": "node",
-      "package-name": "@oaslananka/kicad-mcp-pro",
+      "package-name": "kicad-mcp-pro",
       "component": "mcp-npm",
       "changelog-path": "CHANGELOG.md"
     }

--- a/scripts/check-publish-preflight.mjs
+++ b/scripts/check-publish-preflight.mjs
@@ -24,14 +24,12 @@ function run(command, args) {
 const failures = [];
 const npm = run("npm", [
   "view",
-  `@oaslananka/kicad-mcp-pro@${version}`,
+  `kicad-mcp-pro@${version}`,
   "version",
   "--json",
 ]);
 if (npm.status === 0 && npm.stdout.trim()) {
-  failures.push(
-    `npm package @oaslananka/kicad-mcp-pro@${version} already exists`,
-  );
+  failures.push(`npm package kicad-mcp-pro@${version} already exists`);
 }
 
 const pip = run("python", ["-m", "pip", "index", "versions", "kicad-mcp-pro"]);
@@ -57,7 +55,7 @@ console.log(
   "- PyPI/TestPyPI: owner oaslananka, repository kicad-studio-kit, workflow publish-python.yml, environments pypi/testpypi",
 );
 console.log(
-  "- npm: package @oaslananka/kicad-mcp-pro, provider GitHub Actions, workflow publish-npm.yml, environment npm",
+  "- npm: package kicad-mcp-pro, provider GitHub Actions, workflow publish-npm.yml, environment npm",
 );
 console.log(
   "- MCP Registry: io.github.oaslananka/kicad-mcp-pro via GitHub OIDC",

--- a/scripts/check-release-please-monorepo.mjs
+++ b/scripts/check-release-please-monorepo.mjs
@@ -44,7 +44,7 @@ const EXPECTED_PACKAGES = {
   "packages/mcp-npm": {
     product: "kicad-mcp-pro",
     releaseType: "node",
-    packageName: "@oaslananka/kicad-mcp-pro",
+    packageName: "kicad-mcp-pro",
     component: "mcp-npm",
     versionFile: "packages/mcp-npm/package.json",
   },

--- a/scripts/check-release-provenance.mjs
+++ b/scripts/check-release-provenance.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { exit } from "node:process";
+
+const files = {
+  rootPackage: "package.json",
+  npmPackage: "packages/mcp-npm/package.json",
+  releasePlease: "release-please-config.json",
+  publishExtension: ".github/workflows/publish-extension.yml",
+  publishPython: ".github/workflows/publish-python.yml",
+  publishNpm: ".github/workflows/publish-npm.yml",
+  docsRelease: "docs/release.md",
+  docsPublishing: "docs/publishing.md",
+};
+
+function read(path) {
+  return readFileSync(path, "utf8");
+}
+
+function readJson(path) {
+  return JSON.parse(read(path));
+}
+
+function expect(condition, message, failures) {
+  if (!condition) failures.push(message);
+}
+
+function expectIncludes(content, needle, label, failures) {
+  expect(content.includes(needle), `${label} must include ${needle}`, failures);
+}
+
+function checkPackageNames(failures) {
+  const rootPackage = readJson(files.rootPackage);
+  const npmPackage = readJson(files.npmPackage);
+  const releasePlease = readJson(files.releasePlease);
+  expect(
+    rootPackage.private === true,
+    "root package must remain private",
+    failures,
+  );
+  expect(
+    npmPackage.name === "kicad-mcp-pro",
+    "npm launcher package must be kicad-mcp-pro",
+    failures,
+  );
+  expect(
+    releasePlease.packages["packages/mcp-npm"]["package-name"] ===
+      "kicad-mcp-pro",
+    "Release Please npm package name must be kicad-mcp-pro",
+    failures,
+  );
+}
+
+function checkWorkflowEvidence(failures) {
+  const extension = read(files.publishExtension);
+  const python = read(files.publishPython);
+  const npm = read(files.publishNpm);
+  for (const [label, workflow] of Object.entries({ extension, python, npm })) {
+    expectIncludes(
+      workflow,
+      "sha256sum --check",
+      `${label} workflow`,
+      failures,
+    );
+    expectIncludes(
+      workflow,
+      "gh release upload",
+      `${label} workflow`,
+      failures,
+    );
+    expectIncludes(
+      workflow,
+      "attestations: write",
+      `${label} workflow`,
+      failures,
+    );
+    expectIncludes(workflow, "actions/attest@", `${label} workflow`, failures);
+  }
+  expectIncludes(
+    extension,
+    "release-assets/vscode-extension",
+    "extension workflow",
+    failures,
+  );
+  expectIncludes(
+    extension,
+    "vsce show oaslananka.kicadstudio --json",
+    "extension workflow",
+    failures,
+  );
+  expectIncludes(
+    extension,
+    "ovsx get oaslananka.kicadstudio",
+    "extension workflow",
+    failures,
+  );
+  expectIncludes(
+    python,
+    "generate_release_evidence.py generate",
+    "python workflow",
+    failures,
+  );
+  expectIncludes(
+    python,
+    "generate_release_evidence.py verify-pypi",
+    "python workflow",
+    failures,
+  );
+  expectIncludes(npm, "npm pack --json", "npm workflow", failures);
+  expectIncludes(
+    npm,
+    "npm sbom --sbom-format cyclonedx",
+    "npm workflow",
+    failures,
+  );
+  expectIncludes(npm, "verify-npm-release.mjs", "npm workflow", failures);
+}
+
+function checkDocs(failures) {
+  const release = read(files.docsRelease);
+  const publishing = read(files.docsPublishing);
+  for (const surface of ["VSIX", "Python wheel", "npm launcher tarball"]) {
+    expectIncludes(release, surface, "release docs", failures);
+  }
+  for (const registry of [
+    "Visual Studio Marketplace",
+    "Open VSX",
+    "PyPI",
+    "npm",
+  ]) {
+    expectIncludes(publishing, registry, "publishing docs", failures);
+  }
+  expectIncludes(
+    publishing,
+    "Rollback and re-publish policy",
+    "publishing docs",
+    failures,
+  );
+}
+
+const failures = [];
+checkPackageNames(failures);
+checkWorkflowEvidence(failures);
+checkDocs(failures);
+
+if (failures.length > 0) {
+  console.error("Release provenance check failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  exit(1);
+}
+
+console.log("Release provenance check passed.");

--- a/scripts/check-release-provenance.test.mjs
+++ b/scripts/check-release-provenance.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+test("release provenance policy check passes", () => {
+  const result = spawnSync(
+    process.execPath,
+    ["scripts/check-release-provenance.mjs"],
+    {
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stdout, /Release provenance check passed/);
+});

--- a/scripts/verify-npm-release.mjs
+++ b/scripts/verify-npm-release.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { argv, exit } from "node:process";
+import { setTimeout as sleep } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_REGISTRY_URL = "https://registry.npmjs.org";
+const DEFAULT_RETRIES = 6;
+const DEFAULT_RETRY_DELAY_MS = 10_000;
+
+function parseArgs(args) {
+  const parsed = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    parsed.set(args[index], args[index + 1]);
+  }
+  return parsed;
+}
+
+function required(args, key) {
+  const value = args.get(key);
+  if (!value) throw new Error(`Missing required argument ${key}`);
+  return value;
+}
+
+export function readChecksums(path) {
+  const entries = new Map();
+  for (const line of readFileSync(path, "utf8").split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const [digest, ...nameParts] = line.trim().split(/\s+/);
+    entries.set(nameParts.join(" "), digest);
+  }
+  return entries;
+}
+
+function sha256(buffer) {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`GET ${url} failed: ${response.status}`);
+  return response.json();
+}
+
+async function fetchBytes(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`GET ${url} failed: ${response.status}`);
+  return Buffer.from(await response.arrayBuffer());
+}
+
+export function packageMetadataUrl(
+  packageName,
+  version,
+  registryUrl = DEFAULT_REGISTRY_URL,
+) {
+  return `${registryUrl.replace(/\/$/, "")}/${encodeURIComponent(packageName)}/${version}`;
+}
+
+async function retry(task, attempts, delayMs) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await task();
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) await sleep(delayMs);
+    }
+  }
+  throw lastError;
+}
+
+export async function verifyPublishedNpmDigest({
+  packageName,
+  version,
+  checksumsPath,
+  outputDir = "release-assets/npm-verify",
+  registryUrl = DEFAULT_REGISTRY_URL,
+  retries = DEFAULT_RETRIES,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+}) {
+  const checksums = readChecksums(checksumsPath);
+  const metadata = await retry(
+    () => fetchJson(packageMetadataUrl(packageName, version, registryUrl)),
+    retries,
+    retryDelayMs,
+  );
+  const tarballUrl = metadata?.dist?.tarball;
+  if (!tarballUrl)
+    throw new Error(
+      `npm metadata for ${packageName}@${version} has no tarball URL`,
+    );
+
+  const tarball = await fetchBytes(tarballUrl);
+  const tarballName = basename(new URL(tarballUrl).pathname);
+  const expected = checksums.get(tarballName);
+  const actual = sha256(tarball);
+  if (expected !== actual) {
+    throw new Error(
+      `${tarballName} sha256 mismatch: expected ${expected}, got ${actual}`,
+    );
+  }
+
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(join(outputDir, tarballName), tarball);
+  writeFileSync(
+    join(outputDir, "npm-published-digest.json"),
+    `${JSON.stringify({ package: packageName, version, tarball: tarballUrl, sha256: actual }, null, 2)}\n`,
+  );
+}
+
+async function main() {
+  const args = parseArgs(argv.slice(2));
+  await verifyPublishedNpmDigest({
+    packageName: required(args, "--package"),
+    version: required(args, "--version"),
+    checksumsPath: required(args, "--checksums"),
+    outputDir: args.get("--output-dir") ?? "release-assets/npm-verify",
+    registryUrl: args.get("--registry") ?? DEFAULT_REGISTRY_URL,
+    retries: Number(args.get("--retries") ?? DEFAULT_RETRIES),
+    retryDelayMs: Number(
+      args.get("--retry-delay-ms") ?? DEFAULT_RETRY_DELAY_MS,
+    ),
+  });
+}
+
+if (argv[1] && import.meta.url === pathToFileURL(argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    exit(1);
+  });
+}

--- a/scripts/verify-npm-release.test.mjs
+++ b/scripts/verify-npm-release.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import test from "node:test";
+
+import { verifyPublishedNpmDigest } from "./verify-npm-release.mjs";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function withRegistry(handler, testBody) {
+  const server = createServer(handler);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.equal(typeof address, "object");
+  try {
+    await testBody(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+}
+
+test("verifies the published npm tarball SHA-256 digest", async () => {
+  const tarball = Buffer.from("package-bytes");
+  const checksum = sha256(tarball);
+  const workspace = mkdtempSync(join(tmpdir(), "npm-release-"));
+  const checksums = join(workspace, "SHA256SUMS.txt");
+  await writeFile(checksums, `${checksum}  kicad-mcp-pro-1.0.0.tgz\n`);
+
+  await withRegistry(
+    (request, response) => {
+      if (request.url === "/kicad-mcp-pro/1.0.0") {
+        const baseUrl = `http://${request.headers.host}`;
+        response.setHeader("content-type", "application/json");
+        response.end(
+          JSON.stringify({
+            dist: {
+              tarball: `${baseUrl}/kicad-mcp-pro/-/kicad-mcp-pro-1.0.0.tgz`,
+            },
+          }),
+        );
+        return;
+      }
+      response.end(tarball);
+    },
+    async (registryUrl) => {
+      await verifyPublishedNpmDigest({
+        packageName: "kicad-mcp-pro",
+        version: "1.0.0",
+        checksumsPath: checksums,
+        outputDir: join(workspace, "verify"),
+        registryUrl,
+        retries: 1,
+        retryDelayMs: 0,
+      });
+    },
+  );
+
+  const evidence = JSON.parse(
+    readFileSync(
+      join(workspace, "verify", "npm-published-digest.json"),
+      "utf8",
+    ),
+  );
+  assert.equal(evidence.package, "kicad-mcp-pro");
+  assert.equal(evidence.version, "1.0.0");
+  assert.equal(evidence.sha256, checksum);
+});
+
+test("rejects a published npm tarball digest mismatch", async () => {
+  const workspace = mkdtempSync(join(tmpdir(), "npm-release-"));
+  const checksums = join(workspace, "SHA256SUMS.txt");
+  await writeFile(checksums, `${"0".repeat(64)}  kicad-mcp-pro-1.0.0.tgz\n`);
+
+  await withRegistry(
+    (request, response) => {
+      if (request.url === "/kicad-mcp-pro/1.0.0") {
+        const baseUrl = `http://${request.headers.host}`;
+        response.setHeader("content-type", "application/json");
+        response.end(
+          JSON.stringify({
+            dist: {
+              tarball: `${baseUrl}/kicad-mcp-pro/-/kicad-mcp-pro-1.0.0.tgz`,
+            },
+          }),
+        );
+        return;
+      }
+      response.end("changed");
+    },
+    async (registryUrl) => {
+      await assert.rejects(
+        verifyPublishedNpmDigest({
+          packageName: "kicad-mcp-pro",
+          version: "1.0.0",
+          checksumsPath: checksums,
+          outputDir: join(workspace, "verify"),
+          registryUrl,
+          retries: 1,
+          retryDelayMs: 0,
+        }),
+        /sha256 mismatch/,
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Adds product-scoped release provenance evidence for the VSIX, Python wheel/sdist, and npm launcher tarball.
- Uploads SHA256, CycloneDX SBOM, artifact attestation, release evidence, and post-publish digest verification records to the release workflows.
- Normalizes the npm launcher target to the unscoped `kicad-mcp-pro` package and documents registry targets, rollback, and re-publish policy.

## Linked issue

Closes #185

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [x] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm install --frozen-lockfile` passed
- `uv sync --all-extras --frozen --project packages/mcp-server` passed
- `corepack pnpm run format:check` passed
- `corepack pnpm run lint` passed
- `corepack pnpm run typecheck` passed
- `corepack pnpm run test` passed on rerun with a longer timeout
- `corepack pnpm run release:dry-run` passed warning-clean for deprecations
- `corepack pnpm run release:verify` passed
- `corepack pnpm run verify:dist` passed
- `corepack pnpm run check:publish` passed
- `corepack pnpm run docs:generate && corepack pnpm run docs:check-generated && corepack pnpm run docs:lint && corepack pnpm run docs:links` passed
- `corepack pnpm --filter kicadstudio run workflows:lint` passed
- `corepack pnpm --dir packages/mcp-server run workflows:security` passed
- `corepack pnpm --dir packages/mcp-server run security` passed
- `gitleaks detect --source . --redact --no-banner` passed
- `actionlint .github/workflows/publish-extension.yml .github/workflows/publish-python.yml .github/workflows/publish-npm.yml` passed
- `pre-commit run --all-files` passed

Known local blocker: `corepack pnpm run build` still fails on Windows because of the existing npm-wrapper smoke issue tracked by #191. Product build/package gates for this PR passed, and the PR CI build lane does not invoke that Windows-local recursive npm wrapper smoke.

## Protocol / MCP impact

Checklist reference: `docs/architecture/protocol-change-checklist.md`

- [x] Not applicable; reason: no MCP tool names, schemas, transport behavior, or extension adapter behavior changed. This updates release/package metadata and publish automation only.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [ ] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [ ] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts