### PR TITLE
ci(repo): gate KiCad 10-only canary CLI steps for deprecated lanes (#276)

### DIFF
--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -606,6 +606,12 @@ featureGates:
   kicad10AdvancedExports:
     kicad: ["10.0.x"]
     tools: ["export_odb", "pcb_export_3d_pdf"]
+  kicad10BoardStats:
+    kicad: ["10.0.x"]
+    tools: ["get_board_stats"]
+  kicad10PcbImport:
+    kicad: ["10.0.x"]
+    tools: ["mfg_check_import_support", "mfg_import_pads", "mfg_import_allegro"]
 
 mcpTools:
   required:

--- a/packages/mcp-server/scripts/kicad_canary.py
+++ b/packages/mcp-server/scripts/kicad_canary.py
@@ -266,6 +266,8 @@ def _command_plan(
         "kicad10AdvancedExports",
         kicad_range,
     )
+    board_stats_skip = _feature_skip_reason(compatibility, "kicad10BoardStats", kicad_range)
+    pcb_import_skip = _feature_skip_reason(compatibility, "kicad10PcbImport", kicad_range)
     steps = [
         CanaryStep(name="version", fixture="compatibility", args=("version",)),
         CanaryStep(
@@ -447,12 +449,14 @@ def _command_plan(
                 str(clean_board),
             ),
             outputs=(reports / "board-stats.txt",),
+            skip_reason=board_stats_skip,
         ),
         CanaryStep(
             name="pads-import-capability",
             fixture="kicad-10-0-3-regressions",
             args=("pcb", "import", "--help"),
             required_output_tokens=("--format", "pads"),
+            skip_reason=pcb_import_skip,
         ),
         CanaryStep(
             name="allegro-import-capability",
@@ -460,6 +464,7 @@ def _command_plan(
             args=("pcb", "import", "--help"),
             required_output_tokens=("allegro",),
             optional_capability=True,
+            skip_reason=pcb_import_skip,
         ),
         CanaryStep(
             name="step",
@@ -486,6 +491,7 @@ def _command_plan(
                 str(path_with_spaces_board),
             ),
             outputs=(reports / "path-with-spaces-board-stats.txt",),
+            skip_reason=board_stats_skip,
         ),
         CanaryStep(
             name="unicode-path-board-stats",
@@ -499,6 +505,7 @@ def _command_plan(
                 str(unicode_path_board),
             ),
             outputs=(reports / "unicode-path-board-stats.txt",),
+            skip_reason=board_stats_skip,
         ),
         CanaryStep(
             name="read-only-output-failure",
@@ -513,6 +520,7 @@ def _command_plan(
             ),
             expects_failure=True,
             readonly_dirs=(readonly_output,),
+            skip_reason=board_stats_skip,
         ),
     ]
 

--- a/packages/mcp-server/tests/unit/test_kicad_canary.py
+++ b/packages/mcp-server/tests/unit/test_kicad_canary.py
@@ -38,6 +38,12 @@ def _compatibility_matrix() -> dict[str, object]:
             "kicad10AdvancedExports": {
                 "kicad": ["10.0.x"],
             },
+            "kicad10BoardStats": {
+                "kicad": ["10.0.x"],
+            },
+            "kicad10PcbImport": {
+                "kicad": ["10.0.x"],
+            },
         },
     }
 
@@ -207,6 +213,11 @@ def test_unsupported_feature_steps_are_structured_skips(tmp_path: Path) -> None:
         steps["schematic-pdf-no-property-popups"].skip_reason
         == "kicad10AdvancedExports is not enabled for KiCad 8.x"
     )
+    assert steps["board-stats"].skip_reason == "kicad10BoardStats is not enabled for KiCad 8.x"
+    assert (
+        steps["pads-import-capability"].skip_reason
+        == "kicad10PcbImport is not enabled for KiCad 8.x"
+    )
 
     result = kicad_canary._run_step(Path(sys.executable), steps["gerbers"], tmp_path)
 
@@ -221,6 +232,39 @@ def test_kicad_canary_gates_manufacturing_exports_by_compatibility_range() -> No
     assert supports_feature_gate(compatibility, "manufacturingExports", "10.0.x")
     assert supports_feature_gate(compatibility, "manufacturingExports", "9.x")
     assert not supports_feature_gate(compatibility, "manufacturingExports", "8.x")
