### PR TITLE
fix(kicad-studio): AI Chat scroll anchoring and long-response rendering jank

### DIFF
--- a/apps/vscode-extension/src/ai/chatHtml.ts
+++ b/apps/vscode-extension/src/ai/chatHtml.ts
@@ -141,6 +141,7 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
     }
     #messages {
       overflow: auto;
+      overflow-anchor: auto;
       padding: 14px;
       display: flex;
       flex-direction: column;
@@ -465,12 +466,17 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       return el.scrollHeight - el.scrollTop - el.clientHeight < AUTO_SCROLL_THRESHOLD_PX;
     }
     function scheduleScrollToBottom(shouldStick) {
-      if (!shouldStick || state.scrollPending) {
+      if (state.scrollPending) {
         return;
       }
       state.scrollPending = true;
       requestAnimationFrame(() => {
         state.scrollPending = false;
+        // Re-check: if the user scrolled away between scheduling and the frame,
+        // do not steal their scroll position.
+        if (shouldStick && !isNearBottom(nodes.messages)) {
+          return;
+        }
         nodes.messages.scrollTop = nodes.messages.scrollHeight;
       });
     }
@@ -733,8 +739,11 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
         } else {
           state.history.push(message.message);
         }
-        // Full render with markdown now that streaming is complete.
-        renderMessage(message.message, false);
+        // Defer full markdown render to the next animation frame so the browser
+        // can settle pending streaming layout before the expensive DOM rebuild.
+        requestAnimationFrame(() => {
+          renderMessage(message.message, false);
+        });
       } else if (message.type === 'status') {
         setStatus(message.text || l10n.t('Ready'));
       } else if (message.type === 'busy') {

--- a/apps/vscode-extension/test/unit/chatHtml.test.ts
+++ b/apps/vscode-extension/test/unit/chatHtml.test.ts
@@ -54,4 +54,33 @@ describe('buildChatHtml', () => {
     expect(html).toContain('requestAnimationFrame(() => {');
     expect(html).toContain('quota|rate limit|usage limit|limit reached');
   });
+
+  it('enables native CSS scroll anchoring on the messages container', () => {
+    const html = buildChatHtml({
+      webview: createWebviewMock(),
+      extensionUri: vscode.Uri.file('/extension')
+    });
+
+    expect(html).toContain('overflow-anchor: auto');
+  });
+
+  it('re-checks near-bottom in rAF callback to prevent scroll stealing', () => {
+    const html = buildChatHtml({
+      webview: createWebviewMock(),
+      extensionUri: vscode.Uri.file('/extension')
+    });
+
+    expect(html).toContain('if (shouldStick && !isNearBottom(nodes.messages))');
+  });
+
+  it('defers assistantReplace markdown render with requestAnimationFrame', () => {
+    const html = buildChatHtml({
+      webview: createWebviewMock(),
+      extensionUri: vscode.Uri.file('/extension')
+    });
+
+    expect(html).toContain("message.type === 'assistantReplace'");
+    expect(html).toContain('requestAnimationFrame(() => {');
+    expect(html).toContain('renderMessage(message.message, false)');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes scroll anchoring and rendering jank in the AI Chat webview during long streaming responses.

## Changes

### 1. CSS native scroll anchoring
Added \overflow-anchor: auto\ to the \#messages\ container so the browser's built-in scroll anchoring prevents unwanted scroll jumps when content is added above the viewport.

### 2. rAF re-check in scheduleScrollToBottom
When a scroll is scheduled via \equestAnimationFrame\, the callback now re-verifies \isNearBottom()\ before scrolling. Previously, \shouldStick\ was captured at call time but the rAF could fire after the user had scrolled up — stealing their scroll position. The re-check prevents this by skipping the scroll if the user moved away between scheduling and execution.

### 3. Deferred markdown render in assistantReplace
The expensive full markdown render (via \window.KiCadChatMarkdown.renderMarkdown\) triggered by \ssistantReplace\ is now wrapped in \equestAnimationFrame\, allowing the browser to settle pending streaming layout before the DOM rebuild. This eliminates layout thrash on long responses.

### 4. Tests
Added 3 new tests to \chatHtml.test.ts\:
- CSS \overflow-anchor: auto\ presence
- rAF re-check (\shouldStick && !isNearBottom\)
- \ssistantReplace\ handler wrapping \enderMessage\ in rAF

## Verification
- All 632 unit tests pass
- All 19 integration tests pass

Closes #247