### PR TITLE
chore(repo): suppress abandoned-dependency dashboard noise for retained deps (#244)

### DIFF
--- a/docs/dependency-lifecycle.md
+++ b/docs/dependency-lifecycle.md
@@ -97,6 +97,40 @@ Pin or hold a dependency only when the support boundary is explicit. Examples:
 - Node typings stay inside the Node 24 runtime declared by the workspace.
 - Protocol/runtime packages require dashboard approval because they can affect both the extension and MCP server.
 
+## Abandoned dependencies
+
+Renovate flags a dependency as abandoned when it exceeds the inherited
+`abandonments:recommended` inactivity threshold (one year without a release). Abandonment
+is a maintenance signal, not a vulnerability; security exposure is handled separately by
+`vulnerabilityAlerts` and OSV alerts.
+
+Triage an abandonment flag by deciding one of:
+
+- **Retain** when the package is feature-complete, still actively used, and has no
+  maintained drop-in replacement. Record the decision by adding the package to the
+  abandonment-suppression `packageRules` in `renovate.json` (`abandonmentThreshold: null`,
+  scoped by `matchDatasources` and `matchPackageNames`) so the dashboard stops re-flagging
+  a reviewed steady state. Genuinely new abandonment still surfaces.
+- **Replace** when a maintained alternative exists. Migrate in a scoped PR and remove the
+  suppression entry.
+- **Remove** when the dependency is no longer used.
+
+Reviewed and retained (suppressed) under #244, all still in active use:
+
+| Package                  | Datasource | Used for                                                |
+| ------------------------ | ---------- | ------------------------------------------------------- |
+| `@vscode/test-electron`  | npm        | VS Code extension integration test harness              |
+| `actionlint`             | npm        | GitHub Actions workflow linting                         |
+| `exceljs` (+ `unzipper`) | npm        | spreadsheet/BOM export                                  |
+| `husky`                  | npm        | git hook management                                     |
+| `pngjs`                  | npm        | PNG snapshot/image tooling                              |
+| `docker`                 | pypi       | `freerouting` optional extra (container-driven routing) |
+| `mkdocs-minify-plugin`   | pypi       | documentation site minification                         |
+| `radon`                  | pypi       | code-complexity metrics gate                            |
+
+Revisit a suppressed entry if the package starts blocking a supported KiCad, VS Code, MCP,
+Python, or Node contract, or once a maintained replacement is adopted.
+
 ## Escalation
 
 Create or link a compatibility-regression issue when a dependency update fails canary, contract, or fixture tests. The issue must include:

--- a/renovate.json
+++ b/renovate.json
@@ -153,6 +153,25 @@
       "matchPackageNames": ["@types/node"],
       "allowedVersions": "<25",
       "description": "Keep Node typings aligned with the Node 24 runtime declared by the workspace."
+    },
+    {
+      "description": "Reviewed under #244: these npm packages are flagged abandoned by release inactivity but are intentionally retained, feature-complete tooling that is still actively used; suppress the abandonment flag so the dashboard surfaces only new abandonment. See docs/dependency-lifecycle.md.",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": [
+        "@vscode/test-electron",
+        "actionlint",
+        "exceljs",
+        "unzipper",
+        "husky",
+        "pngjs"
+      ],
+      "abandonmentThreshold": null
+    },
+    {
+      "description": "Reviewed under #244: these Python packages are flagged abandoned by release inactivity but are intentionally retained, feature-complete tooling that is still actively used; suppress the abandonment flag so the dashboard surfaces only new abandonment. See docs/dependency-lifecycle.md.",
+      "matchDatasources": ["pypi"],
+      "matchPackageNames": ["docker", "mkdocs-minify-plugin", "radon"],
+      "abandonmentThreshold": null
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

Governance lane of the Renovate dependency dashboard (#244): triage the **Abandoned Dependencies** section. All nine flagged packages are intentionally retained, feature-complete tooling that is **still actively used**, so the correct action is to record the "retain" decision — not to remove them.

This is a **config + docs change only** — no version, lockfile, or runtime change.

- `renovate.json`: add two documented abandonment-suppression `packageRules` (scoped by `matchDatasources` + `matchPackageNames`, `abandonmentThreshold: null`) so the inherited `abandonments:recommended` preset (1-year inactivity) stops re-flagging a reviewed steady state. Genuinely *new* abandonment still surfaces.
- `docs/dependency-lifecycle.md`: new **Abandoned dependencies** section documenting the retain/replace/remove triage and the reviewed-and-retained list.

Reviewed/retained (all confirmed in active use):

| Package | Datasource | Used for |
| --- | --- | --- |
| `@vscode/test-electron` | npm | extension integration test harness |
| `actionlint` | npm | workflow linting |
| `exceljs` (+ `unzipper`) | npm | spreadsheet/BOM export |
| `husky` | npm | git hooks |
| `pngjs` | npm | PNG snapshot/image tooling |
| `docker` | pypi | `freerouting` optional extra |
| `mkdocs-minify-plugin` | pypi | docs site minification |
| `radon` | pypi | code-complexity metrics gate |

Abandonment is a maintenance signal, not a vulnerability; security exposure stays covered by `vulnerabilityAlerts` + OSV alerts, which are unaffected.

## Linked issue

Refs #244

## Type of change

- [x] type:chore
- [x] type:docs

## Test evidence

- `npx renovate-config-validator --strict` → `Config validated successfully against 1 file(s)`.
- `corepack pnpm run check:forbidden-refs` → no forbidden references.
- `corepack pnpm run docs:lint` / `docs:links` → docs site checks passed.
- `npx prettier --check renovate.json docs/dependency-lifecycle.md` → all matched files use Prettier code style.
- `corepack pnpm run check:version` → 12 pass / 0 fail.
- `node scripts/check-release-please-monorepo.mjs` → policy valid.

## Protocol / MCP impact

- [x] Not applicable; reason: dependency-governance config/docs only. No MCP tool, schema, transport, server-info, compatibility, or version change.

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean — gates verified locally before opening
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally (gates above)
- [x] Lint and typecheck pass
- [ ] Bug fixes include automated regression coverage — n/a (governance config/docs)
- [ ] Bug-fix exceptions — n/a
- [ ] CHANGELOG entry — n/a (no user-facing runtime behavior change)
- [x] Docs updated
- [x] No new committed secrets or build artifacts

Link to Devin session: https://app.devin.ai/sessions/3f2f3597036a4afe840c7c584ce0b98f
Requested by: @oaslananka