### PR TITLE
feat(kicad-studio): gate Allegro import workflow

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -847,6 +847,11 @@
         "category": "%kicadstudio.contributes.commands.85.category%"
       },
       {
+        "command": "kicadstudio.importAllegro",
+        "title": "%kicadstudio.contributes.commands.93.title%",
+        "category": "%kicadstudio.contributes.commands.93.category%"
+      },
+      {
         "command": "kicadstudio.pcm.refresh",
         "title": "%kicadstudio.contributes.commands.86.title%",
         "category": "%kicadstudio.contributes.commands.86.category%",
@@ -1358,6 +1363,10 @@
         {
           "command": "kicadstudio.importGeda",
           "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
+        },
+        {
+          "command": "kicadstudio.importAllegro",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject && kicadstudio.allegroImportSupported"
         }
       ]
     },

--- a/apps/vscode-extension/package.nls.json
+++ b/apps/vscode-extension/package.nls.json
@@ -215,6 +215,8 @@
   "kicadstudio.contributes.commands.84.category": "KiCad Import",
   "kicadstudio.contributes.commands.85.title": "KiCad: Import gEDA/Lepton PCB",
   "kicadstudio.contributes.commands.85.category": "KiCad Import",
+  "kicadstudio.contributes.commands.93.title": "KiCad: Import Allegro Board",
+  "kicadstudio.contributes.commands.93.category": "KiCad Import",
   "kicadstudio.contributes.commands.86.title": "KiCad: Refresh PCM Repositories",
   "kicadstudio.contributes.commands.86.category": "KiCad Library",
   "kicadstudio.contributes.commands.87.title": "KiCad: Filter PCM Packages",

--- a/apps/vscode-extension/package.nls.tr.json
+++ b/apps/vscode-extension/package.nls.tr.json
@@ -215,6 +215,8 @@
   "kicadstudio.contributes.commands.84.category": "KiCad İçe Aktar",
   "kicadstudio.contributes.commands.85.title": "KiCad: gEDA/Lepton PCB İçe Aktar",
   "kicadstudio.contributes.commands.85.category": "KiCad İçe Aktar",
+  "kicadstudio.contributes.commands.93.title": "KiCad: Allegro Kartını İçe Aktar",
+  "kicadstudio.contributes.commands.93.category": "KiCad İçe Aktar",
   "kicadstudio.contributes.commands.86.title": "KiCad: PCM Depolarını Yenile",
   "kicadstudio.contributes.commands.86.category": "KiCad Kütüphane",
   "kicadstudio.contributes.commands.87.title": "KiCad: PCM Paketlerini Filtrele",

--- a/apps/vscode-extension/src/cli/importCommands.ts
+++ b/apps/vscode-extension/src/cli/importCommands.ts
@@ -103,10 +103,14 @@ export class KiCadImportService {
     formats: readonly SupportedPcbImportFormat[] = PCB_IMPORT_FORMATS
   ): Promise<Partial<Record<SupportedPcbImportFormat, boolean>>> {
     const entries = await Promise.all(
-      formats.map(async (format) => [
-        format,
-        await this.isImportFormatSupported(format)
-      ] as const)
+      formats.map(async (format) => {
+        try {
+          return [format, await this.isImportFormatSupported(format)] as const;
+        } catch (error) {
+          this.logger.error(`Import support probe for ${format} failed`, error);
+          return [format, false] as const;
+        }
+      })
     );
     return Object.fromEntries(entries);
   }

--- a/apps/vscode-extension/src/cli/importCommands.ts
+++ b/apps/vscode-extension/src/cli/importCommands.ts
@@ -5,15 +5,38 @@ import { KiCadCliRunner } from './kicadCliRunner';
 import { KiCadCliDetector } from './kicadCliDetector';
 import { Logger } from '../utils/logger';
 
