### PR TITLE
fix(repo): enforce pnpm supply-chain policy

### DIFF
--- a/docs/dependency-lifecycle.md
+++ b/docs/dependency-lifecycle.md
@@ -82,6 +82,8 @@ Vulnerability-fix PRs skip the weekly schedule and should be reviewed first. Kee
 Defer an update when:
 
 - The upstream release is less than the configured minimum release age.
+- The update requires disabling `minimumReleaseAge` or `blockExoticSubdeps` in
+  `pnpm-workspace.yaml`.
 - CI fails because of an upstream regression.
 - The update changes a supported KiCad, VS Code, MCP, Python, Node, pnpm, or package-publish contract.
 - A major update lacks migration notes.

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,6 +15,10 @@ Pull requests and scheduled workflows keep the supply chain surface visible:
 - `Scorecard` publishes repository health findings through code scanning.
 - PyPI and TestPyPI publish jobs use Trusted Publishing through GitHub OIDC and
   upload registry-native attestations through `pypa/gh-action-pypi-publish`.
+- pnpm 11 supply-chain defaults are made explicit in `pnpm-workspace.yaml`:
+  `minimumReleaseAge: 1440` delays newly published npm versions by 24 hours,
+  and `blockExoticSubdeps: true` keeps transitive dependencies on trusted
+  registry, workspace, local, or trusted upstream sources.
 - GHCR image publishing uses GitHub Container Registry, BuildKit SBOM and
   provenance, Trivy image scanning, and keyless Sigstore `cosign` signing.
 - Release publish workflows validate package contents, emit SHA-256 checksum
@@ -51,6 +55,22 @@ corepack pnpm --dir packages/mcp-server run security:local
 
 That gate requires `gitleaks`, workflow linting, and `zizmor`; scanner findings
 must be fixed or triaged before release work proceeds.
+
+## pnpm Lockfile Trust
+
+Keep `trustLockfile` disabled for this public repository. pnpm 11.3 can skip
+the supply-chain verification pass for already-trusted lockfiles, but pull
+requests can include lockfile edits, so CI must continue re-applying
+`minimumReleaseAge` and trust-policy checks during installs. Re-evaluate this
+only if lockfile writes become maintainer-only and the repo has upgraded to
+pnpm 11.3 or newer.
+
+Validate the policy with:
+
+```bash
+corepack pnpm run check:supply-chain
+corepack pnpm config list
+```
 
 Secrets are limited to marketplace publishing where OIDC is not available:
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "check:version": "node scripts/check-version-consistency.mjs && pnpm run check:release-please",
     "check:compatibility": "uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/check_compatibility_matrix.py",
     "check:runtime-policy": "uv run --project packages/mcp-server --all-extras python packages/mcp-server/scripts/runtime_policy.py check",
+    "check:supply-chain": "node scripts/check-pnpm-supply-chain.mjs && node --test scripts/check-pnpm-supply-chain.test.mjs",
     "check:repo-governance": "node scripts/check-repo-governance.mjs",
     "check:governance": "node scripts/sync-governance-project-items.mjs --self-test && pnpm run check:repo-governance",
     "test:ci-lanes": "node --test scripts/check-ci-lanes.test.mjs",
@@ -86,7 +87,7 @@
     "check:docs-site": "pnpm --dir packages/mcp-server run docs:tools:check && pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "check:publish": "node scripts/check-publish-preflight.mjs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:dry-run && pnpm run release:verify && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:dry-run && pnpm run release:verify && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.0",

--- a/packages/mcp-server/scripts/check_submission_readiness.py
+++ b/packages/mcp-server/scripts/check_submission_readiness.py
@@ -282,12 +282,14 @@ def _reviewer_prompts_check() -> CheckResult:
 
 def _readme_check() -> CheckResult:
     text = (ROOT / "README.md").read_text(encoding="utf-8")
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    version = pyproject["project"]["version"]
     required = {
         "canonical repository": "https://github.com/oaslananka/kicad-studio-kit/tree/main/packages/mcp-server",
         "PyPI package": "kicad-mcp-pro",
         "npm wrapper": "kicad-mcp-pro",
         "MCP Registry name": "io.github.oaslananka/kicad-mcp-pro",
-        "version": "1.0.0",
+        "version": f"- Version: `{version}`",
     }
     missing = [label for label, marker in required.items() if marker not in text]
     if missing:

