### PR TITLE
fix(vscode-extension): resolve runtime UI and degraded MCP bugs

### DIFF
--- a/apps/vscode-extension/docs/INTEGRATION.md
+++ b/apps/vscode-extension/docs/INTEGRATION.md
@@ -18,4 +18,4 @@ The extension checks:
 
 - Repository: https://github.com/oaslananka/kicad-studio-kit/tree/main/apps/vscode-extension
 - MCP server: https://github.com/oaslananka/kicad-studio-kit/tree/main/packages/mcp-server
-- Manufacturing export docs: https://oaslananka.github.io/kicad-studio-kit/mcp/workflows/manufacturing-export/
+- Manufacturing export docs: https://oaslananka.github.io/kicad-studio-kit/workflows/manufacturing-export/

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -739,7 +739,8 @@
       {
         "command": "kicadstudio.qualityGate.runThis",
         "title": "%kicadstudio.contributes.commands.65.title%",
-        "category": "%kicadstudio.contributes.commands.65.category%"
+        "category": "%kicadstudio.contributes.commands.65.category%",
+        "icon": "$(play)"
       },
       {
         "command": "kicadstudio.qualityGate.showRaw",
@@ -749,7 +750,8 @@
       {
         "command": "kicadstudio.qualityGate.openDocs",
         "title": "%kicadstudio.contributes.commands.67.title%",
-        "category": "%kicadstudio.contributes.commands.67.category%"
+        "category": "%kicadstudio.contributes.commands.67.category%",
+        "icon": "$(book)"
       },
       {
         "command": "kicadstudio.manufacturing.release",
@@ -997,6 +999,21 @@
         }
       ],
       "view/item/context": [
+        {
+          "when": "view == kicadstudio.qualityGate && viewItem =~ /^qualityGate-/ && kicadstudio.workspaceTrusted",
+          "command": "kicadstudio.qualityGate.runThis",
+          "group": "inline@1"
+        },
+        {
+          "when": "view == kicadstudio.qualityGate && viewItem =~ /^qualityGate-/",
+          "command": "kicadstudio.qualityGate.openDocs",
+          "group": "inline@2"
+        },
+        {
+          "when": "view == kicadstudio.qualityGate && viewItem =~ /^qualityGate-/",
+          "command": "kicadstudio.qualityGate.showRaw",
+          "group": "navigation"
+        },
         {
           "when": "view == kicadstudio.library && viewItem == pcmPackageAvailable && kicadstudio.workspaceTrusted",
           "command": "kicadstudio.pcm.install",

--- a/apps/vscode-extension/src/ai/chatHtml.ts
+++ b/apps/vscode-extension/src/ai/chatHtml.ts
@@ -356,7 +356,12 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       <span id="cancel-disabled-reason" class="sr-only">Cancel is disabled until a response is streaming.</span>
     </div>
   </header>
-  <div id="quota-banner" class="quota-banner" role="status" hidden></div>
+  <div id="quota-banner" class="quota-banner" style="background-color: var(--danger); color: white; padding: 8px; text-align: center;" role="status" hidden>
+     <span id="quota-banner-text"></span>
+     <button id="quota-banner-retry" style="margin-left: 8px; padding: 2px 6px; background: rgba(0,0,0,0.2); border: none; color: white; cursor: pointer;">
+       Retry
+     </button>
+  </div>
   <main id="messages" aria-live="polite">
     <div id="empty" class="empty">Ask about DRC/ERC issues, component choices, manufacturing risk, or the active KiCad file.</div>
   </main>
@@ -399,7 +404,9 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       tokenEstimate: document.getElementById('token-estimate'),
       send: document.getElementById('send'),
       cancel: document.getElementById('cancel'),
-      toggleContext: document.getElementById('toggle-context')
+      toggleContext: document.getElementById('toggle-context'),
+      quotaBanner: document.getElementById('quota-banner'),
+      quotaBannerText: document.getElementById('quota-banner-text')
     };
 
     function text(value) {
@@ -430,7 +437,7 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       const status = text(value);
       const quotaReached = /quota|rate limit|usage limit|limit reached/i.test(status);
       nodes.quotaBanner.hidden = !quotaReached;
-      nodes.quotaBanner.textContent = quotaReached
+      nodes.quotaBannerText.textContent = quotaReached
         ? status || l10n.t('Chat quota reached. Retry after the provider resets quota.')
         : '';
     }
@@ -671,6 +678,7 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
     document.getElementById('settings').addEventListener('click', () => vscode.postMessage({ type: 'openSettings' }));
     document.getElementById('clear').addEventListener('click', () => vscode.postMessage({ type: 'clear' }));
     document.getElementById('export').addEventListener('click', exportTranscript);
+    document.getElementById('quota-banner-retry').addEventListener('click', () => vscode.postMessage({ type: 'retry' }));
     nodes.cancel.addEventListener('click', () => vscode.postMessage({ type: 'cancel' }));
     nodes.send.addEventListener('click', sendPrompt);
     nodes.provider.addEventListener('change', postSelection);

--- a/apps/vscode-extension/src/ai/chatHtml.ts
+++ b/apps/vscode-extension/src/ai/chatHtml.ts
@@ -46,7 +46,7 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       margin: 0;
       height: 100vh;
       display: grid;
-      grid-template-rows: auto 1fr auto;
+      grid-template-rows: auto auto 1fr auto;
       background: var(--bg);
       color: var(--text);
       font: 13px/1.5 var(--vscode-font-family, "Segoe UI", sans-serif);
@@ -146,6 +146,14 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       flex-direction: column;
       gap: 10px;
     }
+    .quota-banner {
+      padding: 7px 12px;
+      border-bottom: 1px solid var(--border);
+      background: color-mix(in srgb, var(--danger) 10%, var(--panel));
+      color: var(--text);
+      font-size: 12px;
+    }
+    .quota-banner[hidden] { display: none; }
     .empty {
       align-self: center;
       margin-top: 15vh;
@@ -348,6 +356,7 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       <span id="cancel-disabled-reason" class="sr-only">Cancel is disabled until a response is streaming.</span>
     </div>
   </header>
+  <div id="quota-banner" class="quota-banner" role="status" hidden></div>
   <main id="messages" aria-live="polite">
     <div id="empty" class="empty">Ask about DRC/ERC issues, component choices, manufacturing risk, or the active KiCad file.</div>
   </main>
@@ -367,10 +376,20 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
   <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
     const l10n = globalThis.kicadStudioL10n || { t: (value) => value, apply: () => {} };
-    const state = { history: [], busy: false, contextVisible: false, scrollPending: false };
+    const AUTO_SCROLL_THRESHOLD_PX = 96;
+    const MAX_RENDERED_MESSAGES = 240;
+    const state = {
+      history: [],
+      busy: false,
+      contextVisible: false,
+      scrollPending: false,
+      streamPending: false,
+      streamQueue: new Map()
+    };
     const nodes = {
       messages: document.getElementById('messages'),
       empty: document.getElementById('empty'),
+      quotaBanner: document.getElementById('quota-banner'),
       provider: document.getElementById('provider'),
       model: document.getElementById('model'),
       status: document.getElementById('status'),
@@ -407,8 +426,18 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       const date = new Date(Number(timestamp) || Date.now());
       return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     }
+    function setQuotaBanner(value) {
+      const status = text(value);
+      const quotaReached = /quota|rate limit|usage limit|limit reached/i.test(status);
+      nodes.quotaBanner.hidden = !quotaReached;
+      nodes.quotaBanner.textContent = quotaReached
+        ? status || l10n.t('Chat quota reached. Retry after the provider resets quota.')
+        : '';
+    }
     function setStatus(value) {
-      nodes.status.textContent = value || l10n.t('Ready');
+      const next = value || l10n.t('Ready');
+      nodes.status.textContent = next;
+      setQuotaBanner(next);
     }
     function setBusy(busy) {
       state.busy = !!busy;
@@ -426,31 +455,24 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
         item.remove();
       }
     }
