### PR TITLE
fix(kicad-mcp-pro): make npm launcher build smoke cross-platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
           package-manager-cache: false
       - run: npm ci --ignore-scripts=false
       - run: npm pack --dry-run
-      - run: node bin/kicad-mcp-pro.js --help || true
+      - run: npm run build
 
   forbidden-refs:
     needs: ci-lanes

--- a/packages/mcp-npm/package.json
+++ b/packages/mcp-npm/package.json
@@ -18,6 +18,7 @@
   },
   "files": [
     "bin/",
+    "scripts/",
     "README.md"
   ],
   "engines": {
@@ -28,6 +29,6 @@
   },
   "scripts": {
     "check": "npm pack --dry-run",
-    "build": "node bin/kicad-mcp-pro.js --help || true"
+    "build": "node scripts/build-smoke.js"
   }
 }

--- a/packages/mcp-npm/scripts/build-smoke.js
+++ b/packages/mcp-npm/scripts/build-smoke.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+"use strict";
+
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const packageRoot = path.resolve(__dirname, "..");
+const wrapperPath = path.join(packageRoot, "bin", "kicad-mcp-pro.js");
+
+const result = spawnSync(process.execPath, [wrapperPath, "--help"], {
+  cwd: packageRoot,
+  encoding: "utf8",
+  windowsHide: true,
+});
+
+function writeChildOutput() {
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+}
+
+if (result.error) {
+  console.error(
+    `Failed to execute npm launcher smoke: ${result.error.message}`,
+  );
+  process.exit(1);
+}
+
+if (result.signal) {
+  console.error(
+    `npm launcher smoke was interrupted by signal ${result.signal}.`,
+  );
+  process.exit(1);
+}
+
+if (result.status === 0) {
+  writeChildOutput();
+  process.exit(0);
+}
+
+const uvxMissing = result.stderr.includes("uvx was not found on PATH.");
+const pythonPackageUnavailable = result.stderr.includes(
+  "Publish the matching Python package before publishing this npm wrapper",
+);
+const knownPrepublishFailure = uvxMissing || pythonPackageUnavailable;
+
+if (!knownPrepublishFailure) {
+  writeChildOutput();
+  console.error(
+    `npm launcher smoke failed with unexpected exit code ${result.status ?? 1}.`,
+  );
+  process.exit(result.status ?? 1);
+}
+
+const reason = uvxMissing
+  ? "uvx is not available on PATH"
+  : "the matching Python package is not available yet";
+
+console.error(
+  [
+    `npm launcher smoke skipped: ${reason}.`,
+    "This is tolerated during repository builds because the matching Python package",
+    "may not be published yet. The wrapper itself still exits non-zero for users.",
+  ].join("\n"),
+);
+process.exit(0);

--- a/packages/mcp-server/tests/unit/test_npm_wrapper.py
+++ b/packages/mcp-server/tests/unit/test_npm_wrapper.py
@@ -20,6 +20,7 @@ def test_npm_wrapper_package_is_separate_from_private_root_package() -> None:
     assert root_package["private"] is True
     assert wrapper_package["name"] == "kicad-mcp-pro"
     assert wrapper_package["bin"]["kicad-mcp-pro"] == "bin/kicad-mcp-pro.js"
+    assert "scripts/" in wrapper_package["files"]
     assert wrapper_package["mcpName"] == "io.github.oaslananka/kicad-mcp-pro"
 
 
@@ -43,3 +44,32 @@ def test_npm_wrapper_fails_clearly_when_uvx_is_missing() -> None:
     assert result.returncode == 127
     assert "uvx was not found on PATH." in result.stderr
     assert "does not install the Python package" in result.stderr
+
+
+def test_npm_wrapper_build_smoke_is_cross_platform() -> None:
+    wrapper_package = json.loads((WRAPPER_ROOT / "package.json").read_text(encoding="utf-8"))
+
+    assert wrapper_package["scripts"]["build"] == "node scripts/build-smoke.js"
+    assert "|| true" not in wrapper_package["scripts"]["build"]
+
+
+def test_npm_wrapper_build_smoke_tolerates_unpublished_python_package() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is not available")
+
+    env = os.environ.copy()
+    env["PATH"] = ""
+    result = subprocess.run(
+        [node, str(WRAPPER_ROOT / "scripts" / "build-smoke.js")],
+        cwd=WRAPPER_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "npm launcher smoke skipped: uvx is not available on PATH." in result.stderr
+    assert "wrapper itself still exits non-zero for users" in result.stderr


### PR DESCRIPTION
## Problem
The npm launcher package used `node bin/kicad-mcp-pro.js --help || true` for its build smoke. That POSIX fallback breaks under Windows npm/cmd execution when the matching Python package is not published yet.

## Solution
- Add a Node-based `packages/mcp-npm/scripts/build-smoke.js` smoke wrapper with no shell-specific fallback.
- Keep the user-facing launcher behavior strict: `bin/kicad-mcp-pro.js` still exits non-zero when `uvx` or the Python package is unavailable.
- Tolerate only known pre-publication smoke failures in repository builds.
- Run the same package `npm run build` smoke from CI.
- Add regression tests for the package script and missing-uvx tolerant build path.

Closes #191

## Validation
- `corepack pnpm --dir packages/mcp-npm run build`
- `corepack pnpm --dir packages/mcp-npm run check`
- `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_npm_wrapper.py -q`
- `corepack pnpm run format:check`
- `corepack pnpm exec prettier --check packages/mcp-npm/package.json packages/mcp-npm/scripts/build-smoke.js`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run test`
- `corepack pnpm run build`
- `corepack pnpm run verify:dist`
- `corepack pnpm run check:ci-lanes`
- `corepack pnpm --filter kicadstudio run workflows:lint`
- `actionlint .github/workflows/ci.yml`
- `corepack pnpm --dir packages/mcp-server run security`
- `gitleaks detect --source . --redact --no-banner`
- `corepack pnpm run check:compatibility`
- `corepack pnpm run check:runtime-policy`
- `corepack pnpm run check:agent-configs`
- `act -W .github/workflows/ci.yml -l`
- `act -W .github/workflows/ci.yml -j mcp-npm -P ubuntu-latest=catthehacker/ubuntu:act-latest`
- `pre-commit run --all-files`