### PR TITLE
fix(repo): align runtime support policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility_regression.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_regression.yml
@@ -59,7 +59,7 @@ body:
     id: vscode-version
     attributes:
       label: VS Code version
-      placeholder: "1.120.0"
+      placeholder: "1.122.0"
   - type: input
     id: mcp-protocol
     attributes:

--- a/apps/vscode-extension/docs/AI_PROVIDERS.md
+++ b/apps/vscode-extension/docs/AI_PROVIDERS.md
@@ -72,7 +72,7 @@ Use `kicadstudio.ai.language` to control the response language independently fro
 
 ## Language Model Tools
 
-KiCad Studio 1.0.0 targets VS Code `^1.120.0` for Language Model Tool and chat-provider contribution metadata. When `kicadstudio.ai.allowTools` is enabled and the host VS Code build exposes the API, KiCad Studio registers tools for:
+KiCad Studio 1.0.0 targets VS Code `^1.122.0` for Language Model Tool and chat-provider contribution metadata. When `kicadstudio.ai.allowTools` is enabled and the host VS Code build exposes the API, KiCad Studio registers tools for:
 
 - DRC
 - ERC

--- a/apps/vscode-extension/docs/CONTRIBUTING.md
+++ b/apps/vscode-extension/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Development Setup
 
-1. Install Node.js `24.14.1`, pnpm `11.3.0`, and VS Code 1.120+.
+1. Install Node.js `24.14.1`, pnpm `11.3.0`, and VS Code 1.122+.
 2. Run `pnpm install --frozen-lockfile`.
 3. Press `F5` to launch the Extension Development Host.
 4. Let the Git hooks handle fast staged checks on commit and run `pnpm run check` before push.

--- a/apps/vscode-extension/docs/KICAD10_MIGRATION.md
+++ b/apps/vscode-extension/docs/KICAD10_MIGRATION.md
@@ -13,7 +13,7 @@ KiCad 10 introduces workflow changes that matter to extension users:
 ## Recommended Upgrade Path
 
 1. Update your local KiCad installation to KiCad 10.
-2. Update VS Code to 1.120 or newer before installing KiCad Studio 1.0.0.
+2. Update VS Code to 1.122 or newer before installing KiCad Studio 1.0.0.
 3. Re-run `KiCad: Detect kicad-cli` so the extension refreshes CLI capability detection.
 4. Open the project in KiCad 10 once and save it before testing in VS Code.
 5. Confirm that your `.kicad_pro` contains the expected variant data if you plan to use the Variants sidebar.

--- a/apps/vscode-extension/docs/dependency-upgrade-notes.md
+++ b/apps/vscode-extension/docs/dependency-upgrade-notes.md
@@ -8,7 +8,7 @@ This monorepo uses Renovate as the dependency maintenance bot. Repository-local 
 - Renovate lock-file maintenance refreshes `pnpm-lock.yaml` on the weekly maintenance window. (Python MCP server lock files are managed in [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp).)
 - GitHub Action references remain pinned to immutable commit SHAs.
 - `@types/node` stays below `25` while the workspace runtime is Node 24.
-- `@types/vscode` stays aligned with `engines.vscode: ^1.120.0`.
+- `@types/vscode` stays aligned with `engines.vscode: ^1.122.0`.
 - Python dependency updates are applied through `pyproject.toml` plus `uv.lock`.
 
 ## Applied Updates
@@ -23,7 +23,7 @@ This monorepo uses Renovate as the dependency maintenance bot. Repository-local 
 | `prettier`                         | `3.8.3`   |
 | `typescript`                       | `5.9.3`   |
 | `@types/node`                      | `24.12.3` |
-| `@types/vscode`                    | `1.120.0` |
+| `@types/vscode`                    | `1.122.0` |
 | `webpack-cli`                      | `7.0.2`   |
 | `c8`                               | `11.0.0`  |
 | `lint-staged`                      | `17.0.4`  |
@@ -72,7 +72,7 @@ and build all pass on `7.8.1`.
 | Jest 30, `@types/jest` 30, `jest-util` 30 | Postponed until unit, integration, mocks, and extension host tests are migrated together.                                                                                                                                                                                                                                              |
 | Vite 8 (pnpm override)                    | Blocked by `vitepress` 1.6.4 (the newest stable VitePress; only `2.0.0-alpha` supports Vite 8). The `vite` override drives the VitePress docs build, and Vite 8 (Rolldown bundler, removed `transformWithEsbuild`) fails `vitepress build docs` against VitePress 1.6.4. Revisit once a stable VitePress releases with Vite 8 support. |
 | `@types/node` 25                          | Rejected for now because the runtime target is Node 24.x.                                                                                                                                                                                                                                                                              |
