### PR TITLE
feat(repo): add KiCad 10.0.3 parity matrix

### DIFF
--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -82,6 +82,351 @@ kicad:
         cliFormat: "solidworks"
         evidence: "KiCad 10 CLI import help advertises the format."
 
+kicad10FeatureParity:
+  reviewed: "2026-05-27"
+  baseline: "10.0.3"
+  primaryIssue: "https://github.com/oaslananka/kicad-studio-kit/issues/177"
+  documentation: "docs/compatibility/kicad-10-0-3-feature-parity.md"
+  allowedStatuses:
+    - "supported"
+    - "not-applicable"
+    - "partial"
+    - "blocked"
+    - "future"
+  sources:
+    releaseNotes: "https://www.kicad.org/blog/2026/05/KiCad-10.0.3-Release/"
+    releaseTag: "https://github.com/KiCad/kicad-source-mirror/releases/tag/10.0.3"
+    cliReference: "https://docs.kicad.org/10.0/en/cli/cli.html"
+    pcbEditorReference: "https://docs.kicad.org/10.0/en/pcbnew/pcbnew.html"
+    pcbnewDeprecation: "https://dev-docs.kicad.org/en/apis-and-binding/pcbnew/"
+    nightlies: "https://www.kicad.org/help/nightlies-and-rcs/"
+  surfaces:
+    importers:
+      altium:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb import --format altium"
+        productSurface: "KiCad Studio extension command and MCP manufacturing probe"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/importCommands.test.ts"
+          - "path:apps/vscode-extension/test/integration/extension.test.ts"
+          - "command:kicad-cli pcb import --help includes altium"
+        notes: "Extension and MCP import paths are gated by CLI help before use."
+      allegro:
+        status: "blocked"
+        nativeSurface: "KiCad PCB Editor GUI Cadence Allegro .brd import"
+        productSurface: "KiCad Studio extension command registered but hidden unless CLI support appears"
+        issue: "https://github.com/oaslananka/kicad-studio-kit/issues/179"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/importCommands.test.ts"
+          - "fixture:kicad-10-0-3-regressions"
+          - "command:kicad-cli pcb import --help does not advertise allegro in KiCad 10.0.3"
+        notes: "KiCad 10.0.3 documents GUI Allegro import, but the stable CLI surface is not available."
+      cadstar:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb import --format cadstar"
+        productSurface: "KiCad Studio extension command"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/importCommands.test.ts"
+          - "command:kicad-cli pcb import --help includes cadstar"
+        notes: "Command remains probe-gated like other importer workflows."
+      eagle:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb import --format eagle"
+        productSurface: "KiCad Studio extension command"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/importCommands.test.ts"
+          - "command:kicad-cli pcb import --help includes eagle"
+        notes: "Command remains probe-gated like other importer workflows."
+      fabmaster:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb import --format fabmaster"
+        productSurface: "KiCad Studio extension command"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/importCommands.test.ts"
+          - "command:kicad-cli pcb import --help includes fabmaster"
+        notes: "Command remains probe-gated like other importer workflows."
+      geda_lepton:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb import --format geda when help advertises the token"
+        productSurface: "KiCad Studio extension command and MCP manufacturing import"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/importCommands.test.ts"
+          - "path:packages/mcp-server/tests/integration/test_manufacturing_tools.py"
+          - "command:kicad-cli pcb import --help includes geda"
+        notes: "The product treats gEDA/Lepton as supported only after capability probing passes."
+      pads:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb import --format pads"
+        productSurface: "KiCad Studio extension command, MCP manufacturing import, and KiCad 10.0.3 fixture probe"
+        evidence:
+          - "path:packages/mcp-server/tests/unit/test_kicad_canary.py"
+          - "path:packages/mcp-server/tests/integration/test_manufacturing_tools.py"
+          - "fixture:kicad-10-0-3-regressions"
+        notes: "KiCad 10.0.3 PADS importer regressions are covered by canary and fixture metadata."
+      pcad:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb import --format pcad"
+        productSurface: "KiCad Studio extension command"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/importCommands.test.ts"
+          - "command:kicad-cli pcb import --help includes pcad"
+        notes: "Command remains probe-gated like other importer workflows."
+      solidworks:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb import --format solidworks"
+        productSurface: "KiCad Studio extension command"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/importCommands.test.ts"
+          - "command:kicad-cli pcb import --help includes solidworks"
+        notes: "Command remains probe-gated like other importer workflows."
+    exports:
+      gerber:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb export gerbers"
+        productSurface: "MCP manufacturing package and extension export workflows"
+        evidence:
+          - "path:packages/mcp-server/scripts/kicad_canary.py"
+          - "path:packages/mcp-server/tests/integration/test_export_tools.py"
+          - "command:corepack pnpm run test:kicad-cli-contract"
+        notes: "Primary KiCad canary requires Gerber export artifacts."
+      drill:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb export drill"
+        productSurface: "MCP manufacturing package and extension export workflows"
+        evidence:
+          - "path:packages/mcp-server/scripts/kicad_canary.py"
+          - "path:packages/mcp-server/tests/integration/test_export_tools.py"
+          - "command:corepack pnpm run test:kicad-cli-contract"
+        notes: "Primary KiCad canary requires drill export artifacts."
+      pdf:
+        status: "supported"
+        nativeSurface: "kicad-cli sch export pdf and pcb export pdf"
+        productSurface: "MCP schematic/PCB export and extension PDF commands"
+        evidence:
+          - "path:packages/mcp-server/scripts/kicad_canary.py"
+          - "path:packages/mcp-server/tests/unit/test_kicad_canary.py"
+          - "command:kicad-cli sch export pdf and pcb export pdf"
+        notes: "Schematic and PCB PDF exports are part of the KiCad 10 canary plan."
+      pcb_pdf_property_popup_suppression:
+        status: "supported"
+        nativeSurface: "kicad-cli sch export pdf --exclude-pdf-property-popups"
+        productSurface: "KiCad 10.0.3 regression canary and fixture metadata"
+        evidence:
+          - "path:packages/mcp-server/scripts/kicad_canary.py"
+          - "path:packages/mcp-server/tests/unit/test_kicad_canary.py"
+          - "fixture:kicad-10-0-3-regressions"
+        notes: "The KiCad 10.0.3 CLI release note feature has a dedicated canary probe."
+      ipc2581:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb export ipc2581"
+        productSurface: "KiCad Studio extension command and MCP export_ipc2581 tool"
+        evidence:
+          - "path:apps/vscode-extension/test/integration/extension.test.ts"
+          - "path:packages/mcp-server/tests/integration/test_pcb_export_validation_surface.py"
+          - "path:packages/mcp-server/tests/integration/test_export_tools.py"
+        notes: "Extension and MCP surfaces both expose IPC-2581 with command-level tests."
+      odbpp:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb export odb"
+        productSurface: "KiCad Studio extension command and MCP export_odb tool"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/exportPresets.test.ts"
+          - "path:packages/mcp-server/tests/integration/test_export_tools.py"
+          - "path:packages/mcp-server/tests/e2e/test_server.py"
+        notes: "ODB++ remains capability-gated by KiCad CLI detection."
+      step:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb export step"
+        productSurface: "MCP export_step and export_3d_step tools"
+        evidence:
+          - "path:packages/mcp-server/tests/integration/test_export_tools.py"
+          - "path:packages/mcp-server/tests/unit/test_release_hardening.py"
+          - "path:packages/mcp-server/scripts/kicad_canary.py"
+        notes: "STEP is a release-gated 3D export with path-safety tests."
+      stepz:
+        status: "future"
+        nativeSurface: "kicad-cli pcb export stepz"
+        productSurface: "No first-class KiCad Studio Kit command or MCP tool yet"
+        issue: "https://github.com/oaslananka/kicad-studio-kit/issues/232"
+        evidence:
+          - "source:https://docs.kicad.org/10.0/en/cli/cli.html"
+        notes: "Documented upstream CLI export; product adoption is intentionally tracked separately."
+      xao:
+        status: "future"
+        nativeSurface: "kicad-cli pcb export xao"
+        productSurface: "No first-class KiCad Studio Kit command or MCP tool yet"
+        issue: "https://github.com/oaslananka/kicad-studio-kit/issues/232"
+        evidence:
+          - "source:https://docs.kicad.org/10.0/en/cli/cli.html"
+        notes: "Documented upstream CLI export; product adoption is intentionally tracked separately."
+    gui_editor:
+      design_blocks:
+        status: "supported"
+        nativeSurface: "KiCad 10 PCB Editor design block workflow"
+        productSurface: "S-expression parser and MCP pcb_block_* tools"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/sExpressionParser.test.ts"
+          - "path:packages/mcp-server/tests/integration/test_pcb_tools.py"
+          - "path:docs/mcp/tools.md"
+        notes: "Product support is headless and tool-oriented, not a replacement for the native GUI editor."
+      graphical_drc_rule_editor:
+        status: "not-applicable"
+        nativeSurface: "KiCad PCB Editor graphical DRC rule editor"
+        productSurface: "Textual .kicad_dru guidance and diagnostics, not a GUI rule editor"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/drcRulesProvider.test.ts"
+          - "path:apps/vscode-extension/src/ai/prompts.ts"
+        notes: "The native graphical editor remains a KiCad GUI feature outside extension/MCP ownership."
+      variants:
+        status: "supported"
+        nativeSurface: "KiCad 10 design variants"
+        productSurface: "Extension variants view and MCP variant_* tools"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/variantProvider.test.ts"
+          - "path:packages/mcp-server/tests/unit/test_variant_diff.py"
+          - "path:packages/mcp-server/tests/integration/test_export_tools.py"
+        notes: "Variant listing, activation, BOM diffing, and export integration are covered."
+      barcode_support:
+        status: "supported"
+        nativeSurface: "KiCad 10 PCB Editor barcode tool"
+        productSurface: "MCP pcb_add_barcode tool"
+        evidence:
+          - "path:packages/mcp-server/tests/unit/test_kicad10_parity_tools.py"
+          - "path:docs/mcp/tools.md"
+          - "source:https://docs.kicad.org/10.0/en/pcbnew/pcbnew.html"
+        notes: "Headless barcode insertion is supported; native visual editing remains in KiCad."
+      time_domain_tuning:
+        status: "partial"
+        nativeSurface: "KiCad 10 interactive time-domain tuning workflows"
+        productSurface: "MCP route_tune_time_domain and tuning profile helpers"
+        issue: "https://github.com/oaslananka/kicad-studio-kit/issues/232"
+        evidence:
+          - "path:packages/mcp-server/tests/unit/test_kicad10_parity_tools.py"
+          - "path:packages/mcp-server/tests/integration/test_routing_tools.py"
+        notes: "The MCP tools model tuning intent, but they do not replace native interactive routing UX."
+    ipc:
+      kicad_python_ipc:
+        status: "supported"
+        nativeSurface: "KiCad IPC API"
+        productSurface: "MCP live context discovery and scheduled GUI smoke coverage"
+        evidence:
+          - "path:packages/mcp-server/tests/gui/test_kicad_gui_live_context.py"
+          - "path:docs/compatibility/kicad-10-to-11-migration.md"
+          - "smoke:corepack pnpm run test:kicad-gui-smoke"
+        notes: "IPC is the supported live-editor direction for KiCad 10 and KiCad 11 readiness."
+      swig_pcbnew_direct_dependency:
+        status: "blocked"
+        nativeSurface: "Deprecated SWIG pcbnew Python bindings"
+        productSurface: "Production direct pcbnew imports are forbidden"
+        issue: "https://github.com/oaslananka/kicad-studio-kit/issues/197"
+        evidence:
+          - "path:packages/mcp-server/scripts/check_no_pcbnew.py"
+          - "path:docs/compatibility/kicad-10-to-11-migration.md"
+          - "source:https://dev-docs.kicad.org/en/apis-and-binding/pcbnew/"
+        notes: "The guard blocks production reliance on an API planned for removal in KiCad 11."
+    vscode_extension:
+      status_surface:
+        status: "supported"
+        nativeSurface: "Detected KiCad CLI version and command help"
+        productSurface: "Status bar and command menu feature availability"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/kicadStatusBar.test.ts"
+          - "path:apps/vscode-extension/test/unit/viewerStatusMenu.test.ts"
+          - "path:apps/vscode-extension/test/unit/kicadCliSupport.test.ts"
+        notes: "The UI reports primary/deprecated/unsupported KiCad lines and feature-level gates."
+      importer_command_gating:
+        status: "supported"
+        nativeSurface: "kicad-cli pcb import --help"
+        productSurface: "Command palette availability and deterministic unsupported warnings"
+        evidence:
+          - "path:apps/vscode-extension/test/unit/importCommands.test.ts"
+          - "path:apps/vscode-extension/test/integration/extension.test.ts"
+        notes: "Importer commands cannot run without the corresponding CLI token."
+    mcp_server:
+      server_info_capability_contract:
+        status: "supported"
+        nativeSurface: "KiCad CLI and IPC runtime discovery"
+        productSurface: "kicad_get_server_info compatibility and capability payload"
+        evidence:
+          - "path:packages/mcp-server/tests/unit/test_server_info_contract.py"
+          - "path:packages/protocol-schemas/test/index.test.ts"
+          - "path:docs/mcp/api-reference.md"
+        notes: "Server-info schema and generated docs are release-gated."
+      empty_project_read_tools:
+        status: "partial"
+        nativeSurface: "Empty KiCad 10.0.3 project files"
+        productSurface: "File-backed MCP read tools and quality gates"
+        issue: "https://github.com/oaslananka/kicad-studio-kit/issues/228"
+        evidence:
+          - "path:packages/mcp-server/tests/integration/test_pcb_tools.py"
+          - "path:packages/mcp-server/tests/integration/test_schematic_tools.py"
+        notes: "Regression coverage is tracked separately so the parity matrix stays bounded."
+      ipc_state_consistency:
+        status: "partial"
+        nativeSurface: "KiCad IPC lifecycle"
+        productSurface: "kicad_get_server_info and tool diagnostics"
+        issue: "https://github.com/oaslananka/kicad-studio-kit/issues/223"
+        evidence:
+          - "path:packages/mcp-server/tests/unit/test_server_info_contract.py"
+          - "path:packages/mcp-server/tests/gui/test_kicad_gui_live_context.py"
+        notes: "Issue #229 tracks additional lifecycle transition coverage."
+    release:
+      vsix_provenance:
+        status: "supported"
+        nativeSurface: "VS Code extension release artifact"
+        productSurface: "VSIX checksum, SBOM, and artifact attestation workflow"
+        evidence:
+          - "path:.github/workflows/publish-extension.yml"
+          - "path:scripts/check-release-provenance.mjs"
+          - "path:docs/release.md"
+        notes: "Release provenance is validated by the release verification gate."
+      wheel_provenance:
+        status: "supported"
+        nativeSurface: "Python wheel and source distribution"
+        productSurface: "PyPI trusted publishing, checksums, SBOM, and attestations"
+        evidence:
+          - "path:.github/workflows/publish-python.yml"
+          - "path:packages/mcp-server/tests/unit/test_release_hardening.py"
+          - "path:docs/publishing.md"
+        notes: "Release evidence is product-scoped for the Python package."
+      npm_tarball_provenance:
+        status: "supported"
+        nativeSurface: "npm launcher tarball"
+        productSurface: "npm provenance, checksum verification, and SBOM workflow"
+        evidence:
+          - "path:.github/workflows/publish-npm.yml"
+          - "path:scripts/check-release-provenance.mjs"
+          - "path:docs/release.md"
+        notes: "npm release evidence is tied to the version-linked MCP product."
+  kicad11Readiness:
+    protocol_upgrade:
+      status: "future"
+      nativeSurface: "MCP protocol and KiCad 11 readiness"
+      productSurface: "Protocol upgrade plan and KiCad 11 manual canary path"
+      issue: "https://github.com/oaslananka/kicad-studio-kit/issues/197"
+      evidence:
+        - "path:docs/compatibility/kicad-10-to-11-migration.md"
+        - "command:corepack pnpm run test:kicad-cli-contract:future"
+      notes: "KiCad 11 is intentionally separate from the KiCad 10.0.3 release-blocking baseline."
+    nightly_canary:
+      status: "supported"
+      nativeSurface: "KiCad development-branch nightly CLI"
+      productSurface: "Manual prerelease smoke command and scheduled canary metadata"
+      evidence:
+        - "path:packages/mcp-server/scripts/kicad_canary.py"
+        - "path:docs/compatibility/kicad-10-to-11-migration.md"
+        - "command:corepack pnpm run test:kicad-cli-contract:nightly"
+      notes: "Nightly runs remain non-release and do not change the stable support line."
+    swig_removal_guard:
+      status: "supported"
+      nativeSurface: "KiCad 11 planned removal of SWIG pcbnew bindings"
+      productSurface: "Production direct-pcbnew import guard"
+      evidence:
+        - "path:packages/mcp-server/scripts/check_no_pcbnew.py"
+        - "path:packages/mcp-server/tests/unit/test_compatibility_matrix.py"
+        - "source:https://dev-docs.kicad.org/en/apis-and-binding/pcbnew/"
+      notes: "The guard keeps KiCad 11 preparation independent from current KiCad 10 parity."
+
 kicadIpcReadiness:
   reviewed: "2026-05-26"
   sources:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -45,6 +45,10 @@ export default defineConfig({
           { text: "Install", link: "/install" },
           { text: "Versions", link: "/versions" },
           { text: "Support Matrix", link: "/support-matrix" },
+          {
+            text: "KiCad 10.0.3 Feature Parity",
+            link: "/compatibility/kicad-10-0-3-feature-parity",
+          },
         ],
       },
       {

--- a/docs/compatibility/kicad-10-0-3-feature-parity.md
+++ b/docs/compatibility/kicad-10-0-3-feature-parity.md
@@ -1,0 +1,122 @@
+# KiCad 10.0.3 Feature Parity
+
+This page is the human-readable view of
+[`compatibility.yaml`](../../compatibility.yaml) `kicad10FeatureParity`. It
+tracks KiCad 10.0.3 parity separately from the current KiCad 11 readiness plan
+so release gates stay focused on the stable KiCad line.
+
+Status vocabulary:
+
+| State            | Meaning                                                                                   |
+| ---------------- | ----------------------------------------------------------------------------------------- |
+| `supported`      | Product support exists and is backed by a test, fixture, command probe, or smoke path.    |
+| `not-applicable` | KiCad-native GUI behavior is intentionally outside the extension or MCP product surface.  |
+| `partial`        | Some product support exists, but a tracked gap remains.                                   |
+| `blocked`        | Product support is intentionally prevented by an upstream or policy boundary.             |
+| `future`         | The upstream feature exists or is expected, but product adoption is scheduled separately. |
+
+## Importers
+
+| Feature id    | State       | Product boundary                                                                                                | Evidence or issue                                                                             |
+| ------------- | ----------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `altium`      | `supported` | Extension import command and MCP manufacturing probe after `kicad-cli pcb import --help` advertises the format. | `apps/vscode-extension/test/unit/importCommands.test.ts`                                      |
+| `allegro`     | `blocked`   | Extension command is registered for future compatibility but hidden unless CLI support appears.                 | [#179](https://github.com/oaslananka/kicad-studio-kit/issues/179), `kicad-10-0-3-regressions` |
+| `cadstar`     | `supported` | Extension command is probe-gated by CLI help.                                                                   | `apps/vscode-extension/test/unit/importCommands.test.ts`                                      |
+| `eagle`       | `supported` | Extension command is probe-gated by CLI help.                                                                   | `apps/vscode-extension/test/unit/importCommands.test.ts`                                      |
+| `fabmaster`   | `supported` | Extension command is probe-gated by CLI help.                                                                   | `apps/vscode-extension/test/unit/importCommands.test.ts`                                      |
+| `geda_lepton` | `supported` | Extension and MCP support require the installed CLI to advertise `geda`.                                        | `packages/mcp-server/tests/integration/test_manufacturing_tools.py`                           |
+| `pads`        | `supported` | Extension, MCP, fixture, and canary coverage exercise the PADS import boundary.                                 | `packages/mcp-server/tests/unit/test_kicad_canary.py`                                         |
+| `pcad`        | `supported` | Extension command is probe-gated by CLI help.                                                                   | `apps/vscode-extension/test/unit/importCommands.test.ts`                                      |
+| `solidworks`  | `supported` | Extension command is probe-gated by CLI help.                                                                   | `apps/vscode-extension/test/unit/importCommands.test.ts`                                      |
+
+## Exports
+
+| Feature id                           | State       | Product boundary                                                                                   | Evidence or issue                                                             |
+| ------------------------------------ | ----------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `gerber`                             | `supported` | MCP manufacturing and extension export workflows depend on the KiCad CLI Gerber export.            | `packages/mcp-server/scripts/kicad_canary.py`                                 |
+| `drill`                              | `supported` | MCP manufacturing and extension export workflows depend on the KiCad CLI drill export.             | `packages/mcp-server/scripts/kicad_canary.py`                                 |
+| `pdf`                                | `supported` | Schematic and PCB PDF exports are part of the primary KiCad canary plan.                           | `packages/mcp-server/tests/unit/test_kicad_canary.py`                         |
+| `pcb_pdf_property_popup_suppression` | `supported` | KiCad 10.0.3-specific PDF flag is covered by a fixture and canary probe.                           | `kicad-10-0-3-regressions`                                                    |
+| `ipc2581`                            | `supported` | Extension command and MCP `export_ipc2581` tool both expose the export.                            | `packages/mcp-server/tests/integration/test_pcb_export_validation_surface.py` |
+| `odbpp`                              | `supported` | Extension command and MCP `export_odb` tool expose ODB++ behind capability checks.                 | `packages/mcp-server/tests/integration/test_export_tools.py`                  |
+| `step`                               | `supported` | MCP `export_step` and `export_3d_step` tools cover the KiCad CLI STEP export.                      | `packages/mcp-server/tests/integration/test_export_tools.py`                  |
+| `stepz`                              | `future`    | KiCad CLI documents STEPZ, but KiCad Studio Kit does not expose a first-class product command yet. | [#232](https://github.com/oaslananka/kicad-studio-kit/issues/232)             |
+| `xao`                                | `future`    | KiCad CLI documents XAO, but KiCad Studio Kit does not expose a first-class product command yet.   | [#232](https://github.com/oaslananka/kicad-studio-kit/issues/232)             |
+
+## GUI Editor
+
+| Feature id                  | State            | Product boundary                                                                                                       | Evidence or issue                                                 |
+| --------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `design_blocks`             | `supported`      | Product support is headless through parser coverage and MCP `pcb_block_*` tools.                                       | `apps/vscode-extension/test/unit/sExpressionParser.test.ts`       |
+| `graphical_drc_rule_editor` | `not-applicable` | The native GUI editor remains a KiCad-owned surface; product support is textual `.kicad_dru` guidance and diagnostics. | `apps/vscode-extension/test/unit/drcRulesProvider.test.ts`        |
+| `variants`                  | `supported`      | Extension variants view and MCP `variant_*` tools cover list, activation, diff, and export integration.                | `apps/vscode-extension/test/unit/variantProvider.test.ts`         |
+| `barcode_support`           | `supported`      | MCP `pcb_add_barcode` supports headless barcode insertion; visual editing stays in KiCad.                              | `packages/mcp-server/tests/unit/test_kicad10_parity_tools.py`     |
+| `time_domain_tuning`        | `partial`        | MCP tuning helpers model intent, but do not replace the native interactive routing UX.                                 | [#232](https://github.com/oaslananka/kicad-studio-kit/issues/232) |
+
+## IPC
+
+| Feature id                      | State       | Product boundary                                                                       | Evidence or issue                                                 |
+| ------------------------------- | ----------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `kicad_python_ipc`              | `supported` | KiCad IPC is the supported live-editor direction for current and future KiCad lines.   | `packages/mcp-server/tests/gui/test_kicad_gui_live_context.py`    |
+| `swig_pcbnew_direct_dependency` | `blocked`   | Production direct `pcbnew` imports are forbidden because SWIG bindings are deprecated. | [#197](https://github.com/oaslananka/kicad-studio-kit/issues/197) |
+
+## Product Surfaces
+
+| Feature id                        | State       | Product boundary                                                                        | Evidence or issue                                                 |
+| --------------------------------- | ----------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `status_surface`                  | `supported` | The extension status bar and command menu expose detected KiCad line and feature gates. | `apps/vscode-extension/test/unit/kicadCliSupport.test.ts`         |
+| `importer_command_gating`         | `supported` | Import commands are unavailable until the matching CLI capability probe passes.         | `apps/vscode-extension/test/unit/importCommands.test.ts`          |
+| `server_info_capability_contract` | `supported` | MCP server-info compatibility and capability payloads are schema and docs gated.        | `packages/mcp-server/tests/unit/test_server_info_contract.py`     |
+| `empty_project_read_tools`        | `partial`   | File-backed empty-project behavior is tracked outside this matrix.                      | [#228](https://github.com/oaslananka/kicad-studio-kit/issues/228) |
+| `ipc_state_consistency`           | `partial`   | IPC lifecycle consistency is tracked in the MCP compatibility milestone.                | [#223](https://github.com/oaslananka/kicad-studio-kit/issues/223) |
+
+## Release
+
+| Feature id               | State       | Product boundary                                                                        | Evidence or issue                         |
+| ------------------------ | ----------- | --------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `vsix_provenance`        | `supported` | VSIX release evidence includes checksums, SBOM, and artifact attestations.              | `.github/workflows/publish-extension.yml` |
+| `wheel_provenance`       | `supported` | Python release evidence includes checksums, SBOM, trusted publishing, and attestations. | `.github/workflows/publish-python.yml`    |
+| `npm_tarball_provenance` | `supported` | npm launcher release evidence includes checksums, SBOM, and provenance.                 | `.github/workflows/publish-npm.yml`       |
+
+## KiCad 11 Readiness
+
+KiCad 11 readiness is represented separately from KiCad 10.0.3 parity:
+
+| Feature id           | State       | Product boundary                                                                                   | Evidence or issue                                                 |
+| -------------------- | ----------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `protocol_upgrade`   | `future`    | MCP protocol and KiCad 11 support planning remain separate from the stable KiCad 10 gate.          | [#197](https://github.com/oaslananka/kicad-studio-kit/issues/197) |
+| `nightly_canary`     | `supported` | Manual nightly canary commands track prerelease behavior without changing the stable support line. | `corepack pnpm run test:kicad-cli-contract:nightly`               |
+| `swig_removal_guard` | `supported` | The direct-`pcbnew` guard keeps production code away from APIs planned for removal.                | `packages/mcp-server/scripts/check_no_pcbnew.py`                  |
+
+## Validation
+
+Linux and macOS:
+
+```bash
+corepack pnpm run check:compatibility
+corepack pnpm run test:contract
+corepack pnpm run test:fixtures
+```
+
+Windows 11 PowerShell:
+
+```powershell
+corepack pnpm run check:compatibility
+corepack pnpm run test:contract
+corepack pnpm run test:fixtures
+```
+
+The compatibility gate verifies that every supported item has product evidence,
+every partial or blocked item links a GitHub issue, and every feature id in the
+matrix appears on this page.
+
+## Source Verification
+
+Checked on 2026-05-27:
+
+- [KiCad 10.0.3 release notes](https://www.kicad.org/blog/2026/05/KiCad-10.0.3-Release/)
+- [KiCad 10.0.3 GitHub release tag](https://github.com/KiCad/kicad-source-mirror/releases/tag/10.0.3)
+- [KiCad 10.0 CLI reference](https://docs.kicad.org/10.0/en/cli/cli.html)
+- [KiCad 10.0 PCB Editor reference](https://docs.kicad.org/10.0/en/pcbnew/pcbnew.html)
+- [KiCad PCB Python bindings deprecation notice](https://dev-docs.kicad.org/en/apis-and-binding/pcbnew/)
+- [KiCad nightly and release candidate guidance](https://www.kicad.org/help/nightlies-and-rcs/)

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -68,23 +68,36 @@ exports.
 after probing `kicad-cli pcb import --help`; this prevents the extension from
 claiming GUI-only importers as CLI-backed workflows.
 
-| Source format | Extension command | KiCad 10 CLI state | User-facing behavior |
-| --- | --- | --- | --- |
-| Altium | `kicadstudio.importAltium` | Supported | Command remains available and validates `--format altium` before opening the picker. |
-| Allegro | `kicadstudio.importAllegro` | Blocked | Command is registered for future compatibility, hidden unless `--format allegro` is advertised, and reports a deterministic warning when invoked without CLI support. |
-| CADSTAR | `kicadstudio.importCadstar` | Supported | Command remains available and validates `--format cadstar` before opening the picker. |
-| Eagle | `kicadstudio.importEagle` | Supported | Command remains available and validates `--format eagle` before opening the picker. |
-| Fabmaster | `kicadstudio.importFabmaster` | Supported | Command remains available and validates `--format fabmaster` before opening the picker. |
-| gEDA/Lepton | `kicadstudio.importGeda` | Probe-gated | Existing command remains available but does not run unless the installed CLI help advertises `geda`. |
-| PADS | `kicadstudio.importPads` | Supported | Command remains available and validates `--format pads` before opening the picker. |
-| P-CAD | `kicadstudio.importPcad` | Supported | Command remains available and validates `--format pcad` before opening the picker. |
-| SolidWorks PCB | `kicadstudio.importSolidworks` | Supported | Command remains available and validates `--format solidworks` before opening the picker. |
+| Source format  | Extension command              | KiCad 10 CLI state | User-facing behavior                                                                                                                                                  |
+| -------------- | ------------------------------ | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Altium         | `kicadstudio.importAltium`     | Supported          | Command remains available and validates `--format altium` before opening the picker.                                                                                  |
+| Allegro        | `kicadstudio.importAllegro`    | Blocked            | Command is registered for future compatibility, hidden unless `--format allegro` is advertised, and reports a deterministic warning when invoked without CLI support. |
+| CADSTAR        | `kicadstudio.importCadstar`    | Supported          | Command remains available and validates `--format cadstar` before opening the picker.                                                                                 |
+| Eagle          | `kicadstudio.importEagle`      | Supported          | Command remains available and validates `--format eagle` before opening the picker.                                                                                   |
+| Fabmaster      | `kicadstudio.importFabmaster`  | Supported          | Command remains available and validates `--format fabmaster` before opening the picker.                                                                               |
+| gEDA/Lepton    | `kicadstudio.importGeda`       | Probe-gated        | Existing command remains available but does not run unless the installed CLI help advertises `geda`.                                                                  |
+| PADS           | `kicadstudio.importPads`       | Supported          | Command remains available and validates `--format pads` before opening the picker.                                                                                    |
+| P-CAD          | `kicadstudio.importPcad`       | Supported          | Command remains available and validates `--format pcad` before opening the picker.                                                                                    |
+| SolidWorks PCB | `kicadstudio.importSolidworks` | Supported          | Command remains available and validates `--format solidworks` before opening the picker.                                                                              |
 
 Allegro fixture coverage is tracked by
 [`kicad-10-0-3-regressions`](kicad-fixture-corpus.md#fixture-coverage). The
 fixture records the stable boundary: KiCad 10 PCB Editor supports Cadence
 Allegro `.brd` import, while current stable CLI help does not advertise
 `--format allegro`.
+
+## KiCad 10.0.3 Feature-Parity Matrix
+
+The full KiCad 10.0.3 parity contract lives in
+[`docs/compatibility/kicad-10-0-3-feature-parity.md`](compatibility/kicad-10-0-3-feature-parity.md)
+and is machine-validated from `compatibility.yaml` `kicad10FeatureParity`.
+It covers importer, CLI/export, GUI/editor, IPC, VS Code extension, MCP server,
+and release artifact surfaces.
+
+Every `supported` feature must link to a test, fixture, command probe, or smoke
+path. Every `partial` or `blocked` feature must link to a GitHub issue. KiCad
+11 readiness risks stay in the separate readiness section so the KiCad 10.0.3
+matrix remains the stable release boundary.
 
 ## KiCad 11 Readiness
 

--- a/packages/mcp-server/scripts/check_compatibility_matrix.py
+++ b/packages/mcp-server/scripts/check_compatibility_matrix.py
@@ -26,6 +26,10 @@ REQUIRED_IPC_AREAS = (
 )
 KICAD_SUPPORT_STATES = {"primary", "supported", "deprecated"}
 KICAD_CI_MODES = {"required", "scheduled", "manual"}
+KICAD10_FEATURE_STATUSES = {"supported", "not-applicable", "partial", "blocked", "future"}
+PRODUCT_EVIDENCE_PREFIXES = ("path:", "fixture:", "command:", "smoke:")
+ISSUE_URL_RE = re.compile(r"^https://github\.com/oaslananka/kicad-studio-kit/issues/\d+$")
+URL_RE = re.compile(r"^https://[^\s]+$")
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -71,13 +75,211 @@ def _tool_names() -> set[str]:
     return set(re.findall(r"^\| `([^`]+)` \|", text, flags=re.MULTILINE))
 
 
-def _validate_repo_relative_path(value: Any, label: str) -> list[str]:
+def _validate_repo_relative_path(value: object, label: str) -> list[str]:
     if not isinstance(value, str) or not value:
         return [f"{label} must be a non-empty relative path"]
     path = Path(value)
     if path.is_absolute() or ".." in path.parts:
         return [f"{label} must stay inside the repository: {value!r}"]
     return []
+
+
+def _repo_path_exists(relative_path: str) -> bool:
+    if "*" in relative_path:
+        return any(REPO_ROOT.glob(relative_path))
+    return (REPO_ROOT / relative_path).exists()
+
+
+def _validate_issue_url(value: object, label: str) -> list[str]:
+    if not isinstance(value, str) or ISSUE_URL_RE.fullmatch(value) is None:
+        return [f"{label} must link to a GitHub issue in this repository"]
+    return []
+
+
+def _validate_evidence_entry(value: object, label: str) -> list[str]:
+    if not isinstance(value, str) or ":" not in value:
+        return [f"{label} must be prefixed evidence such as path:, fixture:, command:, smoke:"]
+    prefix, payload = value.split(":", 1)
+    if not payload:
+        return [f"{label} must include evidence detail after {prefix!r}"]
+    if prefix == "path":
+        errors = _validate_repo_relative_path(payload, label)
+        if not errors and not _repo_path_exists(payload):
+            errors.append(f"{label} path does not exist: {payload!r}")
+        return errors
+    if prefix == "fixture":
+        fixture_path = REPO_ROOT / "packages" / "kicad-fixtures" / "fixtures" / payload
+        return [] if fixture_path.exists() else [f"{label} fixture does not exist: {payload!r}"]
+    if prefix == "source":
+        return [] if URL_RE.fullmatch(payload) else [f"{label} source must be an HTTPS URL"]
+    if prefix in {"command", "smoke"}:
+        return []
+    return [f"{label} uses unknown evidence prefix {prefix!r}"]
+
+
+def _has_product_evidence(evidence: list[object]) -> bool:
+    return any(
+        isinstance(item, str) and item.startswith(PRODUCT_EVIDENCE_PREFIXES) for item in evidence
+    )
+
+
+def _validate_feature_evidence(
+    detail: dict[str, Any],
+    label: str,
+    *,
+    require_product_evidence: bool,
+) -> list[str]:
+    evidence = detail.get("evidence")
+    if not isinstance(evidence, list) or not evidence:
+        return [f"{label}.evidence must be a non-empty list"]
+    errors: list[str] = []
+    for index, item in enumerate(evidence):
+        errors.extend(_validate_evidence_entry(item, f"{label}.evidence[{index}]"))
+    if require_product_evidence and not _has_product_evidence(evidence):
+        errors.append(f"{label}.evidence must include path:, fixture:, command:, or smoke:")
+    return errors
+
+
+def _validate_kicad10_feature(
+    group: str,
+    feature: str,
+    detail: object,
+    docs_text: str,
+    *,
+    label_root: str = "kicad10FeatureParity.surfaces",
+) -> list[str]:
+    label = f"{label_root}.{group}.{feature}"
+    if not isinstance(detail, dict):
+        return [f"{label} must be a mapping"]
+    errors: list[str] = []
+    status = detail.get("status")
+    if status not in KICAD10_FEATURE_STATUSES:
+        errors.append(f"{label}.status must be one of {sorted(KICAD10_FEATURE_STATUSES)!r}")
+    for key in ("nativeSurface", "productSurface", "notes"):
+        if not isinstance(detail.get(key), str) or not detail[key]:
+            errors.append(f"{label}.{key} must be a non-empty string")
+    errors.extend(
+        _validate_feature_evidence(
+            detail,
+            label,
+            require_product_evidence=status == "supported",
+        )
+    )
+    if status in {"partial", "blocked"}:
+        errors.extend(_validate_issue_url(detail.get("issue"), f"{label}.issue"))
+    elif "issue" in detail:
+        errors.extend(_validate_issue_url(detail.get("issue"), f"{label}.issue"))
+    if feature not in docs_text:
+        errors.append(f"{label} is not documented in the parity docs page")
+    return errors
+
+
+def _validate_kicad10_group(
+    group: str,
+    features: object,
+    docs_text: str,
+    *,
+    label_root: str,
+) -> list[str]:
+    if not isinstance(features, dict) or not features:
+        return [f"{label_root}.{group} must be a non-empty mapping"]
+    errors: list[str] = []
+    for feature, detail in features.items():
+        if not isinstance(feature, str) or not feature:
+            errors.append(f"{label_root}.{group} feature keys must be non-empty strings")
+            continue
+        errors.extend(
+            _validate_kicad10_feature(
+                group,
+                feature,
+                detail,
+                docs_text,
+                label_root=label_root,
+            )
+        )
+    return errors
+
+
+def _validate_kicad10_sources(parity: dict[str, Any]) -> list[str]:
+    sources = parity.get("sources")
+    if not isinstance(sources, dict) or not sources:
+        return ["kicad10FeatureParity.sources must be a non-empty mapping"]
+    errors: list[str] = []
+    for key, value in sources.items():
+        if (
+            not isinstance(key, str)
+            or not isinstance(value, str)
+            or URL_RE.fullmatch(value) is None
+        ):
+            errors.append(f"kicad10FeatureParity.sources.{key} must be an HTTPS URL")
+    return errors
+
+
+def _kicad10_docs_text(parity: dict[str, Any]) -> tuple[str, list[str]]:
+    docs_path = parity.get("documentation")
+    label = "kicad10FeatureParity.documentation"
+    errors = _validate_repo_relative_path(docs_path, label)
+    if not isinstance(docs_path, str) or errors:
+        return "", errors
+    full_docs_path = REPO_ROOT / docs_path
+    if not full_docs_path.exists():
+        return "", [f"{label} does not exist: {docs_path!r}"]
+    return full_docs_path.read_text(encoding="utf-8"), []
+
+
+def _validate_kicad10_surface_groups(
+    surfaces: object,
+    docs_text: str,
+) -> list[str]:
+    required_groups = {
+        "importers",
+        "exports",
+        "gui_editor",
+        "ipc",
+        "vscode_extension",
+        "mcp_server",
+        "release",
+    }
+    if not isinstance(surfaces, dict):
+        return ["kicad10FeatureParity.surfaces must be a mapping"]
+    errors: list[str] = []
+    missing = required_groups - set(surfaces)
+    if missing:
+        errors.append(f"kicad10FeatureParity.surfaces missing groups: {sorted(missing)!r}")
+    for group, features in surfaces.items():
+        errors.extend(
+            _validate_kicad10_group(
+                group,
+                features,
+                docs_text,
+                label_root="kicad10FeatureParity.surfaces",
+            )
+        )
+    return errors
+
+
+def _validate_kicad10_feature_parity(matrix: dict[str, Any]) -> list[str]:
+    parity = matrix.get("kicad10FeatureParity")
+    if not isinstance(parity, dict):
+        return ["compatibility.yaml missing top-level 'kicad10FeatureParity'"]
+    errors = _validate_kicad10_sources(parity)
+    if parity.get("baseline") != matrix.get("kicad", {}).get("latestVerified"):
+        errors.append("kicad10FeatureParity.baseline must match kicad.latestVerified")
+    if set(parity.get("allowedStatuses", [])) != KICAD10_FEATURE_STATUSES:
+        errors.append("kicad10FeatureParity.allowedStatuses must match the validator vocabulary")
+
+    docs_text, docs_errors = _kicad10_docs_text(parity)
+    errors.extend(docs_errors)
+    errors.extend(_validate_kicad10_surface_groups(parity.get("surfaces"), docs_text))
+    errors.extend(
+        _validate_kicad10_group(
+            "kicad11Readiness",
+            parity.get("kicad11Readiness"),
+            docs_text,
+            label_root="kicad10FeatureParity",
+        )
+    )
+    return errors
 
 
 def _validate_pcbnew_policy(readiness: dict[str, Any]) -> list[str]:
@@ -116,7 +318,7 @@ def _validate_manual_canary(readiness: dict[str, Any]) -> list[str]:
 
 def _validate_ipc_area(
     area: str,
-    detail: Any,
+    detail: object,
     available_tools: set[str],
 ) -> list[str]:
     if not isinstance(detail, dict):
@@ -217,6 +419,7 @@ def validate_compatibility_matrix() -> list[str]:
     matrix = _read_yaml(REPO_ROOT / "compatibility.yaml")
     errors = _validate_required_shape(matrix)
     errors.extend(_validate_kicad_support_policy(matrix))
+    errors.extend(_validate_kicad10_feature_parity(matrix))
     if errors:
         return errors
 

--- a/packages/mcp-server/tests/unit/test_compatibility_matrix.py
+++ b/packages/mcp-server/tests/unit/test_compatibility_matrix.py
@@ -4,6 +4,7 @@ import yaml
 
 from kicad_mcp.compatibility import COMPATIBILITY_MATRIX, MCP_PROTOCOL_VERSION
 from scripts.check_compatibility_matrix import (
+    KICAD10_FEATURE_STATUSES,
     PCBNEW_POLICY,
     REPO_ROOT,
     REQUIRED_IPC_AREAS,
@@ -50,3 +51,32 @@ def test_kicad_ipc_readiness_contract_covers_pcbnew_and_parity() -> None:
     assert set(REQUIRED_IPC_AREAS).issubset(required_for)
     assert readiness["manualCanary"]["currentNightlyRange"] == "10.99.x"
     assert readiness["manualCanary"]["releaseCandidateRange"] == "11.0.x"
+
+
+def test_kicad10_feature_parity_matrix_tracks_gaps_and_evidence() -> None:
+    matrix = yaml.safe_load((REPO_ROOT / "compatibility.yaml").read_text(encoding="utf-8"))
+    parity = matrix["kicad10FeatureParity"]
+    surfaces = parity["surfaces"]
+
+    assert parity["baseline"] == matrix["kicad"]["latestVerified"]
+    assert set(parity["allowedStatuses"]) == KICAD10_FEATURE_STATUSES
+    assert surfaces["importers"]["allegro"]["status"] == "blocked"
+    assert surfaces["exports"]["stepz"]["issue"].endswith("/issues/232")
+    assert surfaces["gui_editor"]["graphical_drc_rule_editor"]["status"] == "not-applicable"
+    assert surfaces["mcp_server"]["empty_project_read_tools"]["issue"].endswith("/issues/228")
+    assert parity["kicad11Readiness"]["protocol_upgrade"]["issue"].endswith("/issues/197")
+
+    supported_items = [
+        feature
+        for group in surfaces.values()
+        for feature in group.values()
+        if feature["status"] == "supported"
+    ]
+    assert supported_items
+    assert all(
+        any(
+            item.startswith(("path:", "fixture:", "command:", "smoke:"))
+            for item in feature["evidence"]
+        )
+        for feature in supported_items
+    )


### PR DESCRIPTION
## Summary

- Adds a version-controlled KiCad 10.0.3 feature-parity and regression-hardening matrix across importer, export, GUI/editor, IPC/plugin, VS Code extension, MCP server, and release surfaces.
- Documents supported, not-applicable, partial, blocked, and future states with evidence links, issue links, and a separate KiCad 11 readiness section.
- Extends the compatibility validator and unit coverage so CI rejects undocumented feature-state drift.

## Linked issue

Closes #177
Follow-up: #232

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- `uv run --project packages/mcp-server --all-extras pytest packages/mcp-server/tests/unit/test_compatibility_matrix.py -q` — passed, 5 tests
- `corepack pnpm run check:compatibility` — passed
- `corepack pnpm run docs:generate` — passed
- `corepack pnpm run docs:lint` — passed
- `corepack pnpm run docs:links` — passed
- `corepack pnpm run format` — passed
- `corepack pnpm run format:check` — passed
- `corepack pnpm run lint` — passed
- `corepack pnpm run typecheck` — passed
- `corepack pnpm run test` — passed
- `corepack pnpm run build` — passed
- `corepack pnpm run verify:dist` — passed
- `gitleaks detect --source . --redact --no-banner` — passed
- `corepack pnpm run docs:check-generated` — passed
- `corepack pnpm run check` — passed
- `uv run --project packages/mcp-server --all-extras ruff check packages/mcp-server/scripts/check_compatibility_matrix.py packages/mcp-server/tests/unit/test_compatibility_matrix.py` — passed
- PowerShell GitHub Actions deprecation scan for `::set-output`, `::save-state`, insecure Node override, `node12`, `node16`, `node20` — passed
- `actionlint` over `.github/workflows/*.yml` — passed
- `pre-commit run --all-files` — passed
- `git diff --check` — passed

## Protocol / MCP impact

Checklist reference: `docs/architecture/protocol-change-checklist.md`

- [ ] Not applicable; reason:
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [x] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

Compatibility metadata only: no MCP tool names, payload schemas, transport behavior, or extension adapter behavior changed. The validator enforces additive KiCad parity metadata and preserves existing compatibility keys.

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [ ] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts

This is not a bug-fix PR, so the bug-fix regression checkbox is not applicable. No CHANGELOG entry was added because the change is repository compatibility governance/docs and does not alter a released product command, API, or package artifact.