### PR TITLE
fix(kicad-studio/kicad-mcp-pro): mark KiCad 9.x deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ All release surfaces are pinned to `1.0.0`:
 ## KiCad Compatibility
 
 KiCad Studio Kit treats KiCad `10.0.x` as the primary tested line, keeps KiCad
-`9.x` as a supported previous line, and keeps KiCad `8.x` as deprecated
-file-level compatibility. The canonical matrix, tested patch versions, CI
+`9.x` as deprecated best-effort compatibility after upstream EOL, and keeps
+KiCad `8.x` as deprecated file-level compatibility. The canonical matrix, tested patch versions, CI
 coverage level, and feature gates are maintained in
 [docs/support-matrix.md](docs/support-matrix.md) and `compatibility.yaml`.
 

--- a/apps/vscode-extension/CHANGELOG.md
+++ b/apps/vscode-extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Mark KiCad 9.x as a deprecated best-effort compatibility line in status
+  surfaces now that upstream active maintenance has ended.
 - Surface KiCad 8.x, 9.x, and 10.0.x compatibility state in the status
   bar/menu with feature-level capability probe results.
 - Clarify Codex support as an external MCP client workflow, remove it from the

--- a/apps/vscode-extension/src/cli/kicadCliSupport.ts
+++ b/apps/vscode-extension/src/cli/kicadCliSupport.ts
@@ -75,10 +75,10 @@ export function describeKiCadSupportLine(
   }
   if (major === 9) {
     return {
-      state: 'supported',
-      label: `${cli.versionLabel} supported`,
+      state: 'deprecated',
+      label: `${cli.versionLabel} deprecated`,
       detail:
-        'Supported previous KiCad line; covered by scheduled compatibility checks.'
+        'Deprecated KiCad line; upstream active maintenance ended after KiCad 10.0.0.'
     };
   }
   if (major === 8) {

--- a/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
+++ b/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
@@ -3,7 +3,7 @@ export const COMPATIBILITY_MATRIX = {
   kicad: {
     primary: '10.0.x',
     supported: ['10.0.x', '9.x', '8.x'],
-    deprecated: ['8.x']
+    deprecated: ['9.x', '8.x']
   },
   mcp: {
     protocolVersion: '2025-11-25',

--- a/apps/vscode-extension/test/unit/kicadCliSupport.test.ts
+++ b/apps/vscode-extension/test/unit/kicadCliSupport.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../src/cli/kicadCliSupport';
 
 describe('kicadCliSupport', () => {
-  it('classifies the supported KiCad 8, 9, and 10 support lines', () => {
+  it('classifies current KiCad lifecycle support lines', () => {
     expect(parseKiCadMajor({ version: '10.0.3' })).toBe(10);
     expect(
       describeKiCadSupportLine({
@@ -18,7 +18,7 @@ describe('kicadCliSupport', () => {
         version: '9.0.9',
         versionLabel: 'KiCad 9.0.9'
       }).state
-    ).toBe('supported');
+    ).toBe('deprecated');
     expect(
       describeKiCadSupportLine({
         version: '8.0.8',

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -1,8 +1,11 @@
 schemaVersion: 1
-updated: "2026-05-26"
+updated: "2026-05-27"
 source: "https://github.com/oaslananka/kicad-studio-kit"
 
 kicad:
+  # latestVerified must point to a published KiCad stable release confirmed by
+  # the official KiCad release notes and the KiCad/kicad-source-mirror release
+  # tag. Do not forward-reference patch numbers before both sources exist.
   primary: "10.0.x"
   latestVerified: "10.0.3"
   supported:
@@ -10,10 +13,16 @@ kicad:
       state: "primary"
       ci: "required"
       notes: "Primary optimized KiCad CLI and file-format target."
+    # Upstream ended active KiCad 9.x maintenance after KiCad 10.0.0 and
+    # described 9.0.9 as the final 9.0 bug-fix release. Keep this line in
+    # scheduled, non-blocking canaries until removal is announced in the next
+    # minor release.
     - range: "9.x"
-      state: "supported"
+      state: "deprecated"
+      upstreamEol: true
       ci: "scheduled"
-      notes: "Core PCB, schematic, validation, and export workflows remain supported."
+      removal: "next-minor-release"
+      notes: "Upstream KiCad 9.x is no longer actively maintained; core workflows remain best-effort while scheduled canaries gather removal evidence."
     - range: "8.x"
       state: "deprecated"
       ci: "manual"

--- a/docs/changelog/kicad-mcp-pro.md
+++ b/docs/changelog/kicad-mcp-pro.md
@@ -4,6 +4,8 @@ Source: `packages/mcp-server/CHANGELOG.md`
 
 ## [Unreleased]
 
+- Mark KiCad 9.x as a deprecated best-effort compatibility line in MCP
+  discovery metadata while retaining scheduled non-blocking canary coverage.
 - Add `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
   setup troubleshooting.
 - Add real KiCad CLI contract canaries with shared fixtures, Windows primary

--- a/docs/changelog/kicad-studio.md
+++ b/docs/changelog/kicad-studio.md
@@ -4,6 +4,8 @@ Source: `apps/vscode-extension/CHANGELOG.md`
 
 ## [Unreleased]
 
+- Mark KiCad 9.x as a deprecated best-effort compatibility line in status
+  surfaces now that upstream active maintenance has ended.
 - Surface KiCad 8.x, 9.x, and 10.0.x compatibility state in the status
   bar/menu with feature-level capability probe results.
 - Clarify Codex support as an external MCP client workflow, remove it from the

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -26,7 +26,7 @@ Machine-maintained from `compatibility.yaml`. Refresh with
 | Range | State | CI | Notes |
 | --- | --- | --- | --- |
 | 10.0.x | primary | required | Primary optimized KiCad CLI and file-format target. |
-| 9.x | supported | scheduled | Core PCB, schematic, validation, and export workflows remain supported. |
+| 9.x | deprecated | scheduled | Upstream KiCad 9.x is no longer actively maintained; core workflows remain best-effort while scheduled canaries gather removal evidence. |
 | 8.x | deprecated | manual | File-level read and migration support only; removal requires a release note. |
 
 ### Product Versions
@@ -54,12 +54,12 @@ extension features. The runtime checks intentionally probe CLI command help
 before running commands; a version line alone is not enough to enable advanced
 exports.
 
-| KiCad line | Tested patch | Support state | Required validation                         | Extension feature state                                                                                                                                                                     |
-| ---------- | ------------ | ------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 10.0.x     | 10.0.3       | Primary       | Required release gate and KiCad canary lane | Core DRC/ERC, BOM/netlist, Gerbers/drill, jobsets, design variants, 3D PDF, and ODB++ are supported when command probes pass.                                                               |
-| 9.x        | 9.0.9        | Supported     | Scheduled KiCad canary lane                 | Core DRC/ERC, BOM/netlist, Gerbers/drill, jobsets, ODB++, and manufacturing package workflows are supported when command probes pass; KiCad 10-only variants and 3D PDF remain unavailable. |
-| 8.x        | 8.0.x        | Deprecated    | Manual compatibility check                  | Core file-level read, migration, DRC/ERC, BOM/netlist, and Gerber workflows are best-effort when command probes pass; jobsets, variants, 3D PDF, and ODB++ remain unavailable.              |
-| <8         | none         | Unsupported   | None                                        | KiCad Studio reports the detected CLI as unsupported and does not claim feature compatibility.                                                                                              |
+| KiCad line | Tested patch | Support state | Required validation                         | Extension feature state                                                                                                                                                                          |
+| ---------- | ------------ | ------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 10.0.x     | 10.0.3       | Primary       | Required release gate and KiCad canary lane | Core DRC/ERC, BOM/netlist, Gerbers/drill, jobsets, design variants, 3D PDF, and ODB++ are supported when command probes pass.                                                                    |
+| 9.x        | 9.0.9        | Deprecated    | Scheduled non-blocking KiCad canary lane    | Core DRC/ERC, BOM/netlist, Gerbers/drill, jobsets, ODB++, and manufacturing package workflows remain best-effort when command probes pass; KiCad 10-only variants and 3D PDF remain unavailable. |
+| 8.x        | 8.0.x        | Deprecated    | Manual compatibility check                  | Core file-level read, migration, DRC/ERC, BOM/netlist, and Gerber workflows are best-effort when command probes pass; jobsets, variants, 3D PDF, and ODB++ remain unavailable.                   |
+| <8         | none         | Unsupported   | None                                        | KiCad Studio reports the detected CLI as unsupported and does not claim feature compatibility.                                                                                                   |
 
 ## KiCad 11 Readiness
 
@@ -82,13 +82,19 @@ Status surfaces:
 - The status bar shows the detected KiCad support line and warns on deprecated or unsupported CLIs.
 - The `KiCad Studio Commands` status menu lists feature-level availability with precise unsupported reasons.
 - Advanced commands such as ODB++ and 3D PDF export require both their documented KiCad line and a successful `kicad-cli` capability probe.
+- KiCad 9.x remains in feature gates for migration compatibility, but status
+  surfaces label it deprecated because upstream active maintenance ended after
+  KiCad 10.0.0.
 - KiCad 10.0.3 patch-specific regression coverage is tracked by
   [`kicad-10-0-3-regressions`](kicad-fixture-corpus.md#fixture-coverage).
 
-Freshness sources checked on 2026-05-26:
+Freshness sources checked on 2026-05-27:
 
 - KiCad 10.0.3 release notes: <https://www.kicad.org/blog/2026/05/KiCad-10.0.3-Release/>
+- KiCad 10.0.3 GitHub release tag: <https://github.com/KiCad/kicad-source-mirror/releases/tag/10.0.3>
+- KiCad 10.0.0 GitHub release note for KiCad 9.x active-maintenance EOL: <https://github.com/KiCad/kicad-source-mirror/releases/tag/10.0.0>
 - KiCad 9.0.9 release notes: <https://www.kicad.org/blog/2026/04/KiCad-9.0.9-Release/>
+- KiCad 9.0.9 RC note for final 9.0 bug-fix policy: <https://www.kicad.org/blog/2026/04/KiCad-Version-9.0.9-Release-Candidate-1-Available/>
 - KiCad 10.0 CLI reference: <https://docs.kicad.org/10.0/en/cli/cli.html>
 - KiCad nightly CLI reference: <https://docs.kicad.org/master/en/cli/cli.html>
 - KiCad PCB Python bindings deprecation notice: <https://dev-docs.kicad.org/en/apis-and-binding/pcbnew/>
@@ -109,7 +115,7 @@ Freshness sources checked on 2026-05-26:
 
 | Surface      | Primary    | Supported              | Deprecated | Gate                                     |
 | ------------ | ---------- | ---------------------- | ---------- | ---------------------------------------- |
-| KiCad        | 10.0.x     | 9.x                    | 8.x        | `compatibility.yaml` + release preflight |
+| KiCad        | 10.0.x     | none                   | 9.x, 8.x   | `compatibility.yaml` + release preflight |
 | VS Code      | current    | `engines.vscode` 1.120 | none       | extension manifest + VS Code canary      |
 | MCP protocol | 2025-11-25 | 2025-11-25             | older      | well-known server card + matrix          |
 | Node         | 24.x       | `>=24.11.0 <25`        | older      | root and extension package metadata      |
@@ -141,8 +147,8 @@ Python:
 
 KiCad:
 
-- `compatibility.yaml` declares the primary KiCad line, supported previous line, deprecated line,
-  and latest verified patch release.
+- `compatibility.yaml` declares the primary KiCad line, deprecated previous lines,
+  upstream EOL annotations, and latest verified patch release.
 - The primary KiCad line should match the official current stable line once the canary lane is
   green.
 - Lowering the primary line or widening support back to an older line requires both product

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -10,22 +10,22 @@ notes can add detail, but they should not weaken these gates.
 
 ## Gate Summary
 
-| Gate                 | Trigger                                                              | Purpose                                                                                         | Required command                                   |
-| -------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| Fast PR gate         | Every pull request                                                   | Catch formatting, lint, type, unit, package, metadata, boundary, and compatibility regressions. | `corepack pnpm run check`                          |
-| Bug-fix regression   | Every bug-fix pull request                                           | Prove the repeatable bug fails before the fix, passes after it, and references the issue.       | Relevant test command plus PR checklist evidence   |
-| Performance budget   | Product, integration, and shared fixture/schema pull requests        | Report shared baseline drift and fail measured lanes that exceed the regression budget.         | `corepack pnpm run check:performance-budgets`      |
-| Product gate         | Product-scoped changes                                               | Prove the touched product still builds, tests, and packages independently.                      | Product commands below                             |
-| Accessibility gate   | Extension-owned UI and webview changes                               | Prove WCAG 2.1 AA automated checks remain clean for in-scope extension surfaces.                | `corepack pnpm --filter kicadstudio run test:a11y` |
-| Contract gate        | Protocol, compatibility, or cross-product changes                    | Prove extension and MCP assumptions remain aligned.                                             | `corepack pnpm run test:contract`                  |
-| Protocol PR gate     | Protocol, compatibility, or cross-product review changes             | Keep protocol-impact PRs visible through the PR template and architecture guidance.             | `corepack pnpm run check:protocol-pr-template`     |
-| GUI smoke policy     | Real KiCad GUI smoke workflow/test wiring changes                    | Keep live-editor IPC smoke coverage wired without adding GUI work to the PR path.               | `corepack pnpm run check:kicad-gui-smoke`          |
-| Fixture gate         | Parser, diagnostics, command-builder, or KiCad file behavior changes | Prove deterministic KiCad corpus behavior stays stable.                                         | `corepack pnpm run test:fixtures`                  |
-| Nightly quality gate | Scheduled and manual workflow                                        | Re-run the repository gate plus contract and fixture gates outside the fast PR path.            | `.github/workflows/nightly-quality-gates.yml`      |
-| KiCad GUI smoke      | Scheduled and manual workflow                                        | Launch real KiCad editors on Windows primary plus Linux Xvfb and verify MCP live PCB context.   | `.github/workflows/kicad-gui-smoke.yml`            |
-| VS Code canary       | Scheduled and manual workflow                                        | Check supported VS Code host lanes before runtime/API changes reach users.                      | `.github/workflows/vscode-canary.yml`              |
-| KiCad canary         | Scheduled and manual workflow                                        | Check supported KiCad CLI lanes against real fixture exports without publishing packages.       | `.github/workflows/kicad-canary.yml`               |
-| Manual smoke         | Release candidate only                                               | Final human inspection where automation is not practical.                                       | PR notes must name the exact manual check          |
+| Gate                 | Trigger                                                              | Purpose                                                                                                | Required command                                   |
+| -------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| Fast PR gate         | Every pull request                                                   | Catch formatting, lint, type, unit, package, metadata, boundary, and compatibility regressions.        | `corepack pnpm run check`                          |
+| Bug-fix regression   | Every bug-fix pull request                                           | Prove the repeatable bug fails before the fix, passes after it, and references the issue.              | Relevant test command plus PR checklist evidence   |
+| Performance budget   | Product, integration, and shared fixture/schema pull requests        | Report shared baseline drift and fail measured lanes that exceed the regression budget.                | `corepack pnpm run check:performance-budgets`      |
+| Product gate         | Product-scoped changes                                               | Prove the touched product still builds, tests, and packages independently.                             | Product commands below                             |
+| Accessibility gate   | Extension-owned UI and webview changes                               | Prove WCAG 2.1 AA automated checks remain clean for in-scope extension surfaces.                       | `corepack pnpm --filter kicadstudio run test:a11y` |
+| Contract gate        | Protocol, compatibility, or cross-product changes                    | Prove extension and MCP assumptions remain aligned.                                                    | `corepack pnpm run test:contract`                  |
+| Protocol PR gate     | Protocol, compatibility, or cross-product review changes             | Keep protocol-impact PRs visible through the PR template and architecture guidance.                    | `corepack pnpm run check:protocol-pr-template`     |
+| GUI smoke policy     | Real KiCad GUI smoke workflow/test wiring changes                    | Keep live-editor IPC smoke coverage wired without adding GUI work to the PR path.                      | `corepack pnpm run check:kicad-gui-smoke`          |
+| Fixture gate         | Parser, diagnostics, command-builder, or KiCad file behavior changes | Prove deterministic KiCad corpus behavior stays stable.                                                | `corepack pnpm run test:fixtures`                  |
+| Nightly quality gate | Scheduled and manual workflow                                        | Re-run the repository gate plus contract and fixture gates outside the fast PR path.                   | `.github/workflows/nightly-quality-gates.yml`      |
+| KiCad GUI smoke      | Scheduled and manual workflow                                        | Launch real KiCad editors on Windows primary plus Linux Xvfb and verify MCP live PCB context.          | `.github/workflows/kicad-gui-smoke.yml`            |
+| VS Code canary       | Scheduled and manual workflow                                        | Check supported VS Code host lanes before runtime/API changes reach users.                             | `.github/workflows/vscode-canary.yml`              |
+| KiCad canary         | Scheduled and manual workflow                                        | Check primary and deprecated KiCad CLI lanes against real fixture exports without publishing packages. | `.github/workflows/kicad-canary.yml`               |
+| Manual smoke         | Release candidate only                                               | Final human inspection where automation is not practical.                                              | PR notes must name the exact manual check          |
 
 ## Test Layers
 
@@ -42,7 +42,7 @@ notes can add detail, but they should not weaken these gates.
 | MCP integration tests                 | File-backed KiCad behavior, export/manufacturing tools, project quality gates, simulation and routing tools.                                                                                               | `packages/mcp-server/tests/integration/`                                                          | pytest plus optional `kicad-cli`                               | Nightly gate unless the fixture is pure and fast       |
 | MCP E2E tests                         | Server startup, stdio, journal/rollback, release-gate workflows.                                                                                                                                           | `packages/mcp-server/tests/e2e/`                                                                  | pytest                                                         | Nightly gate                                           |
 | Performance budgets                   | Shared activation, scan, viewer, validation, MCP, and memory baselines plus PR budget reports.                                                                                                             | `performance/baselines.json`, `performance-results/`                                              | Node checker, benchmark producers, GitHub workflow artifacts   | Fast PR gate                                           |
-| KiCad CLI contract tests              | KiCad 10 primary behavior plus supported 9.x and deprecated 8.x compatibility where supported.                                                                                                             | Shared fixtures and MCP integration tests                                                         | `kicad-cli`                                                    | Nightly/canary gate                                    |
+| KiCad CLI contract tests              | KiCad 10 primary behavior plus deprecated best-effort 9.x and 8.x compatibility where supported.                                                                                                           | Shared fixtures and MCP integration tests                                                         | `kicad-cli`                                                    | Nightly/canary gate                                    |
 | MCP transport contract tests          | Streamable HTTP initialize flow, initialized notification, session handling, mount paths, stateless behavior, legacy SSE opt-in, `MCP-Protocol-Version`, tool discovery, tool calls, errors, and timeouts. | MCP transport conformance suite and future shared contract package                                | pytest/http client                                             | Contract gate                                          |
 | Real-pair tests                       | Built VS Code extension connected to built MCP server against fixture workspaces.                                                                                                                          | Future shared harness                                                                             | VS Code test host plus local MCP server                        | Nightly gate                                           |
 | Real KiCad GUI IPC smoke              | KiCad application IPC behavior that cannot be proven by file-backed CLI tests.                                                                                                                             | `packages/mcp-server/tests/gui/`                                                                  | KiCad GUI, Xvfb, fixture workspace, MCP server tools           | Nightly/manual only                                    |
@@ -210,22 +210,24 @@ As the M1-M4 roadmap lands, extend this workflow in focused PRs:
 | Server-info contract tests | OASLANA-57     | Verify advertised server-info, capability metadata, and compatibility ranges.                                                                                                |
 | Real-pair E2E              | OASLANA-75     | Build both products, start the server, launch the extension host, connect them, and validate capability handshakes.                                                          |
 | VS Code canary             | OASLANA-81     | Run current stable, insiders, and minimum supported VS Code versions.                                                                                                        |
-| KiCad canary               | OASLANA-82     | Run primary, supported, deprecated, and prerelease KiCad CLI lanes where practical.                                                                                          |
+| KiCad canary               | OASLANA-82     | Run primary, deprecated, and prerelease KiCad CLI lanes where practical.                                                                                                     |
 
 ## KiCad Canary
 
 `.github/workflows/kicad-canary.yml` runs real `kicad-cli` compatibility lanes
 from `compatibility.yaml` every week and on manual dispatch. Required and
-scheduled lanes run by default; manual dispatch can opt into deprecated lanes
-that remain documented but should not block normal scheduled canaries.
+scheduled lanes run by default. Deprecated scheduled lanes run as
+continue-on-error compatibility signals, and manual dispatch can opt into
+manual deprecated lanes that remain documented but do not block normal
+scheduled canaries.
 
 Pull requests that touch the KiCad contract harness, compatibility metadata, or
 fixture corpus run the required KiCad contract smoke lanes only. The PR smoke
 matrix covers the primary KiCad 10.0.x line on Windows with the Chocolatey
 KiCad 10.0.3 install path under `C:\Program Files\KiCad\10.0\bin`, plus the
 Linux primary lane from the KiCad 10 release PPA. Scheduled and manual runs keep
-the heavier matrix: primary 10.0.x, supported 9.x, prerelease/nightly 10.x, and
-manual opt-in deprecated 8.x.
+the heavier matrix: primary 10.0.x, deprecated non-blocking 9.x,
+prerelease/nightly 10.x, and manual opt-in deprecated 8.x.
 
 KiCad 11 readiness is documented as a manual smoke path until a stable package
 or release candidate lane can be installed deterministically in CI. The current

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Mark KiCad 9.x as a deprecated best-effort compatibility line in MCP
+  discovery metadata while retaining scheduled non-blocking canary coverage.
 - Add `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
   setup troubleshooting.
 - Add real KiCad CLI contract canaries with shared fixtures, Windows primary

--- a/packages/mcp-server/scripts/check_compatibility_matrix.py
+++ b/packages/mcp-server/scripts/check_compatibility_matrix.py
@@ -24,6 +24,8 @@ REQUIRED_IPC_AREAS = (
     "export",
     "diagnostics",
 )
+KICAD_SUPPORT_STATES = {"primary", "supported", "deprecated"}
+KICAD_CI_MODES = {"required", "scheduled", "manual"}
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -170,10 +172,51 @@ def _validate_required_shape(matrix: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _validate_kicad_support_policy(matrix: dict[str, Any]) -> list[str]:
+    kicad = matrix.get("kicad")
+    if not isinstance(kicad, dict):
+        return ["compatibility.yaml kicad must be a mapping"]
+    primary = kicad.get("primary")
+    if not isinstance(primary, str) or not primary:
+        return ["compatibility.yaml kicad.primary must be a non-empty string"]
+    entries = kicad.get("supported")
+    if not isinstance(entries, list) or not entries:
+        return ["compatibility.yaml kicad.supported must be a non-empty list"]
+
+    errors: list[str] = []
+    primary_entries = 0
+    for index, entry in enumerate(entries):
+        label = f"kicad.supported[{index}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+        kicad_range = entry.get("range")
+        state = entry.get("state")
+        ci_mode = entry.get("ci")
+        if not isinstance(kicad_range, str) or not kicad_range:
+            errors.append(f"{label}.range must be a non-empty string")
+        if state not in KICAD_SUPPORT_STATES:
+            errors.append(f"{label}.state must be one of {sorted(KICAD_SUPPORT_STATES)!r}")
+        if ci_mode not in KICAD_CI_MODES:
+            errors.append(f"{label}.ci must be one of {sorted(KICAD_CI_MODES)!r}")
+        if not isinstance(entry.get("notes"), str) or not entry["notes"]:
+            errors.append(f"{label}.notes must be a non-empty string")
+        if entry.get("upstreamEol") is True and state != "deprecated":
+            errors.append(f"{label} marks upstreamEol but is not deprecated")
+        if kicad_range == primary:
+            primary_entries += 1
+            if state != "primary" or ci_mode != "required":
+                errors.append(f"{label} must be primary and required for {primary!r}")
+    if primary_entries != 1:
+        errors.append(f"kicad.supported must contain exactly one primary entry for {primary!r}")
+    return errors
+
+
 def validate_compatibility_matrix() -> list[str]:
     """Return compatibility drift errors without exiting."""
     matrix = _read_yaml(REPO_ROOT / "compatibility.yaml")
     errors = _validate_required_shape(matrix)
+    errors.extend(_validate_kicad_support_policy(matrix))
     if errors:
         return errors
 

--- a/packages/mcp-server/src/kicad_mcp/compatibility.py
+++ b/packages/mcp-server/src/kicad_mcp/compatibility.py
@@ -14,7 +14,7 @@ COMPATIBILITY_MATRIX: Final[dict[str, object]] = {
     "kicad": {
         "primary": PRIMARY_KICAD_VERSION,
         "supported": ["10.0.x", "9.x", "8.x"],
-        "deprecated": ["8.x"],
+        "deprecated": ["9.x", "8.x"],
     },
     "mcp": {
         "protocolVersion": MCP_PROTOCOL_VERSION,

--- a/packages/mcp-server/src/kicad_mcp/wellknown.py
+++ b/packages/mcp-server/src/kicad_mcp/wellknown.py
@@ -57,7 +57,7 @@ def get_wellknown_metadata() -> dict[str, object]:
         "serverInfoContract": get_server_info_contract(probe_live_context=False),
         "compatibility": compatibility_summary(),
         "kicad_version_required": (
-            "10.0.x primary, 9.x supported, 8.x deprecated file-level fallback"
+            "10.0.x primary, 9.x deprecated best-effort, 8.x deprecated file-level fallback"
         ),
         "docs": "https://oaslananka.github.io/kicad-studio-kit",
         "registry": "io.github.oaslananka/kicad-mcp-pro",

--- a/packages/mcp-server/tests/unit/test_compatibility_matrix.py
+++ b/packages/mcp-server/tests/unit/test_compatibility_matrix.py
@@ -24,6 +24,18 @@ def test_repository_compatibility_matrix_has_no_drift() -> None:
     assert validate_compatibility_matrix() == []
 
 
+def test_kicad_9_upstream_eol_policy_is_deprecated() -> None:
+    matrix = yaml.safe_load((REPO_ROOT / "compatibility.yaml").read_text(encoding="utf-8"))
+    kicad_9 = next(entry for entry in matrix["kicad"]["supported"] if entry["range"] == "9.x")
+
+    assert kicad_9["state"] == "deprecated"
+    assert kicad_9["upstreamEol"] is True
+    assert kicad_9["ci"] == "scheduled"
+    assert kicad_9["removal"] == "next-minor-release"
+    assert "no longer actively maintained" in kicad_9["notes"]
+    assert COMPATIBILITY_MATRIX["kicad"]["deprecated"] == ["9.x", "8.x"]
+
+
 def test_kicad_ipc_readiness_contract_covers_pcbnew_and_parity() -> None:
     matrix = yaml.safe_load((REPO_ROOT / "compatibility.yaml").read_text(encoding="utf-8"))
     readiness = matrix["kicadIpcReadiness"]

--- a/packages/mcp-server/tests/unit/test_kicad_canary.py
+++ b/packages/mcp-server/tests/unit/test_kicad_canary.py
@@ -20,7 +20,8 @@ def _compatibility_matrix() -> dict[str, object]:
                 },
                 {
                     "range": "9.x",
-                    "state": "supported",
+                    "state": "deprecated",
+                    "upstreamEol": True,
                     "ci": "scheduled",
                 },
                 {
@@ -41,7 +42,7 @@ def _compatibility_matrix() -> dict[str, object]:
     }
 
 
-def test_kicad_canary_matrix_uses_scheduled_compatibility_lanes() -> None:
+def test_kicad_canary_matrix_uses_scheduled_non_blocking_deprecated_lanes() -> None:
     matrix = build_canary_matrix(_compatibility_matrix(), include_manual=False)
 
     assert matrix == {
@@ -68,15 +69,15 @@ def test_kicad_canary_matrix_uses_scheduled_compatibility_lanes() -> None:
                 "continue_on_error": False,
             },
             {
-                "id": "kicad-9-supported-linux",
+                "id": "kicad-9-deprecated-linux",
                 "range": "9.x",
-                "state": "supported",
+                "state": "deprecated",
                 "ci": "scheduled",
                 "os": "ubuntu-24.04",
                 "install": "apt-ppa",
                 "ppa": "ppa:kicad/kicad-9.0-releases",
                 "package": "kicad",
-                "continue_on_error": False,
+                "continue_on_error": True,
             },
             {
                 "id": "kicad-10-nightly-linux",


### PR DESCRIPTION
## Summary

- Keep `kicad.latestVerified` at `10.0.3` because official KiCad release notes and the `KiCad/kicad-source-mirror` release tag now confirm it exists.
- Mark KiCad 9.x as deprecated with `upstreamEol: true`, removal intent, scheduled non-blocking canary coverage, and user-facing status/docs/changelog updates.
- Add compatibility-matrix and canary regression tests so upstream-EOL lines cannot stay marked supported by accident.

## Linked issue

Closes #200

## Type of change

- [x] type:bug
- [ ] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm install --frozen-lockfile` passed.
- Workflow deprecation scan for `::set-output`, `::save-state`, insecure Node override, `node12`, `node16`, and `node20` passed.
- `corepack pnpm run format:check` passed.
- `corepack pnpm run lint` passed.
- `corepack pnpm run typecheck` passed.
- `corepack pnpm run test` passed after rerunning with a longer tool timeout.
- `corepack pnpm run build` passed.
- `gitleaks detect --source . --redact --no-banner` passed.
- `corepack pnpm run verify:dist` passed.
- `uv sync --all-extras --frozen --project packages/mcp-server` passed.
- `uv run --project packages/mcp-server --all-extras pytest` passed: 713 passed, 5 skipped.
- `KICADSTUDIO_PLAYWRIGHT_CHANNEL=chrome corepack pnpm --filter kicadstudio run check` passed.
- `KICADSTUDIO_PLAYWRIGHT_CHANNEL=chrome corepack pnpm run check` passed.
- `pre-commit run --all-files` passed.

Regression coverage:
- `packages/mcp-server/tests/unit/test_compatibility_matrix.py::test_kicad_9_upstream_eol_policy_is_deprecated`
- `packages/mcp-server/tests/unit/test_kicad_canary.py::test_kicad_canary_matrix_uses_scheduled_non_blocking_deprecated_lanes`
- `apps/vscode-extension/test/unit/kicadCliSupport.test.ts` KiCad 9.x lifecycle classification

Source verification:
- Official KiCad release notes category now contains KiCad 10.0.3.
- `gh api repos/KiCad/kicad-source-mirror/releases/tags/10.0.3` returns tag `10.0.3`.
- KiCad 10.0.0 GitHub release body contains the KiCad 9.x active-maintenance EOL statement.
- KiCad 9.0.9 RC post contains the final 9.0 bug-fix release policy text.

## Protocol / MCP impact

- [ ] Not applicable; reason:
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [x] Contract tests updated
- [x] Compatibility matrix updated
- [x] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

Compatibility impact: KiCad 9.x remains in feature gates for migration compatibility, but lifecycle metadata and UI/server discovery now classify it as deprecated because upstream active maintenance ended.

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [ ] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [x] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts