### PR TITLE
chore(deps): update dependency diff to v9

### DIFF
--- a/apps/vscode-extension/docs/dependency-upgrade-notes.md
+++ b/apps/vscode-extension/docs/dependency-upgrade-notes.md
@@ -31,6 +31,17 @@ This monorepo uses Renovate as the dependency maintenance bot. Repository-local 
 | `ovsx`                             | `0.10.12` |
 | `actionlint`                       | `2.0.6`   |
 | `authlib`                          | `1.7.2`   |
+| `diff` (pnpm override)             | `9.0.0`   |
+
+`diff` is a transitive dev/build-tooling dependency (consumed by `mocha`,
+`release-please`, and `code-suggester`); the repo pins a single resolved version through
+the `pnpm-workspace.yaml` `overrides` block. The override was raised from `8.0.4` to the
+`9.0.0` major. The consuming tools still declare sub-`9` ranges (`mocha` `^7.0.0`,
+`release-please`/`code-suggester` `^8.0.3`), so the override forces the major onto them;
+this matches the existing pattern (the `8.0.4` override already exceeded `mocha`'s
+`^7.0.0`). `diff` 9 drops ES5 support (fine for the Node 24 runtime) and changes
+`parsePatch`/`formatPatch` behavior; the full lint, typecheck, test, build, and
+`release-please` dry-run suites pass with `9.0.0`.
 
 ## Postponed Major Updates
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   exceljs>archiver: 8.0.0
   exceljs>fast-csv: 5.0.7
   exceljs>unzipper: 0.12.3
-  diff: 8.0.4
+  diff: 9.0.0
   esbuild: 0.25.0
   glob: 13.0.6
   mocha>serialize-javascript: 7.0.5
@@ -2785,8 +2785,8 @@ packages:
   diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
-  diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dom-serializer@2.0.0:
@@ -7894,7 +7894,7 @@ snapshots:
       '@octokit/rest': 20.1.2
       '@types/yargs': 16.0.11
       async-retry: 1.3.3
-      diff: 8.0.4
+      diff: 9.0.0
       glob: 13.0.6
       parse-diff: 0.11.1
       yargs: 16.2.0
@@ -8093,7 +8093,7 @@ snapshots:
 
   diff-match-patch@1.0.5: {}
 
-  diff@8.0.4: {}
+  diff@9.0.0: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -9494,7 +9494,7 @@ snapshots:
       browser-stdout: 1.3.1
       chokidar: 4.0.3
       debug: 4.4.3(supports-color@8.1.1)
-      diff: 8.0.4
+      diff: 9.0.0
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
       glob: 13.0.6
@@ -9951,7 +9951,7 @@ snapshots:
       conventional-changelog-writer: 6.0.1
       conventional-commits-filter: 3.0.0
       detect-indent: 6.1.0
-      diff: 8.0.4
+      diff: 9.0.0
       figures: 3.2.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ overrides:
   exceljs>archiver: 8.0.0
   exceljs>fast-csv: 5.0.7
   exceljs>unzipper: 0.12.3
-  diff: 8.0.4
+  diff: 9.0.0
   esbuild: 0.25.0
   glob: 13.0.6
   mocha>serialize-javascript: 7.0.5


### PR DESCRIPTION
## Summary

Major-upgrade lane of the Renovate dependency dashboard (#244): raise the pinned `diff` version from `8.0.4` to the `9.0.0` major.

`diff` is a **transitive dev/build-tooling** dependency (no direct import in this repo). It is consumed by `mocha`, `release-please`, and `code-suggester`, and the workspace pins a single resolved version via the `pnpm-workspace.yaml` `overrides` block. This PR bumps that override and the resulting `pnpm-lock.yaml` entries.

```diff
# pnpm-workspace.yaml (overrides)
-  diff: 8.0.4
+  diff: 9.0.0
```

### Compatibility note (why this is safe)

The consuming tools declare sub-`9` ranges — `mocha` `^7.0.0`, `release-please`/`code-suggester` `^8.0.3` — so the override **forces** the major onto them. This is consistent with the pre-existing setup: the `8.0.4` override already exceeded `mocha`'s `^7.0.0`, and the repo intentionally pins one `diff` version workspace-wide.

`diff` v9 ([release notes](https://github.com/kpdecker/jsdiff/releases/tag/v9.0.0)) drops ES5 support (irrelevant on the Node 24 runtime) and changes `parsePatch`/`formatPatch` behavior (filename-header escaping, git-style patch parsing, stricter throws on unpaired headers). The full local suite — including the `mocha`-based extension integration tests and the `release-please` dry-run snapshots that exercise `code-suggester`/`release-please` — passes on `9.0.0`.

Migration record added to `apps/vscode-extension/docs/dependency-upgrade-notes.md`.

## Linked issue

Refs #244

## Type of change

- [x] type:chore

## Test evidence

All run locally against the upgraded lockfile:

- `corepack pnpm run lint` → pass (eslint + ruff + tsc across packages).
- `corepack pnpm run typecheck` → pass.
- `corepack pnpm run test` → pass; mocha extension integration suite `19 passing`, no failures across all packages.
- `corepack pnpm run test:release-please` → 12/12 pass (incl. release-please dry-run snapshots).
- `corepack pnpm run build` → pass (webpack compiled successfully; uv builds OK).
- `corepack pnpm run check:forbidden-refs` / `check:version` → pass.
- `node scripts/check-release-please-monorepo.mjs` → policy valid.
- `npx prettier --check` on changed files → clean.

## Protocol / MCP impact

- [x] Not applicable; reason: transitive dev/build-tooling dependency bump only. No MCP tool, schema, transport, server-info, runtime, or product-version change.

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean — gates verified locally before opening
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally (evidence above)
- [x] Lint and typecheck pass
- [ ] Bug fixes include automated regression coverage — n/a (dependency bump)
- [ ] Bug-fix exceptions — n/a
- [ ] CHANGELOG entry — n/a (transitive dev/build tooling; no user-facing runtime change)
- [x] Docs updated (`dependency-upgrade-notes.md`)
- [x] No new committed secrets or build artifacts

Link to Devin session: https://app.devin.ai/sessions/3f2f3597036a4afe840c7c584ce0b98f
Requested by: @oaslananka