### PR TITLE
fix(kicad-studio): scroll anchoring and long-response rendering jank in AI Chat webview

### DIFF
--- a/apps/vscode-extension/src/ai/chatHtml.ts
+++ b/apps/vscode-extension/src/ai/chatHtml.ts
@@ -141,6 +141,7 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
     }
     #messages {
       overflow: auto;
+      overflow-anchor: auto;
       padding: 14px;
       display: flex;
       flex-direction: column;
@@ -465,12 +466,17 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
       return el.scrollHeight - el.scrollTop - el.clientHeight < AUTO_SCROLL_THRESHOLD_PX;
     }
     function scheduleScrollToBottom(shouldStick) {
-      if (!shouldStick || state.scrollPending) {
+      if (state.scrollPending) {
         return;
       }
       state.scrollPending = true;
       requestAnimationFrame(() => {
         state.scrollPending = false;
+        // Re-check: if the user scrolled away between scheduling and the frame,
+        // do not steal their scroll position.
+        if (shouldStick && !isNearBottom(nodes.messages)) {
+          return;
+        }
         nodes.messages.scrollTop = nodes.messages.scrollHeight;
       });
     }
@@ -733,8 +739,11 @@ export function buildChatHtml(options: ChatHtmlOptions): string {
         } else {
           state.history.push(message.message);
         }
-        // Full render with markdown now that streaming is complete.
-        renderMessage(message.message, false);
+        // Defer full markdown render to the next animation frame so the browser
+        // can settle pending streaming layout before the expensive DOM rebuild.
+        requestAnimationFrame(() => {
+          renderMessage(message.message, false);
+        });
       } else if (message.type === 'status') {
         setStatus(message.text || l10n.t('Ready'));
       } else if (message.type === 'busy') {

--- a/apps/vscode-extension/test/unit/chatHtml.test.ts
+++ b/apps/vscode-extension/test/unit/chatHtml.test.ts
@@ -54,4 +54,33 @@ describe('buildChatHtml', () => {
     expect(html).toContain('requestAnimationFrame(() => {');
     expect(html).toContain('quota|rate limit|usage limit|limit reached');
   });
+
+  it('enables native CSS scroll anchoring on the messages container', () => {
+    const html = buildChatHtml({
+      webview: createWebviewMock(),
+      extensionUri: vscode.Uri.file('/extension')
+    });
+
+    expect(html).toContain('overflow-anchor: auto');
+  });
+
+  it('re-checks near-bottom in rAF callback to prevent scroll stealing', () => {
+    const html = buildChatHtml({
+      webview: createWebviewMock(),
+      extensionUri: vscode.Uri.file('/extension')
+    });
+
+    expect(html).toContain('if (shouldStick && !isNearBottom(nodes.messages))');
+  });
+
+  it('defers assistantReplace markdown render with requestAnimationFrame', () => {
+    const html = buildChatHtml({
+      webview: createWebviewMock(),
+      extensionUri: vscode.Uri.file('/extension')
+    });
+
+    expect(html).toContain("message.type === 'assistantReplace'");
+    expect(html).toContain('requestAnimationFrame(() => {');
+    expect(html).toContain('renderMessage(message.message, false)');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #247 — AI Chat webview scroll anchoring and long-response rendering jank.

### Changes

1. **CSS overflow-anchor: auto** on #messages — enables native browser scroll anchoring to prevent scroll jumps when content is added above the viewport.

2. **Re-check near-bottom inside scheduleScrollToBottom rAF** — previously, \shouldStick\ was captured at call time but the \equestAnimationFrame\ callback fired later. If the user scrolled away between check and frame, the scroll would steal their position. Now the rAF callback re-evaluates \isNearBottom(nodes.messages)\ before scrolling.

3. **Defer assistantReplace markdown render to rAF** — when a long streaming response completes, the full DOM rebuild (markdown parsing + innerHTML) is deferred to the next animation frame so the browser can settle pending streaming layout first.

### Files Changed

- \pps/vscode-extension/src/ai/chatHtml.ts\ — 3 fix hunks (CSS, scroll re-check, rAF defer)
- \pps/vscode-extension/test/unit/chatHtml.test.ts\ — 3 new tests

### Verification

- 632 unit tests, all passing
- Security tests: 7 passing
- Integration tests: 19 passing