### PR TITLE
fix(repo): remove stale local MCP source references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,6 @@
 /.github/ @oaslananka
 /docs/architecture/ @oaslananka
 /apps/vscode-extension/ @oaslananka
-/packages/protocol-schemas/ @oaslananka
 /packages/kicad-fixtures/ @oaslananka
 /packages/test-harness/ @oaslananka
 /examples/ @oaslananka

--- a/scripts/check-boundaries.mjs
+++ b/scripts/check-boundaries.mjs
@@ -24,14 +24,14 @@ const WORKSPACES = [
     name: "test-harness",
     path: "packages/test-harness",
     sourceRoots: ["src", "test"],
-    forbiddenTokens: ["apps/vscode-extension/src", "packages/mcp-npm/bin"],
+    forbiddenTokens: ["apps/vscode-extension/src"],
     forbiddenModules: [/^kicadstudio(?:\/|$)/, /^kicad_mcp(?:\.|$)/],
   },
   {
     name: "kicad-fixtures",
     path: "packages/kicad-fixtures",
     sourceRoots: ["src", "test", "scripts"],
-    forbiddenTokens: ["apps/vscode-extension/src", "packages/mcp-npm/bin"],
+    forbiddenTokens: ["apps/vscode-extension/src"],
     forbiddenModules: [/^kicadstudio(?:\/|$)/, /^kicad_mcp(?:\.|$)/],
   },
 ].map((workspace) => ({


### PR DESCRIPTION
## Summary

- Removes stale `/packages/protocol-schemas/` from CODEOWNERS (directory removed).
- Removes stale `"packages/mcp-npm/bin"` from check-boundaries.mjs forbiddenTokens (package removed).
- These are dead references that no longer match any existing path.

## Scope

- Config/script cleanup only.
- No publish, no tags, no version bump, no package identity change.

## Validation

- `pnpm run check:boundaries` passes
- `pnpm run check:forbidden-refs` passes