--- a/packages/mcp-server/scripts/check_workflows.py
+++ b/packages/mcp-server/scripts/check_workflows.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import pathlib
+import shutil
 import subprocess
 
 import yaml
@@ -19,8 +20,16 @@ WORKSPACE_ACTIONLINT_COMMAND = [
 ]
 
 
+def _resolve_command(command: list[str]) -> list[str]:
+    executable = shutil.which(command[0])
+    if executable is None:
+        msg = f"{command[0]} not found on PATH"
+        raise RuntimeError(msg)
+    return [executable, *command[1:]]
+
+
 def _run(command: list[str]) -> None:
-    result = subprocess.run(command, check=False)
+    result = subprocess.run(_resolve_command(command), check=False)
     if result.returncode != 0:
         raise SystemExit(result.returncode)
 

--- a/packages/mcp-server/tests/unit/test_release_preflight_guard.py
+++ b/packages/mcp-server/tests/unit/test_release_preflight_guard.py
@@ -162,7 +162,6 @@ def test_workflow_lint_does_not_branch_on_local_actionlint_binary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _load_script("check_workflows.py")
-    script_text = (ROOT / "scripts" / "check_workflows.py").read_text(encoding="utf-8")
     workflows = tmp_path / ".github" / "workflows"
     workflows.mkdir(parents=True)
     (workflows / "example.yml").write_text(
@@ -176,5 +175,16 @@ def test_workflow_lint_does_not_branch_on_local_actionlint_binary(
 
     module.main()
 
-    assert "shutil.which" not in script_text
+    assert module.WORKSPACE_ACTIONLINT_COMMAND[0] == "corepack"
     assert commands == [["corepack", "pnpm", "--filter", "kicadstudio", "run", "workflows:lint"]]
+
+
+def test_workflow_lint_resolves_windows_command_shims(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_script("check_workflows.py")
+    monkeypatch.setattr(module.shutil, "which", lambda name: f"C:/tools/{name}.CMD")
+
+    assert module._resolve_command(["corepack", "pnpm", "--version"]) == [
+        "C:/tools/corepack.CMD",
+        "pnpm",
+        "--version",
+    ]

--- a/packages/mcp-server/tests/unit/test_submission_readiness.py
+++ b/packages/mcp-server/tests/unit/test_submission_readiness.py
@@ -1,0 +1,7 @@
+from scripts import check_submission_readiness
+
+
+def test_readme_listing_references_use_current_package_version() -> None:
+    result = check_submission_readiness._readme_check()
+
+    assert result.status == "PASS"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,9 @@ packages:
   - "packages/kicad-fixtures"
   - "packages/test-harness"
 
+minimumReleaseAge: 1440
+blockExoticSubdeps: true
+
 allowBuilds:
   "@go-task/cli": true
   "@vscode/vsce-sign": true

--- a/scripts/check-pnpm-supply-chain.mjs
+++ b/scripts/check-pnpm-supply-chain.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { parse } from "yaml";
+
+const SCRIPT_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = path.resolve(SCRIPT_ROOT, "..");
+const MINIMUM_RELEASE_AGE_MINUTES = 1440;
+const FORBIDDEN_PNPM_SETTINGS = [
+  "minimumReleaseAge",
+  "blockExoticSubdeps",
+  "trustLockfile",
+];
+
+function readText(repoRoot, relativePath, errors, { optional = false } = {}) {
+  const filePath = path.join(repoRoot, relativePath);
+  if (optional && !existsSync(filePath)) {
+    return "";
+  }
+  try {
+    return readFileSync(filePath, "utf8");
+  } catch (error) {
+    errors.push(`Missing ${relativePath}: ${error.message}`);
+    return "";
+  }
+}
+
+function readJson(repoRoot, relativePath, errors) {
+  const text = readText(repoRoot, relativePath, errors);
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    errors.push(`${relativePath} must be strict JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function readYaml(repoRoot, relativePath, errors) {
+  const text = readText(repoRoot, relativePath, errors);
+  try {
+    return parse(text);
+  } catch (error) {
+    errors.push(`${relativePath} must be valid YAML: ${error.message}`);
+    return null;
+  }
+}
+
+function assertCondition(errors, condition, message) {
+  if (!condition) {
+    errors.push(message);
+  }
+}
+
+function validateWorkspace(errors, workspace) {
+  assertCondition(
+    errors,
+    workspace?.minimumReleaseAge === MINIMUM_RELEASE_AGE_MINUTES,
+    "pnpm-workspace.yaml must set minimumReleaseAge: 1440",
+  );
+  assertCondition(
+    errors,
+    workspace?.blockExoticSubdeps === true,
+    "pnpm-workspace.yaml must set blockExoticSubdeps: true",
+  );
+  assertCondition(
+    errors,
+    workspace?.trustLockfile !== true,
+    "pnpm-workspace.yaml must not enable trustLockfile for public PR CI",
+  );
+}
+
+function validatePackageJson(errors, packageJson) {
+  assertCondition(
+    errors,
+    /^pnpm@11\./u.test(packageJson?.packageManager ?? ""),
+    "package.json packageManager must pin pnpm 11.x",
+  );
+  assertCondition(
+    errors,
+    packageJson?.engines?.pnpm === ">=11.0.0 <12",
+    "package.json engines.pnpm must stay on the supported pnpm 11 range",
+  );
+  for (const setting of FORBIDDEN_PNPM_SETTINGS) {
+    assertCondition(
+      errors,
+      packageJson?.pnpm?.[setting] === undefined,
+      `package.json must not define pnpm.${setting}; use pnpm-workspace.yaml`,
+    );
+  }
+}
+
+function validateNpmrc(errors, npmrc) {
+  for (const setting of FORBIDDEN_PNPM_SETTINGS) {
+    assertCondition(
+      errors,
+      !new RegExp(`^\\s*${setting}\\s*=`, "imu").test(npmrc),
+      `.npmrc must not define ${setting}; pnpm 11 reads it from pnpm-workspace.yaml`,
+    );
+  }
+}
+
+function validateSecurityWorkflow(errors, workflow) {
+  for (const phrase of [
+    "pull_request:",
+    "schedule:",
+    "corepack pnpm audit --audit-level high",
+    "corepack pnpm --dir packages/mcp-server run security",
+  ]) {
+    assertCondition(
+      errors,
+      workflow.includes(phrase),
+      `security.yml must include ${phrase}`,
+    );
+  }
+}
+
+function validateMcpSecurityScripts(errors, packageJson) {
+  const scripts = packageJson?.scripts ?? {};
+  assertCondition(
+    errors,
+    scripts.security ===
+      "corepack pnpm run security:bandit && corepack pnpm run security:audit",
+    "packages/mcp-server package.json must run bandit and audit in security",
+  );
+  assertCondition(
+    errors,
+    Boolean(scripts["security:bandit"]),
+    "security:bandit must exist",
+  );
+  assertCondition(
+    errors,
+    Boolean(scripts["security:audit"]),
+    "security:audit must exist",
+  );
+}
+
+export function validatePnpmSupplyChain(repoRoot = DEFAULT_REPO_ROOT) {
+  const errors = [];
+  const workspace = readYaml(repoRoot, "pnpm-workspace.yaml", errors);
+  const rootPackage = readJson(repoRoot, "package.json", errors);
+  const mcpPackage = readJson(
+    repoRoot,
+    "packages/mcp-server/package.json",
+    errors,
+  );
+  const npmrc = readText(repoRoot, ".npmrc", errors, { optional: true });
+  const securityWorkflow = readText(
+    repoRoot,
+    ".github/workflows/security.yml",
+    errors,
+  );
+
+  validateWorkspace(errors, workspace);
+  validatePackageJson(errors, rootPackage);
+  validateMcpSecurityScripts(errors, mcpPackage);
+  validateNpmrc(errors, npmrc);
+  validateSecurityWorkflow(errors, securityWorkflow);
+
+  return errors;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const errors = validatePnpmSupplyChain();
+  if (errors.length > 0) {
+    console.error("pnpm supply-chain check failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log("pnpm supply-chain check passed.");
+  }
+}

--- a/scripts/check-pnpm-supply-chain.test.mjs
+++ b/scripts/check-pnpm-supply-chain.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { validatePnpmSupplyChain } from "./check-pnpm-supply-chain.mjs";
+
+function createFixture(overrides = {}) {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), "pnpm-supply-chain-"));
+  mkdirSync(path.join(repoRoot, ".github/workflows"), { recursive: true });
+  mkdirSync(path.join(repoRoot, "packages/mcp-server"), { recursive: true });
+
+  writeFileSync(
+    path.join(repoRoot, "pnpm-workspace.yaml"),
+    overrides.workspace ??
+      [
+        "packages:",
+        '  - "packages/mcp-server"',
+        "minimumReleaseAge: 1440",
+        "blockExoticSubdeps: true",
+        "",
+      ].join("\n"),
+  );
+  writeFileSync(
+    path.join(repoRoot, "package.json"),
+    JSON.stringify(
+      overrides.rootPackage ?? {
+        packageManager: "pnpm@11.0.8",
+        engines: { pnpm: ">=11.0.0 <12" },
+      },
+    ),
+  );
+  writeFileSync(
+    path.join(repoRoot, "packages/mcp-server/package.json"),
+    JSON.stringify(
+      overrides.mcpPackage ?? {
+        scripts: {
+          "security:bandit":
+            "uv run --all-extras python -m bandit -r src/ -ll -s B104",
+          "security:audit":
+            "uv run --all-extras python scripts/audit_dependencies.py",
+          security:
+            "corepack pnpm run security:bandit && corepack pnpm run security:audit",
+        },
+      },
+    ),
+  );
+  writeFileSync(
+    path.join(repoRoot, ".npmrc"),
+    overrides.npmrc ?? "audit=true\n",
+  );
+  writeFileSync(
+    path.join(repoRoot, ".github/workflows/security.yml"),
+    overrides.securityWorkflow ??
+      [
+        "on:",
+        "  pull_request:",
+        "  schedule:",
+        '    - cron: "23 3 * * 1"',
+        "steps:",
+        "  - run: corepack pnpm audit --audit-level high",
+        "  - run: corepack pnpm --dir packages/mcp-server run security",
+        "",
+      ].join("\n"),
+  );
+
+  return repoRoot;
+}
+
+test("current repository keeps pnpm 11 supply-chain controls explicit", () => {
+  assert.deepEqual(validatePnpmSupplyChain(), []);
+});
+
+test("fixture with expected supply-chain settings passes", () => {
+  const repoRoot = createFixture();
+  try {
+    assert.deepEqual(validatePnpmSupplyChain(repoRoot), []);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("disabled pnpm supply-chain controls fail validation", () => {
+  const repoRoot = createFixture({
+    workspace: [
+      "packages:",
+      '  - "packages/mcp-server"',
+      "minimumReleaseAge: 0",
+      "blockExoticSubdeps: false",
+      "trustLockfile: true",
+      "",
+    ].join("\n"),
+  });
+  try {
+    assert.deepEqual(validatePnpmSupplyChain(repoRoot), [
+      "pnpm-workspace.yaml must set minimumReleaseAge: 1440",
+      "pnpm-workspace.yaml must set blockExoticSubdeps: true",
+      "pnpm-workspace.yaml must not enable trustLockfile for public PR CI",
+    ]);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test(".npmrc and package.json cannot carry ignored pnpm supply-chain settings", () => {
+  const repoRoot = createFixture({
+    npmrc: "minimumReleaseAge=0\n",
+    rootPackage: {
+      packageManager: "pnpm@11.0.8",
+      engines: { pnpm: ">=11.0.0 <12" },
+      pnpm: { blockExoticSubdeps: false },
+    },
+  });
+  try {
+    assert.deepEqual(validatePnpmSupplyChain(repoRoot), [
+      "package.json must not define pnpm.blockExoticSubdeps; use pnpm-workspace.yaml",
+      ".npmrc must not define minimumReleaseAge; pnpm 11 reads it from pnpm-workspace.yaml",
+    ]);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/dev-doctor.mjs
+++ b/scripts/dev-doctor.mjs
@@ -94,6 +94,37 @@ function firstLine(value) {
   return String(value).split(/\r?\n/u).find(Boolean) ?? "";
 }
 
+export function selectWindowsCommand(command, whereOutput) {
+  const candidates = String(whereOutput)
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const executable = candidates.find((candidate) =>
+    [".exe", ".cmd", ".bat", ".com"].includes(
+      path.extname(candidate).toLowerCase(),
+    ),
+  );
+  return executable ?? candidates[0] ?? command;
+}
+
+function resolveCommand(command) {
+  if (
+    process.platform !== "win32" ||
+    path.isAbsolute(command) ||
+    command.includes("/") ||
+    command.includes("\\")
+  ) {
+    return command;
+  }
+  const lookup = spawnSync("where.exe", [command], {
+    encoding: "utf8",
+    shell: false,
+  });
+  return lookup.status === 0
+    ? selectWindowsCommand(command, lookup.stdout)
+    : command;
+}
+
 function run(command, args, options = {}) {
   if (options.commandRunner) {
     const result = options.commandRunner(command, args, {
@@ -108,11 +139,19 @@ function run(command, args, options = {}) {
     };
   }
 
-  const result = spawnSync(command, args, {
-    cwd: options.cwd ?? DEFAULT_REPO_ROOT,
-    encoding: "utf8",
-    shell: false,
-  });
+  const executable = resolveCommand(command);
+  const isWindowsCommandScript =
+    process.platform === "win32" &&
+    [".bat", ".cmd"].includes(path.extname(executable).toLowerCase());
+  const result = spawnSync(
+    isWindowsCommandScript ? (process.env.ComSpec ?? "cmd.exe") : executable,
+    isWindowsCommandScript ? ["/d", "/c", executable, ...args] : args,
+    {
+      cwd: options.cwd ?? DEFAULT_REPO_ROOT,
+      encoding: "utf8",
+      shell: false,
+    },
+  );
   return {
     ok: result.status === 0,
     status: result.status,

--- a/scripts/dev-doctor.test.mjs
+++ b/scripts/dev-doctor.test.mjs
@@ -8,6 +8,7 @@ import {
   createDoctorReport,
   detectDevelopmentEnvironment,
   formatHumanReport,
+  selectWindowsCommand,
   satisfiesSimpleRange,
 } from "./dev-doctor.mjs";
 
@@ -40,6 +41,21 @@ test("dev-doctor enforces the repository Node runtime policy", () => {
   assert.equal(satisfiesSimpleRange("24.16.0", ">=24.11.0 <25"), true);
   assert.equal(satisfiesSimpleRange("24.10.0", ">=24.11.0 <25"), false);
   assert.equal(satisfiesSimpleRange("25.0.0", ">=24.11.0 <25"), false);
+});
+
+test("dev-doctor prefers executable Windows command shims", () => {
+  assert.equal(
+    selectWindowsCommand(
+      "corepack",
+      [
+        "C:\\Program Files\\nodejs\\corepack",
+        "C:\\Program Files\\nodejs\\corepack.cmd",
+        "",
+      ].join("\r\n"),
+    ),
+    "C:\\Program Files\\nodejs\\corepack.cmd",
+  );
+  assert.equal(selectWindowsCommand("missing", ""), "missing");
 });
 
 test("dev-doctor reports the full CI-safe monorepo environment contract", async () => {


### PR DESCRIPTION
## Summary

- Make pnpm 11 supply-chain controls explicit in `pnpm-workspace.yaml` with `minimumReleaseAge: 1440` and `blockExoticSubdeps: true`.
- Add `check:supply-chain` to validate pnpm config, security workflow coverage, and MCP server security script wiring.
- Document the `trustLockfile` decision and keep it disabled for public PR CI.
- Fix Windows local-check blockers found while running the aggregate pre-flight: Corepack/actionlint shim resolution and stale MCP README version validation.

## Linked issue

Fixes #202

## Type of change

- [ ] type:bug
- [ ] type:feature
- [ ] type:docs
- [ ] type:refactor
- [ ] type:perf
- [x] type:security
- [x] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm install --frozen-lockfile` passed.
- `corepack pnpm run check:supply-chain` passed.
- `corepack pnpm config list` showed `minimumReleaseAge: 1440` and `blockExoticSubdeps: true` from workspace config.
- `corepack pnpm --dir packages/mcp-server run security:audit` passed.
- `corepack pnpm audit --audit-level high` passed.
- `corepack pnpm run format:check`, `lint`, `typecheck`, `test`, `build`, and `verify:dist` passed.
- `KICADSTUDIO_PLAYWRIGHT_CHANNEL=chrome corepack pnpm run check` passed locally after Playwright headless-shell download stalled in the local cache; CI still installs the browser shell explicitly.
- `pre-commit run --all-files`, `gitleaks detect --source . --redact --no-banner`, deprecated workflow scan, and `git diff --check` passed.

## Protocol / MCP impact

- [x] Not applicable; reason: repository supply-chain policy and local validation scripts only. No MCP tool names, schemas, transports, server-info payloads, or extension MCP adapter behavior changed.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [ ] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts