### PR TITLE
chore(repo): protocol-schemas release lifecycle documentation

### DIFF
--- a/docs/architecture/repo-structure.md
+++ b/docs/architecture/repo-structure.md
@@ -43,8 +43,11 @@ npm launcher changes belong under `packages/mcp-npm` unless they update Python p
 Shared contracts are consumed from
 [`@oaslananka/kicad-protocol-schemas`](https://www.npmjs.com/package/@oaslananka/kicad-protocol-schemas)
 (published from [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp)).
+See the [schema release lifecycle](../protocol-schemas.md#release-lifecycle) for
+the cross-repo release process and CI validation gates.
 The local `packages/protocol-schemas/` directory is a migration remnant and will
-be removed after the npm-based consumption is validated in CI. Shared test
-utilities live under
+be removed after the npm-based consumption is validated in CI (tracked in
+[#288](https://github.com/oaslananka/kicad-studio-kit/issues/288)).
+Shared test utilities live under
 `packages/test-harness`. Shared packages must stay under `packages/` and must
 not import from any product workspace.

--- a/docs/protocol-schemas.md
+++ b/docs/protocol-schemas.md
@@ -39,6 +39,86 @@ Consumers must reject unknown major versions by default. A fallback path may
 only be used when the caller explicitly chooses degraded compatibility behavior
 and records the diagnostic.
 
+## Release Lifecycle
+
+### Source of truth
+
+The canonical schema source lives in
+[oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp). Publishing a
+new version of `@oaslananka/kicad-protocol-schemas` requires a version tag push
+in the **kicad-mcp** repository. The kicad-mcp npm publish workflow creates a
+GitHub release and pushes the package to npm. The kicad-studio-kit repository
+then consumes the published version as a dependency.
+
+### When to release
+
+A new npm release of `@oaslananka/kicad-protocol-schemas` is required when:
+
+- Adding a new schema file for an MCP tool, capability, or server-info surface.
+- Adding, removing, or renaming fields in an existing schema.
+- Bumping `schemaVersion` for breaking or additive changes.
+- Changing compatibility metadata that the Studio extension or MCP server reads
+  from the package exports (`readSchema`, `compatibility`).
+
+### When a release is NOT required
+
+A schema release is **not** required when:
+
+- Changes are limited to the kicad-studio-kit monorepo (extension adapters,
+  MCP server Python code, tests, documentation, CI workflows).
+- Schema content is unchanged and only consumer code is modified.
+- The change is a Studio-only internal refactor that does not affect the
+  published contract surface.
+
+In those cases, consume the existing npm version without bumping the dependency.
+
+### Cross-repo release process
+
+1. Schema change committed and tagged in `oaslananka/kicad-mcp`.
+2. Tag push triggers the kicad-mcp publish workflow: `npm publish` + GitHub
+   Release creation.
+3. Published version becomes available on npm after registry propagation.
+4. `minimumReleaseAge` in `pnpm-workspace.yaml` must be satisfied (or the new
+   version added to `minimumReleaseAgeExclude`) before CI accepts the version.
+5. Studio bumps the dependency in `package.json`, runs the protocol-schemas
+   contract gate, and completes a PR targeting the studio main branch.
+
+### CI validation gates
+
+The following checks ensure cross-repo integrity:
+
+```bash
+## Protocol schemas package resolves and exports match expectations
+corepack pnpm run check:protocol-schemas
+
+## Protocol-impact PRs must complete the protocol section of the PR template
+corepack pnpm run check:protocol-pr-template
+
+## Compatibility matrix validates against published schemas
+corepack pnpm run check:compatibility
+
+## Full contract suite
+corepack pnpm run test:contract
+```
+
+### pnpm minimumReleaseAge policy
+
+The `pnpm-workspace.yaml` `minimumReleaseAge: 1440` rule prevents CI from
+accepting freshly published packages before 24 hours of registry propagation.
+When a new protocol-schemas version must bypass this window (e.g. a CI pipeline
+consuming a schema release from minutes ago), add the exact version to
+`minimumReleaseAgeExclude`. Revert the exclusion when the age requirement is
+satisfied or on the next version bump.
+
+### cleanup
+
+The local `packages/protocol-schemas/` directory is a migration remnant from
+the pre-npm era. It remains on disk only as a reference during the transition
+and will be removed in a follow-up PR once the npm-based consumption is fully
+validated in CI (tracked in
+[#288](https://github.com/oaslananka/kicad-studio-kit/issues/288)). Do not
+introduce new code that depends on the local path.
+
 ## Migration
 
 Schema migrations are additive before they are breaking. Renames keep the old


### PR DESCRIPTION
## Summary

Adds the Release Lifecycle section to \docs/protocol-schemas.md\ covering when and how to release schema changes from the kicad-mcp repo to npm, and how the kicad-studio-kit monorepo consumes them.

Part of #290.

## Changes

- **docs/protocol-schemas.md**: New \Release Lifecycle\ section with:
  - Source of truth (kicad-mcp repo → npm publish)
  - When to release vs when a release is NOT required
  - Cross-repo release process (5 steps with CI gates)
  - pnpm \minimumReleaseAge\ bypass policy
  - Migration remnant cleanup plan (links #288)
- **docs/architecture/repo-structure.md**: Added cross-reference to the lifecycle doc and explicit issue link for cleanup.

## Verification

- \docs:lint\ ✅
- \docs:links\ ✅