### PR TITLE
chore(kicad-mcp-pro): refresh container base images (#244)

### DIFF
--- a/packages/mcp-server/Dockerfile
+++ b/packages/mcp-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.11-alpine3.22@sha256:2fd93799bfc6381d078a8f656a5f45d6092e5d11d16f55889b3d5cbfdc64f045 AS builder
+FROM python:3.13.12-alpine3.22@sha256:41351b07080ccfaa27bf38dde20de79ee6a0ac74a58c00c6d7a7d96ac4e69716 AS builder
 
 ARG UV_VERSION=0.11.16
 ENV UV_NO_CACHE=1
@@ -13,7 +13,7 @@ RUN uv build --wheel --out-dir /dist \
     --format requirements.txt \
     --output-file /dist/requirements.txt
 
-FROM python:3.13.11-alpine3.22@sha256:2fd93799bfc6381d078a8f656a5f45d6092e5d11d16f55889b3d5cbfdc64f045 AS runtime
+FROM python:3.13.12-alpine3.22@sha256:41351b07080ccfaa27bf38dde20de79ee6a0ac74a58c00c6d7a7d96ac4e69716 AS runtime
 
 ARG KICAD_MCP_VERSION=0.0.0
 ARG VCS_REF=unknown

--- a/packages/mcp-server/Dockerfile.kicad10
+++ b/packages/mcp-server/Dockerfile.kicad10
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3 AS kicad
+FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb AS kicad
 
 ARG KICAD_APPIMAGE_URL
 ARG DEBIAN_FRONTEND=noninteractive
@@ -14,7 +14,7 @@ RUN curl -fL "${KICAD_APPIMAGE_URL}" -o /tmp/kicad.AppImage \
     && mkdir -p /opt/kicad-appimage \
     && cp -a squashfs-root/. /opt/kicad-appimage/
 
-FROM python:3.13.11-slim@sha256:2b9c9803c6a287cafa0a8c917211dddd23dcd2016f049690ee5219f5d3f1636e AS builder
+FROM python:3.13.12-slim@sha256:f1927c75e81efd1e091dbd64b6c0ecaa5630b38635a3d1c04034ac636e1f94c8 AS builder
 ARG UV_VERSION=0.11.16
 WORKDIR /app
 RUN python -m pip install --no-cache-dir --disable-pip-version-check --root-user-action=ignore "uv==${UV_VERSION}"
@@ -22,7 +22,7 @@ COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ src/
 RUN uv sync --frozen --extra http --extra simulation --extra freerouting
 
-FROM python:3.13.11-slim@sha256:2b9c9803c6a287cafa0a8c917211dddd23dcd2016f049690ee5219f5d3f1636e AS runtime
+FROM python:3.13.12-slim@sha256:f1927c75e81efd1e091dbd64b6c0ecaa5630b38635a3d1c04034ac636e1f94c8 AS runtime
 ARG KICAD_MCP_VERSION=0.0.0
 ARG VCS_REF=unknown
 ARG DEBIAN_FRONTEND=noninteractive

--- a/packages/mcp-server/scripts/check_docker_metadata.py
+++ b/packages/mcp-server/scripts/check_docker_metadata.py
@@ -65,7 +65,7 @@ def main() -> int:
             errors.append(f"{path} must silence intentional root pip install warnings")
 
     dockerfile = dockerfiles["Dockerfile"]
-    if "python:3.13.11-alpine3.22@sha256:" not in dockerfile:
+    if "python:3.13.12-alpine3.22@sha256:" not in dockerfile:
         errors.append("Dockerfile must use the Trivy-clean pinned Python Alpine base")
     if (
         "ENV PYTHONDONTWRITEBYTECODE=1" not in dockerfile

--- a/packages/mcp-server/tests/unit/test_release_hardening.py
+++ b/packages/mcp-server/tests/unit/test_release_hardening.py
@@ -710,7 +710,7 @@ def test_docker_metadata_contains_mcp_oci_label_and_release_image_contract() -> 
     assert "pip install --no-cache-dir uv" not in kicad_dockerfile
     assert f"UV_VERSION={uv_version}" in dockerfile
     assert f"UV_VERSION={uv_version}" in kicad_dockerfile
-    assert "python:3.13.11-alpine3.22@sha256:" in dockerfile
+    assert "python:3.13.12-alpine3.22@sha256:" in dockerfile
     assert "KICAD_MCP_HOST=0.0.0.0" in dockerfile
     assert "ARG KICAD_CLI_APK_PACKAGE" in dockerfile
     assert "apk upgrade --no-cache" in dockerfile


### PR DESCRIPTION
## Summary

Refreshes the SHA-pinned base images for the MCP server containers (the gated container-image lane of #244, approved for this work):

- `Dockerfile` (alpine): `python:3.13.11-alpine3.22` → `python:3.13.12-alpine3.22` (new digest) on both builder and runtime stages.
- `Dockerfile.kicad10` (slim): `python:3.13.11-slim` → `python:3.13.12-slim` (new digest) on builder + runtime stages, and a `debian:bookworm-slim` digest refresh on the kicad stage.
- Updates the two release-hardening guards that pin the expected alpine base tag so they track `3.13.12`:
  - `packages/mcp-server/scripts/check_docker_metadata.py`
  - `packages/mcp-server/tests/unit/test_release_hardening.py`

python `3.13.11 → 3.13.12` is a CPython patch bump; the debian digest refresh picks up newer security updates. All `FROM` references stay digest-pinned.

## Linked issue

Refs #244

## Type of change

- [x] type:chore

## Test evidence

Local validation:
- `docker build` (alpine `Dockerfile`) → succeeds on `python:3.13.12-alpine3.22`; `docker run --rm … --help` works; image config assertions (non-root `kicadmcp`, entrypoint, `CMD ["--transport","streamable-http"]`, `EXPOSE 3334`, host/transport env) all pass.
- `docker build -f Dockerfile.kicad10 --target builder` → succeeds on `python:3.13.12-slim` (`uv sync` clean). The heavy KiCad AppImage stage was skipped locally; CI's container workflow covers the alpine build path.
- Trivy `--severity HIGH,CRITICAL --exit-code 1` on the alpine image → exit 0, alpine 3.22.3, **0 findings** (mirrors CI's security gate).
- `python scripts/check_docker_metadata.py` → "Docker metadata validation passed."
- `pytest tests/unit/test_release_hardening.py tests/unit/test_docker_image.py` → 73 passed.
- `node scripts/check-release-please-monorepo.mjs` → PASS.

## Protocol / MCP impact

- [x] Not applicable; reason: base-image digest/patch refresh only — no MCP tool names, schemas, capabilities, transport, server-info, or adapter behavior change.

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [ ] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [ ] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [ ] CHANGELOG entry (if user-visible) — n/a, not user-visible
- [ ] Docs updated (if user-visible) — n/a, not user-visible
- [x] No new committed secrets or build artifacts

Link to Devin session: https://app.devin.ai/sessions/3f2f3597036a4afe840c7c584ce0b98f
Requested by: @oaslananka