### PR TITLE
ci(repo): align uv pin for release metadata sync

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,6 +68,25 @@ jobs:
 
             corepack enable
             corepack pnpm install --frozen-lockfile
+            # Release Please branches can lag main; match uv to the branch pin before syncing.
+            branch_uv_version="$(sed -nE 's/^required-version[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' packages/mcp-server/uv.toml)"
+            if [ -z "${branch_uv_version}" ]; then
+              echo "Unable to read required uv version from packages/mcp-server/uv.toml" >&2
+              exit 1
+            fi
+
+            current_uv_version="$(uv --version | awk '{print $2}')"
+            if [ "${current_uv_version}" != "${branch_uv_version}" ]; then
+              curl -LsSf "https://astral.sh/uv/${branch_uv_version}/install.sh" | sh
+              export PATH="${HOME}/.local/bin:${PATH}"
+            fi
+
+            actual_uv_version="$(uv --version | awk '{print $2}')"
+            if [ "${actual_uv_version}" != "${branch_uv_version}" ]; then
+              echo "Expected uv ${branch_uv_version}, found ${actual_uv_version}" >&2
+              exit 1
+            fi
+
             uv sync --all-extras --frozen --project packages/mcp-server
             corepack pnpm --dir packages/mcp-server run metadata:sync
 


### PR DESCRIPTION
## Summary

Fixes the post-merge Release Please failure from PR #221. The metadata sync job switched into stale open Release Please branches whose `packages/mcp-server/uv.toml` still required `uv 0.11.12`, while the runner had already installed `uv 0.11.16` from main. The workflow now re-reads each checked-out release branch's `uv.toml`, installs that exact uv version when needed, and verifies it before `uv sync`.

## Linked issue

Closes #198

## Type of change

- [ ] type:bug
- [ ] type:feature
- [ ] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [x] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm install --frozen-lockfile` passed
- `corepack pnpm run format:check` passed
- `corepack pnpm run lint` passed
- `corepack pnpm run typecheck` passed
- `corepack pnpm run test` passed
- `corepack pnpm run build` passed
- `corepack pnpm audit --audit-level high` passed
- `corepack pnpm --dir packages/mcp-server run security` passed
- `corepack pnpm run verify:dist` passed
- `uv sync --all-extras --frozen --project packages/mcp-server` passed
- `uv run --project packages/mcp-server --all-extras pytest` passed (`713 passed, 5 skipped`)
- `KICADSTUDIO_PLAYWRIGHT_CHANNEL=chrome corepack pnpm run check` passed
- `actionlint` passed for all workflows with an explicit file list
- `yamllint .github/workflows/` passed
- `gitleaks detect --source . --redact --no-banner` passed
- `act -W .github/workflows/release-please.yml -l` passed
- `act -n -W .github/workflows/release-please.yml` passed
- `pre-commit run --all-files` passed

Regression evidence: failed main run `26497012546` reached `uv sync` on `release-please--branches--main--groups--kicad-mcp-pro` with branch `uv.toml` requiring `0.11.12` while the runner had `0.11.16`. This PR makes the workflow align uv after each branch switch.

## Protocol / MCP impact

- [x] Not applicable; reason: CI workflow-only fix for Release Please metadata synchronization. No MCP tool names, schemas, transport behavior, server-info payloads, compatibility metadata, or extension adapter behavior changed.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [ ] Docs updated
- [ ] Release notes considered for both products
- [ ] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [x] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