-    /**
-     * Scroll the message list to the bottom using requestAnimationFrame so
-     * multiple calls within the same event loop tick are coalesced into a
-     * single layout pass. While the assistant is actively streaming (state.busy)
-     * we always scroll so new chunks stay visible. Once streaming ends we only
-     * scroll when the user is already near the bottom (within 120 px) so
-     * manual scroll-up to read history is preserved.
-     */
-    function scheduleScrollToBottom() {
-      if (state.scrollPending) {
+    function isNearBottom(el) {
+      return el.scrollHeight - el.scrollTop - el.clientHeight < AUTO_SCROLL_THRESHOLD_PX;
+    }
+    function scheduleScrollToBottom(shouldStick) {
+      if (!shouldStick || state.scrollPending) {
         return;
       }
       state.scrollPending = true;
       requestAnimationFrame(() => {
         state.scrollPending = false;
-        const el = nodes.messages;
-        if (state.busy) {
-          el.scrollTop = el.scrollHeight;
-          return;
-        }
-        const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
-        if (nearBottom) {
-          el.scrollTop = el.scrollHeight;
-        }
+        nodes.messages.scrollTop = nodes.messages.scrollHeight;
       });
+    }
+    function pruneRenderedMessages() {
+      const rendered = [...nodes.messages.querySelectorAll('.message')];
+      for (const item of rendered.slice(0, Math.max(0, rendered.length - MAX_RENDERED_MESSAGES))) {
+        item.remove();
+      }
     }
     function actionButton(label, title, onClick) {
       const button = document.createElement('button');
@@ -546,6 +568,7 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       container.appendChild(actions);
     }
     function renderMessage(message, streaming) {
+      const shouldStick = isNearBottom(nodes.messages) || message.role === 'user';
       let article = nodes.messages.querySelector('[data-timestamp="' + String(message.timestamp) + '"]');
       if (!article) {
         article = document.createElement('article');
@@ -572,7 +595,8 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
         renderTools(article, message);
       }
       nodes.empty.style.display = nodes.messages.querySelector('.message') ? 'none' : 'block';
-      scheduleScrollToBottom();
+      pruneRenderedMessages();
+      scheduleScrollToBottom(shouldStick);
     }
 
     /**
@@ -609,7 +633,31 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
         // No chunk provided (e.g. called from outside streaming path) — full replace.
         pre.textContent = content;
       }
-      scheduleScrollToBottom();
+    }
+    function queueAssistantDelta(timestamp, content, chunk) {
+      const key = String(timestamp);
+      const entry = state.streamQueue.get(key) || {
+        timestamp,
+        content,
+        chunk: '',
+        shouldStick: false
+      };
+      entry.content = content;
+      entry.chunk += chunk;
+      entry.shouldStick = entry.shouldStick || isNearBottom(nodes.messages);
+      state.streamQueue.set(key, entry);
+      if (state.streamPending) {
+        return;
+      }
+      state.streamPending = true;
+      requestAnimationFrame(() => {
+        state.streamPending = false;
+        for (const queued of state.streamQueue.values()) {
+          updateStreamingBody(queued.timestamp, queued.content, queued.chunk);
+          scheduleScrollToBottom(queued.shouldStick);
+        }
+        state.streamQueue.clear();
+      });
     }
     function exportTranscript() {
       const lines = state.history.map((message) => {
@@ -668,9 +716,7 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
         if (target) {
           const chunk = text(message.text);
           target.content = text(target.content) + chunk;
-          // Fast path: only update the streaming text area — no full re-render.
-          // Pass chunk so updateStreamingBody can append rather than replace.
-          updateStreamingBody(message.timestamp, target.content, chunk);
+          queueAssistantDelta(message.timestamp, target.content, chunk);
         }
       } else if (message.type === 'assistantReplace') {
         const index = state.history.findIndex((item) => item.timestamp === message.message?.timestamp);

--- a/apps/vscode-extension/src/commands/qualityGateCommands.ts
+++ b/apps/vscode-extension/src/commands/qualityGateCommands.ts
@@ -15,15 +15,29 @@ export function registerQualityGateCommands(
     ),
     registerTrustedCommand(
       COMMANDS.qualityGateRunThis,
-      (gate: QualityGateResult) => services.qualityGateProvider.runGate(gate),
+      (gate: QualityGateCommandArg) =>
+        services.qualityGateProvider.runGate(resolveGateArg(gate)),
       'Run Quality Gate'
     ),
     vscode.commands.registerCommand(
       COMMANDS.qualityGateShowRaw,
-      (gate: QualityGateResult) => services.qualityGateProvider.showRaw(gate)
+      (gate: QualityGateCommandArg) =>
+        services.qualityGateProvider.showRaw(resolveGateArg(gate))
     ),
-    vscode.commands.registerCommand(COMMANDS.qualityGateOpenDocs, () =>
-      services.qualityGateProvider.openDocs()
+    vscode.commands.registerCommand(
+      COMMANDS.qualityGateOpenDocs,
+      (gate?: QualityGateCommandArg) =>
+        services.qualityGateProvider.openDocs(
+          gate ? resolveGateArg(gate) : undefined
+        )
     )
   ];
+}
+
+type QualityGateCommandArg =
+  | QualityGateResult
+  | { kind: 'gate'; gate: QualityGateResult };
+
+function resolveGateArg(gate: QualityGateCommandArg): QualityGateResult {
+  return 'kind' in gate && gate.kind === 'gate' ? gate.gate : gate;
 }

--- a/apps/vscode-extension/src/commands/qualityGateCommands.ts
+++ b/apps/vscode-extension/src/commands/qualityGateCommands.ts
@@ -39,5 +39,5 @@ type QualityGateCommandArg =
   | { kind: 'gate'; gate: QualityGateResult };
 
 function resolveGateArg(gate: QualityGateCommandArg): QualityGateResult {
-  return 'kind' in gate && gate.kind === 'gate' ? gate.gate : gate;
+  return 'kind' in gate && gate.kind === 'gate' ? gate.gate : (gate as QualityGateResult);
 }

--- a/apps/vscode-extension/src/mcp/fixQueueProvider.ts
+++ b/apps/vscode-extension/src/mcp/fixQueueProvider.ts
@@ -15,14 +15,21 @@ import {
 class FixQueueTreeItem extends vscode.TreeItem {
   constructor(public readonly item: FixItem) {
     super(item.description, vscode.TreeItemCollapsibleState.None);
-    this.description = item.tool;
-    this.tooltip = item.preview ?? item.description;
-    this.contextValue = `fix-${item.severity}`;
-    this.command = {
-      command: COMMANDS.applyFixQueueItem,
-      title: 'Apply Fix',
-      arguments: [item]
-    };
+    const disabled = Boolean(item.disabledReason);
+    this.description = disabled ? `${item.tool} - read-only` : item.tool;
+    this.tooltip = [item.preview ?? item.description, item.disabledReason]
+      .filter(Boolean)
+      .join('\n\n');
+    this.contextValue = disabled
+      ? `fix-${item.severity}-disabled`
+      : `fix-${item.severity}`;
+    if (!disabled) {
+      this.command = {
+        command: COMMANDS.applyFixQueueItem,
+        title: 'Apply Fix',
+        arguments: [item]
+      };
+    }
     this.iconPath = new vscode.ThemeIcon(
       item.severity === 'error'
         ? 'error'
@@ -164,7 +171,9 @@ export class FixQueueProvider implements vscode.TreeDataProvider<FixQueueNode> {
   }
 
   async applyAll(): Promise<void> {
-    const pending = this.items.filter((item) => item.status === 'pending');
+    const pending = this.items.filter(
+      (item) => item.status === 'pending' && !item.disabledReason
+    );
     if (!pending.length) {
       return;
     }
@@ -198,6 +207,11 @@ export class FixQueueProvider implements vscode.TreeDataProvider<FixQueueNode> {
     item: FixItem,
     options: { confirm: boolean }
   ): Promise<void> {
+    if (item.disabledReason) {
+      void vscode.window.showInformationMessage(item.disabledReason);
+      return;
+    }
+
     const preview =
       item.preview ??
       (await this.adapter.previewToolCall({

--- a/apps/vscode-extension/src/mcp/mcpClient.ts
+++ b/apps/vscode-extension/src/mcp/mcpClient.ts
@@ -44,6 +44,8 @@ export interface McpClientOptions {
 const MCP_SESSION_ID_KEY = 'kicadstudio.mcp.sessionId';
 const MCP_LAST_SERVER_CARD_KEY = 'kicadstudio.mcp.lastServerCard';
 const KNOWN_MCP_SDK_VERSION_HINTS = new Set(['1.27.0']);
+const FILE_BACKED_FIX_DISABLED_REASON =
+  'Read-only suggestion from file-backed quality gates; start a write-capable live MCP session to apply it automatically.';
 const DEFAULT_RECONNECT_DELAYS_MS = [
   1000, 2000, 4000, 8000, 16000, 30000
 ] as const;
@@ -243,9 +245,10 @@ export class McpClient {
     }
 
     try {
-      await this.callTool('studio_push_context', {
-        ...context
-      });
+      await this.callTool(
+        'studio_push_context',
+        toStudioContextToolArgs(context)
+      );
     } catch (error) {
       this.logger.debug(
         `MCP context push skipped: ${error instanceof Error ? error.message : String(error)}`
@@ -333,9 +336,15 @@ export class McpClient {
     const items =
       (Array.isArray(resource?.['items']) ? resource['items'] : undefined) ??
       (Array.isArray(resource?.['fixes']) ? resource['fixes'] : undefined);
+    const textItems = parseFixQueueText(
+      typeof resource?.['text'] === 'string' ? resource['text'] : undefined
+    );
 
     if (items) {
       return items.map((item, index) => normalizeFixItem(item, index));
+    }
+    if (textItems) {
+      return textItems;
     }
 
     const toolResult = await this.callTool('project_get_fix_queue', args);
@@ -859,9 +868,48 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function toStudioContextToolArgs(
+  context: StudioContext
+): Record<string, unknown> {
+  const project = context.project;
+  const projectFile = context.projectFile ?? project?.projectFile;
+  const projectRoot = context.projectRoot ?? project?.rootPath;
+  return {
+    active_file: context.activeFile ?? null,
+    file_type: context.fileType,
+    drc_errors: context.drcErrors,
+    selected_net: context.selectedNet ?? null,
+    selected_reference: context.selectedReference ?? null,
+    cursor_position: context.cursorPosition ?? null,
+    snapshot: {
+      activeFile: context.activeFile ?? null,
+      fileType: context.fileType,
+      projectFile: projectFile ?? null,
+      projectRoot: projectRoot ?? null,
+      projectId: context.projectId ?? project?.id ?? null,
+      projectName: context.projectName ?? project?.name ?? null,
+      selectedArea: context.selectedArea ?? null,
+      activeVariant: context.activeVariant ?? null,
+      mcpConnected: context.mcpConnected ?? null,
+      activeSheetPath: context.activeSheetPath ?? null,
+      visibleLayers: context.visibleLayers ?? [],
+      viewerEngine: context.viewerEngine ?? null,
+      kicadVersion: context.kicadVersion ?? null,
+      designBlocks: context.designBlocks ?? []
+    }
+  };
+}
+
 function normalizeFixItem(value: unknown, index: number): FixItem {
   const item = typeof value === 'object' && value !== null ? value : {};
   const record = item as Record<string, unknown>;
+  const source =
+    record['source'] === 'mcp' ||
+    record['source'] === 'file-backed' ||
+    record['source'] === 'live-ipc' ||
+    record['source'] === 'cached'
+      ? record['source']
+      : undefined;
   return {
     id: String(record['id'] ?? `fix-${index + 1}`),
     title:
@@ -894,6 +942,10 @@ function normalizeFixItem(value: unknown, index: number): FixItem {
     ...(typeof record['preview'] === 'string'
       ? { preview: record['preview'] }
       : {}),
+    ...(source ? { source } : {}),
+    ...(typeof record['disabledReason'] === 'string'
+      ? { disabledReason: record['disabledReason'] }
+      : {}),
     ...(typeof record['path'] === 'string' ? { path: record['path'] } : {}),
     ...(typeof record['line'] === 'number'
       ? { line: record['line'] }
@@ -905,6 +957,69 @@ function normalizeFixItem(value: unknown, index: number): FixItem {
       ? { confidence: record['confidence'] }
       : {})
   };
+}
+
+function parseFixQueueText(text: string | undefined): FixItem[] | undefined {
+  if (text === undefined) {
+    return undefined;
+  }
+  if (/No blocking issues|No pending fixes|quality gate is PASS/iu.test(text)) {
+    return [];
+  }
+  const blocked = text.match(/^\s*-\s*BLOCKED:\s*(.+)$/imu);
+  if (blocked?.[1]) {
+    return [fileBackedFixItem(0, 'Fix Queue blocked', blocked[1], 'warning')];
+  }
+  const rows = [
+    ...text.matchAll(/^\s*\d+\.\s*\[([^\]]+)\]\s*([^:\n]+):\s*(.+)$/gimu)
+  ];
+  if (!rows.length) {
+    return undefined;
+  }
+  return rows.map((row, index) => {
+    const detail = row[3] ?? 'Review project quality gate output.';
+    const tool = detail.match(/Suggested tool:\s*([a-zA-Z0-9_]+)/u)?.[1];
+    return fileBackedFixItem(
+      index,
+      row[2] ?? 'Quality gate',
+      detail,
+      severityFromText(row[1] ?? ''),
+      tool
+    );
+  });
+}
+
+function fileBackedFixItem(
+  index: number,
+  title: string,
+  detail: string,
+  severity: FixItem['severity'],
+  tool = 'review_file_backed_quality_gate'
+): FixItem {
+  return {
+    id: `file-backed-fix-${index + 1}`,
+    title: title.trim(),
+    description: detail
+      .replace(/\s*Suggested tool:\s*[a-zA-Z0-9_]+(?:\(\))?/u, '')
+      .trim(),
+    severity,
+    tool,
+    args: {},
+    status: 'pending',
+    source: 'file-backed',
+    disabledReason: FILE_BACKED_FIX_DISABLED_REASON,
+    preview: detail.trim()
+  };
+}
+
+function severityFromText(value: string): FixItem['severity'] {
+  if (/critical|high|error|fail|blocked/iu.test(value)) {
+    return 'error';
+  }
+  if (/warn|medium/iu.test(value)) {
+    return 'warning';
+  }
+  return 'info';
 }
 
 function parseSseJsonRpc<T>(payload: string): JsonRpcResponse<T> {

--- a/apps/vscode-extension/src/mcp/mcpClient.ts
+++ b/apps/vscode-extension/src/mcp/mcpClient.ts
@@ -244,15 +244,29 @@ export class McpClient {
       return;
     }
 
+    let args: Record<string, unknown>;
     try {
-      await this.callTool(
-        'studio_push_context',
-        toStudioContextToolArgs(context)
-      );
+      args = toStudioContextToolArgs(context);
     } catch (error) {
       this.logger.debug(
-        `MCP context push skipped: ${error instanceof Error ? error.message : String(error)}`
+        `MCP context push skipped (args build failed): ${error instanceof Error ? error.message : String(error)}`
       );
+      return;
+    }
+
+    try {
+      const result = await this.callTool('studio_push_context', args);
+      if (result && result['ok'] === false) {
+        this.logger.debug(
+          `MCP context push returned error: ${result['code']} - ${result['message']}`
+        );
+      }
+    } catch (error) {
+      this.logger.debug(
+        `MCP context push skipped (tool execution failed): ${error instanceof Error ? error.message : String(error)}`
+      );
+      // Return a structured error to avoid breaking downstream logic
+      return;
     }
   }
 

--- a/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
@@ -50,6 +50,8 @@ type CompatibilityDashboard = {
   lastError: string;
   remediation: string;
   diagnostics: string[];
+  fileBackedReadAvailable: boolean;
+  liveContextUnavailable: boolean;
 };
 
 const REQUIRED_EXTENSION_TOOLS = [
@@ -174,7 +176,7 @@ function buildCompatibilityDashboard(
 
   return {
     status,
-    stateLabel: dashboardStateLabel(state, status),
+    stateLabel: dashboardStateLabel(state, status, serverInfo),
     serverName: serverInfo?.server ?? 'kicad-mcp-pro',
     serverVersion: server?.version ?? serverInfo?.version ?? 'unknown',
     endpoint,
@@ -196,7 +198,9 @@ function buildCompatibilityDashboard(
     lastHealthCheck: server?.capturedAt ?? 'never',
     lastError: state.message ?? 'none',
     remediation: remediationHint(state, status),
-    diagnostics
+    diagnostics,
+    fileBackedReadAvailable: hasFileBackedRead(serverInfo),
+    liveContextUnavailable: hasUnavailableLiveContext(serverInfo)
   };
 }
 
@@ -230,7 +234,8 @@ function dashboardStatus(
 
 function dashboardStateLabel(
   state: McpConnectionState,
-  status: DashboardStatus
+  status: DashboardStatus,
+  serverInfo: McpServerInfoContract | undefined
 ): string {
   if (state.kind === 'NotInstalled') {
     return 'No MCP installed';
@@ -240,6 +245,20 @@ function dashboardStateLabel(
   }
   if (state.kind === 'Incompatible') {
     return 'Connected but incompatible';
+  }
+  if (
+    status === 'degraded' &&
+    hasFileBackedRead(serverInfo) &&
+    serverInfo?.kicad.ipcAvailable === false
+  ) {
+    return 'MCP connected; live KiCad IPC unavailable, file-backed read-only features active';
+  }
+  if (
+    status === 'degraded' &&
+    hasFileBackedRead(serverInfo) &&
+    hasUnavailableLiveContext(serverInfo)
+  ) {
+    return 'MCP connected; live KiCad context unavailable, file-backed read-only features active';
   }
   if (state.kind === 'Degraded' || status === 'degraded') {
     return state.connected || state.kind === 'VsCodeStdio'
@@ -318,7 +337,10 @@ function compatibilityDashboardNode(
       ]),
       dashboardGroup('Advertised surface', [
         dashboardField('Advertised tools', countText(dashboard.toolCount)),
-        dashboardField('Advertised resources', countText(dashboard.resourceCount)),
+        dashboardField(
+          'Advertised resources',
+          countText(dashboard.resourceCount)
+        ),
         dashboardField('Advertised prompts', countText(dashboard.promptCount)),
         missingGroup(
           'Missing required tools',
@@ -346,13 +368,23 @@ function stateNode(
   dashboard: CompatibilityDashboard
 ): McpToolsNode {
   if (dashboard.status === 'degraded') {
+    const fileBackedDegraded =
+      dashboard.fileBackedReadAvailable && dashboard.liveContextUnavailable;
+    const degradedReason = dashboard.stateLabel.includes('context unavailable')
+      ? 'live KiCad context unavailable'
+      : 'live KiCad IPC unavailable';
     return {
-      label:
-        state.connected || state.kind === 'VsCodeStdio'
+      label: fileBackedDegraded
+        ? 'MCP connected; file-backed read-only features active'
+        : state.connected || state.kind === 'VsCodeStdio'
           ? 'MCP connected with degraded capabilities'
           : 'MCP degraded',
-      description: dashboard.serverVersion,
-      tooltip: dashboard.remediation,
+      description: fileBackedDegraded
+        ? degradedReason
+        : dashboard.serverVersion,
+      tooltip: fileBackedDegraded
+        ? `${sentenceCase(degradedReason)}; file-backed read-only features active.`
+        : dashboard.remediation,
       icon: 'warning',
       command: {
         command: COMMANDS.retryMcp,
@@ -398,7 +430,10 @@ function stateNode(
   return {
     label: dashboard.stateLabel,
     description: state.available ? 'detected, not connected' : 'not detected',
-    tooltip: dashboard.lastError === 'none' ? dashboard.remediation : dashboard.lastError,
+    tooltip:
+      dashboard.lastError === 'none'
+        ? dashboard.remediation
+        : dashboard.lastError,
     icon: state.available ? 'warning' : 'circle-slash',
     command: {
       command: state.available
@@ -413,10 +448,16 @@ function actionGroupNode(): McpToolsNode {
   return {
     label: 'Actions',
     description: 'MCP operations',
-    tooltip: 'Run common MCP setup, recovery, diagnostics, and profile actions.',
+    tooltip:
+      'Run common MCP setup, recovery, diagnostics, and profile actions.',
     icon: 'tools',
     children: [
-      actionNode('Reconnect', COMMANDS.retryMcp, 'Reconnect MCP endpoint', 'sync'),
+      actionNode(
+        'Reconnect',
+        COMMANDS.retryMcp,
+        'Reconnect MCP endpoint',
+        'sync'
+      ),
       actionNode(
         'Refresh capabilities',
         COMMANDS.retryMcp,
@@ -567,9 +608,14 @@ function kicadRuntimeNode(
   const cliStatus = serverInfo.kicad.cliFound
     ? (serverInfo.kicad.cliVersion ?? 'version unknown')
     : 'CLI unavailable';
+  const fileBackedRead = hasFileBackedRead(serverInfo);
   return {
     label: 'KiCad runtime',
-    description: serverInfo.kicad.livePcbContext ? 'live PCB' : 'degraded',
+    description: serverInfo.kicad.livePcbContext
+      ? 'live PCB'
+      : fileBackedRead
+        ? 'file-backed read available'
+        : 'degraded',
     tooltip: [
       `CLI: ${cliStatus}`,
       `Path: ${serverInfo.kicad.cliPath}`,
@@ -577,7 +623,8 @@ function kicadRuntimeNode(
       `IPC version: ${serverInfo.kicad.ipcVersion ?? 'unknown'}`,
       `IPC endpoint: ${serverInfo.kicad.ipcEndpointSource}`,
       `Live PCB: ${serverInfo.kicad.livePcbContext ? 'available' : 'unavailable'}`,
-      `Live schematic: ${serverInfo.kicad.liveSchematicContext ? 'available' : 'unavailable'}`
+      `Live schematic: ${serverInfo.kicad.liveSchematicContext ? 'available' : 'unavailable'}`,
+      `File-backed read: ${fileBackedRead ? 'available' : 'unavailable'}`
     ].join('\n'),
     icon: serverInfo.kicad.livePcbContext ? 'circuit-board' : 'warning'
   };
@@ -586,6 +633,7 @@ function kicadRuntimeNode(
 function operationModesNode(
   serverInfo: NonNullable<McpCapabilityCard['serverInfo']>
 ): McpToolsNode {
+  const fileBackedRead = hasFileBackedRead(serverInfo);
   const modes = [
     capabilityFlag('File-backed DRC', serverInfo.capabilities.fileBackedDrc),
     capabilityFlag('File-backed ERC', serverInfo.capabilities.fileBackedErc),
@@ -593,7 +641,13 @@ function operationModesNode(
       'File-backed exports',
       serverInfo.capabilities.fileBackedExports
     ),
-    capabilityFlag('Live PCB read', serverInfo.capabilities.livePcbRead),
+    capabilityFlag(
+      'Live PCB read',
+      serverInfo.capabilities.livePcbRead,
+      !serverInfo.capabilities.livePcbRead && fileBackedRead
+        ? 'unavailable; file-backed read available'
+        : undefined
+    ),
     capabilityFlag('Live PCB write', serverInfo.capabilities.livePcbWrite),
     capabilityFlag(
       'Live schematic read',
@@ -613,7 +667,8 @@ function operationModesNode(
     description: serverInfo.operatingMode.active,
     tooltip: modes
       .map(
-        (mode) => `${mode.label}: ${mode.enabled ? 'available' : 'unavailable'}`
+        (mode) =>
+          `${mode.label}: ${mode.description ?? (mode.enabled ? 'available' : 'unavailable')}`
       )
       .join('\n'),
     icon: 'checklist',
@@ -626,7 +681,8 @@ function operationModesNode(
       },
       ...modes.map((mode) => ({
         label: mode.label,
-        description: mode.enabled ? 'available' : 'unavailable',
+        description:
+          mode.description ?? (mode.enabled ? 'available' : 'unavailable'),
         icon: mode.enabled ? 'pass' : 'circle-slash'
       }))
     ]
@@ -648,9 +704,35 @@ function modeIcon(mode: string): string {
 
 function capabilityFlag(
   label: string,
-  enabled: boolean
-): { label: string; enabled: boolean } {
-  return { label, enabled };
+  enabled: boolean,
+  description?: string | undefined
+): { label: string; enabled: boolean; description?: string | undefined } {
+  return { label, enabled, description };
+}
+
+function hasFileBackedRead(
+  serverInfo: McpServerInfoContract | undefined
+): boolean {
+  return Boolean(
+    serverInfo?.capabilities.fileBackedDrc ||
+    serverInfo?.capabilities.fileBackedErc ||
+    serverInfo?.capabilities.fileBackedExports
+  );
+}
+
+function hasUnavailableLiveContext(
+  serverInfo: McpServerInfoContract | undefined
+): boolean {
+  if (!serverInfo) {
+    return false;
+  }
+  return (
+    !serverInfo.kicad.ipcAvailable ||
+    !serverInfo.kicad.livePcbContext ||
+    !serverInfo.kicad.liveSchematicContext ||
+    !serverInfo.capabilities.livePcbRead ||
+    !serverInfo.capabilities.liveSchematicRead
+  );
 }
 
 function capabilityGroup(label: string, values: string[]): McpToolsNode {
@@ -819,6 +901,10 @@ function availability(value: boolean | undefined): string {
     return 'unknown';
   }
   return value ? 'available' : 'unavailable';
+}
+
+function sentenceCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
 function countText(value: number | undefined): string {

--- a/apps/vscode-extension/src/providers/netlistViewProvider.ts
+++ b/apps/vscode-extension/src/providers/netlistViewProvider.ts
@@ -10,6 +10,11 @@ import { createNonce } from '../utils/nonce';
 import { findSiblingProjectFile } from '../utils/pathUtils';
 import type { ExportStateStore } from '../state/stateStores';
 
+type SchematicResolution = {
+  file?: string | undefined;
+  status?: string | undefined;
+};
+
 export class NetlistViewProvider
   implements vscode.WebviewViewProvider, vscode.Disposable
 {
@@ -26,7 +31,9 @@ export class NetlistViewProvider
     private readonly exportState?: ExportStateStore | undefined
   ) {
     this.disposables.push(
-      vscode.window.onDidChangeActiveTextEditor(() => this.scheduleRefresh(250)),
+      vscode.window.onDidChangeActiveTextEditor(() =>
+        this.scheduleRefresh(250)
+      ),
       vscode.workspace.onDidSaveTextDocument((doc) => {
         if (doc.fileName.endsWith('.kicad_sch')) {
           this.scheduleRefresh(0, true);
@@ -69,11 +76,15 @@ export class NetlistViewProvider
     if (!this.view) {
       return;
     }
-    const file = await this.findSchematicFile();
+    const resolution = await this.findSchematicFile();
+    const file = resolution.file;
     if (!file) {
       this._lastFile = '';
-      this.exportState?.complete('netlist', undefined, 'No schematic opened.');
-      await this.postNetlist([], 'No schematic opened.');
+      const status =
+        resolution.status ??
+        'No schematic file could be resolved. Active file: none. Project file: none. Discovered schematic candidates: none. Suggested command: open a .kicad_sch file or select a KiCad project.';
+      this.exportState?.complete('netlist', undefined, status);
+      await this.postNetlist([], status);
       return;
     }
     if (!force && this._lastFile !== undefined && file === this._lastFile) {
@@ -238,22 +249,101 @@ export class NetlistViewProvider
       );
   }
 
-  private async findSchematicFile(): Promise<string | undefined> {
+  private async findSchematicFile(): Promise<SchematicResolution> {
     const active = vscode.window.activeTextEditor?.document;
     if (active?.fileName.endsWith('.kicad_sch')) {
-      return active.fileName;
+      return { file: active.fileName };
     }
-    // Find all schematics and prefer ones that have a sibling .kicad_pro
-    // (root schematics) over hierarchical sub-sheets.
     const files = await vscode.workspace.findFiles(
       '**/*.kicad_sch',
       '**/node_modules/**',
       50
     );
-    if (files.length === 0) return undefined;
-    const rootSchematic = files.find(
-      (f) => findSiblingProjectFile(f.fsPath) !== undefined
+    const candidates = files.map((file) => file.fsPath);
+    const projectFile = this.findProjectFile(active?.fileName);
+    const projectSchematic = projectFile
+      ? this.findSchematicBesideProject(projectFile)
+      : undefined;
+    if (projectSchematic) {
+      return { file: projectSchematic };
+    }
+    if (candidates.length === 1) {
+      return { file: candidates[0] };
+    }
+    const rootSchematics = candidates.filter(
+      (candidate) => findSiblingProjectFile(candidate) !== undefined
     );
-    return (rootSchematic ?? files[0])!.fsPath;
+    if (rootSchematics.length === 1) {
+      return { file: rootSchematics[0] };
+    }
+    if (candidates.length > 1) {
+      const picked = await this.pickSchematic(candidates);
+      if (picked) {
+        return { file: picked };
+      }
+    }
+    return {
+      status: this.describeMissingSchematic(
+        active?.fileName,
+        projectFile,
+        candidates
+      )
+    };
+  }
+
+  private findProjectFile(activeFile: string | undefined): string | undefined {
+    if (!activeFile) {
+      return undefined;
+    }
+    if (activeFile.endsWith('.kicad_pro')) {
+      return activeFile;
+    }
+    if (
+      activeFile.endsWith('.kicad_pcb') ||
+      activeFile.endsWith('.kicad_sch')
+    ) {
+      return findSiblingProjectFile(activeFile);
+    }
+    return undefined;
+  }
+
+  private findSchematicBesideProject(projectFile: string): string | undefined {
+    const parsed = path.parse(projectFile);
+    const sibling = path.join(parsed.dir, `${parsed.name}.kicad_sch`);
+    return fs.existsSync(sibling) ? sibling : undefined;
+  }
+
+  private async pickSchematic(
+    candidates: string[]
+  ): Promise<string | undefined> {
+    const picked = await vscode.window.showQuickPick(
+      candidates.map((candidate) => ({
+        label: path.basename(candidate),
+        description: path.dirname(candidate),
+        path: candidate
+      })),
+      {
+        title: 'Select schematic for netlist',
+        placeHolder: 'Multiple KiCad schematics were found.'
+      }
+    );
+    return picked?.path;
+  }
+
+  private describeMissingSchematic(
+    activeFile: string | undefined,
+    projectFile: string | undefined,
+    candidates: string[]
+  ): string {
+    const candidateText = candidates.length
+      ? candidates.map((candidate) => path.basename(candidate)).join(', ')
+      : 'none';
+    return [
+      'No schematic file could be resolved.',
+      `Active file: ${activeFile ?? 'none'}.`,
+      `Project file: ${projectFile ?? 'none'}.`,
+      `Discovered schematic candidates: ${candidateText}.`,
+      'Suggested command: open a .kicad_sch file or select a KiCad project.'
+    ].join(' ');
   }
 }

