### PR TITLE
fix(kicad-studio): Runtime UI and MCP degraded-mode handling (#250, #249)

### DIFF
--- a/apps/vscode-extension/l10n/bundle.l10n.tr.json
+++ b/apps/vscode-extension/l10n/bundle.l10n.tr.json
@@ -35,6 +35,7 @@
   "Fix Queue could not refresh": "Düzeltme kuyruğu yenilenemedi",
   "Retry MCP connection": "MCP bağlantısını yeniden deneyin",
   "Retry MCP Connection": "MCP bağlantısını yeniden dene",
+  "The MCP connection was interrupted or is in a degraded state. {message} Retry the connection or check the MCP server status.": "MCP bağlantısı kesildi veya bozuk durumda. {message} Bağlantıyı yeniden deneyin veya MCP sunucu durumunu kontrol edin.",
   "Fix Queue needs the HTTP MCP transport; VS Code stdio cannot serve queued repair actions.": "Düzeltme Kuyruğu HTTP MCP taşımasına ihtiyaç duyar; VS Code stdio kuyruktaki onarım eylemlerini sunamaz.",
   "Upgrade kicad-mcp-pro before loading AI repair actions.": "AI onarım eylemlerini yüklemeden önce kicad-mcp-pro'yu yükseltin.",
   "Connect kicad-mcp-pro over HTTP before loading AI repair actions.": "AI onarım eylemlerini yüklemeden önce kicad-mcp-pro'yu HTTP üzerinden bağlayın.",

--- a/apps/vscode-extension/src/i18n.ts
+++ b/apps/vscode-extension/src/i18n.ts
@@ -56,6 +56,8 @@ export const SOURCE_MESSAGES = {
     'Fix Queue needs the HTTP MCP transport; VS Code stdio cannot serve queued repair actions.',
   fixQueueBlockIncompatible:
     'Upgrade kicad-mcp-pro before loading AI repair actions.',
+  fixQueueBlockDegraded:
+    'The MCP connection was interrupted or is in a degraded state. {message} Retry the connection or check the MCP server status.',
   fixQueueBlockDefault:
     'Connect kicad-mcp-pro over HTTP before loading AI repair actions.',
   pcmNoLibrariesLabel: 'No PCM libraries indexed',

--- a/apps/vscode-extension/src/mcp/fixQueueProvider.ts
+++ b/apps/vscode-extension/src/mcp/fixQueueProvider.ts
@@ -65,6 +65,25 @@ export class FixQueueProvider implements vscode.TreeDataProvider<FixQueueNode> {
   getChildren(): FixQueueNode[] {
     const state = this.mcpState?.getState();
     if (state && !supportsHttpFixQueue(state)) {
+      if (state.kind === 'Degraded') {
+        const diagnostics = state.server?.capabilities?.diagnostics ?? [];
+        const detail = diagnostics.length
+          ? diagnostics.join(' ')
+          : fixQueueBlockMessage(state);
+        return [
+          sidebarState(
+            'error',
+            localize('fixQueueUnavailableLabel'),
+            localize('fixQueueRefreshErrorDescription'),
+            detail,
+            'warning',
+            {
+              command: COMMANDS.retryMcp,
+              title: localize('fixQueueRetryCommand')
+            }
+          )
+        ];
+      }
       return [
         sidebarState(
           'error',
@@ -255,9 +274,16 @@ function supportsHttpFixQueue(state: McpConnectionState): boolean {
 }
 
 function fixQueueBlockMessage(state: McpConnectionState): string {
-  return state.kind === 'VsCodeStdio'
-    ? localize('fixQueueBlockStdio')
-    : state.kind === 'Incompatible'
-      ? localize('fixQueueBlockIncompatible')
-      : localize('fixQueueBlockDefault');
+  if (state.kind === 'VsCodeStdio') {
+    return localize('fixQueueBlockStdio');
+  }
+  if (state.kind === 'Incompatible') {
+    return localize('fixQueueBlockIncompatible');
+  }
+  if (state.kind === 'Degraded') {
+    return localize('fixQueueBlockDegraded', {
+      message: state.message ?? 'The server is unreachable.'
+    });
+  }
+  return localize('fixQueueBlockDefault');
 }

--- a/apps/vscode-extension/src/providers/netlistViewProvider.ts
+++ b/apps/vscode-extension/src/providers/netlistViewProvider.ts
@@ -15,6 +15,8 @@ type SchematicResolution = {
   status?: string | undefined;
 };
 
+const LAST_SCHEMATIC_STORAGE_KEY = 'kicadstudio.netlist.lastSchematic';
+
 export class NetlistViewProvider
   implements vscode.WebviewViewProvider, vscode.Disposable
 {
@@ -30,6 +32,9 @@ export class NetlistViewProvider
     private readonly logger?: Logger,
     private readonly exportState?: ExportStateStore | undefined
   ) {
+    this._lastFile = context.workspaceState?.get<string | undefined>(
+      LAST_SCHEMATIC_STORAGE_KEY
+    );
     this.disposables.push(
       vscode.window.onDidChangeActiveTextEditor(() =>
         this.scheduleRefresh(250)
@@ -91,6 +96,7 @@ export class NetlistViewProvider
       return;
     }
     this._lastFile = file;
+    void this.context.workspaceState?.update(LAST_SCHEMATIC_STORAGE_KEY, file);
     const uri = vscode.Uri.file(file);
     if (!this.runner) {
       this.exportState?.fail(
@@ -265,19 +271,35 @@ export class NetlistViewProvider
     // over falling back to prompting if there are multiple candidates.
     // Except if the user specifically opened a different project.
     if (this._lastFile && candidates.includes(this._lastFile)) {
-       const activeProject = this.findProjectFile(active?.fileName);
-       const lastProject = this.findProjectFile(this._lastFile);
-       if (!activeProject || activeProject === lastProject) {
-         return { file: this._lastFile };
-       }
+      const activeProject = this.findProjectFile(active?.fileName);
+      const lastProject = this.findProjectFile(this._lastFile);
+      if (!activeProject || activeProject === lastProject) {
+        return { file: this._lastFile };
+      }
     }
 
     const projectFile = this.findProjectFile(active?.fileName);
-    const projectSchematic = projectFile
-      ? this.findSchematicBesideProject(projectFile)
-      : undefined;
-    if (projectSchematic) {
-      return { file: projectSchematic };
+    if (projectFile) {
+      const projectSchematic = this.findSchematicBesideProject(projectFile);
+      if (projectSchematic) {
+        return { file: projectSchematic };
+      }
+    }
+
+    // Fallback: when no active editor and no cached schematic, discover
+    // KiCad project files and resolve their sibling .kicad_sch.
+    if (!projectFile && !this._lastFile) {
+      const projectFiles = await vscode.workspace.findFiles(
+        '**/*.kicad_pro',
+        '**/node_modules/**',
+        5
+      );
+      for (const projectUri of projectFiles) {
+        const sibling = this.findSchematicBesideProject(projectUri.fsPath);
+        if (sibling) {
+          return { file: sibling };
+        }
+      }
     }
     if (candidates.length === 1) {
       return { file: candidates[0] };


### PR DESCRIPTION
Fixes #250
Fixes #249

## Root cause

- **#250**: Fix Queue tree view had no Degraded state handler in `getChildren()`, so degraded MCP connections caused Fix Queue to hard-fail with generic "Use HTTP MCP transport" instead of showing cached server diagnostics with recovery guidance.
- **#249**: NetlistViewProvider lost active schematic context across VS Code reloads because the last schematic file path was only held in-memory (`_lastFile`) and not persisted to workspaceState. It also had no fallback for discovering schematics from sibling `.kicad_pro` project files when no editor context existed.

## Implementation summary

### #250 - Fix Queue degraded state
- `fixQueueProvider.ts`: Added Degraded state handling in `getChildren()` — renders cached `state.server.capabilities.diagnostics` items and a retry-MCP action button instead of early-clearing the tree with generic message.
- `fixQueueBlockMessage()`: Added Degraded branch that returns localized message with `{message}` template populated from `state.message`.
- `i18n.ts`: Added `fixQueueBlockDegraded` key.
- `bundle.l10n.tr.json`: Added Turkish translation.

### #249 - NetlistViewProvider persistence
- `netlistViewProvider.ts`: Added `LAST_SCHEMATIC_STORAGE_KEY` constant.
- Constructor reads persisted `_lastFile` from `context.workspaceState` on construction (survives reloads).
- `refresh()` writes resolved schematic to workspaceState on successful resolution.
- Added project-aware fallback: when no active editor and no cached schematic, searches workspace `.kicad_pro` files for sibling `.kicad_sch` schematics.
- Made `workspaceState` access null-safe with optional chaining for test compatibility.

### Test fixes
- Fixed 12 netlistViewProvider tests that crashed on mock context without `workspaceState`.

## Tests run

```
corepack pnpm run check:kicad-studio:    82 suites, 627 tests, 7 security, 76 a11y — all pass
corepack pnpm run check:kicad-mcp-pro:   full pytest suite, 90.27% coverage — all pass
corepack pnpm run check:compatibility:   validated
corepack pnpm run check:runtime-policy:  pass
corepack pnpm run check:version:         pass
corepack pnpm run check:forbidden-refs:  pass
corepack pnpm run check:boundaries:      pass
```

## Remaining limitations
- #224 / #226 (file-backed fallback for additional tools, standardized empty responses) are NOT addressed — out of scope for this PR.
- #248 / #247 were not touched.

## Confirmation
- No OASLANA-211 trackingIssue schema/fixture changes are included
- No cache/runtime artifacts committed
- Only 4 extension source files modified (fixQueueProvider.ts, netlistViewProvider.ts, i18n.ts, bundle.l10n.tr.json)
- No MCP server (Python) changes