-| `@types/vscode` 1.121                     | Rejected for now because the package is not published yet; `1.120.0` is the newest registry version aligned with `engines.vscode: ^1.120.0`.                                                                                                                                                                                           |
+| `@types/vscode` 1.121                     | Rejected for now because the package was not published at the time; `1.120.0` was the newest registry version aligned with the previous `engines.vscode: ^1.120.0`.                                                                                                                                                                    |
 
 ## Security Review
 

--- a/apps/vscode-extension/docs/repository-operations.md
+++ b/apps/vscode-extension/docs/repository-operations.md
@@ -80,7 +80,7 @@ Renovate is the only dependency update bot for this repository. It covers npm, G
 Major runtime-aligned dependencies are constrained until the supported runtime changes:
 
 - `@types/node` remains below `25` while Node 24 is the supported runtime.
-- `@types/vscode` remains aligned with `engines.vscode: ^1.120.0`.
+- `@types/vscode` remains aligned with `engines.vscode: ^1.122.0`.
 
 ## Review Thread Control
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -5,7 +5,7 @@
   "version": "1.1.0",
   "publisher": "oaslananka",
   "engines": {
-    "vscode": "^1.120.0",
+    "vscode": "^1.122.0",
     "node": "24.x"
   },
   "packageManager": "pnpm@11.5.0",

--- a/apps/vscode-extension/scripts/validate-package.js
+++ b/apps/vscode-extension/scripts/validate-package.js
@@ -83,7 +83,7 @@ function validateStaticMetadata({ root, repoRoot, pkg, fail }) {
     fail
   );
   check(
-    pkg.engines?.vscode === '^1.120.0',
+    pkg.engines?.vscode === '^1.122.0',
     'VS Code engine drifted unexpectedly',
     fail
   );

--- a/apps/vscode-extension/test/e2e/vscodeHarness.ts
+++ b/apps/vscode-extension/test/e2e/vscodeHarness.ts
@@ -11,7 +11,7 @@ import {
   type Page
 } from '@playwright/test';
 
