### PR TITLE
fix(repo): enforce compatibility contract maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - run: corepack pnpm run check:compatibility
+      - run: corepack pnpm run check:compatibility-contract
       - run: corepack pnpm run check:governance
       - run: corepack pnpm run check:agent-configs
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:fixtures": "pnpm run check:fixtures",
     "check:kicad-fixtures": "pnpm --dir packages/kicad-fixtures run check",
     "check:protocol-schemas": "node --test scripts/check-protocol-schemas-package.test.mjs && node --input-type=module -e \"import pkg from '@oaslananka/kicad-protocol-schemas'; console.log('protocol-schemas resolves OK:', typeof pkg.readSchema === 'function' ? 'readSchema present' : 'readSchema missing')\"",
+    "check:compatibility-contract": "node scripts/check-compatibility-contract.mjs",
     "build:kicad-studio": "pnpm --filter kicadstudiokit run build",
     "build:kicad-mcp-pro": "pnpm --dir packages/mcp-server run build",
     "package:kicad-studio": "pnpm --filter kicadstudiokit run package",
@@ -87,7 +88,7 @@
     "check:docs-site": "pnpm --dir packages/mcp-server run docs:tools:check && pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "check:publish": "node scripts/check-publish-preflight.mjs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:runtime-policy && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:dry-run && pnpm run release:verify && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility && pnpm run check:compatibility-contract && pnpm run check:runtime-policy && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:kicad-gui-smoke && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:dry-run && pnpm run release:verify && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.0",