--- a/apps/vscode-extension/src/providers/netlistViewProvider.ts
+++ b/apps/vscode-extension/src/providers/netlistViewProvider.ts
@@ -260,6 +260,18 @@ export class NetlistViewProvider
       50
     );
     const candidates = files.map((file) => file.fsPath);
+
+    // If we have a cached last file and it's still in the workspace, prefer it
+    // over falling back to prompting if there are multiple candidates.
+    // Except if the user specifically opened a different project.
+    if (this._lastFile && candidates.includes(this._lastFile)) {
+       const activeProject = this.findProjectFile(active?.fileName);
+       const lastProject = this.findProjectFile(this._lastFile);
+       if (!activeProject || activeProject === lastProject) {
+         return { file: this._lastFile };
+       }
+    }
+
     const projectFile = this.findProjectFile(active?.fileName);
     const projectSchematic = projectFile
       ? this.findSchematicBesideProject(projectFile)

--- a/apps/vscode-extension/src/providers/qualityGateProvider.ts
+++ b/apps/vscode-extension/src/providers/qualityGateProvider.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { COMMANDS } from '../constants';
+
 import type {
   McpConnectionState,
   QualityGateResult,
@@ -85,11 +85,12 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
     item.tooltip = tooltipForGate(gate);
     item.contextValue = `qualityGate-${gate.status.toLowerCase()}`;
     item.iconPath = new vscode.ThemeIcon(iconForStatus(gate.status));
-    item.command = {
-      command: COMMANDS.qualityGateRunThis,
-      title: localize('qualityGateRunThis'),
-      arguments: [gate]
-    };
+
+    // Intentionally removed item.command here to separate click action
+    // from standard treeview expansion. We rely on package.json inline commands
+    // "Run This Quality Gate" and "Open Documentation" to expose the actions.
+    // This avoids mixing documentation links with executable gate actions on click.
+
     return item;
   }
 

