### PR TITLE
docs(repo): add ADR process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,28 @@ Changing `engines.vscode`, Python `requires-python`, or the primary KiCad suppor
 the matching `compatibility.yaml` update, this support matrix update, and product changelog context
 when a lower runtime boundary is introduced.
 
+## Architecture Decision Records
+
+Architecture, product, protocol, release, and security decisions that affect
+the monorepo structure, integration surface, or compatibility policy must be
+documented as Architecture Decision Records (ADRs).
+
+An ADR is **required** for:
+
+- Monorepo structure changes (adding, removing, or merging workspaces).
+- MCP protocol or schema breaking changes.
+- KiCad version support policy changes.
+- Release model changes.
+- Product dependency boundary changes.
+- Bundling or distribution changes.
+- Security or supply-chain policy changes.
+
+An ADR is **not required** for routine dependency updates, bug fixes,
+cosmetic changes, CI/tooling changes, or test-only changes.
+
+See [docs/adr/README.md](docs/adr/README.md) for the full process, template,
+and index of existing ADRs.
+
 ## Dev Container
 
 The repository includes a VS Code Dev Containers and GitHub Codespaces setup in

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,33 @@
+# ADR NNNN: Title
+
+Status: Proposed | Accepted | Deprecated | Superseded by `NNNN`
+
+Date: YYYY-MM-DD
+
+## Context
+
+Why is this decision needed? What problem does it solve? What constraints,
+prior decisions, or external factors shaped the options?
+
+## Decision
+
+What was decided? Be specific enough that a future contributor can
+understand the exact scope of the decision. Include configuration values,
+manifest entries, version ranges, or policy language when relevant.
+
+## Consequences
+
+What are the trade-offs? List positive and negative consequences. Note
+migration effort, compatibility impact, and anything that will break if
+this decision is reversed.
+
+## Alternatives Considered
+
+What other approaches were evaluated? Why was each rejected? This section
+helps future readers understand why the chosen path was preferred.
+
+## Related
+
+- Related issues or PRs (e.g., #67, PR #264).
+- Supersedes ADR NNNN if this ADR replaces an earlier decision.
+- Linked architecture documents or policy files.

--- a/docs/adr/0001-monorepo-two-products.md
+++ b/docs/adr/0001-monorepo-two-products.md
@@ -1,0 +1,69 @@
+# ADR 0001: Monorepo Two Products
+
+Status: Accepted
+
+Date: 2026-05-30
+
+## Context
+
+KiCad Studio Kit ships two independently released products — a VS Code
+extension (`kicadstudiokit`) and a Python MCP server with an npm launcher
+wrapper (`kicad-mcp-pro`) — plus a private shared test harness. Before this
+ADR, the repository used a pnpm workspace structure but did not formally
+document which paths are product workspaces, which are shared infrastructure,
+and which are root-owned orchestration.
+
+The repository had accumulated a mix of workspace layouts:
+
+- `apps/` for the VS Code extension.
+- `packages/` for the MCP server, npm launcher, and test harness.
+
+This follows the pnpm convention (`apps/` for deployable applications,
+`packages/` for libraries and utilities) but the distinction was implicit.
+
+## Decision
+
+Adopt the following monorepo topology as binding policy:
+
+| Path                    | Role                               | Published                 |
+| ----------------------- | ---------------------------------- | ------------------------- |
+| `apps/vscode-extension` | VS Code / Open VSX extension       | VSIX                      |
+| `packages/mcp-server`   | Python MCP server                  | sdist/wheel, MCP Registry |
+| `packages/mcp-npm`      | npm launcher for the Python server | npm                       |
+| `packages/test-harness` | Private shared test utilities      | Never                     |
+
+Additional rules:
+
+- Do not introduce additional canonical repositories, mirrors, or alternate
+  release roots.
+- The repository root is `private: true` and owns orchestration only:
+  package manager config, version preflight scripts, release workflows, and
+  documentation.
+- Cross-product work must flow through compatibility metadata, MCP manifests,
+  shared fixtures, and contract tests — not through direct source imports.
+
+## Consequences
+
+- Positive: Clear ownership boundaries reduce accidental cross-product
+  coupling. New contributors can determine which workspace to modify from
+  the path alone.
+- Positive: Release Please can target product-specific version files without
+  root-version conflicts.
+- Negative: Shared code between products must be duplicated or extracted to
+  a shared package, adding overhead for genuinely cross-cutting concerns.
+- Negative: Root configuration changes (CI, release, docs) require awareness
+  of all product surfaces.
+
+## Alternatives Considered
+
+- **Separate repositories per product**: Rejected. Would lose shared CI,
+  compatibility validation, contract tests, and coordinated release notes.
+- **Flat workspace with no `apps/`/`packages/` split**: Rejected. The
+  `apps/` vs `packages/` convention signals deployability vs library intent
+  and is widely understood by pnpm users.
+
+## Related
+
+- Supersedes prior implicit topology conventions.
+- Documented in `docs/architecture/repo-structure.md`.
+- Issue #67.

--- a/docs/adr/0002-mcp-contract-first-integration.md
+++ b/docs/adr/0002-mcp-contract-first-integration.md
@@ -1,0 +1,70 @@
+# ADR 0002: MCP Contract-First Integration
+
+Status: Accepted
+
+Date: 2026-05-30
+
+## Context
+
+The two products in the monorepo — the VS Code extension and the MCP server —
+integrate through the Model Context Protocol (MCP). Before this ADR, the
+integration surface was documented but the exact contract boundary was not
+formally defined.
+
+The products must stay independent at source level while interoperating at
+runtime. This requires a clear contract that both sides implement and that
+can be validated in CI.
+
+## Decision
+
+Adopt a contract-first integration model:
+
+1. **Compatibility metadata** — All integration surfaces are declared in
+   `compatibility.yaml` at the repository root, with matching assertions in
+   the extension (`apps/vscode-extension/src/mcp/compatibilityMatrix.ts`) and
+   the MCP server (`packages/mcp-server/src/kicad_mcp/compatibility.py`).
+
+2. **MCP manifests** — The MCP server declares its capabilities through
+   `mcp.json` and `server.json` under `packages/mcp-server/`. The extension
+   reads these manifests at runtime to determine which tools and features
+   are available.
+
+3. **MCP protocol** — Tool names, parameter schemas, capability metadata,
+   transport behavior, and server-info payloads are part of the integration
+   contract. Any change to these requires updating both product surfaces and
+   the compatibility validation scripts.
+
+4. **Contract tests** — `corepack pnpm run test:contract` validates that
+   both sides agree on the integration surface. CI must run contract tests
+   when either product changes.
+
+5. **Protocol change checklist** — The PR template requires a protocol impact
+   section. The full checklist is documented in
+   `docs/architecture/protocol-change-checklist.md`.
+
+## Consequences
+
+- Positive: Either product can be developed and released independently as
+  long as the contract is preserved.
+- Positive: CI catches contract drift before release.
+- Positive: Newcomers can understand the integration surface from the
+  manifests and contract tests.
+- Negative: Protocol changes require coordinated updates in both products,
+  adding overhead for cross-cutting features.
+- Negative: The compatibility metadata must be kept in sync manually or
+  through CI enforcement. Outdated metadata can block valid releases.
+
+## Alternatives Considered
+
+- **Shared protocol schema package**: Rejected. The MCP protocol version
+  and JSON-RPC layer are standard; our product-specific contract is best
+  expressed through compatibility tests rather than a shared schema that
+  would couple the products at build time.
+- **Extension imports server compatibility module directly**: Rejected.
+  Would violate the no-cross-product-imports boundary (ADR 0004).
+
+## Related
+
+- Documented in `docs/architecture/product-boundaries.md`.
+- Protocol change checklist: `docs/architecture/protocol-change-checklist.md`.
+- Issue #67.

--- a/docs/adr/0003-independent-release-model.md
+++ b/docs/adr/0003-independent-release-model.md
@@ -1,0 +1,83 @@
+# ADR 0003: Independent Release Model
+
+Status: Accepted
+
+Date: 2026-05-30
+
+## Context
+
+The monorepo produces three release surfaces: a VS Code extension (VSIX), a
+Python MCP server (sdist/wheel + MCP Registry), and an npm launcher wrapper.
+Before this ADR, the release model used Release Please with linked versions
+for the MCP product but the relationship between product versions and the
+root version was not formally documented.
+
+The products have different release cadences:
+
+- The extension may release multiple times in a week for UI fixes.
+- The MCP server releases are driven by protocol changes or KiCad
+  compatibility updates.
+- The npm launcher only changes when the Python package name or version
+  coordination changes.
+
+Locking all products to the same version would force unnecessary releases
+and create version bloat.
+
+## Decision
+
+Adopt an independent release model where each product version is decoupled:
+
+1. **Version sources** — Each product owns its version file:
+   - Extension: `apps/vscode-extension/package.json`
+   - Python MCP server: `packages/mcp-server/pyproject.toml`
+   - npm launcher: `packages/mcp-npm/package.json`
+
+2. **Linked MCP product** — `packages/mcp-server` and `packages/mcp-npm` are
+   linked through Release Please's `linked-versions` plugin and release as a
+   single `kicad-mcp-pro` product.
+
+3. **Extension independence** — The extension is intentionally not part of
+   the `kicad-mcp-pro` linked-version group. It can release independently.
+
+4. **Conventional Commit scopes** define the release boundary:
+   - `kicad-studio` → extension-only release PR.
+   - `kicad-mcp-pro` → MCP server + npm launcher release PR.
+   - `repo` → repository governance, docs, CI (no product release).
+   - `deps` → dependency-only updates (no product release unless a product
+     manifest changed).
+   - `kicad-studio/kicad-mcp-pro` → cross-product change that CI must
+     validate before Release Please runs.
+
+5. **Compatibility gate** — Before any release, compatibility metadata must
+   agree across the root matrix, extension, and MCP server. Protocol or
+   schema changes must update compatibility metadata for both products
+   before either release PR is merged.
+
+## Consequences
+
+- Positive: Each product releases at its own cadence. A UI fix in the
+  extension does not require an MCP server release.
+- Positive: Version numbers reflect meaningful changes per product rather
+  than lockstep increments.
+- Positive: Release Please automation handles version proposals through
+  `.release-please-manifest.json` and `release-please-config.json`.
+- Negative: Cross-product changes require careful scope separation and may
+  need two release PRs.
+- Negative: Compatibility metadata must be manually kept in sync or
+  validated in CI to prevent incompatible releases.
+
+## Alternatives Considered
+
+- **Single version for all products**: Rejected. Would force unnecessary
+  MCP server releases for extension-only changes and inflate version
+  numbers for both products.
+- **Separate repositories with independent release pipelines**: Rejected.
+  Would lose shared CI, compatibility validation, and coordinated release
+  communication (see ADR 0001).
+
+## Related
+
+- Documented in `docs/architecture/release-model.md`.
+- Release Please config: `release-please-config.json`,
+  `.release-please-manifest.json`.
+- Issue #67.

--- a/docs/adr/0004-no-direct-cross-product-imports.md
+++ b/docs/adr/0004-no-direct-cross-product-imports.md
@@ -1,0 +1,69 @@
+# ADR 0004: No Direct Cross-Product Imports
+
+Status: Accepted
+
+Date: 2026-05-30
+
+## Context
+
+The monorepo contains multiple product workspaces that must stay decoupled
+at source level while interoperating at runtime. Before this ADR, the
+dependency boundaries were documented in `docs/architecture/product-boundaries.md`
+but were not captured as a formal architecture decision.
+
+Allowing direct imports between products would create tight coupling,
+making independent releases (ADR 0003) impossible and breaking the
+contract-first integration model (ADR 0002).
+
+## Decision
+
+Adopt strict product dependency boundaries as binding policy:
+
+| From                    | May depend on                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------- |
+| `apps/vscode-extension` | npm deps, VS Code APIs, KiCad CLI process calls, MCP protocol data, test harness in tests only |
+| `packages/mcp-server`   | Python deps, KiCad Python/CLI integrations, MCP protocol data                                  |
+| `packages/mcp-npm`      | Node stdlib and the published Python package name only                                         |
+| `packages/test-harness` | Node stdlib and shared packages only                                                           |
+| Future shared packages  | External deps and other shared packages only                                                   |
+
+Explicitly forbidden:
+
+- The extension must not import Python server modules (`kicad_mcp.*`).
+- The MCP server must not import VS Code extension source or npm wrapper
+  implementation.
+- The npm launcher must not import extension source or Python server source.
+- No product may use relative imports into another product workspace.
+- Production source must not import `@oaslananka/kicad-test-harness` or
+  path-reference `packages/test-harness`.
+- Shared packages (`packages/*`) must not depend on `apps/*`.
+
+Integration happens through MCP protocol and compatibility metadata only.
+The boundary checker (`corepack pnpm run check:boundaries`) enforces these
+rules in CI.
+
+## Consequences
+
+- Positive: Products can be developed, tested, and released independently.
+- Positive: CI catches boundary violations before merge.
+- Positive: Clear ownership — each team (or contributor) can work on their
+  product without worrying about breaking another product's imports.
+- Negative: Shared logic must be duplicated or extracted to a shared
+  package, which requires an ADR (see "When an ADR Is Required").
+- Negative: Cross-product debugging requires reading compatibility metadata
+  and MCP protocol traces rather than following import chains.
+
+## Alternatives Considered
+
+- **Shared internal package for all cross-product code**: Rejected. Would
+  create a coupling point that undermines independence. A shared package
+  requires an ADR and must be narrowly scoped.
+- **No import restrictions (free-for-all)**: Rejected. Would make
+  independent releases impossible and create circular dependency risk.
+
+## Related
+
+- Enforced by `corepack pnpm run check:boundaries`.
+- Documented in `docs/architecture/product-boundaries.md`.
+- Ownership declared in `.github/CODEOWNERS`.
+- Issue #67.

--- a/docs/adr/0005-kicad-version-support-policy.md
+++ b/docs/adr/0005-kicad-version-support-policy.md
@@ -1,0 +1,77 @@
+# ADR 0005: KiCad Version Support Policy
+
+Status: Accepted
+
+Date: 2026-05-30
+
+## Context
+
+KiCad Studio Kit depends on `kicad-cli` for core extension workflows: DRC/ERC,
+BOM/netlist extraction, exports (Gerbers, drill, 3D PDF, STEP, ODB++), and
+design variant support. KiCad releases new major versions on an annual cycle,
+and upstream support for older versions ends when a new major is released.
+
+Before this ADR, support levels were documented in `compatibility.yaml` and
+`docs/support-matrix.md` but the policy for adding, deprecating, and removing
+KiCad support lines was not formalized.
+
+## Decision
+
+Adopt a three-tier KiCad version support model:
+
+| Tier        | Meaning                                                        | CI Requirement        | Feature Gate |
+| ----------- | -------------------------------------------------------------- | --------------------- | ------------ |
+| Primary     | Optimized target. All features must work.                      | Required release gate | Full         |
+| Deprecated  | Best-effort. Core workflows remain available; no new features. | Scheduled canary      | Limited      |
+| Unsupported | Not tested. No feature claims.                                 | None                  | Disabled     |
+
+Policy rules:
+
+1. **Primary designation** — Assigned to the latest KiCad stable major
+   version. All extension features must be validated against this version
+   before release.
+
+2. **Deprecation trigger** — When a new KiCad major version is released,
+   the previous major moves from Primary to Deprecated. The version before
+   that moves from Deprecated to Unsupported.
+
+3. **Deprecation period** — A deprecated version keeps best-effort
+   compatibility for approximately one KiCad release cycle. Removal
+   requires a release note and a scheduled canary lane in CI that gathers
+   failure evidence before the version is marked Unsupported.
+
+4. **Runtime probing** — The extension probes `kicad-cli --version` and
+   feature-specific help output before enabling commands. A version line
+   alone is not sufficient to enable advanced exports.
+
+5. **CI requirements** — Primary versions run as a required release gate.
+   Deprecated versions run as scheduled non-blocking canary lanes.
+   Unsupported versions have no CI commitment.
+
+## Consequences
+
+- Positive: Users on older KiCad versions get clear messaging about what is
+  supported and what is best-effort.
+- Positive: CI catches KiCad CLI regressions against the primary version
+  before release.
+- Positive: The canary lane provides data-driven evidence for when to drop
+  deprecated versions.
+- Negative: Maintaining backward compatibility with deprecated versions
+  adds test and documentation overhead.
+- Negative: Users on deprecated versions may see degraded functionality
+  without a clear migration path beyond "upgrade KiCad."
+
+## Alternatives Considered
+
+- **Support every KiCad version indefinitely**: Rejected. Would multiply
+  test matrix and documentation burden. No upstream project does this.
+- **Single-version support (latest only)**: Rejected. Would break existing
+  users during the annual KiCad release cycle. The deprecated tier provides
+  a transition period.
+
+## Related
+
+- Source of truth: `compatibility.yaml`.
+- Documented in `docs/support-matrix.md`.
+- KiCad support lines tracked in `compatibility.yaml` under `kicad.versions`.
+- Issue #67.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,96 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the
+KiCad Studio Kit monorepo. ADRs capture important decisions about
+architecture, product boundaries, MCP protocol compatibility, release
+and publishing policy, and security/supply-chain posture.
+
+## Status Values
+
+Each ADR has one of the following statuses:
+
+| Status     | Meaning                                                    |
+| ---------- | ---------------------------------------------------------- |
+| Proposed   | Under review; not yet adopted.                             |
+| Accepted   | Agreed and currently in effect.                            |
+| Superseded | Replaced by a later ADR. Links to the superseding ADR.     |
+| Deprecated | No longer recommended but retained for historical context. |
+| Rejected   | Considered and explicitly not adopted.                     |
+
+## When an ADR Is Required
+
+An ADR is **mandatory** before implementing any change that affects:
+
+1. **Monorepo structure** — adding, removing, or merging product
+   workspaces, changing the topology, or changing the package manager.
+2. **MCP protocol or schema** — breaking tool names, parameter shapes,
+   capability metadata, transport mode, or compatibility assertions.
+3. **KiCad version support policy** — adding, deprecating, or removing
+   a KiCad support line.
+4. **Release model** — changing versioning, publish targets, artifact
+   format, or release-please configuration.
+5. **Product dependency boundaries** — allowing or forbidding a new
+   dependency direction between workspaces.
+6. **Bundling or distribution** — bundling the MCP server with the
+   extension, changing how products are packaged or delivered.
+7. **Security or supply-chain** — adding a new dependency with broad
+   access, changing credential handling, or adopting a new vulnerability
+   management process.
+
+An ADR is **not required** for:
+
+- Routine dependency updates (patch/minor bumps, security patches for
+  existing dependencies).
+- Bug fixes that do not change the documented architecture.
+- Cosmetic or UI-only changes.
+- CI or tooling changes that do not affect product behavior or
+  compatibility.
+- Test-only changes.
+
+When in doubt, open a **Proposed** ADR. It is easier to skip an
+unnecessary ADR during review than to retroactively document a decision
+that was not recorded.
+
+## Numbering and Naming Convention
+
+- ADRs are numbered sequentially: `0001`, `0002`, ..., `NNNN`.
+- File name: `NNNN-kebab-case-title.md`.
+- Numbers are never reused. A superseded ADR keeps its original number.
+- The next ADR number is `0009` (the first unused number as of this
+  writing).
+
+## How Superseding Works
+
+1. The new ADR is created with status **Accepted** (or **Proposed**).
+2. The new ADR body includes a "Supersedes" line referencing the old ADR.
+3. The old ADR's status is updated to **Superseded by NNNN** with a link.
+4. Both ADRs remain in the repository for historical traceability.
+
+## Review and Merge Expectations
+
+- **Proposed** ADRs are reviewed through a pull request. At least one
+  maintainer (`@oaslananka`) must approve before the ADR can be Accepted.
+- **Accepted** ADRs are considered binding policy. Subsequent work must
+  follow the accepted decision unless a superseding ADR changes it.
+- ADR-only PRs follow the same CI gates as code PRs.
+- ADR changes that also change product behavior must be reviewed alongside
+  the behavioral change.
+
+## Index
+
+| #    | Title                                                                        | Status   |
+| ---- | ---------------------------------------------------------------------------- | -------- |
+| 0001 | [Monorepo Two Products](0001-monorepo-two-products.md)                       | Accepted |
+| 0002 | [MCP Contract-First Integration](0002-mcp-contract-first-integration.md)     | Accepted |
+| 0003 | [Independent Release Model](0003-independent-release-model.md)               | Accepted |
+| 0004 | [No Direct Cross-Product Imports](0004-no-direct-cross-product-imports.md)   | Accepted |
+| 0005 | [KiCad Version Support Policy](0005-kicad-version-support-policy.md)         | Accepted |
+| 0006 | [VS Code Web Compatibility](0006-vscode-web-compatibility.md)                | Accepted |
+| 0007 | [Agent Onboarding and MCP Config Pack](0007-agent-onboarding-config-pack.md) | Accepted |
+| 0008 | [MCP 2026-07-28 Protocol Upgrade](0008-mcp-2026-07-28-protocol-upgrade.md)   | Accepted |
+
+## Creating a New ADR
+
+```bash
+cp docs/adr/0000-template.md docs/adr/$(printf '%04d' $(($(ls docs/adr/*.md | wc -l)))).md
+```

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,6 +91,17 @@ that was not recorded.
 
 ## Creating a New ADR
 
+The next number is `max(existing numbered ADR) + 1`. `0000-template.md` and
+`README.md` are not counted. Superseded ADRs keep their numbers and remain in
+the sequence.
+
 ```bash
-cp docs/adr/0000-template.md docs/adr/$(printf '%04d' $(($(ls docs/adr/*.md | wc -l)))).md
+next="$(
+  python - <<'PY'
+from pathlib import Path
+numbers = [int(p.stem[:4]) for p in Path("docs/adr").glob("[0-9][0-9][0-9][0-9]-*.md") if p.name != "0000-template.md"]
+print(f"{max(numbers, default=0) + 1:04d}")
+PY
+)"
+cp docs/adr/0000-template.md "docs/adr/${next}-kebab-case-title.md"
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,5 +19,6 @@ Detailed architecture documents:
 - [Testing strategy](architecture/testing-strategy.md)
 - [Migration phases](architecture/migration-phases.md)
 - [M0 completion audit](architecture/m0-completion-audit.md)
+- [Architecture Decision Records (ADR index)](adr/README.md)
 - [ADR 0006: VS Code Web compatibility](adr/0006-vscode-web-compatibility.md)
 - [KiCad Studio and MCP integration](integration/kicad-studio-mcp.md)


### PR DESCRIPTION
Fixes #67

## Summary

- Adds an ADR process for architecture, product, protocol, and release decisions.
- Adds ADR template (0000-template.md) and index (README.md).
- Documents when ADRs are required and how they are superseded.
- Adds 5 initial ADRs documenting current architecture decisions:
  - ADR 0001: Monorepo Two Products
  - ADR 0002: MCP Contract-First Integration
  - ADR 0003: Independent Release Model
  - ADR 0004: No Direct Cross-Product Imports
  - ADR 0005: KiCad Version Support Policy
- Links ADR process from CONTRIBUTING.md and architecture docs.

## Validation

- corepack pnpm run check:docs-site ✓
- corepack pnpm run check:version ✓
- corepack pnpm run check:forbidden-refs ✓