-export type SupportedPcbImportFormat =
-  | 'pads'
-  | 'altium'
-  | 'eagle'
-  | 'cadstar'
-  | 'fabmaster'
-  | 'pcad'
-  | 'geda'
-  | 'solidworks';
+export const PCB_IMPORT_FORMATS = [
+  'pads',
+  'altium',
+  'eagle',
+  'cadstar',
+  'fabmaster',
+  'pcad',
+  'geda',
+  'solidworks',
+  'allegro'
+] as const;
+
+export type SupportedPcbImportFormat = (typeof PCB_IMPORT_FORMATS)[number];
+
+const PCB_IMPORT_FORMAT_LABELS: Record<SupportedPcbImportFormat, string> = {
+  pads: 'PADS',
+  altium: 'Altium',
+  eagle: 'Eagle',
+  cadstar: 'CADSTAR',
+  fabmaster: 'Fabmaster',
+  pcad: 'P-CAD',
+  geda: 'gEDA/Lepton',
+  solidworks: 'SolidWorks',
+  allegro: 'Allegro'
+};
+
+const PCB_IMPORT_UNSUPPORTED_HINTS: Partial<
+  Record<SupportedPcbImportFormat, string>
+> = {
+  allegro:
+    'KiCad 10 PCB Editor supports Allegro .brd import, but this kicad-cli build does not expose --format allegro. Use KiCad PCB Editor File > Import > Non-KiCad Board File until a KiCad CLI build advertises Allegro import.'
+};
 
 export class KiCadImportService {
   constructor(
@@ -24,14 +47,13 @@ export class KiCadImportService {
 
   async importBoard(format: SupportedPcbImportFormat): Promise<void> {
     if (!(await this.isImportFormatSupported(format))) {
-      void vscode.window.showWarningMessage(
-        `This KiCad CLI does not advertise ${format} PCB import support.`
-      );
+      void vscode.window.showWarningMessage(unsupportedImportMessage(format));
       return;
     }
 
+    const label = PCB_IMPORT_FORMAT_LABELS[format];
     const selection = await vscode.window.showOpenDialog({
-      title: `Import ${format} board`,
+      title: `Import ${label} board`,
       canSelectFiles: true,
       canSelectFolders: false,
       canSelectMany: false
@@ -58,7 +80,7 @@ export class KiCadImportService {
           inputFile
         ],
         cwd: path.dirname(inputFile),
-        progressTitle: `Importing ${format} board`
+        progressTitle: `Importing ${label} board`
       });
 
       const projectFile = await ensureProjectForImportedBoard(outputFile);
@@ -77,7 +99,19 @@ export class KiCadImportService {
     }
   }
 
-  private async isImportFormatSupported(
+  async getImportFormatSupportSnapshot(
+    formats: readonly SupportedPcbImportFormat[] = PCB_IMPORT_FORMATS
+  ): Promise<Partial<Record<SupportedPcbImportFormat, boolean>>> {
+    const entries = await Promise.all(
+      formats.map(async (format) => [
+        format,
+        await this.isImportFormatSupported(format)
+      ] as const)
+    );
+    return Object.fromEntries(entries);
+  }
+
+  async isImportFormatSupported(
     format: SupportedPcbImportFormat
   ): Promise<boolean> {
     if (!(await this.detector.hasCapability('pcbImport'))) {
@@ -87,11 +121,19 @@ export class KiCadImportService {
     if (!help) {
       return false;
     }
-    if (format === 'geda') {
-      return /\bgeda\b/i.test(help);
-    }
-    return new RegExp(`\\b${escapeRegExp(format)}\\b`, 'i').test(help);
+    return importFormatHelpPattern(format).test(help);
   }
+}
+
+function unsupportedImportMessage(format: SupportedPcbImportFormat): string {
+  const label = PCB_IMPORT_FORMAT_LABELS[format];
+  const base = `This KiCad CLI does not advertise ${label} PCB import support.`;
+  const hint = PCB_IMPORT_UNSUPPORTED_HINTS[format];
+  return hint ? `${base} ${hint}` : base;
+}
+
+function importFormatHelpPattern(format: SupportedPcbImportFormat): RegExp {
+  return new RegExp(`\\b${escapeRegExp(format)}\\b`, 'i');
 }
 
 function escapeRegExp(value: string): string {

--- a/apps/vscode-extension/src/cli/kicadCliDetector.ts
+++ b/apps/vscode-extension/src/cli/kicadCliDetector.ts
@@ -26,6 +26,7 @@ export type KiCadCliCapabilitySnapshot = Partial<
   Record<KiCadCliCapabilityName, boolean>
 > & {
   variantOption?: boolean;
+  allegroImport?: boolean;
 };
 
 export function getCliCandidates(
@@ -255,18 +256,20 @@ export class KiCadCliDetector {
       return undefined;
     }
 
-    const [commandResults, variantOption] = await Promise.all([
+    const [commandResults, variantOption, allegroImport] = await Promise.all([
       Promise.all(
         STATUS_MENU_CAPABILITY_COMMANDS.map(
           async (command) =>
             [command, await this.hasCapability(command)] as const
         )
       ),
-      this.commandHelpIncludes(['sch', 'export', 'pdf'], /--variant\b/)
+      this.commandHelpIncludes(['sch', 'export', 'pdf'], /--variant\b/),
+      this.commandHelpIncludes(['pcb', 'import'], /\ballegro\b/i)
     ]);
     return {
       ...(Object.fromEntries(commandResults) as KiCadCliCapabilitySnapshot),
-      variantOption
+      variantOption,
+      allegroImport
     };
   }
 

--- a/apps/vscode-extension/src/cli/kicadCliSupport.ts
+++ b/apps/vscode-extension/src/cli/kicadCliSupport.ts
@@ -24,7 +24,8 @@ export interface KiCadFeatureSupport {
     | 'jobsets'
     | 'variants'
     | 'odb-export'
-    | 'three-d-pdf-export';
+    | 'three-d-pdf-export'
+    | 'allegro-pcb-import';
   label: string;
   state: KiCadFeatureState;
   summary: string;
@@ -175,6 +176,18 @@ export function buildKiCadFeatureSupport(options: {
         '3D PDF export is enabled for KiCad 10 when the `pcb export 3dpdf` command probe passes.',
       unsupportedReason:
         '3D PDF export requires KiCad 10+ and a kicad-cli build that exposes `pcb export 3dpdf`.'
+    }),
+    feature({
+      id: 'allegro-pcb-import',
+      label: 'Allegro PCB import',
+      major,
+      minimumMajor: 10,
+      capabilityKeys: ['allegroImport'],
+      capabilities,
+      supportedReason:
+        'Allegro import is enabled when `kicad-cli pcb import --help` advertises the Allegro format.',
+      unsupportedReason:
+        'Allegro import is available in the KiCad PCB Editor, but the extension command requires a KiCad 10+ CLI build that exposes `pcb import --format allegro`.'
     })
   ];
 }

--- a/apps/vscode-extension/src/commands/exportCommands.ts
+++ b/apps/vscode-extension/src/commands/exportCommands.ts
@@ -185,6 +185,11 @@ export function registerExportCommands(
       COMMANDS.importGeda,
       () => services.importService.importBoard('geda'),
       'Import gEDA/Lepton Board'
+    ),
+    registerTrustedCommand(
+      COMMANDS.importAllegro,
+      () => services.importService.importBoard('allegro'),
+      'Import Allegro Board'
     )
   ];
 }

--- a/apps/vscode-extension/src/constants.ts
+++ b/apps/vscode-extension/src/constants.ts
@@ -157,7 +157,8 @@ export const COMMANDS = {
   importFabmaster: 'kicadstudio.importFabmaster',
   importPcad: 'kicadstudio.importPcad',
   importSolidworks: 'kicadstudio.importSolidworks',
-  importGeda: 'kicadstudio.importGeda'
+  importGeda: 'kicadstudio.importGeda',
+  importAllegro: 'kicadstudio.importAllegro'
 } as const;
 export const CONTEXT_KEYS = {
   hasProject: 'kicadstudio.hasProject',
@@ -178,6 +179,7 @@ export const CONTEXT_KEYS = {
   mcpManufacturingMode: 'kicadstudio.mcpManufacturingMode',
   mcpExperimentalMode: 'kicadstudio.mcpExperimentalMode',
   hasVariants: 'kicadstudio.hasVariants',
+  allegroImportSupported: 'kicadstudio.allegroImportSupported',
   workspaceTrusted: 'kicadstudio.workspaceTrusted'
 } as const;
 export const SETTINGS = {

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -568,10 +568,10 @@ export async function activate(
     const provider = await aiProviders.getProvider();
     const cli = trusted ? await cliDetector.detect() : undefined;
     const kicadVersionMajor = Number(cli?.version.split('.')[0] ?? '0');
-    const allegroImportSupported =
-      trusted && cli
-        ? await importService.isImportFormatSupported('allegro')
-        : false;
+    const allegroImportSupported = await detectAllegroImportSupport(
+      trusted,
+      Boolean(cli)
+    );
     const hasVariants = await workspaceHasVariants();
     const mcpProfile = readConfiguredMcpProfile();
     const persistedProjectId = context.workspaceState.get<string>(
@@ -649,6 +649,22 @@ export async function activate(
       drc: diagnosticState.getSnapshot().drc,
       erc: diagnosticState.getSnapshot().erc
     });
+  }
+
+  async function detectAllegroImportSupport(
+    trusted: boolean,
+    cliDetected: boolean
+  ): Promise<boolean> {
+    if (!trusted || !cliDetected) {
+      return false;
+    }
+
+    try {
+      return await importService.isImportFormatSupported('allegro');
+    } catch (error) {
+      logger.error('Allegro import capability probe failed', error);
+      return false;
+    }
   }
 
   async function selectActiveProject(

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -568,6 +568,10 @@ export async function activate(
     const provider = await aiProviders.getProvider();
     const cli = trusted ? await cliDetector.detect() : undefined;
     const kicadVersionMajor = Number(cli?.version.split('.')[0] ?? '0');
+    const allegroImportSupported =
+      trusted && cli
+        ? await importService.isImportFormatSupported('allegro')
+        : false;
     const hasVariants = await workspaceHasVariants();
     const mcpProfile = readConfiguredMcpProfile();
     const persistedProjectId = context.workspaceState.get<string>(
@@ -621,6 +625,11 @@ export async function activate(
       'setContext',
       CONTEXT_KEYS.hasVariants,
       projectSnapshot.hasVariants
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.allegroImportSupported,
+      allegroImportSupported
     );
     await vscode.commands.executeCommand(
       'setContext',

--- a/apps/vscode-extension/test/integration/extension.test.ts
+++ b/apps/vscode-extension/test/integration/extension.test.ts
@@ -310,6 +310,14 @@ suite('Extension Integration', () => {
       [
         'kicadstudio.importGeda',
         ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
+      ],
+      [
+        'kicadstudio.importAllegro',
+        [
+          'kicadstudio.workspaceTrusted',
+          'kicadstudio.hasProject',
+          'kicadstudio.allegroImportSupported'
+        ]
       ]
     ] as Array<[string, string[]]>) {
       assertCommandPaletteWhen(commandPalette, command, expectedContexts);

--- a/apps/vscode-extension/test/unit/importCommands.test.ts
+++ b/apps/vscode-extension/test/unit/importCommands.test.ts
@@ -140,6 +140,26 @@ describe('KiCadImportService', () => {
     });
   });
 
+  it('fails closed when an import support snapshot probe rejects', async () => {
+    const error = new Error('probe failed');
+    const { service, logger } = createService({
+      detector: {
+        hasCapability: jest.fn().mockRejectedValue(error),
+        getCommandHelp: jest.fn()
+      }
+    });
+
+    await expect(
+      service.getImportFormatSupportSnapshot(['allegro'])
+    ).resolves.toEqual({
+      allegro: false
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      'Import support probe for allegro failed',
+      error
+    );
+  });
+
   it('stops without running kicad-cli when the import picker is cancelled', async () => {
     const { service, runner } = createService();
     (window.showOpenDialog as jest.Mock).mockResolvedValue(undefined);

--- a/apps/vscode-extension/test/unit/importCommands.test.ts
+++ b/apps/vscode-extension/test/unit/importCommands.test.ts
@@ -89,10 +89,55 @@ describe('KiCadImportService', () => {
     await service.importBoard('pads');
 
     expect(window.showWarningMessage).toHaveBeenCalledWith(
-      expect.stringContaining('does not advertise pads PCB import support')
+      expect.stringContaining('does not advertise PADS PCB import support')
     );
     expect(window.showOpenDialog).not.toHaveBeenCalled();
     expect(runner.runWithProgress).not.toHaveBeenCalled();
+  });
+
+  it('keeps Allegro hidden behind the kicad-cli import format probe', async () => {
+    const { service, runner } = createService({
+      detector: {
+        hasCapability: jest.fn().mockResolvedValue(true),
+        getCommandHelp: jest
+          .fn()
+          .mockResolvedValue(
+            'Usage: kicad-cli pcb import --format pads|altium|solidworks'
+          )
+      }
+    });
+
+    await service.importBoard('allegro');
+
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('does not advertise Allegro PCB import support')
+    );
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('KiCad 10 PCB Editor supports Allegro .brd import')
+    );
+    expect(window.showOpenDialog).not.toHaveBeenCalled();
+    expect(runner.runWithProgress).not.toHaveBeenCalled();
+  });
+
+  it('reports per-format import support from kicad-cli help', async () => {
+    const { service } = createService({
+      detector: {
+        hasCapability: jest.fn().mockResolvedValue(true),
+        getCommandHelp: jest
+          .fn()
+          .mockResolvedValue(
+            'Usage: kicad-cli pcb import --format pads|altium|allegro'
+          )
+      }
+    });
+
+    await expect(
+      service.getImportFormatSupportSnapshot(['pads', 'allegro', 'geda'])
+    ).resolves.toEqual({
+      pads: true,
+      allegro: true,
+      geda: false
+    });
   });
 
   it('stops without running kicad-cli when the import picker is cancelled', async () => {
@@ -129,7 +174,7 @@ describe('KiCadImportService', () => {
         inputFile
       ],
       cwd: tempDir,
-      progressTitle: 'Importing pads board'
+      progressTitle: 'Importing PADS board'
     });
     expect(JSON.parse(fs.readFileSync(projectFile, 'utf8'))).toEqual({
       meta: {
@@ -163,6 +208,44 @@ describe('KiCadImportService', () => {
     await service.importBoard('pads');
 
     expect(fs.readFileSync(projectFile, 'utf8')).toBe('{"existing":true}\n');
+  });
+
+  it('imports Allegro boards when kicad-cli advertises the format', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kicad-import-'));
+    const inputFile = path.join(tempDir, 'legacy-allegro.brd');
+    fs.writeFileSync(inputFile, 'legacy board', 'utf8');
+    const outputFile = path.join(tempDir, 'legacy-allegro.kicad_pcb');
+    const { service, runner } = createService({
+      detector: {
+        hasCapability: jest.fn().mockResolvedValue(true),
+        getCommandHelp: jest
+          .fn()
+          .mockResolvedValue(
+            'Usage: kicad-cli pcb import --format pads|altium|allegro'
+          )
+      }
+    });
+    (window.showOpenDialog as jest.Mock).mockResolvedValue([
+      Uri.file(inputFile)
+    ]);
+
+    await service.importBoard('allegro');
+
+    expect(runner.runWithProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: [
+          'pcb',
+          'import',
+          '--format',
+          'allegro',
+          '--output',
+          outputFile,
+          inputFile
+        ],
+        cwd: tempDir,
+        progressTitle: 'Importing Allegro board'
+      })
+    );
   });
 
   it('logs the failed import and shows the underlying error message once', async () => {

--- a/apps/vscode-extension/test/unit/kicadCliDetector.test.ts
+++ b/apps/vscode-extension/test/unit/kicadCliDetector.test.ts
@@ -307,13 +307,18 @@ describe('KiCadCliDetector', () => {
         gerbers: true,
         pdf3d: true,
         odb: false,
-        variantOption: true
+        variantOption: true,
+        allegroImport: true
       })
     );
     expect(detector.hasCapability).toHaveBeenCalledWith('jobset');
     expect(detector.commandHelpIncludes).toHaveBeenCalledWith(
       ['sch', 'export', 'pdf'],
       /--variant\b/
+    );
+    expect(detector.commandHelpIncludes).toHaveBeenCalledWith(
+      ['pcb', 'import'],
+      /\ballegro\b/i
     );
   });
 

--- a/apps/vscode-extension/test/unit/kicadCliSupport.test.ts
+++ b/apps/vscode-extension/test/unit/kicadCliSupport.test.ts
@@ -63,7 +63,8 @@ describe('kicadCliSupport', () => {
         jobset: true,
         pdf3d: true,
         odb: true,
-        variantOption: true
+        variantOption: true,
+        allegroImport: true
       }
     });
 
@@ -83,6 +84,10 @@ describe('kicadCliSupport', () => {
         }),
         expect.objectContaining({
           id: 'three-d-pdf-export',
+          state: 'available'
+        }),
+        expect.objectContaining({
+          id: 'allegro-pcb-import',
           state: 'available'
         })
       ])
@@ -177,6 +182,28 @@ describe('kicadCliSupport', () => {
       expect.objectContaining({
         state: 'unsupported',
         summary: 'missing pdf3d'
+      })
+    );
+  });
+
+  it('marks Allegro PCB import unsupported when the CLI help omits the format', () => {
+    const features = buildKiCadFeatureSupport({
+      cli: {
+        path: '/usr/bin/kicad-cli',
+        version: '10.0.3',
+        versionLabel: 'KiCad 10.0.3',
+        source: 'path'
+      },
+      capabilities: {
+        allegroImport: false
+      }
+    });
+
+    expect(features.find((item) => item.id === 'allegro-pcb-import')).toEqual(
+      expect.objectContaining({
+        state: 'unsupported',
+        summary: 'missing allegroImport',
+        reason: expect.stringContaining('KiCad PCB Editor')
       })
     );
   });

--- a/apps/vscode-extension/test/unit/viewerStatusMenu.test.ts
+++ b/apps/vscode-extension/test/unit/viewerStatusMenu.test.ts
@@ -35,7 +35,8 @@ describe('buildStatusMenuItems', () => {
         jobset: true,
         pdf3d: true,
         odb: false,
-        variantOption: true
+        variantOption: true,
+        allegroImport: false
       },
       snapshot: {
         drc: {
@@ -90,6 +91,10 @@ describe('buildStatusMenuItems', () => {
         expect.objectContaining({
           label: '$(pass) 3D PDF export',
           description: 'available'
+        }),
+        expect.objectContaining({
+          label: '$(warning) Allegro PCB import',
+          description: 'missing allegroImport'
         })
       ])
     );

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -28,6 +28,59 @@ kicad:
       ci: "manual"
       notes: "File-level read and migration support only; removal requires a release note."
   dropped: []
+  pcbImportWorkflows:
+    reviewed: "2026-05-27"
+    commandProbe: "kicad-cli pcb import --help"
+    sources:
+      cliReference: "https://docs.kicad.org/10.0/en/cli/cli.html"
+      pcbEditorReference: "https://docs.kicad.org/10.0/en/pcbnew/pcbnew.html"
+    formats:
+      altium:
+        status: "supported"
+        extensionCommand: "kicadstudio.importAltium"
+        cliFormat: "altium"
+        evidence: "KiCad 10 CLI import help advertises the format."
+      allegro:
+        status: "blocked"
+        extensionCommand: "kicadstudio.importAllegro"
+        cliFormat: "allegro"
+        evidence: "KiCad 10 PCB Editor supports Cadence Allegro .brd import, but KiCad 10 CLI import help does not advertise --format allegro."
+        fixture: "packages/kicad-fixtures/fixtures/kicad-10-0-3-regressions/importers/allegro-capability-probe.json"
+      cadstar:
+        status: "supported"
+        extensionCommand: "kicadstudio.importCadstar"
+        cliFormat: "cadstar"
+        evidence: "KiCad 10 CLI import help advertises the format."
+      eagle:
+        status: "supported"
+        extensionCommand: "kicadstudio.importEagle"
+        cliFormat: "eagle"
+        evidence: "KiCad 10 CLI import help advertises the format."
+      fabmaster:
+        status: "supported"
+        extensionCommand: "kicadstudio.importFabmaster"
+        cliFormat: "fabmaster"
+        evidence: "KiCad 10 CLI import help advertises the format."
+      geda:
+        status: "probe-gated"
+        extensionCommand: "kicadstudio.importGeda"
+        cliFormat: "geda"
+        evidence: "Existing extension command remains guarded by kicad-cli help because current stable CLI docs do not advertise gEDA in --format options."
+      pads:
+        status: "supported"
+        extensionCommand: "kicadstudio.importPads"
+        cliFormat: "pads"
+        evidence: "KiCad 10 CLI import help advertises the format."
+      pcad:
+        status: "supported"
+        extensionCommand: "kicadstudio.importPcad"
+        cliFormat: "pcad"
+        evidence: "KiCad 10 CLI import help advertises the format."
+      solidworks:
+        status: "supported"
+        extensionCommand: "kicadstudio.importSolidworks"
+        cliFormat: "solidworks"
+        evidence: "KiCad 10 CLI import help advertises the format."
 
 kicadIpcReadiness:
   reviewed: "2026-05-26"

--- a/docs/extension/commands.md
+++ b/docs/extension/commands.md
@@ -3,7 +3,7 @@
 Machine-maintained from `apps/vscode-extension/package.json` and `package.nls.json`.
 Refresh with `corepack pnpm run docs:generate`.
 
-Total contributed commands: 93.
+Total contributed commands: 94.
 
 | Command ID | Title | Category |
 | --- | --- | --- |
@@ -93,6 +93,7 @@ Total contributed commands: 93.
 | `kicadstudio.importPcad` | KiCad: Import P-CAD Board | KiCad Import |
 | `kicadstudio.importSolidworks` | KiCad: Import SolidWorks PCB | KiCad Import |
 | `kicadstudio.importGeda` | KiCad: Import gEDA/Lepton PCB | KiCad Import |
+| `kicadstudio.importAllegro` | KiCad: Import Allegro Board | KiCad Import |
 | `kicadstudio.pcm.refresh` | KiCad: Refresh PCM Repositories | KiCad Library |
 | `kicadstudio.pcm.filter` | KiCad: Filter PCM Packages | KiCad Library |
 | `kicadstudio.pcm.install` | KiCad: Install PCM Package | KiCad Library |

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -61,6 +61,31 @@ exports.
 | 8.x        | 8.0.x        | Deprecated    | Manual compatibility check                  | Core file-level read, migration, DRC/ERC, BOM/netlist, and Gerber workflows are best-effort when command probes pass; jobsets, variants, 3D PDF, and ODB++ remain unavailable.                   |
 | <8         | none         | Unsupported   | None                                        | KiCad Studio reports the detected CLI as unsupported and does not claim feature compatibility.                                                                                                   |
 
+## KiCad 10 PCB Import Workflow Matrix
+
+`compatibility.yaml` tracks extension-facing PCB import workflows under
+`kicad.pcbImportWorkflows`. KiCad Studio shows or runs importer commands only
+after probing `kicad-cli pcb import --help`; this prevents the extension from
+claiming GUI-only importers as CLI-backed workflows.
+
+| Source format | Extension command | KiCad 10 CLI state | User-facing behavior |
+| --- | --- | --- | --- |
+| Altium | `kicadstudio.importAltium` | Supported | Command remains available and validates `--format altium` before opening the picker. |
+| Allegro | `kicadstudio.importAllegro` | Blocked | Command is registered for future compatibility, hidden unless `--format allegro` is advertised, and reports a deterministic warning when invoked without CLI support. |
+| CADSTAR | `kicadstudio.importCadstar` | Supported | Command remains available and validates `--format cadstar` before opening the picker. |
+| Eagle | `kicadstudio.importEagle` | Supported | Command remains available and validates `--format eagle` before opening the picker. |
+| Fabmaster | `kicadstudio.importFabmaster` | Supported | Command remains available and validates `--format fabmaster` before opening the picker. |
+| gEDA/Lepton | `kicadstudio.importGeda` | Probe-gated | Existing command remains available but does not run unless the installed CLI help advertises `geda`. |
+| PADS | `kicadstudio.importPads` | Supported | Command remains available and validates `--format pads` before opening the picker. |
+| P-CAD | `kicadstudio.importPcad` | Supported | Command remains available and validates `--format pcad` before opening the picker. |
+| SolidWorks PCB | `kicadstudio.importSolidworks` | Supported | Command remains available and validates `--format solidworks` before opening the picker. |
+
+Allegro fixture coverage is tracked by
+[`kicad-10-0-3-regressions`](kicad-fixture-corpus.md#fixture-coverage). The
+fixture records the stable boundary: KiCad 10 PCB Editor supports Cadence
+Allegro `.brd` import, while current stable CLI help does not advertise
+`--format allegro`.
+
 ## KiCad 11 Readiness
 
 KiCad 11 is not a primary support target yet. The readiness contract is tracked
@@ -96,6 +121,7 @@ Freshness sources checked on 2026-05-27:
 - KiCad 9.0.9 release notes: <https://www.kicad.org/blog/2026/04/KiCad-9.0.9-Release/>
 - KiCad 9.0.9 RC note for final 9.0 bug-fix policy: <https://www.kicad.org/blog/2026/04/KiCad-Version-9.0.9-Release-Candidate-1-Available/>
 - KiCad 10.0 CLI reference: <https://docs.kicad.org/10.0/en/cli/cli.html>
+- KiCad 10.0 PCB Editor import reference: <https://docs.kicad.org/10.0/en/pcbnew/pcbnew.html>
 - KiCad nightly CLI reference: <https://docs.kicad.org/master/en/cli/cli.html>
 - KiCad PCB Python bindings deprecation notice: <https://dev-docs.kicad.org/en/apis-and-binding/pcbnew/>
 - KiCad nightly and release candidate guidance: <https://www.kicad.org/help/nightlies-and-rcs/>

--- a/packages/kicad-fixtures/fixtures/kicad-10-0-3-regressions/importers/allegro-capability-probe.json
+++ b/packages/kicad-fixtures/fixtures/kicad-10-0-3-regressions/importers/allegro-capability-probe.json
@@ -1,6 +1,6 @@
 {
   "format": "allegro",
   "status": "capability-probe-only",
-  "reason": "KiCad 10.0.3 CLI documentation does not list Allegro as a pcb import format.",
+  "reason": "KiCad 10.0.3 PCB Editor documentation lists Cadence Allegro import, but CLI documentation does not list Allegro as a pcb import format.",
   "command": ["kicad-cli", "pcb", "import", "--help"]
 }

--- a/scripts/generate-kicad-fixture-corpus.mjs
+++ b/scripts/generate-kicad-fixture-corpus.mjs
@@ -222,7 +222,7 @@ const fixtures = [
           format: "allegro",
           status: "capability-probe-only",
           reason:
-            "KiCad 10.0.3 CLI documentation does not list Allegro as a pcb import format.",
+            "KiCad 10.0.3 PCB Editor documentation lists Cadence Allegro import, but CLI documentation does not list Allegro as a pcb import format.",
           command: ["kicad-cli", "pcb", "import", "--help"],
         }),
       },


### PR DESCRIPTION
## Summary

- Add a future-ready `kicadstudio.importAllegro` command contribution that is hidden unless the installed KiCad CLI advertises Allegro PCB import support.
- Add Allegro capability probing, deterministic unsupported-user messaging, status-menu support reporting, and unit/integration coverage.
- Update KiCad 10 importer compatibility docs, generated command docs, and fixture corpus metadata to document the GUI-supported / CLI-blocked Allegro boundary.

## Linked issue

Closes #179

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `corepack pnpm install --frozen-lockfile` - passed
- `corepack pnpm run fixtures:kicad:generate` - passed
- `corepack pnpm run docs:generate` - passed
- `corepack pnpm run format:check` - passed
- `corepack pnpm --filter kicadstudio run lint` - passed
- `corepack pnpm --filter kicadstudio run typecheck` - passed
- `corepack pnpm --filter kicadstudio run test:unit` - passed: 82 suites, 621 tests, 2 snapshots
- `corepack pnpm run docs:lint` - passed
- `corepack pnpm run docs:check-generated` - passed
- `corepack pnpm run check:fixtures` - passed
- `corepack pnpm run check:compatibility` - passed
- `corepack pnpm run docs:links` - passed
- `corepack pnpm run lint` - passed
- `corepack pnpm run typecheck` - passed
- `corepack pnpm run test` - passed
- `corepack pnpm run build` - passed
- `corepack pnpm run verify:dist` - passed
- `gitleaks detect --source . --redact --no-banner` - passed
- workflow deprecation scan for `::set-output`, `::save-state`, insecure Node overrides, node12/node16/node20 - passed
- `corepack pnpm --filter kicadstudio exec actionlint <workflow files>` - passed
- `corepack pnpm run check` - passed; optional dev-doctor warnings for missing local shellcheck/Xvfb/KiCad CLI are environment-only and unrelated
- `pre-commit run --all-files` - passed

## Protocol / MCP impact

No MCP protocol schema, MCP server implementation, transport behavior, or extension MCP adapter behavior changed. This PR updates compatibility metadata and extension CLI command availability only.

Checklist reference: `docs/architecture/protocol-change-checklist.md`

- [ ] Not applicable; reason:
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [x] Compatibility matrix updated
- [x] Server-info/capabilities payload updated: not applicable, no MCP server-info/capability payload changed
- [x] Docs updated
- [x] Release notes considered for both products: no changelog entry added because the command remains hidden until KiCad CLI exposes stable Allegro import support
- [x] Backward compatibility impact documented: existing import formats remain unchanged; Allegro command is gated by CLI capability probing

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval: not applicable, feature/compatibility work
- [x] CHANGELOG entry (if user-visible): not applicable, hidden capability-gated command
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts