### PR TITLE
docs(repo): clean stale MCP ownership references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ corepack pnpm run build:kicad-studio
 corepack pnpm run package:kicad-studio
 ```
 
-For MCP server work:
+For MCP server work (transitional — canonical source at [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp)):
 
 ```bash
 uv sync --all-extras --frozen --project packages/mcp-server
@@ -110,9 +110,8 @@ CODEOWNERS review should match the changed paths:
 - `.github/` for CI, release, labels, and governance.
 - `docs/architecture/` for architecture and release model.
 - `apps/vscode-extension/` for KiCad Studio extension work.
-- `packages/mcp-server/` for KiCad MCP Pro server and MCP Registry metadata.
-- `packages/mcp-npm/` for npm launcher work.
-- `packages/protocol-schemas/` for protocol schemas and compatibility review.
+- `packages/mcp-server/` for KiCad MCP Pro server and MCP Registry metadata (transitional — canonical source is [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp)).
+- `packages/mcp-npm/` for npm launcher work (transitional — will move to [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp)).
 - `packages/test-harness/` for shared test-only fixtures, mocks, golden
   assertions, temporary workspaces, and MCP/webview helpers.
 - `examples/` for user-facing KiCad examples.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 Monorepo for:
 
 - KiCad Studio VS Code extension (`apps/vscode-extension`)
-- KiCad MCP Pro server (`packages/mcp-server`)
-- npm launcher wrapper (`packages/mcp-npm`)
+- KiCad MCP Pro server (`packages/mcp-server`) — transitional; canonical source is [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp)
+- npm launcher wrapper (`packages/mcp-npm`) — transitional; will move to [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp)
 - shared test harness (`packages/test-harness`)
 
 Canonical repository: https://github.com/oaslananka/kicad-studio-kit

--- a/docs/architecture/product-boundaries.md
+++ b/docs/architecture/product-boundaries.md
@@ -4,13 +4,13 @@ The monorepo has three product workspaces, but the products must stay decoupled 
 
 ## Allowed dependencies
 
-| From                    | May depend on                                                                                          |
-| ----------------------- | ------------------------------------------------------------------------------------------------------ |
-| `apps/vscode-extension` | npm dependencies, VS Code APIs, KiCad CLI process calls, MCP protocol data, test harness in tests only |
-| `packages/mcp-server`   | Python dependencies, KiCad Python/CLI integrations, MCP protocol data                                  |
-| `packages/mcp-npm`      | Node standard library and the published Python package name                                            |
-| `packages/test-harness` | Node standard library and shared packages only                                                         |
-| future shared packages  | external dependencies and other shared packages only                                                   |
+| From                    | May depend on                                                                                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `apps/vscode-extension` | npm dependencies, VS Code APIs, KiCad CLI process calls, MCP protocol data, test harness in tests only                                                             |
+| `packages/mcp-server`   | Python dependencies, KiCad Python/CLI integrations, MCP protocol data (transitional — see [ADR-0009](../adr/0009-split-kicad-mcp-pro-into-separate-repository.md)) |
+| `packages/mcp-npm`      | Node standard library and the published Python package name (transitional — will move to `oaslananka/kicad-mcp`)                                                   |
+| `packages/test-harness` | Node standard library and shared packages only                                                                                                                     |
+| future shared packages  | external dependencies and other shared packages only                                                                                                               |
 
 ## Forbidden dependencies
 

--- a/docs/architecture/repo-structure.md
+++ b/docs/architecture/repo-structure.md
@@ -9,6 +9,8 @@ KiCad Studio Kit is one GitHub repository with three independently validated rel
 | `packages/mcp-npm`      | Thin npm launcher for the Python server             | `kicad-mcp-pro`                                        |
 | `packages/test-harness` | Private shared test utilities                       | Not published                                          |
 
+> **Note:** `packages/mcp-server` and `packages/mcp-npm` are transitional copies. The canonical MCP source is [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp). See [ADR-0009](../adr/0009-split-kicad-mcp-pro-into-separate-repository.md).
+
 The folder names intentionally preserve the package roots used by the current publish workflows:
 
 - `apps/vscode-extension` keeps VS Code extension-root semantics for VSIX packaging.

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -1,8 +1,9 @@
 # kicad-mcp-pro
 
-`kicad-mcp-pro` is the MCP server in `packages/mcp-server`. It exposes KiCad project discovery,
+`kicad-mcp-pro` is the MCP server published from
+[oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp). It exposes KiCad project discovery,
 schematic and PCB inspection, validation, exports, manufacturing workflows, library lookup, and
-release-quality checks to MCP clients.
+release-quality checks to MCP clients. The in-repo development copy lives in `packages/mcp-server`.
 
 ## Main User Paths
 
@@ -16,9 +17,8 @@ release-quality checks to MCP clients.
 
 ## Source Files
 
-- Python package: `packages/mcp-server/pyproject.toml`
-- Server entrypoint: `packages/mcp-server/src/kicad_mcp/server.py`
-- Tool modules: `packages/mcp-server/src/kicad_mcp/tools/`
+- Published package: `kicad-mcp-pro` (PyPI) / `ghcr.io/oaslananka/kicad-mcp-pro` (Docker)
+- Development source: `packages/mcp-server/` (transitional — will move to `oaslananka/kicad-mcp`)
 - Server-info schema: `@oaslananka/kicad-protocol-schemas/schemas/kicad-mcp-server-info.schema.json`
 
 The MCP tool catalog is generated from the registered server tools with:


### PR DESCRIPTION
## Summary

- Cleans stale docs references after the kicad-mcp split.
- Preserves published artifact, compatibility canary, release coordination, and emergency flow references.
- Does not touch packages/mcp-server or packages/mcp-npm.

## Changes

| File | Change |
|------|--------|
| \README.md\ | Added transitional notes to MCP packages in monorepo listing |
| \CONTRIBUTING.md\ | Added transitional notes to MCP server work section and CODEOWNERS; removed stale \packages/protocol-schemas\ reference |
| \docs/mcp/index.md\ | Updated to reference \oaslananka/kicad-mcp\ as canonical source; replaced local path references with published package |
| \docs/architecture/repo-structure.md\ | Added transitional callout referencing ADR-0009 |
| \docs/architecture/product-boundaries.md\ | Added transitional notes to MCP server and npm launcher rows |

## Validation
- format:check ✓ | lint ✓ | docs:lint ✓ | docs:links ✓ | check:version ✓
- check:compatibility ✓ | check:compatibility-contract ✓ | check:protocol-schemas ✓ | check:ci-lanes --all ✓

## Scope
- Docs/reference cleanup only.
- No source deletion.
- No CI deletion.
- No publish/tag/version/package identity changes.

Refs #286