+
+
+def test_issue_276_deprecated_kicad9_lane_skips_kicad10_only_cli_steps(tmp_path: Path) -> None:
+    # Regression for #276: the KiCad 9.x deprecated canary lane failed because
+    # `pcb export stats` and `pcb import` are KiCad 10-only CLI surfaces that
+    # KiCad 9.0.9 does not provide. They must be gated as structured skips so
+    # the best-effort deprecated lane only exercises core workflows.
+    compatibility = _compatibility_matrix()
+    assert not supports_feature_gate(compatibility, "kicad10BoardStats", "9.x")
+    assert not supports_feature_gate(compatibility, "kicad10PcbImport", "9.x")
+    assert supports_feature_gate(compatibility, "kicad10BoardStats", "10.0.x")
+    assert supports_feature_gate(compatibility, "kicad10PcbImport", "10.0.x")
+
+    steps = {step.name: step for step in kicad_canary._command_plan(tmp_path, compatibility, "9.x")}
+
+    for name in [
+        "board-stats",
+        "path-with-spaces-board-stats",
+        "unicode-path-board-stats",
+        "read-only-output-failure",
+    ]:
+        assert steps[name].skip_reason == "kicad10BoardStats is not enabled for KiCad 9.x"
+    for name in ["pads-import-capability", "allegro-import-capability"]:
+        assert steps[name].skip_reason == "kicad10PcbImport is not enabled for KiCad 9.x"
+
+    # Core best-effort workflows stay active on the deprecated lane.
+    for name in ["clean-erc", "clean-drc", "bom", "netlist", "gerbers", "step"]:
+        assert steps[name].skip_reason is None
+
+    skipped = kicad_canary._run_step(Path(sys.executable), steps["board-stats"], tmp_path)
+    assert skipped["ok"] is True
+    assert skipped["skipped"] is True
+    assert skipped["reason"] == "kicad10BoardStats is not enabled for KiCad 9.x"
 
 
 def test_missing_cli_writes_structured_summary(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

The scheduled `kicad-9-deprecated-linux` KiCad canary lane has been auto-filing #276 because it ran **KiCad 10-only `kicad-cli` surfaces against KiCad 9.0.9**, which does not provide them:

- `pcb export stats` → steps `board-stats`, `path-with-spaces-board-stats`, `unicode-path-board-stats`, and the `read-only-output-failure` guard. KiCad 9.0.9 `pcb export` has no `stats` subcommand (`Failed to parse 'stats', did you mean 'step'`).
- `pcb import --help` capability probes → `pads-import-capability` (and `allegro-import-capability`). KiCad 9.0.9 `pcb` has no `import` subcommand at all (only `{drc,export,render}`), so the `--format`/`pads` tokens are absent.

Every *core* 9.x workflow already passed (ERC, DRC, BOM, netlist, gerbers, drill, STEP, PDF/SVG). The failures were purely KiCad-10-only feature gaps, not a 9.x regression.

ADR-0005 defines the deprecated tier as best-effort with a **limited feature gate**. This PR brings the canary in line with that policy by adding two feature gates and applying them as structured skips, mirroring the existing `manufacturingExports` / `kicad10AdvancedExports` pattern:

```yaml
# compatibility.yaml featureGates
kicad10BoardStats:   { kicad: ["10.0.x"], tools: ["get_board_stats"] }
kicad10PcbImport:    { kicad: ["10.0.x"], tools: ["mfg_check_import_support", "mfg_import_pads", "mfg_import_allegro"] }
```

```python
# kicad_canary.py: 4 board-stats steps -> skip_reason=board_stats_skip
#                  2 import probes      -> skip_reason=pcb_import_skip
```

On the deprecated 9.x lane these six steps now record `ok:true, skipped:true` instead of failing. The primary `10.0.x` lane (Linux + Windows) and the `10.0.x` nightly lane are unaffected — the gates include `10.0.x`, so those steps run exactly as before (and `pads-import-capability` keeps its hard `--format`/`pads` assertion on the primary lane).

`featureGates` is consumed only by `check_compatibility_matrix.py`, `kicad_canary.py`, and its unit test — it does not drive runtime tool gating or generated docs, so no doc regeneration is required.

## Linked issue

Closes #276

## Type of change

- [x] type:bug
- [ ] type:feature
- [ ] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

Root cause confirmed from the #276 run artifact (`kicad-canary-kicad-9-deprecated-linux`, run 26700520512): KiCad `9.0.9`; failing steps = `board-stats` (x3) + `pads-import-capability`; logs show `Failed to parse 'stats'` and `pcb [--help] {drc,export,render}` (no `import`).

Commands run locally (all pass):
- `check_compatibility_matrix.py` → `Compatibility matrix validation passed.` (validates the two new gates reference real registered tools)
- `pytest packages/mcp-server/tests/unit/test_kicad_canary.py` → 15 passed
- `pytest packages/mcp-server` (full suite) → all passed
- `ruff check` / `ruff format --check`, `check:ci-lanes`, `check-release-please-monorepo.mjs` → pass

New regression test: `test_issue_276_deprecated_kicad9_lane_skips_kicad10_only_cli_steps` asserts the six KiCad-10-only steps become structured skips on the `9.x` lane while core steps stay active. `test_unsupported_feature_steps_are_structured_skips` also extended for the new gates on `8.x`.

## Protocol / MCP impact

- [x] Compatibility matrix updated — added two `featureGates` entries (`kicad10BoardStats`, `kicad10PcbImport`).

Reason scoped: these gates are CI/canary metadata only (no MCP tool names, schemas, transport, or server-info changes; no runtime tool-gating consumer). Tool *names* referenced by the gates already exist in the registry; no tool behavior changed.

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean — opened after local gates green
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [ ] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [ ] CHANGELOG entry (if user-visible) — not user-visible (CI/canary metadata; no runtime behavior change)
- [ ] Docs updated (if user-visible) — `featureGates` is not rendered into generated docs
- [x] No new committed secrets or build artifacts

Link to Devin session: https://app.devin.ai/sessions/3f2f3597036a4afe840c7c584ce0b98f
Requested by: @oaslananka