### PR TITLE
fix(kicad-studio): repair extension listing media links

### DIFF
--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -9,7 +9,7 @@ KiCad Studio turns VS Code into a focused KiCad workspace for project navigation
 Canonical repository: https://github.com/oaslananka/kicad-studio-kit/tree/main/apps/vscode-extension
 
 - Extension ID: `oaslananka.kicadstudiokit`
-- Version: `1.0.0`
+- Version: `1.1.0`
 - Supported MCP: `kicad-mcp-pro >=3.5.2 <4.0.0`
 - Supported KiCad projects: KiCad 8.x, 9.x, and 10.x project, schematic, PCB, DRC, and jobset files
 
@@ -68,7 +68,7 @@ corepack pnpm --filter kicadstudiokit run package
 
 ## MCP Compatibility
 
-KiCad Studio 1.0.0 supports `kicad-mcp-pro >=3.5.2 <4.0.0` and was tested against `3.5.2`. If a connected server reports a version outside the required range, MCP-dependent commands are disabled while KiCad-only features continue to work.
+KiCad Studio 1.1.0 supports `kicad-mcp-pro >=3.5.2 <4.0.0` and was tested against `3.5.2`. If a connected server reports a version outside the required range, MCP-dependent commands are disabled while KiCad-only features continue to work.
 
 ## Marketplace Listing Copy
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -46,6 +46,8 @@
     "color": "#1a1a2e",
     "theme": "dark"
   },
+  "baseImagesUrl": "https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension",
+  "baseContentUrl": "https://github.com/oaslananka/kicad-studio-kit/blob/main/apps/vscode-extension",
   "repository": {
     "type": "git",
     "url": "https://github.com/oaslananka/kicad-studio-kit",

--- a/apps/vscode-extension/scripts/check-marketplace-assets.js
+++ b/apps/vscode-extension/scripts/check-marketplace-assets.js
@@ -163,6 +163,14 @@ function assertPackageMetadata() {
   ) {
     fail('package.json must expose marketplace:check');
   }
+  if (!packageJson.baseImagesUrl) {
+    fail('package.json must set baseImagesUrl for marketplace image rendering');
+  }
+  if (
+    !packageJson.baseImagesUrl.startsWith('https://raw.githubusercontent.com/')
+  ) {
+    fail('package.json baseImagesUrl must point to raw.githubusercontent.com');
+  }
 }
 
 function assertMarketplaceAssets() {
@@ -193,13 +201,36 @@ function assertMarketplaceAssets() {
 }
 
 function assertMarketplaceMarkdown() {
+  const packageJson = readJson('package.json');
   const readme = readText('README.md');
   const listing = readText('docs/marketplace-listing.md');
   const firstLines = readme.split('\n').slice(0, 5).join('\n');
+  const expectedVersion = packageJson.version;
 
   if (!firstLines.includes('assets/marketplace/hero.png')) {
     fail('README.md must place the hero image at the top');
   }
+
+  // Version text in README must match package.json
+  const versionPattern = new RegExp(
+    `Version:\\s*\`${escapeRegExp(expectedVersion)}\``
+  );
+  if (!versionPattern.test(readme)) {
+    fail(
+      `README.md must declare Version: \`${expectedVersion}\` matching package.json`
+    );
+  }
+
+  // MCP Compatibility section version
+  const mcpCompatPattern = new RegExp(
+    `KiCad Studio ${escapeRegExp(expectedVersion)}\\s+supports`
+  );
+  if (!mcpCompatPattern.test(readme)) {
+    fail(
+      `README.md MCP Compatibility section must reference KiCad Studio ${expectedVersion}`
+    );
+  }
+
   for (const heading of [
     'Quick Start',
     'Feature Matrix',

--- a/apps/vscode-extension/test/marketplace-assets.test.ts
+++ b/apps/vscode-extension/test/marketplace-assets.test.ts
@@ -16,6 +16,7 @@ type PackageJson = {
     color?: string;
     theme?: string;
   };
+  baseImagesUrl?: string;
   scripts?: Record<string, string>;
 };
 
@@ -90,6 +91,9 @@ describe('marketplace listing assets', () => {
     });
     expect(packageJson.scripts?.['marketplace:check']).toBe(
       'node scripts/check-marketplace-assets.js'
+    );
+    expect(packageJson.baseImagesUrl).toBe(
+      'https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension'
     );
   });
 


### PR DESCRIPTION
Fixes #260

## Summary
- Adds \aseImagesUrl\ and \aseContentUrl\ to \package.json\ so VS Code Marketplace and Open VSX can resolve README image URLs
- Fixes stale version text in README.md (hardcoded \1.0.0\ → \1.1.0\)
- Hardens \marketplace:check\ to fail when \aseImagesUrl\ is missing or README version doesn't match \package.json\

## Root cause
Relative image paths like \ssets/marketplace/hero.png\ in README.md fail to render in both Marketplaces without an explicit \aseImagesUrl\. The publish workflow sets this for Open VSX via CLI flags, but \sce\ (VS Code Marketplace) needs it in \package.json\.

## Validation
- corepack pnpm --filter kicadstudiokit run marketplace:check ✅
- corepack pnpm --filter kicadstudiokit run build ✅
- corepack pnpm --filter kicadstudiokit run package ✅
- corepack pnpm run check:version ✅
- corepack pnpm run check:ci-lanes ✅