### PR TITLE
docs(kicad-mcp-pro): record verified official MCP Registry status (#272)

### DIFF
--- a/packages/mcp-server/PUBLIC_LISTING.md
+++ b/packages/mcp-server/PUBLIC_LISTING.md
@@ -5,11 +5,18 @@ This file is intentionally maintained in the repository root so reviewers and ma
 
 ## Listing Targets
 
-| Target                        | Status        | Submitted (UTC) | Approved (UTC) | Listing URL |
-| ----------------------------- | ------------- | --------------- | -------------- | ----------- |
-| Anthropic Connector Directory | Not submitted |                 |                |             |
-| ChatGPT Apps                  | Not submitted |                 |                |             |
-| OpenAI/MCP Registry           | Not submitted |                 |                |             |
+| Target                        | Status                  | Submitted (UTC)      | Approved (UTC)       | Listing URL                                                                |
+| ----------------------------- | ----------------------- | -------------------- | -------------------- | -------------------------------------------------------------------------- |
+| Anthropic Connector Directory | Not submitted           |                      |                      |                                                                            |
+| ChatGPT Apps                  | Not submitted           |                      |                      |                                                                            |
+| OpenAI/MCP Registry           | Listed (stale: `2.1.0`) | 2026-04-15T21:15:40Z | 2026-04-15T21:15:40Z | <https://registry.modelcontextprotocol.io/v0/servers?search=kicad-mcp-pro> |
+
+> OpenAI/MCP Registry status verified 2026-05-31 (issue #272): the server
+> `io.github.oaslananka/kicad-mcp-pro` is `active` in the official registry but pinned at
+> `2.1.0` from before the monorepo migration, while the current product line is `3.6.0`.
+> Refreshing the listing requires a production publish — see
+> [`docs/submission/openai-mcp-registry.md`](docs/submission/openai-mcp-registry.md)
+> "Verified Registry Status" for the update path. No publish was performed during verification.
 
 ## Pre-submission Gate
 
@@ -43,8 +50,9 @@ Replace the five screenshots in `docs/assets/screenshots/` with real 1920x1080 c
 
 ## Submission Log
 
-| Date (UTC) | Target | Version | Outcome | Notes |
-| ---------- | ------ | ------- | ------- | ----- |
+| Date (UTC) | Target              | Version | Outcome            | Notes                                                                                                         |
+| ---------- | ------------------- | ------- | ------------------ | ------------------------------------------------------------------------------------------------------------- |
+| 2026-04-15 | OpenAI/MCP Registry | 2.1.0   | Published (active) | Pre-monorepo publish; discovered during #272 verification on 2026-05-31. Listing is stale vs current `3.6.0`. |
 
 ## Target Field Values
 

--- a/packages/mcp-server/docs/submission/openai-mcp-registry.md
+++ b/packages/mcp-server/docs/submission/openai-mcp-registry.md
@@ -9,6 +9,64 @@ This document covers the registry publish path driven by `server.json`.
 - Keep `mcp.json` synchronized with `server.json` and `pyproject.toml`.
 - Version must match `src/kicad_mcp/__init__.py`.
 
+## Verified Registry Status (2026-05-31)
+
+Verification of the official MCP Registry (`registry.modelcontextprotocol.io`) for
+`io.github.oaslananka/kicad-mcp-pro`, per issue #272. No publish was performed and no
+version, tag, or release identity was changed.
+
+| Field            | Official registry record                              | Canonical repo (`server.json`)                   |
+| ---------------- | ----------------------------------------------------- | ------------------------------------------------ |
+| Listing status   | `active`, `isLatest: true`                            | n/a                                              |
+| Published (UTC)  | `2026-04-15T21:15:40Z`                                | n/a                                              |
+| Version          | `2.1.0`                                               | `3.6.0`                                          |
+| Packages         | `pypi` only                                           | `pypi`, `npm`, `oci`                             |
+| `repository.url` | legacy standalone `kicad-mcp-pro` repo (pre-monorepo) | `https://github.com/oaslananka/kicad-studio-kit` |
+
+Findings:
+
+- The server **is** listed and active in the official registry, so the historical
+  "Not submitted" entry in `PUBLIC_LISTING.md` was inaccurate and has been corrected.
+- The listing is **stale**: the registry shows `2.1.0` while the current product line is
+  `3.6.0` (PyPI already has `3.6.0`). The record predates the monorepo migration, so its
+  `repository.url` still points at the legacy standalone repository and it advertises only
+  the PyPI package.
+- `server.json` and `mcp.json` both validate against the official
+  `2025-12-11` `server.schema.json`, and `metadata:check` / `submission:check` pass, so the
+  current manifest is publish-ready.
+
+Verification commands:
+
+```bash
+# Listing status + version in the official registry
+curl -fsS "https://registry.modelcontextprotocol.io/v0/servers?search=kicad-mcp-pro"
+
+# Local manifest validity + publish payload (target/endpoint, no publish)
+corepack pnpm --dir packages/mcp-server run mcp:manifest:check
+corepack pnpm --dir packages/mcp-server run publish:mcp:dry-run
+```
+
+### Endpoint and Workflow Verification
+
+- `publish_mcp_registry.py` defaults `MCP_REGISTRY_TARGET=official`; with no
+  `MCP_REGISTRY_URL` override it delegates to the pinned `mcp-publisher` CLI, which targets
+  the official registry (`registry.modelcontextprotocol.io`) by default. Endpoint confirmed
+  correct.
+- `.github/workflows/publish-mcp-registry.yml` `publish` job runs `mcp-publisher login
+github-oidc` then `mcp-publisher publish` from `packages/mcp-server`, gated to
+  `release: published` or `workflow_dispatch` with `dry_run=false`.
+
+### Update Path (to refresh the listing to the current version)
+
+No stored registry API token is required — the official target authenticates via GitHub
+OIDC under the `oaslananka` namespace (`id-token: write`).
+
+1. Confirm PyPI/GHCR artifacts exist for the target version (PyPI `3.6.0` already published).
+2. Trigger the publish job via a GitHub `release: published` event, or manually via
+   `workflow_dispatch` with `dry_run=false`.
+3. Approve the `mcp-registry` GitHub Environment when prompted (manual environment gate).
+4. Re-run the `search` command above and confirm `version` and `repository.url` updated.
+
 ## Dry Run Flow
 
 - [ ] Run `pnpm run submission:check` first.

--- a/packages/mcp-server/docs/submission/openai-mcp-registry.md
+++ b/packages/mcp-server/docs/submission/openai-mcp-registry.md
@@ -52,8 +52,8 @@ corepack pnpm --dir packages/mcp-server run publish:mcp:dry-run
   `MCP_REGISTRY_URL` override it delegates to the pinned `mcp-publisher` CLI, which targets
   the official registry (`registry.modelcontextprotocol.io`) by default. Endpoint confirmed
   correct.
-- `.github/workflows/publish-mcp-registry.yml` `publish` job runs `mcp-publisher login
-github-oidc` then `mcp-publisher publish` from `packages/mcp-server`, gated to
+- `.github/workflows/publish-mcp-registry.yml` `publish` job runs `mcp-publisher login github-oidc`
+  then `mcp-publisher publish` from `packages/mcp-server`, gated to
   `release: published` or `workflow_dispatch` with `dry_run=false`.
 
 ### Update Path (to refresh the listing to the current version)


### PR DESCRIPTION
## Summary

Research/verification task for #272: confirm whether `io.github.oaslananka/kicad-mcp-pro` is registered in the official MCP Registry and record the result. **No publish was performed and no version, tag, or release identity was changed.**

Key finding — the server **is** listed and `active`, but the listing is **stale**:

| | Official registry (`registry.modelcontextprotocol.io`) | Canonical repo (`server.json`) |
| --- | --- | --- |
| Status | `active`, `isLatest: true`, published `2026-04-15T21:15:40Z` | n/a |
| Version | `2.1.0` | `3.6.0` |
| Packages | `pypi` only | `pypi`, `npm`, `oci` |
| `repository.url` | legacy standalone repo (pre-monorepo) | monorepo `kicad-studio-kit` |

Changes (docs only):
- `packages/mcp-server/docs/submission/openai-mcp-registry.md`: new **Verified Registry Status (2026-05-31)** section — drift table, verification commands, endpoint/workflow verification, and the update path (incl. auth + manual gate).
- `packages/mcp-server/PUBLIC_LISTING.md`: corrected the inaccurate `OpenAI/MCP Registry → Not submitted` row to `Listed (stale: 2.1.0)` with the listing URL and date, plus a Submission Log entry and a verification note.

Additional verified facts:
- `server.json`/`mcp.json` validate against the official `2025-12-11` `server.schema.json`.
- `publish-mcp-registry.yml` targets the **correct official endpoint** via `mcp-publisher` (`publish_mcp_registry.py` defaults `MCP_REGISTRY_TARGET=official`, delegating to the CLI which uses `registry.modelcontextprotocol.io`). Auth is GitHub **OIDC** under the `oaslananka` namespace — **no stored registry API token** is needed; the `publish` job is gated by `release: published` / manual `workflow_dispatch` and the `mcp-registry` GitHub Environment (manual approval).

## Linked issue

Closes #272

## Type of change

- [x] type:docs

## Test evidence

Run on Node 24.16.0 / uv 0.11.16:

- Registry lookup: `curl -fsS "https://registry.modelcontextprotocol.io/v0/servers?search=kicad-mcp-pro"` → `count: 1`, `version 2.1.0`, `status active`, `isLatest true`.
- `corepack pnpm --dir packages/mcp-server run mcp:manifest:check` → both manifests valid.
- Remote schema validation of `server.json`/`mcp.json` against official `2025-12-11` schema → VALID.
- `corepack pnpm --dir packages/mcp-server run publish:mcp:dry-run` → `dry_run: true`, `target: official`, `version 3.6.0`, packages `pypi/npm/oci` (no publish).
- `corepack pnpm --dir packages/mcp-server run submission:check` → all PASS.
- `corepack pnpm run check:forbidden-refs` → no forbidden references (old repo URL deliberately not written as a literal).

## Protocol / MCP impact

- [x] Not applicable; reason: documentation-only verification record. No protocol version, schema, tool, transport, server-info, or compatibility metadata changed.
- [x] Docs updated

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean — gates verified locally before opening
- [x] No publish workflow was triggered — verification only; no release/dispatch
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally (relevant gates above)
- [x] Lint and typecheck pass (`check:forbidden-refs`, `submission:check`, manifest validation)
- [ ] Bug fixes include automated regression coverage — n/a (docs/verification only)
- [ ] Bug-fix exceptions — n/a
- [ ] CHANGELOG entry — n/a (no user-facing behavior change)
- [x] Docs updated
- [x] No new committed secrets or build artifacts

Link to Devin session: https://app.devin.ai/sessions/3f2f3597036a4afe840c7c584ce0b98f
Requested by: @oaslananka