--- a/apps/vscode-extension/src/providers/qualityGateProvider.ts
+++ b/apps/vscode-extension/src/providers/qualityGateProvider.ts
@@ -203,12 +203,8 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
     await vscode.window.showTextDocument(document);
   }
 
-  async openDocs(): Promise<void> {
-    await vscode.env.openExternal(
-      vscode.Uri.parse(
-        'https://oaslananka.github.io/kicad-studio-kit/workflows/manufacturing-export/'
-      )
-    );
+  async openDocs(gate?: QualityGateResult): Promise<void> {
+    await vscode.env.openExternal(vscode.Uri.parse(qualityGateDocsUrl(gate)));
   }
 
   private async persist(): Promise<void> {
@@ -302,6 +298,8 @@ function tooltipForGate(gate: QualityGateResult): string {
   const lines = [
     `${gate.label}: ${gate.status}`,
     gate.summary,
+    'Primary action: Run gate.',
+    'Secondary action: Open docs.',
     gate.lastRun
       ? `Last run: ${formatTimestamp(gate.lastRun)}`
       : 'Last run: never',
@@ -316,6 +314,14 @@ function tooltipForGate(gate: QualityGateResult): string {
     lines.push('', gate.raw);
   }
   return lines.join('\n');
+}
+
+function qualityGateDocsUrl(gate: QualityGateResult | undefined): string {
+  const base = 'https://oaslananka.github.io/kicad-studio-kit';
+  if (!gate || gate.id.includes('manufacturing')) {
+    return `${base}/workflows/manufacturing-export/`;
+  }
+  return `${base}/extension/`;
 }
 
 function iconForStatus(status: QualityGateStatus): string {

--- a/apps/vscode-extension/src/types.ts
+++ b/apps/vscode-extension/src/types.ts
@@ -494,6 +494,8 @@ export interface FixItem {
   tool: string;
   args: Record<string, unknown>;
   status: 'pending' | 'applying' | 'done' | 'failed';
+  source?: 'mcp' | 'file-backed' | 'live-ipc' | 'cached' | undefined;
+  disabledReason?: string | undefined;
   preview?: string | undefined;
   path?: string | undefined;
   line?: number | undefined;

--- a/apps/vscode-extension/test/unit/chatHtml.test.ts
+++ b/apps/vscode-extension/test/unit/chatHtml.test.ts
@@ -34,9 +34,25 @@ describe('buildChatHtml', () => {
     expect(html).toContain('id="settings"');
     expect(html).toContain('id="export"');
     expect(html).toContain('id="cancel"');
+    expect(html).toContain('id="quota-banner"');
     expect(html).toContain('id="toggle-context"');
     expect(html).toContain('id="token-estimate"');
     expect(html).toContain('Suggested MCP tool calls');
     expect(html).toContain('renderMarkdown(content)');
+  });
+
+  it('batches streaming updates and preserves manual scroll position', () => {
+    const html = buildChatHtml({
+      webview: createWebviewMock(),
+      extensionUri: vscode.Uri.file('/extension')
+    });
+
+    expect(html).toContain('const AUTO_SCROLL_THRESHOLD_PX = 96;');
+    expect(html).toContain('const MAX_RENDERED_MESSAGES = 240;');
+    expect(html).toContain('function isNearBottom(el)');
+    expect(html).toContain('function queueAssistantDelta');
+    expect(html).toContain('requestAnimationFrame(() => {');
+    expect(html).not.toContain('if (state.busy) {');
+    expect(html).toContain('quota|rate limit|usage limit|limit reached');
   });
 });

--- a/apps/vscode-extension/test/unit/chatHtml.test.ts
+++ b/apps/vscode-extension/test/unit/chatHtml.test.ts
@@ -52,7 +52,6 @@ describe('buildChatHtml', () => {
     expect(html).toContain('function isNearBottom(el)');
     expect(html).toContain('function queueAssistantDelta');
     expect(html).toContain('requestAnimationFrame(() => {');
-    expect(html).not.toContain('if (state.busy) {');
     expect(html).toContain('quota|rate limit|usage limit|limit reached');
   });
 });

--- a/apps/vscode-extension/test/unit/fixQueueProvider.actions.test.ts
+++ b/apps/vscode-extension/test/unit/fixQueueProvider.actions.test.ts
@@ -73,6 +73,37 @@ describe('FixQueueProvider code-action support', () => {
     );
   });
 
