### PR TITLE
ci(repo): update docs workflow Node to 24.16.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24.11.0
+          node-version: 24.16.0
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: true


### PR DESCRIPTION
## Summary

Resolves the Renovate dashboard (#244) **GitHub Actions `node`** pending-approval item. The only hardcoded Node version across the workflows is in the docs deploy workflow; every other job resolves Node from `.node-version` (which stays at the major `24`). This bumps that single pin:

```diff
# .github/workflows/docs.yml (actions/setup-node)
-          node-version: 24.11.0
+          node-version: 24.16.0
```

`24.16.0` is a published Node 24.x release and stays within the repo's Node 24 baseline. Renovate gates `github-actions` updates behind dashboard approval (`risk:medium`), which is why this is a manual, isolated change. Note the commit/PR uses the release-please-allowed scope `repo` rather than Renovate's `github-actions` semantic scope (the latter is not in the repo's allowed scope list).

## Linked issue

Refs #244

## Type of change

- [x] type:chore

## Test evidence

- `corepack pnpm run check:ci-lanes` → 9 pass, 0 fail.
- `apps/vscode-extension` `pnpm run workflows:lint` → clean.
- `node scripts/check-release-please-monorepo.mjs` → policy valid.
- `actionlint` runs in CI against the workflow.

## Protocol / MCP impact

- [x] Not applicable; reason: CI workflow toolchain version bump only. No product code, MCP schema, transport, server-info, or adapter behavior change.

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean — gates verified locally before opening
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [ ] Bug fixes include automated regression coverage — n/a (CI version bump)
- [ ] Bug-fix exceptions — n/a
- [ ] CHANGELOG entry — n/a (no user-visible runtime change)
- [ ] Docs updated — n/a (no behavior change)
- [x] No new committed secrets or build artifacts

Link to Devin session: https://app.devin.ai/sessions/3f2f3597036a4afe840c7c584ce0b98f
Requested by: @oaslananka