### PR TITLE
docs(repo): complete protocol schemas lifecycle guidance

### DIFF
--- a/docs/RELEASE-COORDINATION.md
+++ b/docs/RELEASE-COORDINATION.md
@@ -71,7 +71,7 @@ releases independently from its own Release Please PR.
 
 | Artifact                                          | Owned by                            | Release trigger                                         |
 | ------------------------------------------------- | ----------------------------------- | ------------------------------------------------------- |
-| `@oaslananka/kicad-protocol-schemas`              | `oaslananka/kicad-mcp`              | Tag push in kicad-mcp                                   |
+| `@oaslananka/kicad-protocol-schemas`              | `oaslananka/kicad-mcp`              | Release published (tag-based) + `workflow_dispatch`     |
 | PyPI `kicad-mcp-pro`                              | `oaslananka/kicad-mcp`              | Release Please + `publish-python.yml`                   |
 | `ghcr.io/oaslananka/kicad-mcp-pro`                | This repo                           | MCP server GitHub Release + `publish-mcp-container.yml` |
 | MCP Registry `io.github.oaslananka/kicad-mcp-pro` | This repo                           | MCP server GitHub Release + `publish-mcp-registry.yml`  |
@@ -172,7 +172,7 @@ See [Product Dry Runs](publishing.md#product-dry-runs) for what each validates.
 
 **For a protocol schemas release (kicad-mcp repo):**
 
-- [ ] Version tag pushed triggers publish workflow automatically.
+- [ ] GitHub Release published or `workflow_dispatch` triggers the publish workflow.
 - [ ] After publish, this repo (kicad-studio-kit) must:
   1. Bump `@oaslananka/kicad-protocol-schemas` in `package.json`.
   2. Run `corepack pnpm install --frozen-lockfile` to update lockfile.

--- a/docs/protocol-schemas.md
+++ b/docs/protocol-schemas.md
@@ -136,10 +136,21 @@ Work items for further cross-repo compatibility hardening are tracked in
 
 The canonical schema source lives in
 [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp). Publishing a
-new version of `@oaslananka/kicad-protocol-schemas` requires a version tag push
-in the **kicad-mcp** repository. The kicad-mcp npm publish workflow creates a
-GitHub release and pushes the package to npm. The kicad-studio-kit repository
-then consumes the published version as a dependency.
+new version of `@oaslananka/kicad-protocol-schemas` is owned by the
+**kicad-mcp** repository. The kicad-studio-kit repository then consumes the
+published version as a dependency.
+
+### CI trigger
+
+The kicad-mcp publish workflow (`publish-protocol-schemas.yml`) triggers on
+**GitHub Release published** (tag-based, via Release Please) and supports
+manual `workflow_dispatch` for ad-hoc or emergency publishes. This is the
+finalized CI trigger for protocol-schema releases.
+
+The v1.x line starts with the dual trigger (release + manual dispatch).
+Graduating to tag-only publishing may be considered once the release trust
+is well established. Renovate handles consumer dependency updates regardless
+of the trigger choice.
 
 ### When to release
 
@@ -166,12 +177,15 @@ In those cases, consume the existing npm version without bumping the dependency.
 ### Cross-repo release process
 
 1. Schema change committed and tagged in `oaslananka/kicad-mcp`.
-2. Tag push triggers the kicad-mcp publish workflow: `npm publish` + GitHub
-   Release creation.
-3. Published version becomes available on npm after registry propagation.
-4. `minimumReleaseAge` in `pnpm-workspace.yaml` must be satisfied (or the new
+2. Release Please creates a GitHub Release, which triggers the kicad-mcp
+   publish workflow (`publish-protocol-schemas.yml`): `npm publish` + GitHub
+   Release assets.
+3. For ad-hoc or emergency publishes, `workflow_dispatch` may be used directly
+   from the kicad-mcp Actions tab.
+4. Published version becomes available on npm after registry propagation.
+5. `minimumReleaseAge` in `pnpm-workspace.yaml` must be satisfied (or the new
    version added to `minimumReleaseAgeExclude`) before CI accepts the version.
-5. Studio bumps the dependency in `package.json`, runs the protocol-schemas
+6. Studio bumps the dependency in `package.json`, runs the protocol-schemas
    contract gate, and completes a PR targeting the studio main branch.
 
 ### CI validation gates


### PR DESCRIPTION
## Summary
- Completes D1 (CI trigger decision) and finalizes remaining Section D items from #290.
- Documents the actual CI trigger: Release published (tag-based) + \workflow_dispatch\ as implemented in oaslananka/kicad-mcp.
- Updates RELEASE-COORDINATION.md to match the actual trigger.
- Keeps kicad-studio-kit as a published artifact consumer with compatibility checks.

## Validation
- pnpm run format:check — passed
- pnpm run lint — passed
- pnpm run docs:lint — passed
- pnpm run docs:links — passed
- packages/protocol-schemas absence verified

## Scope
- Documentation/lifecycle guidance only.
- No local protocol schema source restored.
- No publish.
- No tags.
- No version bump.
- No package identity change.

Closes #290