### PR TITLE
docs(kicad-studio/kicad-mcp-pro/repo): normalize changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
-## 1.0.0
+All notable changes to the KiCad Studio Kit monorepo will be documented in this
+file.
 
-- Establish the canonical KiCad Studio Kit monorepo baseline.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and released packages in this repository adhere to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html). The root changelog
+records repository-wide release governance and monorepo changes; product
+changelogs remain the release-owned sources for package-specific changes.
+
+Comparison links will be added after the first public release tags are
+published.
+
+## [Unreleased]
+
+### Changed
+
+- Normalized the root and product changelog sources to Keep a Changelog 1.1.0
+  structure so release evidence and generated docs can be audited consistently.
+
+## [1.0.0] - 2026-05-20
+
+### Added
+
+- Established the canonical KiCad Studio Kit monorepo baseline.

--- a/apps/vscode-extension/CHANGELOG.md
+++ b/apps/vscode-extension/CHANGELOG.md
@@ -1,21 +1,41 @@
 # Changelog
 
+All notable changes to the KiCad Studio VS Code extension will be documented in
+this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this extension adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Comparison links will be added after the first public component tags are
+published.
+
 ## [Unreleased]
 
-- Mark KiCad 9.x as a deprecated best-effort compatibility line in status
-  surfaces now that upstream active maintenance has ended.
+### Added
+
 - Surface KiCad 8.x, 9.x, and 10.0.x compatibility state in the status
   bar/menu with feature-level capability probe results.
-- Clarify Codex support as an external MCP client workflow, remove it from the
-  direct extension provider settings, and migrate legacy
-  `kicadstudio.ai.provider=codex` selections to GitHub Copilot.
 - Add explicit KiCanvas/CLI SVG fallback/metadata-only viewer engine state,
   toolbar engine badges, unsupported-control disabling, and regression coverage
   for fallback diagnostics.
+
+### Changed
+
+- Clarify Codex support as an external MCP client workflow, remove it from the
+  direct extension provider settings, and migrate legacy
+  `kicadstudio.ai.provider=codex` selections to GitHub Copilot.
 - Restyle the KiCanvas viewer toolbar with VS Code theme tokens, compact
   spacing, and a single primary reload action for dark, light, and high-contrast
   themes.
 
-## [1.0.0]
+### Deprecated
 
-- Baseline KiCad Studio extension release from the canonical monorepo.
+- Mark KiCad 9.x as a deprecated best-effort compatibility line in status
+  surfaces now that upstream active maintenance has ended.
+
+## [1.0.0] - 2026-05-20
+
+### Added
+
+- Released the baseline KiCad Studio extension from the canonical monorepo.

--- a/apps/vscode-extension/CHANGELOG.md
+++ b/apps/vscode-extension/CHANGELOG.md
@@ -14,24 +14,24 @@ published.
 
 ### Added
 
-- Surface KiCad 8.x, 9.x, and 10.0.x compatibility state in the status
+- Surfaced KiCad 8.x, 9.x, and 10.0.x compatibility state in the status
   bar/menu with feature-level capability probe results.
-- Add explicit KiCanvas/CLI SVG fallback/metadata-only viewer engine state,
+- Added explicit KiCanvas/CLI SVG fallback/metadata-only viewer engine state,
   toolbar engine badges, unsupported-control disabling, and regression coverage
   for fallback diagnostics.
 
 ### Changed
 
-- Clarify Codex support as an external MCP client workflow, remove it from the
-  direct extension provider settings, and migrate legacy
+- Clarified Codex support as an external MCP client workflow, removed it from the
+  direct extension provider settings, and migrated legacy
   `kicadstudio.ai.provider=codex` selections to GitHub Copilot.
-- Restyle the KiCanvas viewer toolbar with VS Code theme tokens, compact
+- Restyled the KiCanvas viewer toolbar with VS Code theme tokens, compact
   spacing, and a single primary reload action for dark, light, and high-contrast
   themes.
 
 ### Deprecated
 
