### PR TITLE
docs(repo): surface MCP 2026-07-28 next protocol (ADR-0008 Phase 0)

### DIFF
--- a/docs/architecture/migration-phases.md
+++ b/docs/architecture/migration-phases.md
@@ -52,8 +52,9 @@ Related issues: #37, #53, #54, #55, #76.
 
 ## Phase M2 - MCP 2026-07-28 Protocol Upgrade
 
-- [ ] Add `nextProtocolVersion: "2026-07-28"` tracking field to `compatibility.yaml`
-- [ ] Create ADR 0008 with phased upgrade plan
+- [x] Add `nextProtocolVersion: "2026-07-28"` tracking field to `compatibility.yaml`
+- [x] Create ADR 0008 with phased upgrade plan
+- [x] Surface `2026-07-28` as the tracked next protocol line in `docs/support-matrix.md`
 - [ ] P0: Update transport layer — `Mcp-Method`/`Mcp-Name` headers, remove session handshake
 - [ ] P0: Add `server/discover` response for capability discovery
 - [ ] P1: Bump MCP Python SDK when RC with 2026-07-28 support ships

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -20,6 +20,7 @@ Machine-maintained from `compatibility.yaml`. Refresh with
 | pnpm | `>=11.0.0 <12` |
 | Python | `>=3.13` |
 | MCP protocol | `2025-11-25` |
+| MCP protocol (next) | `2026-07-28` |
 
 ### KiCad Support
 
@@ -160,6 +161,13 @@ Freshness sources checked on 2026-05-27:
 | Node         | 24.x       | `>=24.11.0 <25`        | older      | root and extension package metadata      |
 | pnpm         | 11.x       | `>=11.0.0 <12`         | older      | root package metadata                    |
 | Python       | 3.13       | 3.13, 3.14             | older      | `pyproject.toml` and CI                  |
+
+The MCP protocol revision `2026-07-28` is the tracked next protocol target. It is
+recorded as `nextProtocolVersion` in `compatibility.yaml` and surfaced in the
+generated runtime baseline above, but it is not yet adopted: the active protocol
+stays `2025-11-25` until the Python MCP SDK ships 2026-07-28 support. The phased
+upgrade plan and per-file change list are maintained in
+[ADR 0008](adr/0008-mcp-2026-07-28-protocol-upgrade.md).
 
 ## Minimum-Bump Policy
 

--- a/scripts/generate-docs-site.mjs
+++ b/scripts/generate-docs-site.mjs
@@ -293,7 +293,11 @@ Machine-maintained from \`compatibility.yaml\`. Refresh with
 | Node | \`${compatibility.node.range}\` |
 | pnpm | \`${compatibility.pnpm.range}\` |
 | Python | \`${compatibility.python.range}\` |
-| MCP protocol | \`${compatibility.mcp.protocolVersion}\` |
+| MCP protocol | \`${compatibility.mcp.protocolVersion}\` |${
+    compatibility.mcp.nextProtocolVersion
+      ? `\n| MCP protocol (next) | \`${compatibility.mcp.nextProtocolVersion}\` |`
+      : ""
+  }
 
 ### KiCad Support
 


### PR DESCRIPTION
## Summary

Completes the remaining documentation/tracking groundwork for ADR-0008 Phase 0 (MCP `2026-07-28` protocol upgrade preparation). Phase 0 is preparation only — the **active** MCP protocol stays `2025-11-25`; no transport, schema, or server behavior changes here. The `2026-07-28` target is already recorded as `mcp.nextProtocolVersion` in `compatibility.yaml` (added in #262); this PR makes it visible in the docs and checks off the now-complete Phase 0 items.

Changes:
- `scripts/generate-docs-site.mjs`: render `compatibility.mcp.nextProtocolVersion` as an `MCP protocol (next)` row in the generated support-matrix runtime baseline (conditional — only emitted when the field is present, so it stays correct after the eventual upgrade).
- `docs/support-matrix.md`: regenerated baseline now shows the next-protocol row; added a short note in the non-generated *Current Platform Policy* section explaining `2026-07-28` is tracked-but-not-adopted and linking ADR-0008.
- `docs/architecture/migration-phases.md`: checked off the completed Phase 0 items (`nextProtocolVersion` field, ADR 0008) and recorded the support-matrix surfacing.

Per ADR-0008, the Phase 0 file list was `compatibility.yaml` (already done in #262), `docs/architecture/migration-phases.md`, and `docs/support-matrix.md`.

## Linked issue

Refs ADR-0008 and #197 (Phase M2 tracker). No issue auto-closed — Phase 1+ remains blocked on the Python MCP SDK shipping `2026-07-28` support.

## Type of change

- [x] type:docs

## Test evidence

All run locally on Node 24.16.0 / pnpm 11.3.0 / uv 0.11.16:

- `corepack pnpm run docs:generate` — regenerated; only the support-matrix baseline row changed.
- `corepack pnpm run docs:check-generated` — passed (generated block matches generator).
- `corepack pnpm run docs:lint` / `docs:links` — passed.
- `corepack pnpm run docs:build` (vitepress) — build complete.
- `corepack pnpm run check:compatibility` — passed.
- `corepack pnpm run check:runtime-policy` — passed.
- `corepack pnpm run check:ci-lanes` — 9/9 passed.
- `corepack pnpm run check:protocol-pr-template` — passed.
- `corepack pnpm run check:protocol-schemas` — passed.

## Protocol / MCP impact

This PR surfaces already-tracked compatibility metadata in docs; it does **not** change the active protocol version, tool names/schemas, transport, server-info payloads, or adapter behavior.

- [x] Compatibility matrix updated (docs surfacing of `nextProtocolVersion`; active `protocolVersion` unchanged)
- [x] Docs updated
- [x] Backward compatibility impact documented — none; active protocol remains `2025-11-25`
- [ ] Protocol schema updated — n/a
- [ ] MCP server implementation updated — n/a
- [ ] Extension MCP adapter updated — n/a
- [ ] Contract tests updated — n/a
- [ ] Server-info/capabilities payload updated — n/a
- [ ] Release notes considered for both products — n/a (no behavior change)

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean — gates verified locally before opening
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [ ] Bug fixes include automated regression coverage — n/a (docs/tracking only)
- [ ] Bug-fix exceptions explain why automation is not practical — n/a
- [ ] CHANGELOG entry — not user-facing behavior; tracking docs only
- [x] Docs updated
- [x] No new committed secrets or build artifacts

Link to Devin session: https://app.devin.ai/sessions/3f2f3597036a4afe840c7c584ce0b98f
Requested by: @oaslananka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oaslananka/kicad-studio-kit/pull/273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->