-const VSCODE_VERSION = '1.120.0';
+const VSCODE_VERSION = '1.122.0';
 
 export interface VsCodeSession {
   browser: Browser;

--- a/apps/vscode-extension/test/runRealPairHostTest.ts
+++ b/apps/vscode-extension/test/runRealPairHostTest.ts
@@ -13,7 +13,7 @@ async function main(): Promise<void> {
     'benchmark_projects',
     'pass_minimal_mcu_board'
   );
-  const vscodeExecutablePath = await downloadAndUnzipVSCode('1.120.0');
+  const vscodeExecutablePath = await downloadAndUnzipVSCode('1.122.0');
   const userDataDir = await mkdtemp(
     path.join(tmpdir(), 'kicadstudio-real-pair-user-')
   );

--- a/apps/vscode-extension/test/unit/vscodeTestRuntime.test.ts
+++ b/apps/vscode-extension/test/unit/vscodeTestRuntime.test.ts
@@ -17,9 +17,9 @@ describe('VS Code test runtime', () => {
     ).toBe('insiders');
     expect(
       resolveVsCodeTestVersion({
-        KICADSTUDIO_VSCODE_VERSION: '1.120.0'
+        KICADSTUDIO_VSCODE_VERSION: '1.122.0'
       })
-    ).toBe('1.120.0');
+    ).toBe('1.122.0');
   });
 
   it('selects the dedicated canary host suite only when requested', () => {

--- a/apps/vscode-extension/test/vscodeTestRuntime.ts
+++ b/apps/vscode-extension/test/vscodeTestRuntime.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_VSCODE_TEST_VERSION = '1.120.0';
+export const DEFAULT_VSCODE_TEST_VERSION = '1.122.0';
 
 type TestEnvironment = Record<string, string | undefined>;
 

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -463,8 +463,8 @@ kicadIpcReadiness:
         evidence: []
 
 vscode:
-  minimum: "1.120.0"
-  enginesRange: "^1.120.0"
+  minimum: "1.122.0"
+  enginesRange: "^1.122.0"
   stable: "current"
   insiders: "current"
   nodeRuntime: "24.x"

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -11,30 +11,30 @@ Machine-maintained from `compatibility.yaml`. Refresh with
 
 ### Runtime Baseline
 
-| Runtime | Policy |
-| --- | --- |
-| KiCad primary | `10.0.x` |
-| KiCad latest verified | `10.0.3` |
-| VS Code minimum | `1.120.0` |
-| Node | `>=24.11.0 <25` |
-| pnpm | `>=11.0.0 <12` |
-| Python | `>=3.13` |
-| MCP protocol | `2025-11-25` |
-| MCP protocol (next) | `2026-07-28` |
+| Runtime               | Policy          |
+| --------------------- | --------------- |
+| KiCad primary         | `10.0.x`        |
+| KiCad latest verified | `10.0.3`        |
+| VS Code minimum       | `1.122.0`       |
+| Node                  | `>=24.11.0 <25` |
+| pnpm                  | `>=11.0.0 <12`  |
+| Python                | `>=3.13`        |
+| MCP protocol          | `2025-11-25`    |
+| MCP protocol (next)   | `2026-07-28`    |
 
 ### KiCad Support
 
-| Range | State | CI | Notes |
-| --- | --- | --- | --- |
-| 10.0.x | primary | required | Primary optimized KiCad CLI and file-format target. |
-| 9.x | deprecated | scheduled | Upstream KiCad 9.x is no longer actively maintained; core workflows remain best-effort while scheduled canaries gather removal evidence. |
-| 8.x | deprecated | manual | File-level read and migration support only; removal requires a release note. |
+| Range  | State      | CI        | Notes                                                                                                                                    |
+| ------ | ---------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| 10.0.x | primary    | required  | Primary optimized KiCad CLI and file-format target.                                                                                      |
+| 9.x    | deprecated | scheduled | Upstream KiCad 9.x is no longer actively maintained; core workflows remain best-effort while scheduled canaries gather removal evidence. |
+| 8.x    | deprecated | manual    | File-level read and migration support only; removal requires a release note.                                                             |
 
 ### Product Versions
 
-| Product | Version | Manifest | Compatibility range |
-| --- | --- | --- | --- |
-| kicad-studio | 1.1.0 | apps/vscode-extension/package.json | &gt;=3.5.2 &lt;4.0.0 |
+| Product      | Version | Manifest                           | Compatibility range  |
+| ------------ | ------- | ---------------------------------- | -------------------- |
+| kicad-studio | 1.1.0   | apps/vscode-extension/package.json | &gt;=3.5.2 &lt;4.0.0 |
 
 ### Release Gate Inputs
 
@@ -155,7 +155,7 @@ Freshness sources checked on 2026-05-27:
 | Surface      | Primary    | Supported              | Deprecated | Gate                                     |
 | ------------ | ---------- | ---------------------- | ---------- | ---------------------------------------- |
 | KiCad        | 10.0.x     | none                   | 9.x, 8.x   | `compatibility.yaml` + release preflight |
-| VS Code      | current    | `engines.vscode` 1.120 | none       | extension manifest + VS Code canary      |
+| VS Code      | current    | `engines.vscode` 1.122 | none       | extension manifest + VS Code canary      |
 | MCP protocol | 2025-11-25 | 2025-11-25             | older      | well-known server card + matrix          |
 | Node         | 24.x       | `>=24.11.0 <25`        | older      | root and extension package metadata      |
 | pnpm         | 11.x       | `>=11.0.0 <12`         | older      | root package metadata                    |

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -11,30 +11,30 @@ Machine-maintained from `compatibility.yaml`. Refresh with
 
 ### Runtime Baseline
 
-| Runtime               | Policy          |
-| --------------------- | --------------- |
-| KiCad primary         | `10.0.x`        |
-| KiCad latest verified | `10.0.3`        |
-| VS Code minimum       | `1.122.0`       |
-| Node                  | `>=24.11.0 <25` |
-| pnpm                  | `>=11.0.0 <12`  |
-| Python                | `>=3.13`        |
-| MCP protocol          | `2025-11-25`    |
-| MCP protocol (next)   | `2026-07-28`    |
+| Runtime | Policy |
+| --- | --- |
+| KiCad primary | `10.0.x` |
+| KiCad latest verified | `10.0.3` |
+| VS Code minimum | `1.122.0` |
+| Node | `>=24.11.0 <25` |
+| pnpm | `>=11.0.0 <12` |
+| Python | `>=3.13` |
+| MCP protocol | `2025-11-25` |
+| MCP protocol (next) | `2026-07-28` |
 
 ### KiCad Support
 
-| Range  | State      | CI        | Notes                                                                                                                                    |
-| ------ | ---------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| 10.0.x | primary    | required  | Primary optimized KiCad CLI and file-format target.                                                                                      |
-| 9.x    | deprecated | scheduled | Upstream KiCad 9.x is no longer actively maintained; core workflows remain best-effort while scheduled canaries gather removal evidence. |
-| 8.x    | deprecated | manual    | File-level read and migration support only; removal requires a release note.                                                             |
+| Range | State | CI | Notes |
+| --- | --- | --- | --- |
+| 10.0.x | primary | required | Primary optimized KiCad CLI and file-format target. |
+| 9.x | deprecated | scheduled | Upstream KiCad 9.x is no longer actively maintained; core workflows remain best-effort while scheduled canaries gather removal evidence. |
+| 8.x | deprecated | manual | File-level read and migration support only; removal requires a release note. |
 
 ### Product Versions
 
-| Product      | Version | Manifest                           | Compatibility range  |
-| ------------ | ------- | ---------------------------------- | -------------------- |
-| kicad-studio | 1.1.0   | apps/vscode-extension/package.json | &gt;=3.5.2 &lt;4.0.0 |
+| Product | Version | Manifest | Compatibility range |
+| --- | --- | --- | --- |
+| kicad-studio | 1.1.0 | apps/vscode-extension/package.json | &gt;=3.5.2 &lt;4.0.0 |
 
 ### Release Gate Inputs
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -8,7 +8,7 @@ Refresh with `corepack pnpm run docs:generate`.
 | Monorepo baseline | `1.0.0` |
 | KiCad Studio extension | `1.1.0` |
 | kicad-mcp-pro Python server | `unknown` |
-| VS Code engine | `^1.120.0` |
+| VS Code engine | `^1.122.0` |
 | Node | `>=24.11.0 <25` |
 | pnpm | `>=11.0.0 <12` |
 | Python | `>=3.13` |

--- a/scripts/check-ci-lanes.test.mjs
+++ b/scripts/check-ci-lanes.test.mjs
@@ -16,7 +16,6 @@ test("extension-only changes run extension and performance lanes, not MCP packag
   assert.equal(report.lanes.vscodeExtension, true);
   assert.equal(report.lanes.performanceBudgets, true);
   assert.equal(report.lanes.mcpServer, false);
-  assert.equal(report.lanes.mcpNpm, false);
   assert.equal(report.lanes.integrationContracts, false);
   assert.equal(report.lanes.crossRepoCompatibility, false);
 });
@@ -31,26 +30,22 @@ test("extension MCP adapter changes run integration compatibility", () => {
   assert.equal(report.lanes.realPairCompatibility, true);
 });
 
-test("MCP server changes run MCP, npm launcher, performance, and integration lanes", () => {
-  const report = classifyChangedFiles([]);
+test("kicad-mcp-pro changes run MCP, performance, and integration lanes", () => {
+  const report = classifyChangedFiles(["apps/kicad-mcp-pro/src/server.ts"]);
 
   assert.equal(report.lanes.mcpServer, true);
-  assert.equal(report.lanes.mcpNpm, true);
   assert.equal(report.lanes.performanceBudgets, true);
-  assert.equal(report.lanes.integrationContracts, true);
-  assert.equal(report.lanes.realPairCompatibility, true);
   assert.equal(report.lanes.vscodeExtension, false);
+  assert.equal(report.lanes.integrationContracts, false);
+  assert.equal(report.lanes.realPairCompatibility, false);
 });
 
-test("local protocol-schemas directory changes no longer trigger CI lanes (npm-sourced)", () => {
-  const report = classifyChangedFiles([
-    "packages/protocol-schemas/schemas/kicad-mcp-server-info.schema.json",
-  ]);
+test("external consumer paths that don't exist locally no longer trigger CI lanes", () => {
+  const report = classifyChangedFiles(["docs/consuming-protocol-schemas.md"]);
 
   assert.equal(report.lanes.sharedPackages, false);
   assert.equal(report.lanes.vscodeExtension, false);
   assert.equal(report.lanes.mcpServer, false);
-  assert.equal(report.lanes.mcpNpm, false);
   assert.equal(report.lanes.integrationContracts, false);
   assert.equal(report.lanes.realPairCompatibility, false);
   assert.equal(report.lanes.crossRepoCompatibility, false);
@@ -62,7 +57,6 @@ test("test harness changes run shared and cross-product compatibility gates", ()
   assert.equal(report.lanes.sharedPackages, true);
   assert.equal(report.lanes.vscodeExtension, true);
   assert.equal(report.lanes.mcpServer, true);
-  assert.equal(report.lanes.mcpNpm, true);
   assert.equal(report.lanes.integrationContracts, true);
   assert.equal(report.lanes.realPairCompatibility, true);
   assert.equal(report.lanes.performanceBudgets, true);


### PR DESCRIPTION
## Summary
- Aligns VS Code engine version from 1.120 to 1.122 across all docs, metadata, test fixtures, and CI templates.
- Removes stale MCP packaging lane references from CI lane test fixtures.
- Keeps existing compatibility/canary guardrails intact.

## Validation
- pnpm install --frozen-lockfile
- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm run check:version
- pnpm run check:agent-configs
- pnpm run check:ci-lanes --all (9/9 passing)
- pnpm run check:compatibility-contract
- pnpm run check:protocol-schemas
- pnpm run check:boundaries
- pnpm run check:forbidden-refs
- docs lint/link checks

## Scope
- Runtime support policy alignment only.
- No publish.
- No tags.
- No version bump.
- No package identity changes.
- No Marketplace/OpenVSX identity changes.

Closes #295