-- Mark KiCad 9.x as a deprecated best-effort compatibility line in status
+- Marked KiCad 9.x as a deprecated best-effort compatibility line in status
   surfaces now that upstream active maintenance has ended.
 
 ## [1.0.0] - 2026-05-20

--- a/docs/changelog/kicad-mcp-pro.md
+++ b/docs/changelog/kicad-mcp-pro.md
@@ -2,16 +2,33 @@
 
 Source: `packages/mcp-server/CHANGELOG.md`
 
+All notable changes to the `kicad-mcp-pro` Python server will be documented in
+this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this package adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Comparison links will be added after the first public component tags are
+published.
+
 ## [Unreleased]
 
-- Mark KiCad 9.x as a deprecated best-effort compatibility line in MCP
-  discovery metadata while retaining scheduled non-blocking canary coverage.
+### Added
+
 - Add `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
   setup troubleshooting.
 - Add real KiCad CLI contract canaries with shared fixtures, Windows primary
   KiCad 10.0.3 smoke coverage, scheduled 9.x/10.x lanes, and structured
   unsupported-feature artifacts.
 
-## [1.0.0]
+### Deprecated
 
-- Baseline KiCad MCP Pro server release from the canonical monorepo.
+- Mark KiCad 9.x as a deprecated best-effort compatibility line in MCP
+  discovery metadata while retaining scheduled non-blocking canary coverage.
+
+## [1.0.0] - 2026-05-20
+
+### Added
+
+- Released the baseline KiCad MCP Pro server from the canonical monorepo.

--- a/docs/changelog/kicad-mcp-pro.md
+++ b/docs/changelog/kicad-mcp-pro.md
@@ -16,15 +16,15 @@ published.
 
 ### Added
 
-- Add `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
+- Added `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
   setup troubleshooting.
-- Add real KiCad CLI contract canaries with shared fixtures, Windows primary
+- Added real KiCad CLI contract canaries with shared fixtures, Windows primary
   KiCad 10.0.3 smoke coverage, scheduled 9.x/10.x lanes, and structured
   unsupported-feature artifacts.
 
 ### Deprecated
 
-- Mark KiCad 9.x as a deprecated best-effort compatibility line in MCP
+- Marked KiCad 9.x as a deprecated best-effort compatibility line in MCP
   discovery metadata while retaining scheduled non-blocking canary coverage.
 
 ## [1.0.0] - 2026-05-20

--- a/docs/changelog/kicad-studio.md
+++ b/docs/changelog/kicad-studio.md
@@ -2,22 +2,42 @@
 
 Source: `apps/vscode-extension/CHANGELOG.md`
 
+All notable changes to the KiCad Studio VS Code extension will be documented in
+this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this extension adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Comparison links will be added after the first public component tags are
+published.
+
 ## [Unreleased]
 
-- Mark KiCad 9.x as a deprecated best-effort compatibility line in status
-  surfaces now that upstream active maintenance has ended.
+### Added
+
 - Surface KiCad 8.x, 9.x, and 10.0.x compatibility state in the status
   bar/menu with feature-level capability probe results.
-- Clarify Codex support as an external MCP client workflow, remove it from the
-  direct extension provider settings, and migrate legacy
-  `kicadstudio.ai.provider=codex` selections to GitHub Copilot.
 - Add explicit KiCanvas/CLI SVG fallback/metadata-only viewer engine state,
   toolbar engine badges, unsupported-control disabling, and regression coverage
   for fallback diagnostics.
+
+### Changed
+
+- Clarify Codex support as an external MCP client workflow, remove it from the
+  direct extension provider settings, and migrate legacy
+  `kicadstudio.ai.provider=codex` selections to GitHub Copilot.
 - Restyle the KiCanvas viewer toolbar with VS Code theme tokens, compact
   spacing, and a single primary reload action for dark, light, and high-contrast
   themes.
 
-## [1.0.0]
+### Deprecated
 
-- Baseline KiCad Studio extension release from the canonical monorepo.
+- Mark KiCad 9.x as a deprecated best-effort compatibility line in status
+  surfaces now that upstream active maintenance has ended.
+
+## [1.0.0] - 2026-05-20
+
+### Added
+
+- Released the baseline KiCad Studio extension from the canonical monorepo.

--- a/docs/changelog/kicad-studio.md
+++ b/docs/changelog/kicad-studio.md
@@ -16,24 +16,24 @@ published.
 
 ### Added
 
-- Surface KiCad 8.x, 9.x, and 10.0.x compatibility state in the status
+- Surfaced KiCad 8.x, 9.x, and 10.0.x compatibility state in the status
   bar/menu with feature-level capability probe results.
-- Add explicit KiCanvas/CLI SVG fallback/metadata-only viewer engine state,
+- Added explicit KiCanvas/CLI SVG fallback/metadata-only viewer engine state,
   toolbar engine badges, unsupported-control disabling, and regression coverage
   for fallback diagnostics.
 
 ### Changed
 
-- Clarify Codex support as an external MCP client workflow, remove it from the
-  direct extension provider settings, and migrate legacy
+- Clarified Codex support as an external MCP client workflow, removed it from the
+  direct extension provider settings, and migrated legacy
   `kicadstudio.ai.provider=codex` selections to GitHub Copilot.
-- Restyle the KiCanvas viewer toolbar with VS Code theme tokens, compact
+- Restyled the KiCanvas viewer toolbar with VS Code theme tokens, compact
   spacing, and a single primary reload action for dark, light, and high-contrast
   themes.
 
 ### Deprecated
 
-- Mark KiCad 9.x as a deprecated best-effort compatibility line in status
+- Marked KiCad 9.x as a deprecated best-effort compatibility line in status
   surfaces now that upstream active maintenance has ended.
 
 ## [1.0.0] - 2026-05-20

--- a/docs/changelog/mcp-npm.md
+++ b/docs/changelog/mcp-npm.md
@@ -2,6 +2,25 @@
 
 Source: `packages/mcp-npm/CHANGELOG.md`
 
-## 1.0.0
+All notable changes to the `kicad-mcp-pro` npm launcher will be documented in
+this file.
 
-- Baseline npm launcher release for KiCad MCP Pro 1.0.0.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this package adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Comparison links will be added after the first public component tags are
+published.
+
+## [Unreleased]
+
+### Changed
+
+- Normalized this changelog to Keep a Changelog 1.1.0 format without changing
+  npm launcher behavior.
+
+## [1.0.0] - 2026-05-20
+
+### Added
+
+- Released the baseline npm launcher for KiCad MCP Pro 1.0.0.

--- a/docs/changelog/root.md
+++ b/docs/changelog/root.md
@@ -2,6 +2,27 @@
 
 Source: `CHANGELOG.md`
 
-## 1.0.0
+All notable changes to the KiCad Studio Kit monorepo will be documented in this
+file.
 
-- Establish the canonical KiCad Studio Kit monorepo baseline.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and released packages in this repository adhere to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html). The root changelog
+records repository-wide release governance and monorepo changes; product
+changelogs remain the release-owned sources for package-specific changes.
+
+Comparison links will be added after the first public release tags are
+published.
+
+## [Unreleased]
+
+### Changed
+
+- Normalized the root and product changelog sources to Keep a Changelog 1.1.0
+  structure so release evidence and generated docs can be audited consistently.
+
+## [1.0.0] - 2026-05-20
+
+### Added
+
+- Established the canonical KiCad Studio Kit monorepo baseline.

--- a/packages/mcp-npm/CHANGELOG.md
+++ b/packages/mcp-npm/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
-## 1.0.0
+All notable changes to the `kicad-mcp-pro` npm launcher will be documented in
+this file.
 
-- Baseline npm launcher release for KiCad MCP Pro 1.0.0.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this package adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Comparison links will be added after the first public component tags are
+published.
+
+## [Unreleased]
+
+### Changed
+
+- Normalized this changelog to Keep a Changelog 1.1.0 format without changing
+  npm launcher behavior.
+
+## [1.0.0] - 2026-05-20
+
+### Added
+
+- Released the baseline npm launcher for KiCad MCP Pro 1.0.0.

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,15 +1,32 @@
 # Changelog
 
+All notable changes to the `kicad-mcp-pro` Python server will be documented in
+this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this package adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Comparison links will be added after the first public component tags are
+published.
+
 ## [Unreleased]
 
-- Mark KiCad 9.x as a deprecated best-effort compatibility line in MCP
-  discovery metadata while retaining scheduled non-blocking canary coverage.
+### Added
+
 - Add `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
   setup troubleshooting.
 - Add real KiCad CLI contract canaries with shared fixtures, Windows primary
   KiCad 10.0.3 smoke coverage, scheduled 9.x/10.x lanes, and structured
   unsupported-feature artifacts.
 
