### PR TITLE
fix(repo): replace linear-specific issue metadata

### DIFF
--- a/packages/kicad-fixtures/manifest.json
+++ b/packages/kicad-fixtures/manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "generatedBy": "scripts/generate-kicad-fixture-corpus.mjs",
-  "linearIssue": "OASLANA-53",
+  "trackingIssue": "OASLANA-53",
   "githubIssue": 54,
   "root": "packages/kicad-fixtures/fixtures",
   "expectedRoot": "packages/kicad-fixtures/expected",

--- a/packages/kicad-fixtures/src/index.ts
+++ b/packages/kicad-fixtures/src/index.ts
@@ -61,7 +61,7 @@ export interface KicadFixtureManifestEntry {
 export interface KicadFixtureManifest {
   schemaVersion: 1;
   generatedBy: string;
-  linearIssue: "OASLANA-53";
+  trackingIssue: "OASLANA-53";
   githubIssue: 54;
   root: string;
   expectedRoot: string;

--- a/packages/kicad-fixtures/test/paths.test.ts
+++ b/packages/kicad-fixtures/test/paths.test.ts
@@ -17,7 +17,7 @@ import {
 test("loads the shared KiCad fixture manifest with stable semantic IDs", () => {
   const manifest = loadKicadFixtureManifest();
 
-  assert.equal(manifest.linearIssue, "OASLANA-53");
+  assert.equal(manifest.trackingIssue, "OASLANA-53");
   assert.equal(manifest.githubIssue, 54);
   assert.deepEqual(
     manifest.fixtures.map((fixture) => fixture.id),

--- a/packages/mcp-server/tests/unit/test_path_safety.py
+++ b/packages/mcp-server/tests/unit/test_path_safety.py
@@ -55,7 +55,7 @@ def test_path_utils_wrapper_resolves_safe_paths(tmp_path: Path) -> None:
 
 
 def test_cross_platform_path_fixture_covers_required_mcp_scenarios() -> None:
-    assert PATH_REGRESSION_CASES["linearIssue"] == "OASLANA-112"
+    assert PATH_REGRESSION_CASES["trackingIssue"] == "OASLANA-112"
     assert [scenario["id"] for scenario in PATH_REGRESSION_CASES["scenarios"]] == [
         "project-path-with-spaces",
         "unicode-project-path",

--- a/packages/mcp-server/tests/unit/test_protocol_schemas_contract.py
+++ b/packages/mcp-server/tests/unit/test_protocol_schemas_contract.py
@@ -34,7 +34,7 @@ def test_protocol_schema_package_exposes_required_contracts() -> None:
     for schema_file in REQUIRED_SCHEMA_FILES:
         schema = _load_schema(schema_file)
         assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
-        assert schema["x-kicad-studio-kit"]["linearIssue"] == "OASLANA-52"
+        assert schema["x-kicad-studio-kit"]["trackingIssue"] == "OASLANA-52"
 
 
 def test_advertised_tool_metadata_matches_shared_capability_schema() -> None:

--- a/packages/protocol-schemas/schemas/bom-netlist-summary.schema.json
+++ b/packages/protocol-schemas/schemas/bom-netlist-summary.schema.json
@@ -138,7 +138,7 @@
     }
   },
   "x-kicad-studio-kit": {
-    "linearIssue": "OASLANA-52",
+    "trackingIssue": "OASLANA-52",
     "schemaVersion": "1.0.0"
   }
 }

--- a/packages/protocol-schemas/schemas/compatibility-manifest.schema.json
+++ b/packages/protocol-schemas/schemas/compatibility-manifest.schema.json
@@ -78,7 +78,7 @@
     }
   },
   "x-kicad-studio-kit": {
-    "linearIssue": "OASLANA-52",
+    "trackingIssue": "OASLANA-52",
     "schemaVersion": "1.0.0"
   }
 }

--- a/packages/protocol-schemas/schemas/extension-active-context.schema.json
+++ b/packages/protocol-schemas/schemas/extension-active-context.schema.json
@@ -103,7 +103,7 @@
     }
   },
   "x-kicad-studio-kit": {
-    "linearIssue": "OASLANA-52",
+    "trackingIssue": "OASLANA-52",
     "schemaVersion": "1.0.0"
   }
 }

--- a/packages/protocol-schemas/schemas/kicad-mcp-server-info.schema.json
+++ b/packages/protocol-schemas/schemas/kicad-mcp-server-info.schema.json
@@ -375,7 +375,7 @@
     }
   },
   "x-kicad-studio-kit": {
-    "linearIssue": "OASLANA-52",
+    "trackingIssue": "OASLANA-52",
     "schemaVersion": "1.0.0"
   }
 }

--- a/packages/protocol-schemas/schemas/mcp-server-health.schema.json
+++ b/packages/protocol-schemas/schemas/mcp-server-health.schema.json
@@ -80,7 +80,7 @@
     }
   },
   "x-kicad-studio-kit": {
-    "linearIssue": "OASLANA-52",
+    "trackingIssue": "OASLANA-52",
     "schemaVersion": "1.0.0"
   }
 }