--- a/scripts/check-compatibility-contract.mjs
+++ b/scripts/check-compatibility-contract.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_ROOT, "..");
+
+const COMPATIBILITY_CONTRACT_FILES = ["compatibility.yaml"];
+const DOCS_FILES = [
+  "docs/RELEASE-COORDINATION.md",
+  "docs/EMERGENCY-RELEASE-FLOW.md",
+  "docs/publishing.md",
+  "docs/protocol-schemas.md",
+];
+
+const REQUIRED_FILES = [
+  { path: "compatibility.yaml", label: "Compatibility contract" },
+  {
+    path: ".github/workflows/cross-repo-compatibility.yml",
+    label: "Cross-repo compatibility workflow",
+  },
+  {
+    path: "docs/RELEASE-COORDINATION.md",
+    label: "Release coordination runbook",
+  },
+  { path: "docs/EMERGENCY-RELEASE-FLOW.md", label: "Emergency release flow" },
+];
+
+function readFile(filePath) {
+  return fs.readFileSync(path.join(REPO_ROOT, filePath), "utf8");
+}
+
+function fileExists(filePath) {
+  return fs.existsSync(path.join(REPO_ROOT, filePath));
+}
+
+function gitDiffNames(range) {
+  const output = execFileSync("git", ["diff", "--name-only", range], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return output.split(/\r?\n/).filter(Boolean);
+}
+
+function detectChangedFiles(options = {}) {
+  if (options.changedFiles && options.changedFiles.length > 0) {
+    return options.changedFiles;
+  }
+  const baseSha = options.baseSha || process.env.GITHUB_BASE_SHA || "";
+  const headSha = options.headSha || process.env.GITHUB_HEAD_SHA || "";
+  const eventName = options.eventName || process.env.GITHUB_EVENT_NAME || "";
+
+  if (eventName === "pull_request" || eventName === "pull_request_target") {
+    if (baseSha) {
+      return gitDiffNames(`${baseSha}...${headSha || "HEAD"}`);
+    }
+  }
+  if (eventName === "push") {
+    const before = options.before || process.env.GITHUB_EVENT_BEFORE || "";
+    if (before && !/^0{40}$/.test(before)) {
+      const sha = options.sha || process.env.GITHUB_SHA || "HEAD";
+      return gitDiffNames(`${before}..${sha}`);
+    }
+  }
+  return [];
+}
+
+function checkContractExists(errors) {
+  for (const file of REQUIRED_FILES) {
+    if (!fileExists(file.path)) {
+      errors.push(`${file.path}: missing required ${file.label}`);
+    }
+  }
+}
+
+function checkCompatibilityYamlReferences(errors) {
+  if (!fileExists("compatibility.yaml")) return;
+  const content = readFile("compatibility.yaml");
+
+  if (!content.includes("mcp:")) {
+    errors.push("compatibility.yaml: missing mcp: section");
+  }
+  if (!content.includes("protocolVersion:")) {
+    errors.push("compatibility.yaml: missing mcp.protocolVersion");
+  }
+  if (!content.includes("kicad-mcp-pro:")) {
+    errors.push("compatibility.yaml: missing kicad-mcp-pro product definition");
+  }
+  if (!content.includes("products:")) {
+    errors.push("compatibility.yaml: missing products: section");
+  }
+}
+
+function checkStudioConsumesPublishedPackage(errors) {
+  const extensionPkgPath = "apps/vscode-extension/package.json";
+  const extensionPkg = JSON.parse(
+    fs.readFileSync(path.join(REPO_ROOT, extensionPkgPath), "utf8"),
+  );
+
+  const allDeps = {
+    ...(extensionPkg.dependencies || {}),
+    ...(extensionPkg.devDependencies || {}),
+  };
+
+  if (!allDeps["@oaslananka/kicad-protocol-schemas"]) {
+    errors.push(
+      `${extensionPkgPath}: must depend on published @oaslananka/kicad-protocol-schemas`,
+    );
+  }
+
+  for (const depName of Object.keys(allDeps)) {
+    if (
+      depName.includes("protocol-schemas") &&
+      !depName.startsWith("@oaslananka/kicad-protocol-schemas")
+    ) {
+      errors.push(
+        `${extensionPkgPath}: unexpected protocol-schemas dependency: ${depName}`,
+      );
+    }
+  }
+}
+
+function checkLocalProtocolSchemasAbsent(errors) {
+  const localPaths = [
+    "packages/protocol-schemas",
+    "packages/kicad-protocol-schemas",
+    "apps/protocol-schemas",
+  ];
+  for (const dirPath of localPaths) {
+    if (fs.existsSync(path.join(REPO_ROOT, dirPath))) {
+      errors.push(
+        `${dirPath}: local protocol-schemas must remain absent; use published @oaslananka/kicad-protocol-schemas`,
+      );
+    }
+  }
+}
+
+function checkDocsChangedWithContract(errors, changedFiles) {
+  const contractChanged = changedFiles.some((file) =>
+    COMPATIBILITY_CONTRACT_FILES.some(
+      (cf) => file === cf || file.startsWith(cf),
+    ),
+  );
+  if (!contractChanged) return;
+
+  const docsChanged = changedFiles.some((file) =>
+    DOCS_FILES.some((df) => file === df),
+  );
+  if (!docsChanged) {
+    errors.push(
+      "compatibility.yaml changed but no matching docs update found. " +
+        "When the compatibility contract changes, update at least one of: " +
+        DOCS_FILES.join(", "),
+    );
+  }
+}
+
+export function validateCompatibilityContract(options = {}) {
+  const errors = [];
+  const changedFiles = detectChangedFiles(options);
+
+  checkContractExists(errors);
+  checkCompatibilityYamlReferences(errors);
+  checkStudioConsumesPublishedPackage(errors);
+  checkLocalProtocolSchemasAbsent(errors);
+  checkDocsChangedWithContract(errors, changedFiles);
+
+  return errors;
+}
+
+function parseCliArgs(argv) {
+  const options = { changedFiles: [] };
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--base") {
+      options.baseSha = argv[++index];
+    } else if (arg === "--head") {
+      options.headSha = argv[++index];
+    } else if (arg === "--event") {
+      options.eventName = argv[++index];
+    } else if (arg === "--before") {
+      options.before = argv[++index];
+    } else if (arg === "--sha") {
+      options.sha = argv[++index];
+    } else if (arg === "--files") {
+      while (argv[index + 1] && !argv[index + 1].startsWith("--")) {
+        options.changedFiles.push(argv[++index]);
+      }
+    } else {
+      options.changedFiles.push(arg);
+    }
+  }
+  return options;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const options = parseCliArgs(process.argv.slice(2));
+  const errors = validateCompatibilityContract(options);
+  if (errors.length > 0) {
+    console.error("Compatibility contract validation failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

Completes **#288 Item D** — compatibility contract maintenance automation.

### What was added

New check script \scripts/check-compatibility-contract.mjs\ with 5 validation rules:

| # | Check | What it verifies |
|---|-------|------------------|
| 1 | **Contract exists** | \compatibility.yaml\, cross-repo workflow, RELEASE-COORDINATION.md, EMERGENCY-RELEASE-FLOW.md all present |
| 2 | **YAML references** | \compatibility.yaml\ contains \mcp:\, \protocolVersion:\, \kicad-mcp-pro:\, \products:\ |
| 3 | **Studio uses published package** | Extension depends on \@oaslananka/kicad-protocol-schemas\, not a local protocol-schemas dep |
| 4 | **Local protocol-schemas absent** | \packages/protocol-schemas\ etc do not exist |
| 5 | **Docs must change with contract** | When \compatibility.yaml\ is in the diff, at least one docs file must also change |

### Wiring

- \package.json\: added \check:compatibility-contract\ script, chained into root \check\ script after \check:compatibility\
- \.github/workflows/ci.yml\: added step to \metadata\ job (after compatibility step)

### Constraints honored

- ✅ No publish, no tag, no version bump
- ✅ No package identity change, no source deletion
- ✅ \packages/mcp-server\ and \packages/mcp-npm\ untouched
- ✅ \#286\ cleanup remains separate
- ✅ \#288\ closed only when this PR merges (completing A-D)