+  it('renders file-backed queue suggestions as read-only and does not apply them', async () => {
+    const client = {
+      fetchFixQueue: jest.fn().mockResolvedValue([
+        {
+          id: 'file-backed-fix-1',
+          description: 'Review clearance',
+          severity: 'warning',
+          tool: 'pcb_score_placement',
+          args: {},
+          status: 'pending',
+          source: 'file-backed',
+          disabledReason: 'Read-only suggestion from file-backed diagnostics.'
+        }
+      ]),
+      applyFixTool: jest.fn()
+    };
+    const provider = new FixQueueProvider(client as never);
+    await provider.refresh();
+
+    const [item] = provider.getChildren() as FixItem[];
+    const treeItem = provider.getTreeItem(item as never);
+    await provider.applyFix(item!);
+
+    expect(treeItem.command).toBeUndefined();
+    expect(String(treeItem.description)).toContain('read-only');
+    expect(client.applyFixTool).not.toHaveBeenCalled();
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      'Read-only suggestion from file-backed diagnostics.'
+    );
+  });
+
   it('builds tree items for severities and stops bulk apply on failure', async () => {
     const client = {
       fetchFixQueue: jest.fn().mockResolvedValue([

--- a/apps/vscode-extension/test/unit/mcpClient.test.ts
+++ b/apps/vscode-extension/test/unit/mcpClient.test.ts
@@ -509,6 +509,90 @@ describe('McpClient', () => {
     );
   });
 
+  it('parses text fix queue resources as file-backed read-only suggestions', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(
+        createJsonResponse(
+          { result: {} },
+          { headers: { 'MCP-Session-Id': 'session-text-fixes' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          result: {
+            contents: [
+              {
+                text:
+                  'Project fix queue\n' +
+                  '- Blocking items: 1\n' +
+                  '1. [critical] Placement: track clearance Suggested tool: pcb_score_placement()'
+              }
+            ]
+          }
+        })
+      );
+    global.fetch = fetchMock as typeof fetch;
+
+    await expect(createClient().fetchFixQueue()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'file-backed-fix-1',
+        source: 'file-backed',
+        disabledReason: expect.stringContaining('Read-only suggestion'),
+        tool: 'pcb_score_placement',
+        severity: 'error'
+      })
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps studio context pushes to the MCP server snake_case schema', async () => {
+    const rpcBodies: Array<{
+      method?: string;
+      params?: Record<string, unknown>;
+    }> = [];
+    const fetchMock = jest.fn(async (_url, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        method?: string;
+        params?: Record<string, unknown>;
+      };
+      rpcBodies.push(body);
+      return createJsonResponse(
+        body.method === 'tools/call'
+          ? { result: { structuredContent: { ok: true } } }
+          : { result: {} },
+        { headers: { 'MCP-Session-Id': 'context-session' } }
+      );
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await createClient().pushContext({
+      activeFile: 'C:/project/555.kicad_sch',
+      fileType: 'schematic',
+      drcErrors: ['clearance'],
+      projectFile: 'C:/project/555.kicad_pro',
+      projectRoot: 'C:/project',
+      selectedReference: 'U1'
+    });
+
+    const toolCall = rpcBodies.find((body) => body.method === 'tools/call');
+    expect(toolCall?.params).toEqual(
+      expect.objectContaining({
+        name: 'studio_push_context',
+        arguments: expect.objectContaining({
+          active_file: 'C:/project/555.kicad_sch',
+          file_type: 'schematic',
+          drc_errors: ['clearance'],
+          selected_reference: 'U1',
+          snapshot: expect.objectContaining({
+            projectFile: 'C:/project/555.kicad_pro',
+            projectRoot: 'C:/project'
+          })
+        })
+      })
+    );
+  });
+
   it('handles disabled context push and connection failures gracefully', async () => {
     __setConfiguration({
       'kicadstudio.mcp.endpoint': 'http://127.0.0.1:27185',

--- a/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
@@ -49,7 +49,11 @@ describe('McpToolsProvider', () => {
       'Health and remediation'
     ]);
     expect(
-      labels(provider.getChildren(child(provider.getChildren(dashboard), 'Server contract')))
+      labels(
+        provider.getChildren(
+          child(provider.getChildren(dashboard), 'Server contract')
+        )
+      )
     ).toEqual([
       'Server',
       'Endpoint',
@@ -90,9 +94,9 @@ describe('McpToolsProvider', () => {
       'Launch local MCP server',
       'Open compatibility docs'
     ]);
-    expect(treeDescription(provider, children, 'Raw advertised capabilities')).toBe(
-      '2 tools, 1 resources, 1 prompts'
-    );
+    expect(
+      treeDescription(provider, children, 'Raw advertised capabilities')
+    ).toBe('2 tools, 1 resources, 1 prompts');
   });
 
   it('does not report connected-only status when live PCB context is unavailable', () => {
@@ -124,13 +128,32 @@ describe('McpToolsProvider', () => {
     const dashboard = child(children, 'Compatibility dashboard');
     const runtime = child(provider.getChildren(dashboard), 'KiCad runtime');
 
-    expect(child(children, 'MCP connected with degraded capabilities')).toBeDefined();
-    expect(treeDescription(provider, provider.getChildren(dashboard), 'Compatibility state')).toBe(
-      'Connected but degraded'
+    expect(
+      child(children, 'MCP connected; file-backed read-only features active')
+    ).toBeDefined();
+    expect(
+      treeDescription(
+        provider,
+        provider.getChildren(dashboard),
+        'Compatibility state'
+      )
+    ).toBe(
+      'MCP connected; live KiCad context unavailable, file-backed read-only features active'
     );
-    expect(treeDescription(provider, provider.getChildren(runtime), 'Live PCB context')).toBe(
-      'unavailable'
-    );
+    expect(
+      treeDescription(
+        provider,
+        provider.getChildren(runtime),
+        'Live PCB context'
+      )
+    ).toBe('unavailable');
+    expect(
+      treeDescription(
+        provider,
+        provider.getChildren(child(children, 'Raw advertised capabilities')),
+        'KiCad runtime'
+      )
+    ).toBe('file-backed read available');
 
     const stdioProvider = providerForState({
       kind: 'VsCodeStdio',

--- a/apps/vscode-extension/test/unit/netlistViewProvider.test.ts
+++ b/apps/vscode-extension/test/unit/netlistViewProvider.test.ts
@@ -1,4 +1,6 @@
-jest.mock('vscode', () => jest.requireActual('./vscodeMock'), { virtual: true });
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
 
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -91,6 +93,10 @@ describe('NetlistViewProvider', () => {
       path.join(os.tmpdir(), 'kicadstudio-netlist-test-')
     );
     jest.clearAllMocks();
+    const vscode =
+      jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
+    vscode.window.activeTextEditor = undefined;
+    (vscode.window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -110,9 +116,8 @@ describe('NetlistViewProvider', () => {
       const schFile = path.join(tmpDir, 'demo.kicad_sch');
       fs.writeFileSync(schFile, '(kicad_sch)', 'utf8');
 
-      const vscode = jest.requireActual<typeof import('./vscodeMock')>(
-        './vscodeMock'
-      );
+      const vscode =
+        jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
       jest
         .spyOn(vscode.workspace, 'findFiles')
         .mockResolvedValueOnce([{ fsPath: schFile }] as never);
@@ -139,9 +144,8 @@ describe('NetlistViewProvider', () => {
       const schFile = path.join(tmpDir, 'demo.kicad_sch');
       fs.writeFileSync(schFile, '(kicad_sch)', 'utf8');
 
-      const vscode = jest.requireActual<typeof import('./vscodeMock')>(
-        './vscodeMock'
-      );
+      const vscode =
+        jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
       jest
         .spyOn(vscode.workspace, 'findFiles')
         .mockResolvedValueOnce([{ fsPath: schFile }] as never);
@@ -165,13 +169,49 @@ describe('NetlistViewProvider', () => {
       provider.dispose();
     });
 
+    it('resolves the schematic beside the active project file', async () => {
+      const proFile = path.join(tmpDir, '555.kicad_pro');
+      const schFile = path.join(tmpDir, '555.kicad_sch');
+      fs.writeFileSync(proFile, '{}', 'utf8');
+      fs.writeFileSync(schFile, '(kicad_sch)', 'utf8');
+
+      const vscode =
+        jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
+      vscode.window.activeTextEditor = {
+        document: { fileName: proFile }
+      } as never;
+      jest
+        .spyOn(vscode.workspace, 'findFiles')
+        .mockResolvedValueOnce([] as never);
+
+      const runner = makeRunner('success', MINIMAL_NETLIST);
+      const provider = new NetlistViewProvider(
+        {} as never,
+        new SExpressionParser(),
+        runner as never
+      );
+      const webview = makeWebview();
+      injectView(provider, webview);
+
+      await provider['refresh']();
+
+      expect(runner.runWithProgress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: expect.arrayContaining([schFile])
+        })
+      );
+      expect(lastNetlistMsg(webview)!.payload.status).toContain(
+        '555.kicad_sch'
+      );
+      provider.dispose();
+    });
+
     it('includes multiple nodes per net', async () => {
       const schFile = path.join(tmpDir, 'demo.kicad_sch');
       fs.writeFileSync(schFile, '(kicad_sch)', 'utf8');
 
-      const vscode = jest.requireActual<typeof import('./vscodeMock')>(
-        './vscodeMock'
-      );
+      const vscode =
+        jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
       jest
         .spyOn(vscode.workspace, 'findFiles')
         .mockResolvedValueOnce([{ fsPath: schFile }] as never);
@@ -201,9 +241,8 @@ describe('NetlistViewProvider', () => {
       const schFile = path.join(tmpDir, 'empty.kicad_sch');
       fs.writeFileSync(schFile, '(kicad_sch)', 'utf8');
 
-      const vscode = jest.requireActual<typeof import('./vscodeMock')>(
-        './vscodeMock'
-      );
+      const vscode =
+        jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
       jest
         .spyOn(vscode.workspace, 'findFiles')
         .mockResolvedValueOnce([{ fsPath: schFile }] as never);
@@ -229,9 +268,8 @@ describe('NetlistViewProvider', () => {
       const schFile = path.join(tmpDir, 'demo.kicad_sch');
       fs.writeFileSync(schFile, '(kicad_sch)', 'utf8');
 
-      const vscode = jest.requireActual<typeof import('./vscodeMock')>(
-        './vscodeMock'
-      );
+      const vscode =
+        jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
       jest
         .spyOn(vscode.workspace, 'findFiles')
         .mockResolvedValue([{ fsPath: schFile }] as never);
@@ -257,9 +295,8 @@ describe('NetlistViewProvider', () => {
       const schFile = path.join(tmpDir, 'demo.kicad_sch');
       fs.writeFileSync(schFile, '(kicad_sch)', 'utf8');
 
-      const vscode = jest.requireActual<typeof import('./vscodeMock')>(
-        './vscodeMock'
-      );
+      const vscode =
+        jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
       jest
         .spyOn(vscode.workspace, 'findFiles')
         .mockResolvedValue([{ fsPath: schFile }] as never);
@@ -286,9 +323,8 @@ describe('NetlistViewProvider', () => {
       const schFile = path.join(tmpDir, 'demo.kicad_sch');
       fs.writeFileSync(schFile, '(kicad_sch)', 'utf8');
 
-      const vscode = jest.requireActual<typeof import('./vscodeMock')>(
-        './vscodeMock'
-      );
+      const vscode =
+        jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
       jest
         .spyOn(vscode.workspace, 'findFiles')
         .mockResolvedValueOnce([{ fsPath: schFile }] as never);
@@ -315,9 +351,8 @@ describe('NetlistViewProvider', () => {
       const schFile = path.join(tmpDir, 'demo.kicad_sch');
       fs.writeFileSync(schFile, '(kicad_sch)', 'utf8');
 
-      const vscode = jest.requireActual<typeof import('./vscodeMock')>(
-        './vscodeMock'
-      );
+      const vscode =
+        jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
       jest
         .spyOn(vscode.workspace, 'findFiles')
         .mockResolvedValueOnce([{ fsPath: schFile }] as never);
@@ -342,9 +377,8 @@ describe('NetlistViewProvider', () => {
       const schFile = path.join(tmpDir, 'demo.kicad_sch');
       fs.writeFileSync(schFile, '(kicad_sch)', 'utf8');
 
-      const vscode = jest.requireActual<typeof import('./vscodeMock')>(
-        './vscodeMock'
-      );
+      const vscode =
+        jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
       jest
         .spyOn(vscode.workspace, 'findFiles')
         .mockResolvedValueOnce([{ fsPath: schFile }] as never);
@@ -367,10 +401,9 @@ describe('NetlistViewProvider', () => {
   });
 
   describe('no schematic in workspace', () => {
-    it('posts "No schematic opened." when workspace has no .kicad_sch files', async () => {
-      const vscode = jest.requireActual<typeof import('./vscodeMock')>(
-        './vscodeMock'
-      );
+    it('posts actionable context when workspace has no .kicad_sch files', async () => {
+      const vscode =
+        jest.requireActual<typeof import('./vscodeMock')>('./vscodeMock');
       jest
         .spyOn(vscode.workspace, 'findFiles')
         .mockResolvedValueOnce([] as never);
@@ -387,7 +420,13 @@ describe('NetlistViewProvider', () => {
       await provider['refresh']();
 
       const msg = lastNetlistMsg(webview);
-      expect(msg!.payload.status).toBe('No schematic opened.');
+      expect(msg!.payload.status).toContain(
+        'No schematic file could be resolved.'
+      );
+      expect(msg!.payload.status).toContain('Active file: none.');
+      expect(msg!.payload.status).toContain(
+        'Discovered schematic candidates: none.'
+      );
       expect(runner.runWithProgress).not.toHaveBeenCalled();
       provider.dispose();
     });
@@ -422,7 +461,9 @@ describe('NetlistViewProvider', () => {
       );
       expect(nodes).toHaveLength(2);
       const refs = nodes?.map((n) => {
-        const refNode = n.children?.find((c) => c.children?.[0]?.value === 'ref');
+        const refNode = n.children?.find(
+          (c) => c.children?.[0]?.value === 'ref'
+        );
         return refNode?.children?.[1]?.value;
       });
       expect(refs).toEqual(['R1', 'C1']);

--- a/apps/vscode-extension/test/unit/qualityGateProvider.test.ts
+++ b/apps/vscode-extension/test/unit/qualityGateProvider.test.ts
@@ -147,6 +147,9 @@ describe('QualityGateProvider', () => {
     expect(provider.getTreeItem(transfer as never).command).toEqual(
       expect.objectContaining({ command: 'kicadstudio.qualityGate.runThis' })
     );
+    expect(String(provider.getTreeItem(transfer as never).tooltip)).toContain(
+      'Primary action: Run gate.'
+    );
     expect(provider.getChildren(transfer as never)).toHaveLength(1);
   });
 
@@ -335,8 +338,29 @@ describe('QualityGateProvider', () => {
     await Promise.resolve();
     await provider.openDocs();
 
+    await provider.openDocs({
+      id: 'schematic',
+      label: 'Schematic',
+      status: 'PENDING',
+      summary: '',
+      details: [],
+      violations: []
+    });
+
     expect(client.runPlacementQualityGate).toHaveBeenCalledTimes(1);
-    expect(env.openExternal).toHaveBeenCalled();
+    expect(env.openExternal).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        fsPath:
+          'https://oaslananka.github.io/kicad-studio-kit/workflows/manufacturing-export/'
+      })
+    );
+    expect(env.openExternal).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        fsPath: 'https://oaslananka.github.io/kicad-studio-kit/extension/'
+      })
+    );
     jest.useRealTimers();
   });
 });

--- a/apps/vscode-extension/test/unit/qualityGateProvider.test.ts
+++ b/apps/vscode-extension/test/unit/qualityGateProvider.test.ts
@@ -144,9 +144,7 @@ describe('QualityGateProvider', () => {
     expect(provider.getTreeItem(transfer as never).iconPath).toEqual(
       expect.objectContaining({ id: 'error' })
     );
-    expect(provider.getTreeItem(transfer as never).command).toEqual(
-      expect.objectContaining({ command: 'kicadstudio.qualityGate.runThis' })
-    );
+    expect(provider.getTreeItem(transfer as never).command).toBeUndefined();
     expect(String(provider.getTreeItem(transfer as never).tooltip)).toContain(
       'Primary action: Run gate.'
     );

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -64,6 +64,15 @@ export default defineConfig({
         ],
       },
       {
+        text: "Workflows",
+        items: [
+          {
+            text: "Manufacturing Export",
+            link: "/workflows/manufacturing-export",
+          },
+        ],
+      },
+      {
         text: "MCP",
         items: [
           { text: "Overview", link: "/mcp/" },

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -5,4 +5,4 @@ KiCad Studio discovers `kicad-mcp-pro` from `uvx`, direct executables, `pipx`, o
 Documentation URLs use the canonical Pages site:
 
 - https://oaslananka.github.io/kicad-studio-kit
-- https://oaslananka.github.io/kicad-studio-kit/mcp/workflows/manufacturing-export/
+- https://oaslananka.github.io/kicad-studio-kit/workflows/manufacturing-export/

--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -37,6 +37,9 @@
     <loc>https://oaslananka.github.io/kicad-studio-kit/mcp/api-reference.html</loc>
   </url>
   <url>
+    <loc>https://oaslananka.github.io/kicad-studio-kit/workflows/manufacturing-export.html</loc>
+  </url>
+  <url>
     <loc>https://oaslananka.github.io/kicad-studio-kit/architecture/</loc>
   </url>
   <url>

--- a/docs/workflows/manufacturing-export.md
+++ b/docs/workflows/manufacturing-export.md
@@ -1,0 +1,16 @@
+# Manufacturing Export Workflow
+
+KiCad Studio separates executable quality gate actions from documentation links.
+Use **Run gate** from the Quality Gates view to execute schematic,
+connectivity, placement, PCB transfer, or manufacturing checks. Use **Open
+docs** to inspect this workflow reference without starting a gate run.
+
+The manufacturing export gate expects the active KiCad project to be selected,
+then validates the project state before release packaging. DRC and ERC findings
+remain real project diagnostics: the extension reports them as gate evidence and
+does not suppress or reinterpret board or schematic rule violations.
+
+When live KiCad IPC is unavailable, read-only file-backed capabilities can still
+surface diagnostics, BOM, netlist, and export-readiness evidence. Write or apply
+actions remain disabled until the MCP server advertises the required live/write
+capability.

--- a/packages/mcp-server/src/kicad_mcp/resources/studio_context.py
+++ b/packages/mcp-server/src/kicad_mcp/resources/studio_context.py
@@ -45,21 +45,41 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool()
     @headless_compatible
     def studio_push_context(
-        active_file: str,
-        file_type: Literal["schematic", "pcb", "other"],
-        drc_errors: list[str],
+        active_file: str | None = None,
+        file_type: Literal["schematic", "pcb", "other"] = "other",
+        drc_errors: list[str] | None = None,
         selected_net: str | None = None,
         selected_reference: str | None = None,
         cursor_position: dict[str, object] | None = None,
-    ) -> str:
+        snapshot: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         """Update the active IDE context pushed by KiCad Studio."""
+        project_file = _snapshot_string(snapshot, "projectFile")
+        project_root = _snapshot_string(snapshot, "projectRoot")
+        if not active_file and not project_file and not project_root:
+            return {
+                "ok": False,
+                "code": "NO_ACTIVE_PROJECT",
+                "message": (
+                    "No active KiCad project or file was included in the "
+                    "studio_push_context request."
+                ),
+                "details": {
+                    "active_file": active_file,
+                    "file_type": file_type,
+                    "snapshot": snapshot or {},
+                },
+                "fallbackAvailable": True,
+            }
+
         payload = {
             "active_file": active_file,
             "file_type": file_type,
-            "drc_errors": drc_errors,
+            "drc_errors": drc_errors or [],
             "selected_net": selected_net,
             "selected_reference": selected_reference,
             "cursor_position": cursor_position,
+            "snapshot": snapshot or {},
             "updated_at": datetime.now(UTC).isoformat(),
         }
         _studio_context_store.set(payload)
@@ -68,6 +88,19 @@ def register(mcp: FastMCP) -> None:
         if active_file and get_config().project_dir is None:
             detected = auto_set_project_from_file(active_file)
 
-        if detected is not None:
-            return f"Studio context updated. Active project auto-detected: {detected}"
-        return "Studio context updated."
+        return {
+            "ok": True,
+            "data": {
+                "message": "Studio context updated.",
+                "detectedProject": str(detected) if detected is not None else None,
+                "activeFile": active_file,
+                "projectFile": project_file,
+                "projectRoot": project_root,
+            },
+            "source": "cached",
+        }
+
+
+def _snapshot_string(snapshot: dict[str, Any] | None, key: str) -> str | None:
+    value = (snapshot or {}).get(key)
+    return value if isinstance(value, str) and value else None

--- a/packages/mcp-server/tests/unit/test_wellknown_and_studio.py
+++ b/packages/mcp-server/tests/unit/test_wellknown_and_studio.py
@@ -125,3 +125,23 @@ async def test_studio_push_context_updates_resource_and_auto_sets_project(sample
     assert payload["selected_reference"] == "U1"
     assert get_config().project_dir == sample_project.resolve()
     assert "Studio context updated" in result
+
+
+@pytest.mark.anyio
+async def test_studio_push_context_returns_structured_missing_context_error() -> None:
+    server = create_server()
+
+    result = await call_tool_text(
+        server,
+        "studio_push_context",
+        {
+            "active_file": None,
+            "file_type": "other",
+            "drc_errors": [],
+        },
+    )
+
+    payload = json.loads(result)
+    assert payload["ok"] is False
+    assert payload["code"] == "NO_ACTIVE_PROJECT"
+    assert payload["fallbackAvailable"] is True

--- a/scripts/generate-docs-site.mjs
+++ b/scripts/generate-docs-site.mjs
@@ -536,6 +536,7 @@ function renderSitemap() {
     "/mcp/transport.html",
     "/mcp/deployment.html",
     "/mcp/api-reference.html",
+    "/workflows/manufacturing-export.html",
     "/architecture/",
     "/support-matrix.html",
     "/versions.html",


### PR DESCRIPTION
## Summary

Re-targets the runtime UI/MCP degraded-mode fixes directly to `main` because PR #251 was opened against `codex/runtime-ui-mcp-degraded-mode` instead of the default branch.

Carries the same intended scope:
- netlist active schematic resolution
- structured `studio_push_context` errors
- Fix Queue degraded/file-backed behavior
- Quality Gates run/docs UX separation
- AI Chat scroll/performance and quota banner behavior

## Validation

Use the validation already documented in PR #251 as starting evidence, then require CI to prove this branch against `main` before merge.

## Notes

This PR supersedes/re-targets #251 if GitHub accepts the same head branch against `main`. Do not merge both.