--- a/packages/protocol-schemas/schemas/mcp-tool-capability.schema.json
+++ b/packages/protocol-schemas/schemas/mcp-tool-capability.schema.json
@@ -71,7 +71,7 @@
     }
   },
   "x-kicad-studio-kit": {
-    "linearIssue": "OASLANA-52",
+    "trackingIssue": "OASLANA-52",
     "schemaVersion": "1.0.0"
   }
 }

--- a/packages/protocol-schemas/schemas/mcp-tool-discovery.schema.json
+++ b/packages/protocol-schemas/schemas/mcp-tool-discovery.schema.json
@@ -92,7 +92,7 @@
     }
   },
   "x-kicad-studio-kit": {
-    "linearIssue": "OASLANA-52",
+    "trackingIssue": "OASLANA-52",
     "schemaVersion": "1.0.0"
   }
 }

--- a/packages/protocol-schemas/schemas/normalized-diagnostic.schema.json
+++ b/packages/protocol-schemas/schemas/normalized-diagnostic.schema.json
@@ -59,7 +59,7 @@
     }
   },
   "x-kicad-studio-kit": {
-    "linearIssue": "OASLANA-52",
+    "trackingIssue": "OASLANA-52",
     "schemaVersion": "1.0.0"
   }
 }

--- a/scripts/check-kicad-fixtures-package.test.mjs
+++ b/scripts/check-kicad-fixtures-package.test.mjs
@@ -62,7 +62,7 @@ test("OASLANA-53 shared package owns the deterministic KiCad fixture corpus", ()
 
   const manifest = readJson("packages/kicad-fixtures/manifest.json");
   assert.equal(manifest.schemaVersion, 1);
-  assert.equal(manifest.linearIssue, "OASLANA-53");
+  assert.equal(manifest.trackingIssue, "OASLANA-53");
   assert.equal(manifest.githubIssue, 54);
   assert.equal(manifest.root, "packages/kicad-fixtures/fixtures");
   assert.equal(manifest.expectedRoot, "packages/kicad-fixtures/expected");

--- a/scripts/check-protocol-schemas-package.test.mjs
+++ b/scripts/check-protocol-schemas-package.test.mjs
@@ -75,7 +75,7 @@ test("OASLANA-52 package owns every required compatibility schema", () => {
       ),
     );
     assert.equal(schema.type, "object");
-    assert.equal(schema["x-kicad-studio-kit"]?.linearIssue, "OASLANA-52");
+    assert.equal(schema["x-kicad-studio-kit"]?.trackingIssue, "OASLANA-52");
     assert.match(
       schema["x-kicad-studio-kit"]?.schemaVersion,
       /^[0-9]+\.[0-9]+\.[0-9]+$/u,

--- a/scripts/generate-kicad-fixture-corpus.mjs
+++ b/scripts/generate-kicad-fixture-corpus.mjs
@@ -1010,7 +1010,7 @@ function corpusManifest() {
   return {
     schemaVersion: 1,
     generatedBy: generatorPath,
-    linearIssue: "OASLANA-53",
+    trackingIssue: "OASLANA-53",
     githubIssue: 54,
     root: fixturesRootRelative,
     expectedRoot: expectedRootRelative,

--- a/test-fixtures/path-regression-cases.json
+++ b/test-fixtures/path-regression-cases.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "linearIssue": "OASLANA-112",
+  "trackingIssue": "OASLANA-112",
   "ciMatrix": ["ubuntu-24.04", "windows-2025-vs2026", "macos-15"],
   "scenarios": [
     {


### PR DESCRIPTION
Fixes #211

## Summary

Pure `linearIssue` → `trackingIssue` rename across schema metadata annotations, fixture manifest, type definitions, and test assertions. No behavior change.

## Schema/fixture/protocol changes

17 files changed, all one-for-one key renames:

- **7 protocol schemas** (`packages/protocol-schemas/schemas/*.json`): `x-kicad-studio-kit.linearIssue` → `x-kicad-studio-kit.trackingIssue`
- **3 TypeScript sources**: fixture manifest type interface, test assertion, generator script
- **2 Python test files**: path regression and protocol schema contract assertions
- **2 JSON test fixtures**: `manifest.json`, `path-regression-cases.json`
- **2 .mjs test files**: fixture and protocol schema package checks
- **1 .mjs generator**: `generate-kicad-fixture-corpus.mjs`

## Remaining Linear references (intentional, not renamed)

- `.github/copilot-instructions.md`: Process instructions about linking PRs to Linear issues
- `.github/DISCUSSION_TEMPLATE/beta-feedback.yml`: Process note about maintainer workflow
- `packages/mcp-server/**`: `PlacementStrategy.Literal["linear"]` — component placement strategy, not issue metadata
- `packages/mcp-server/**`: `Regulator_Linear:LM1117` — KiCad library component ID, not issue metadata

## Tests run

```
corepack pnpm run check:protocol-schemas    ok 3/3
corepack pnpm run check:fixtures            ok 2/2
corepack pnpm run check:compatibility       validated
corepack pnpm run check:version             ok
```

## Confirmation

- No runtime UI/MCP degraded-mode changes are included
- No cache/runtime artifacts committed
- Only `linearIssue` → `trackingIssue` renames, no unrelated field changes