-## [1.0.0]
+### Deprecated
 
-- Baseline KiCad MCP Pro server release from the canonical monorepo.
+- Mark KiCad 9.x as a deprecated best-effort compatibility line in MCP
+  discovery metadata while retaining scheduled non-blocking canary coverage.
+
+## [1.0.0] - 2026-05-20
+
+### Added
+
+- Released the baseline KiCad MCP Pro server from the canonical monorepo.

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -14,15 +14,15 @@ published.
 
 ### Added
 
-- Add `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
+- Added `kicad-mcp-pro doctor`, JSON diagnostics, and redacted support bundles for
   setup troubleshooting.
-- Add real KiCad CLI contract canaries with shared fixtures, Windows primary
+- Added real KiCad CLI contract canaries with shared fixtures, Windows primary
   KiCad 10.0.3 smoke coverage, scheduled 9.x/10.x lanes, and structured
   unsupported-feature artifacts.
 
 ### Deprecated
 
-- Mark KiCad 9.x as a deprecated best-effort compatibility line in MCP
+- Marked KiCad 9.x as a deprecated best-effort compatibility line in MCP
   discovery metadata while retaining scheduled non-blocking canary coverage.
 
 ## [1.0.0] - 2026-05-20

--- a/scripts/check-agent-configs.mjs
+++ b/scripts/check-agent-configs.mjs
@@ -261,7 +261,7 @@ const requiredReferences = {
     "docs/agents/codex-support.md",
   ],
   "apps/vscode-extension/CHANGELOG.md": [
-    "Clarify Codex support as an external MCP client workflow",
+    "Clarified Codex support as an external MCP client workflow",
     "kicadstudio.ai.provider=codex",
   ],
   "packages/mcp-server/docs/client-configuration.md": [


### PR DESCRIPTION
## Summary

- Normalize the root, KiCad Studio extension, MCP server, and npm launcher changelog sources to Keep a Changelog 1.1.0 structure.
- Refresh generated `docs/changelog/*` pages from the source changelogs.
- Update the agent-config changelog evidence guard to the normalized past-tense Codex support entry.
- Document that comparison links will be added after the first public repo/component tags exist.

## Linked issue

Closes #188

## Type of change

- [ ] type:bug
- [ ] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm run docs:lint` - passed
- `corepack pnpm run docs:links` - passed
- `corepack pnpm run check:release-please` - passed
- `corepack pnpm run check:version` - passed
- `corepack pnpm run docs:check-generated` - passed
- `corepack pnpm install --frozen-lockfile` - passed
- `corepack pnpm run format:check` - passed
- `corepack pnpm run lint` - passed
- `corepack pnpm run typecheck` - passed
- `corepack pnpm run test` - passed
- `corepack pnpm run build` - passed
- `corepack pnpm run verify:dist` - passed; VSIX, Python sdist/wheel, and npm dry-run package verified
- `gitleaks detect --source . --redact --no-banner` - passed
- `actionlint <expanded workflow file list>` - passed
- `pre-commit run --all-files` - passed
- `corepack pnpm --filter kicadstudio run test:a11y` - passed after repairing the local Playwright headless-shell cache
- `corepack pnpm run check:agent-configs` - passed after updating the changelog evidence guard
- `corepack pnpm run check` - passed on final rerun

## Protocol / MCP impact

- [x] Not applicable; reason: changelog/check-only change, no MCP tool names, schemas, transport behavior, server-info payloads, compatibility metadata, or extension adapter behavior changed.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [x] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts