### PR TITLE
fix(repo): align sub-package pnpm version policy

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -8,7 +8,7 @@
     "vscode": "^1.120.0",
     "node": "24.x"
   },
-  "packageManager": "pnpm@11.3.0",
+  "packageManager": "pnpm@11.5.0",
   "devEngines": {
     "runtime": {
       "name": "node",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Monorepo for KiCad Studio VS Code extension and KiCad MCP Pro server.",
   "license": "MIT",
-  "packageManager": "pnpm@11.3.0",
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
   "engines": {
     "node": ">=24.11.0 <25",
     "pnpm": ">=11.0.0 <12"

--- a/packages/kicad-fixtures/package.json
+++ b/packages/kicad-fixtures/package.json
@@ -13,7 +13,7 @@
     "manifest.json",
     "README.md"
   ],
-  "packageManager": "pnpm@11.3.0",
+  "packageManager": "pnpm@11.5.0",
   "engines": {
     "node": ">=24.11.0 <25",
     "pnpm": ">=11.0.0 <12"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -2,7 +2,7 @@
   "name": "kicad-mcp-pro-server",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.3.0",
+  "packageManager": "pnpm@11.5.0",
   "scripts": {
     "metadata:sync": "uv run --all-extras python scripts/sync_mcp_metadata.py --write",
     "metadata:check": "uv run --all-extras python scripts/sync_mcp_metadata.py --check",

--- a/packages/protocol-schemas/package.json
+++ b/packages/protocol-schemas/package.json
@@ -17,7 +17,7 @@
     "schemas/",
     "README.md"
   ],
-  "packageManager": "pnpm@11.3.0",
+  "packageManager": "pnpm@11.5.0",
   "engines": {
     "node": ">=24.11.0 <25",
     "pnpm": ">=11.0.0 <12"

--- a/packages/test-harness/package.json
+++ b/packages/test-harness/package.json
@@ -10,7 +10,7 @@
     "dist/",
     "README.md"
   ],
-  "packageManager": "pnpm@11.3.0",
+  "packageManager": "pnpm@11.5.0",
   "engines": {
     "node": ">=24.11.0 <25",
     "pnpm": ">=11.0.0 <12"


### PR DESCRIPTION
## Summary
- Aligns sub-package packageManager declarations with the root pnpm 11.5.0 policy.
- Prevents Corepack from downgrading to pnpm 11.3.0 during nested package scripts.
- Fixes local validation failures for KiCad Studio extension build/package checks.

## Validation
- pnpm run check:version
- pnpm run check:compatibility
- pnpm run check:runtime-policy
- pnpm run check:kicad-studio
- pnpm run check:kicad-mcp-pro
- pnpm run test:contract
- pnpm --filter kicadstudiokit run marketplace:check
- pnpm --filter kicadstudiokit run build
- pnpm --filter kicadstudiokit run package
- pnpm --filter kicadstudiokit run package:validate

## Scope
- No product version changes.
- No dependency updates.
- No publishing performed.