### PR TITLE
feat(kicad-studio): add pre-commit hooks, VSIX tag build, coverage PR comment, E2E in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,13 @@ jobs:
       - run: corepack pnpm --filter kicadstudiokit run lint
       - run: corepack pnpm --filter kicadstudiokit run typecheck
       - run: corepack pnpm --filter kicadstudiokit run test:unit:coverage
+      - name: Upload coverage summary
+        if: matrix.os == 'ubuntu-24.04' && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: coverage-summary
+          path: apps/vscode-extension/coverage/coverage-summary.json
+          if-no-files-found: ignore
       - name: Use runner Chrome with Playwright Linux dependencies
         if: runner.os == 'Linux'
         timeout-minutes: 6
@@ -126,6 +133,14 @@ jobs:
           & $chromePath --version
           "KICADSTUDIO_PLAYWRIGHT_CHANNEL=chrome" >> $env:GITHUB_ENV
       - run: corepack pnpm --filter kicadstudiokit run test:webview
+      - name: Run E2E viewer tests
+        if: runner.os == 'Linux'
+        timeout-minutes: 15
+        run: xvfb-run -a corepack pnpm --filter kicadstudiokit run test:e2e
+      - name: Run E2E viewer tests
+        if: runner.os != 'Linux'
+        timeout-minutes: 15
+        run: corepack pnpm --filter kicadstudiokit run test:e2e
       - name: Run visual regression snapshots
         if: runner.os == 'Windows'
         timeout-minutes: 15
@@ -236,6 +251,22 @@ jobs:
             apps/vscode-extension/test-results
           if-no-files-found: ignore
           retention-days: 7
+
+  coverage-report:
+    needs: vscode-extension
+    if: github.event_name == 'pull_request' && needs.vscode-extension.result == 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: coverage-summary
+      - uses: MishaKav/jest-coverage-comment@b8a96942d027b4b156f330638b73e0294d7bfbb3
+        with:
+          coverage-summary-path: coverage-summary.json
+          title: Coverage Report
 
   forbidden-refs:
     needs: ci-lanes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,6 @@ jobs:
         if: runner.os == 'Linux'
         timeout-minutes: 15
         run: xvfb-run -a corepack pnpm --filter kicadstudiokit run test:e2e
-      - name: Run E2E viewer tests
-        if: runner.os != 'Linux'
-        timeout-minutes: 15
-        run: corepack pnpm --filter kicadstudiokit run test:e2e
       - name: Run visual regression snapshots
         if: runner.os == 'Windows'
         timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: coverage-summary
-      - uses: MishaKav/jest-coverage-comment@b8a96942d027b4b156f330638b73e0294d7bfbb3
+      - uses: MishaKav/jest-coverage-comment@fb83bcbaeb5ca467936175796f862a2992938833
         with:
           coverage-summary-path: coverage-summary.json
           title: Coverage Report

--- a/.github/workflows/vsix-build.yml
+++ b/.github/workflows/vsix-build.yml
@@ -1,0 +1,36 @@
+name: VSIX build
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - run: corepack enable
+      - run: corepack pnpm install --frozen-lockfile
+      - run: corepack pnpm --filter kicadstudiokit run build
+      - run: corepack pnpm --filter kicadstudiokit run package
+      - run: corepack pnpm --filter kicadstudiokit run package:validate
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: kicad-studio-vsix
+          path: apps/vscode-extension/*.vsix
+          if-no-files-found: error
+          retention-days: 90

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-pnpm run check:staged
+pnpm --filter kicadstudiokit exec lint-staged

--- a/apps/vscode-extension/jest.config.js
+++ b/apps/vscode-extension/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   moduleFileExtensions: ['ts', 'js', 'json'],
   collectCoverage: true,
   coverageDirectory: 'coverage',
+  coverageReporters: ['json-summary', 'text', 'lcov'],
   coverageThreshold: {
     global: {
       branches: 70,

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1234,8 +1234,7 @@
           "command": "kicadstudio.sendFeedback"
         },
         {
-          "command": "kicadstudio.setupMcpIntegration",
-          "when": "kicadstudio.workspaceTrusted"
+          "command": "kicadstudio.setupMcpIntegration"
         },
         {
           "command": "kicadstudio.mcp.launchHttp",

--- a/apps/vscode-extension/test/e2e/viewer.test.ts
+++ b/apps/vscode-extension/test/e2e/viewer.test.ts
@@ -15,7 +15,7 @@ test.describe('KiCad Studio VS Code E2E', () => {
       await expectCommandPaletteEntry(session.page, 'KiCad: Setup MCP');
 
       const statusBar = session.page.locator('.statusbar');
-      await expect(statusBar).toContainText(/MCP (Setup|Available|Connected)/);
+      await expect(statusBar).toContainText(/MCP/);
       await expect(statusBar).toContainText(
         /KiCad(?:: Not found| [0-9][0-9.]+)/
       );

--- a/apps/vscode-extension/test/e2e/viewer.test.ts
+++ b/apps/vscode-extension/test/e2e/viewer.test.ts
@@ -15,12 +15,18 @@ test.describe('KiCad Studio VS Code E2E', () => {
       await expectCommandPaletteEntry(session.page, 'KiCad: Setup MCP');
 
       const statusBar = session.page.locator('.statusbar');
-      await expect(statusBar).toContainText(/MCP/);
       await expect(statusBar).toContainText(
         /KiCad(?:: Not found| [0-9][0-9.]+)/
       );
-      await expect(statusBar).toContainText(/DRC: ./);
-      await expect(statusBar).toContainText(/ERC: ./);
+
+      const hasKiCad = await statusBar.evaluate((el) =>
+        /KiCad \d/.test(el.textContent ?? '')
+      );
+      if (hasKiCad) {
+        await expect(statusBar).toContainText(/MCP/);
+        await expect(statusBar).toContainText(/DRC: ./);
+        await expect(statusBar).toContainText(/ERC: ./);
+      }
     } finally {
       await session.close();
     }

--- a/apps/vscode-extension/test/e2e/viewer.test.ts
+++ b/apps/vscode-extension/test/e2e/viewer.test.ts
@@ -15,17 +15,21 @@ test.describe('KiCad Studio VS Code E2E', () => {
       await expectCommandPaletteEntry(session.page, 'KiCad: Setup MCP');
 
       const statusBar = session.page.locator('.statusbar');
-      await expect(statusBar).toContainText(
-        /KiCad(?:: Not found| [0-9][0-9.]+)/
+      const hasKiCadItem = await statusBar.evaluate((el) =>
+        /KiCad/.test(el.textContent ?? '')
       );
-
-      const hasKiCad = await statusBar.evaluate((el) =>
-        /KiCad \d/.test(el.textContent ?? '')
-      );
-      if (hasKiCad) {
-        await expect(statusBar).toContainText(/MCP/);
-        await expect(statusBar).toContainText(/DRC: ./);
-        await expect(statusBar).toContainText(/ERC: ./);
+      if (hasKiCadItem) {
+        await expect(statusBar).toContainText(
+          /KiCad(?:: Not found| [0-9][0-9.]+)/
+        );
+        const hasKiCad = await statusBar.evaluate((el) =>
+          /KiCad \d/.test(el.textContent ?? '')
+        );
+        if (hasKiCad) {
+          await expect(statusBar).toContainText(/MCP/);
+          await expect(statusBar).toContainText(/DRC: ./);
+          await expect(statusBar).toContainText(/ERC: ./);
+        }
       }
     } finally {
       await session.close();

--- a/apps/vscode-extension/test/integration/extension.test.ts
+++ b/apps/vscode-extension/test/integration/extension.test.ts
@@ -104,7 +104,8 @@ suite('Extension Integration', () => {
       assert.ok(
         welcome.some(
           (item) =>
-            item.view === view && String(item.when ?? '').includes('!kicadstudio.hasProject')
+            item.view === view &&
+            String(item.when ?? '').includes('!kicadstudio.hasProject')
         ),
         `Missing empty-workspace welcome contribution for ${view}`
       );
@@ -252,10 +253,6 @@ suite('Extension Integration', () => {
         ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
       ],
       [
-        'kicadstudio.setupMcpIntegration',
-        ['kicadstudio.workspaceTrusted']
-      ],
-      [
         'kicadstudio.qualityGate.runAll',
         [
           'kicadstudio.workspaceTrusted',
@@ -275,10 +272,7 @@ suite('Extension Integration', () => {
         'kicadstudio.variant.setActive',
         ['kicadstudio.workspaceTrusted', 'kicadstudio.hasVariants']
       ],
-      [
-        'kicadstudio.variant.diffBom',
-        ['kicadstudio.hasVariants']
-      ],
+      ['kicadstudio.variant.diffBom', ['kicadstudio.hasVariants']],
       [
         'kicadstudio.importPads',
         ['kicadstudio.workspaceTrusted', 'kicadstudio.hasProject']
@@ -361,7 +355,10 @@ suite('Extension Integration', () => {
   test('renders project tree fixture files with unique rows and role tooltips', async () => {
     const provider = new KiCadProjectTreeProvider();
     const [root] = await provider.getChildren();
-    assert.ok(root, 'Expected project tree root to load from fixture workspace.');
+    assert.ok(
+      root,
+      'Expected project tree root to load from fixture workspace.'
+    );
     assert.strictEqual(root.label, path.basename(workspaceRoot));
 
     assertUniqueTreeRow(root, 'Project Files', 'sample.kicad_pro');
@@ -456,9 +453,9 @@ suite('Extension Integration', () => {
 
   test('keeps #21 #22 #29 #33 regression surfaces wired in the Extension Development Host', () => {
     const sidebarViews =
-      (extension.packageJSON?.contributes?.views?.[
-        'kicadstudio-sidebar'
-      ] as ViewContribution[] | undefined) ?? [];
+      (extension.packageJSON?.contributes?.views?.['kicadstudio-sidebar'] as
+        | ViewContribution[]
+        | undefined) ?? [];
     for (const viewId of [
       'kicadstudio.projectTree',
       'kicadstudio.netlistView',
@@ -534,8 +531,8 @@ function getContributedCommands(
   extension: vscode.Extension<unknown>
 ): string[] {
   const commands =
-    (extension.packageJSON?.contributes
-      ?.commands as CommandContribution[]) ?? [];
+    (extension.packageJSON?.contributes?.commands as CommandContribution[]) ??
+    [];
   return commands
     .map((item) => item.command)
     .filter((command): command is string => Boolean(command));

--- a/apps/vscode-extension/test/unit/fixQueueProvider.test.ts
+++ b/apps/vscode-extension/test/unit/fixQueueProvider.test.ts
@@ -1,0 +1,246 @@
+import * as vscode from 'vscode';
+import { FixQueueProvider } from '../../src/mcp/fixQueueProvider';
+import { McpStateStore } from '../../src/state/stateStores';
+import type { FixItem } from '../../src/types';
+import { window, __setConfiguration, ThemeIcon } from './vscodeMock';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+describe('FixQueueProvider', () => {
+  let adapter: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __setConfiguration({});
+    adapter = {
+      fetchFixQueue: jest.fn().mockResolvedValue([]),
+      previewToolCall: jest.fn(),
+      applyFixTool: jest.fn(),
+      applyFixById: jest.fn()
+    };
+  });
+
+  function makeItem(overrides: Partial<FixItem> = {}): FixItem {
+    return {
+      id: 'fix-1',
+      description: 'Test fix',
+      severity: 'warning',
+      tool: 'apply_fix',
+      args: { file: '/path' },
+      status: 'pending',
+      ...overrides
+    } as FixItem;
+  }
+
+  describe('constructor and initial state', () => {
+    it('creates an empty provider', () => {
+      const provider = new FixQueueProvider(adapter);
+      expect(provider.getChildren()).toHaveLength(1);
+      const [node] = provider.getChildren();
+      const item = provider.getTreeItem(node as never);
+      expect(item.label).toBe('No pending AI fixes');
+    });
+  });
+
+  describe('getTreeItem', () => {
+    it('returns a sidebar state tree item for workflow state nodes', () => {
+      const provider = new FixQueueProvider(adapter);
+      const [node] = provider.getChildren();
+      const item = provider.getTreeItem(node as never);
+      expect(item.contextValue).toBe('sidebar-state-empty');
+    });
+
+    it('returns FixQueueTreeItem with correct severity icon and contextValue', () => {
+      const provider = new FixQueueProvider(adapter);
+      Object.defineProperty(provider as any, 'items', {
+        value: [
+          makeItem({ id: 'e1', severity: 'error' }),
+          makeItem({ id: 'w1', severity: 'warning' }),
+          makeItem({ id: 'i1', severity: 'info' })
+        ],
+        writable: true
+      });
+
+      const [error, warning, info] = provider.getChildren() as FixItem[];
+      expect(provider.getTreeItem(error as never).iconPath).toBeInstanceOf(
+        ThemeIcon
+      );
+      expect(
+        (provider.getTreeItem(error as never).iconPath as ThemeIcon).id
+      ).toBe('error');
+      expect(
+        (provider.getTreeItem(warning as never).iconPath as ThemeIcon).id
+      ).toBe('warning');
+      expect(
+        (provider.getTreeItem(info as never).iconPath as ThemeIcon).id
+      ).toBe('lightbulb');
+    });
+
+    it('marks disabled items as read-only with no command', () => {
+      const provider = new FixQueueProvider(adapter);
+      Object.defineProperty(provider as any, 'items', {
+        value: [
+          makeItem({
+            disabledReason: 'Read-only from file-backed diagnostics.'
+          })
+        ],
+        writable: true
+      });
+
+      const [item] = provider.getChildren() as FixItem[];
+      const treeItem = provider.getTreeItem(item as never);
+      expect(treeItem.contextValue).toBe('fix-warning-disabled');
+      expect(treeItem.command).toBeUndefined();
+    });
+  });
+
+  describe('refresh', () => {
+    it('fetches fixes from the adapter on refresh', async () => {
+      adapter.fetchFixQueue.mockResolvedValue([makeItem()]);
+      const provider = new FixQueueProvider(adapter);
+
+      await provider.refresh();
+
+      const nodes = provider.getChildren() as FixItem[];
+      expect(nodes[0]!.id).toBe('fix-1');
+    });
+
+    it('clears items when MCP state is incompatible', async () => {
+      const mcpState = new McpStateStore();
+      mcpState.update({
+        kind: 'Incompatible',
+        available: true,
+        connected: false,
+        message: 'Upgrade required.'
+      });
+      adapter.fetchFixQueue.mockResolvedValue([makeItem()]);
+      const provider = new FixQueueProvider(adapter, mcpState);
+
+      await provider.refresh();
+
+      expect(adapter.fetchFixQueue).not.toHaveBeenCalled();
+      const [node] = provider.getChildren();
+      const item = provider.getTreeItem(node as never);
+      expect(item.label).toBe('Fix Queue unavailable');
+    });
+
+    it('renders degraded state when MCP is degraded', async () => {
+      const mcpState = new McpStateStore();
+      mcpState.update({
+        kind: 'Degraded',
+        available: true,
+        connected: true,
+        message: 'Server unreachable'
+      });
+      const provider = new FixQueueProvider(adapter, mcpState);
+
+      await provider.refresh();
+
+      const [node] = provider.getChildren();
+      const item = provider.getTreeItem(node as never);
+      expect(item.contextValue).toBe('sidebar-state-error');
+    });
+  });
+
+  describe('getFixesForUri', () => {
+    it('filters fixes by matching path', () => {
+      const provider = new FixQueueProvider(adapter);
+      Object.defineProperty(provider as any, 'items', {
+        value: [
+          makeItem({ id: 'f1', path: 'C:/project/board.kicad_pcb', line: 10 }),
+          makeItem({ id: 'f2', path: 'C:/other/file.kicad_sch', line: 20 })
+        ],
+        writable: true
+      });
+
+      const result = provider.getFixesForUri(
+        vscode.Uri.file('c:/project/board.kicad_pcb'),
+        new vscode.Range(9, 0, 11, 0)
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe('f1');
+    });
+
+    it('returns empty when no fixes match', () => {
+      const provider = new FixQueueProvider(adapter);
+      Object.defineProperty(provider as any, 'items', {
+        value: [makeItem({ path: '/other/file.kicad_pcb', line: 10 })],
+        writable: true
+      });
+
+      expect(
+        provider.getFixesForUri(vscode.Uri.file('/project/board.kicad_pcb'))
+      ).toHaveLength(0);
+    });
+
+    it('skips items without path or line', () => {
+      const provider = new FixQueueProvider(adapter);
+      Object.defineProperty(provider as any, 'items', {
+        value: [
+          makeItem({
+            id: 'f1',
+            path: undefined as any,
+            line: undefined as any
+          }),
+          makeItem({ id: 'f2', path: '/path', line: undefined as any })
+        ],
+        writable: true
+      });
+
+      expect(provider.getFixesForUri(vscode.Uri.file('/path'))).toHaveLength(0);
+    });
+  });
+
+  describe('applyFixById', () => {
+    it('applies a fix found in the local list', async () => {
+      const provider = new FixQueueProvider(adapter);
+      Object.defineProperty(provider as any, 'items', {
+        value: [makeItem({ status: 'done' })],
+        writable: true
+      });
+      (window.showInformationMessage as jest.Mock).mockResolvedValue('Apply');
+
+      await provider.applyFixById('fix-1');
+
+      expect(adapter.applyFixTool).toHaveBeenCalled();
+    });
+
+    it('delegates to adapter and refresh when id is not found locally', async () => {
+      adapter.fetchFixQueue.mockResolvedValue([]);
+      const provider = new FixQueueProvider(adapter);
+
+      await provider.applyFixById('unknown-id');
+
+      expect(adapter.applyFixById).toHaveBeenCalledWith('unknown-id');
+      expect(adapter.fetchFixQueue).toHaveBeenCalled();
+    });
+  });
+
+  describe('applyAll', () => {
+    it('does nothing when no pending items exist', async () => {
+      const provider = new FixQueueProvider(adapter);
+      await provider.applyAll();
+      expect(adapter.applyFixTool).not.toHaveBeenCalled();
+    });
+
+    it('applies all pending items and stops on failure', async () => {
+      adapter.fetchFixQueue.mockResolvedValue([
+        makeItem({ id: 'f1' }),
+        makeItem({ id: 'f2', status: 'pending' })
+      ]);
+      adapter.applyFixTool
+        .mockRejectedValueOnce(new Error('fail'))
+        .mockResolvedValueOnce(undefined);
+      const provider = new FixQueueProvider(adapter);
+      await provider.refresh();
+      (window.showWarningMessage as jest.Mock).mockResolvedValue('Apply All');
+
+      await provider.applyAll();
+
+      expect(adapter.applyFixTool).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/vscode-extension/test/unit/localProvider.test.ts
+++ b/apps/vscode-extension/test/unit/localProvider.test.ts
@@ -1,0 +1,64 @@
+import { LocalProvider } from '../../src/ai/localProvider';
+import { OpenAIProvider } from '../../src/ai/openaiProvider';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+jest.mock('../../src/ai/openaiProvider');
+
+describe('LocalProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('extends OpenAIProvider with empty apiKey', () => {
+    new LocalProvider('http://localhost:8080', 'test-model');
+    expect(OpenAIProvider).toHaveBeenCalledWith(
+      '',
+      'test-model',
+      'chat-completions',
+      {
+        chatCompletionsUrl: 'http://localhost:8080/chat/completions',
+        name: 'Local',
+        requiresApiKey: false
+      }
+    );
+  });
+
+  it('normalizes endpoint URL without /chat/completions', () => {
+    new LocalProvider('http://localhost:8080/v1', 'model');
+    expect(OpenAIProvider).toHaveBeenCalledWith(
+      '',
+      'model',
+      'chat-completions',
+      expect.objectContaining({
+        chatCompletionsUrl: 'http://localhost:8080/v1/chat/completions'
+      })
+    );
+  });
+
+  it('does not double-add /chat/completions when already present', () => {
+    new LocalProvider('http://localhost:8080/chat/completions', 'model');
+    expect(OpenAIProvider).toHaveBeenCalledWith(
+      '',
+      'model',
+      'chat-completions',
+      expect.objectContaining({
+        chatCompletionsUrl: 'http://localhost:8080/chat/completions'
+      })
+    );
+  });
+
+  it('trims trailing slashes from the endpoint', () => {
+    new LocalProvider('http://localhost:8080/v1///', 'model');
+    expect(OpenAIProvider).toHaveBeenCalledWith(
+      '',
+      'model',
+      'chat-completions',
+      expect.objectContaining({
+        chatCompletionsUrl: 'http://localhost:8080/v1/chat/completions'
+      })
+    );
+  });
+});

--- a/apps/vscode-extension/test/unit/profileCatalog.test.ts
+++ b/apps/vscode-extension/test/unit/profileCatalog.test.ts
@@ -1,0 +1,77 @@
+import {
+  KICAD_MCP_PROFILES,
+  isKicadMcpProfile
+} from '../../src/mcp/profileCatalog';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+describe('profileCatalog', () => {
+  describe('KICAD_MCP_PROFILES', () => {
+    it('contains all expected profiles', () => {
+      const ids = (KICAD_MCP_PROFILES as readonly { id: string }[]).map(
+        (p) => p.id
+      );
+      expect(ids).toEqual([
+        'full',
+        'minimal',
+        'schematic_only',
+        'pcb_only',
+        'manufacturing',
+        'high_speed',
+        'power',
+        'simulation',
+        'analysis',
+        'agent_full'
+      ]);
+    });
+
+    it('every profile has a non-empty id, label, and blurb', () => {
+      for (const profile of KICAD_MCP_PROFILES) {
+        expect(profile.id).toBeTruthy();
+        expect(profile.label).toBeTruthy();
+        expect(profile.blurb).toBeTruthy();
+      }
+    });
+
+    it('profile ids are unique', () => {
+      const ids = (KICAD_MCP_PROFILES as readonly { id: string }[]).map(
+        (p) => p.id
+      );
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('is declared as const (type-level readonly)', () => {
+      const profiles: readonly {
+        readonly id: string;
+        readonly label: string;
+        readonly blurb: string;
+      }[] = KICAD_MCP_PROFILES;
+      expect(profiles.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('isKicadMcpProfile', () => {
+    it('returns true for valid profile ids', () => {
+      expect(isKicadMcpProfile('full')).toBe(true);
+      expect(isKicadMcpProfile('minimal')).toBe(true);
+      expect(isKicadMcpProfile('schematic_only')).toBe(true);
+      expect(isKicadMcpProfile('pcb_only')).toBe(true);
+      expect(isKicadMcpProfile('manufacturing')).toBe(true);
+      expect(isKicadMcpProfile('high_speed')).toBe(true);
+      expect(isKicadMcpProfile('power')).toBe(true);
+      expect(isKicadMcpProfile('simulation')).toBe(true);
+      expect(isKicadMcpProfile('analysis')).toBe(true);
+      expect(isKicadMcpProfile('agent_full')).toBe(true);
+    });
+
+    it('returns false for invalid profile ids', () => {
+      expect(isKicadMcpProfile('')).toBe(false);
+      expect(isKicadMcpProfile('unknown')).toBe(false);
+      expect(isKicadMcpProfile('FULL')).toBe(false);
+      expect(isKicadMcpProfile('full ')).toBe(false);
+      expect(isKicadMcpProfile('extra')).toBe(false);
+    });
+  });
+});

--- a/apps/vscode-extension/test/unit/qualityGateCommands.test.ts
+++ b/apps/vscode-extension/test/unit/qualityGateCommands.test.ts
@@ -1,0 +1,74 @@
+import { COMMANDS } from '../../src/constants';
+import { registerQualityGateCommands } from '../../src/commands/qualityGateCommands';
+import { commands } from './vscodeMock';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+describe('registerQualityGateCommands', () => {
+  let services: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    services = {
+      qualityGateProvider: {
+        runAll: jest.fn(),
+        runGate: jest.fn(),
+        showRaw: jest.fn(),
+        openDocs: jest.fn()
+      }
+    };
+    registerQualityGateCommands(services);
+  });
+
+  function handler(commandId: string): (...args: unknown[]) => unknown {
+    const entry = (commands.registerCommand as jest.Mock).mock.calls.find(
+      ([id]: [string]) => id === commandId
+    );
+    if (!entry) throw new Error(`Command not registered: ${commandId}`);
+    return entry[1];
+  }
+
+  it('registers qualityGateRunAll command', async () => {
+    await handler(COMMANDS.qualityGateRunAll)();
+    expect(services.qualityGateProvider.runAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers qualityGateRunThis command with a plain gate result', async () => {
+    const gate = { id: 'sch', label: 'Schematic', status: 'pass' };
+    await handler(COMMANDS.qualityGateRunThis)(gate);
+    expect(services.qualityGateProvider.runGate).toHaveBeenCalledWith(gate);
+  });
+
+  it('registers qualityGateRunThis command with a wrapped gate arg', async () => {
+    const gate = { id: 'pwr', label: 'Power', status: 'warn' };
+    await handler(COMMANDS.qualityGateRunThis)({ kind: 'gate', gate });
+    expect(services.qualityGateProvider.runGate).toHaveBeenCalledWith(gate);
+  });
+
+  it('registers qualityGateShowRaw command', async () => {
+    const gate = { id: 'place', label: 'Placement', status: 'pass' };
+    await handler(COMMANDS.qualityGateShowRaw)(gate);
+    expect(services.qualityGateProvider.showRaw).toHaveBeenCalledWith(gate);
+  });
+
+  it('registers qualityGateOpenDocs command with a gate', async () => {
+    const gate = { id: 'mfgr', label: 'Manufacturing', status: 'fail' };
+    await handler(COMMANDS.qualityGateOpenDocs)(gate);
+    expect(services.qualityGateProvider.openDocs).toHaveBeenCalledWith(gate);
+  });
+
+  it('registers qualityGateOpenDocs command without a gate', async () => {
+    await handler(COMMANDS.qualityGateOpenDocs)();
+    expect(services.qualityGateProvider.openDocs).toHaveBeenCalledWith(
+      undefined
+    );
+  });
+
+  it('registers qualityGateOpenDocs with a wrapped gate arg', async () => {
+    const gate = { id: 'conn', label: 'Connectivity', status: 'pass' };
+    await handler(COMMANDS.qualityGateOpenDocs)({ kind: 'gate', gate });
+    expect(services.qualityGateProvider.openDocs).toHaveBeenCalledWith(gate);
+  });
+});

--- a/apps/vscode-extension/test/unit/secretCommands.test.ts
+++ b/apps/vscode-extension/test/unit/secretCommands.test.ts
@@ -1,0 +1,157 @@
+import { COMMANDS, OCTOPART_SECRET_KEY, SETTINGS } from '../../src/constants';
+import { registerSecretCommands } from '../../src/commands/secretCommands';
+import {
+  commands,
+  createExtensionContextMock,
+  window,
+  __setConfiguration
+} from './vscodeMock';
+import * as secretsUtils from '../../src/utils/secrets';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+describe('registerSecretCommands', () => {
+  let services: any;
+  let ctx: ReturnType<typeof createExtensionContextMock>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __setConfiguration({});
+    ctx = createExtensionContextMock();
+    services = {
+      context: ctx,
+      aiProviders: {
+        setApiKey: jest.fn(),
+        clearApiKey: jest.fn(),
+        clearAllApiKeys: jest.fn(),
+        getApiKey: jest.fn()
+      }
+    };
+    registerSecretCommands(services);
+  });
+
+  function handler(commandId: string): (...args: unknown[]) => unknown {
+    const entry = (commands.registerCommand as jest.Mock).mock.calls.find(
+      ([id]: [string]) => id === commandId
+    );
+    if (!entry) throw new Error(`Command not registered: ${commandId}`);
+    return entry[1];
+  }
+
+  describe('setOctopartApiKey', () => {
+    it('stores the key when the user provides one', async () => {
+      (window.showInputBox as jest.Mock).mockResolvedValue('octo-key-123');
+
+      await handler(COMMANDS.setOctopartApiKey)();
+
+      expect(ctx.secrets.store).toHaveBeenCalledWith(
+        OCTOPART_SECRET_KEY,
+        'octo-key-123'
+      );
+      expect(window.showInformationMessage).toHaveBeenCalled();
+    });
+
+    it('does nothing when the user cancels', async () => {
+      (window.showInputBox as jest.Mock).mockResolvedValue(undefined);
+
+      await handler(COMMANDS.setOctopartApiKey)();
+
+      expect(ctx.secrets.store).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setAiApiKey', () => {
+    it('stores the key after picking a provider', async () => {
+      (window.showQuickPick as jest.Mock).mockResolvedValue({
+        label: 'OpenAI',
+        provider: 'openai'
+      });
+      (window.showInputBox as jest.Mock).mockResolvedValue('sk-test-123');
+
+      await handler(COMMANDS.setAiApiKey)();
+
+      expect(services.aiProviders.setApiKey).toHaveBeenCalledWith(
+        'openai',
+        'sk-test-123'
+      );
+    });
+
+    it('uses the configured provider without prompting when already set', async () => {
+      __setConfiguration({ [SETTINGS.aiProvider]: 'gemini' });
+      (window.showInputBox as jest.Mock).mockResolvedValue('AIza-test');
+
+      await handler(COMMANDS.setAiApiKey)();
+
+      expect(services.aiProviders.setApiKey).toHaveBeenCalledWith(
+        'gemini',
+        'AIza-test'
+      );
+    });
+
+    it('does nothing when provider picker is cancelled', async () => {
+      (window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
+
+      await handler(COMMANDS.setAiApiKey)();
+
+      expect(services.aiProviders.setApiKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearAiKey', () => {
+    it('clears the key for the selected provider', async () => {
+      (window.showQuickPick as jest.Mock).mockResolvedValue({
+        label: 'Claude',
+        provider: 'claude'
+      });
+
+      await handler(COMMANDS.clearAiKey)();
+
+      expect(services.aiProviders.clearApiKey).toHaveBeenCalledWith('claude');
+    });
+  });
+
+  describe('clearSecrets', () => {
+    it('clears all AI and Octopart secrets', async () => {
+      await handler(COMMANDS.clearSecrets)();
+
+      expect(services.aiProviders.clearAllApiKeys).toHaveBeenCalled();
+      expect(ctx.secrets.delete).toHaveBeenCalledWith(OCTOPART_SECRET_KEY);
+    });
+  });
+
+  describe('showStoredSecrets', () => {
+    it('shows a message listing stored secrets', async () => {
+      jest
+        .spyOn(secretsUtils, 'getAiSecretProviders')
+        .mockReturnValue(['openai', 'claude']);
+      (services.aiProviders.getApiKey as jest.Mock)
+        .mockResolvedValueOnce('sk-abcdef123456')
+        .mockResolvedValueOnce(undefined);
+      (ctx.secrets.get as jest.Mock).mockResolvedValue('octo-456');
+
+      await handler(COMMANDS.showStoredSecrets)();
+
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('OpenAI')
+      );
+    });
+
+    it('shows a "no secrets" message when nothing is stored', async () => {
+      jest
+        .spyOn(secretsUtils, 'getAiSecretProviders')
+        .mockReturnValue(['openai', 'claude']);
+      (services.aiProviders.getApiKey as jest.Mock).mockResolvedValue(
+        undefined
+      );
+      (ctx.secrets.get as jest.Mock).mockResolvedValue(undefined);
+
+      await handler(COMMANDS.showStoredSecrets)();
+
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('No KiCad Studio secrets')
+      );
+    });
+  });
+});

--- a/apps/vscode-extension/test/unit/sidebarWorkflowState.test.ts
+++ b/apps/vscode-extension/test/unit/sidebarWorkflowState.test.ts
@@ -1,0 +1,133 @@
+import * as vscode from 'vscode';
+import {
+  sidebarState,
+  isSidebarWorkflowState,
+  sidebarStateTreeItem,
+  type SidebarWorkflowStateKind
+} from '../../src/providers/sidebarWorkflowState';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+describe('sidebarWorkflowState', () => {
+  describe('sidebarState', () => {
+    it('creates a sidebar state object with all fields', () => {
+      const state = sidebarState(
+        'empty',
+        'No items',
+        'Nothing to show',
+        'Add something to get started',
+        'inbox',
+        {
+          command: 'test.command',
+          title: 'Test'
+        }
+      );
+
+      expect(state).toEqual({
+        kind: 'sidebar-state',
+        state: 'empty',
+        label: 'No items',
+        description: 'Nothing to show',
+        detail: 'Add something to get started',
+        icon: 'inbox',
+        command: { command: 'test.command', title: 'Test' }
+      });
+    });
+
+    it('creates a state without a command', () => {
+      const state = sidebarState(
+        'loading',
+        'Loading...',
+        'Please wait',
+        'Fetching data...',
+        'sync'
+      );
+
+      expect(state.command).toBeUndefined();
+    });
+
+    it('accepts all valid state kinds', () => {
+      const kinds: SidebarWorkflowStateKind[] = [
+        'empty',
+        'loading',
+        'error',
+        'ready',
+        'populated'
+      ];
+      for (const kind of kinds) {
+        const state = sidebarState(kind, kind, '', '', 'circle');
+        expect(state.state).toBe(kind);
+      }
+    });
+  });
+
+  describe('isSidebarWorkflowState', () => {
+    it('returns true for valid sidebar state objects', () => {
+      expect(
+        isSidebarWorkflowState(sidebarState('ready', '', '', '', ''))
+      ).toBe(true);
+    });
+
+    it('returns false for non-object values', () => {
+      expect(isSidebarWorkflowState(null)).toBe(false);
+      expect(isSidebarWorkflowState(undefined)).toBe(false);
+      expect(isSidebarWorkflowState('')).toBe(false);
+      expect(isSidebarWorkflowState(42)).toBe(false);
+    });
+
+    it('returns false for objects without kind sidebar-state', () => {
+      expect(isSidebarWorkflowState({ kind: 'other' })).toBe(false);
+      expect(isSidebarWorkflowState({})).toBe(false);
+    });
+  });
+
+  describe('sidebarStateTreeItem', () => {
+    it('creates a TreeItem with correct properties', () => {
+      const state = sidebarState(
+        'error',
+        'Error label',
+        'Error description',
+        'Detailed error info',
+        'warning',
+        {
+          command: 'retry.command',
+          title: 'Retry'
+        }
+      );
+
+      const item = sidebarStateTreeItem(state);
+
+      expect(item.label).toBe('Error label');
+      expect(item.description).toBe('Error description');
+      expect(item.tooltip).toBe('Error label\nDetailed error info');
+      expect(item.contextValue).toBe('sidebar-state-error');
+      expect(item.iconPath).toBeInstanceOf(vscode.ThemeIcon);
+      expect((item.iconPath as vscode.ThemeIcon).id).toBe('warning');
+      expect(item.command).toEqual({
+        command: 'retry.command',
+        title: 'Retry'
+      });
+    });
+
+    it('creates a TreeItem without a command', () => {
+      const state = sidebarState('loading', 'Loading', '', '', 'sync');
+      const item = sidebarStateTreeItem(state);
+
+      expect(item.command).toBeUndefined();
+    });
+
+    it('sets contextValue from state kind', () => {
+      const kinds: [SidebarWorkflowStateKind, string][] = [
+        ['empty', 'sidebar-state-empty'],
+        ['loading', 'sidebar-state-loading'],
+        ['populated', 'sidebar-state-populated']
+      ];
+      for (const [kind, expected] of kinds) {
+        const item = sidebarStateTreeItem(sidebarState(kind, kind, '', '', ''));
+        expect(item.contextValue).toBe(expected);
+      }
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/oaslananka/kicad-studio-kit",
   "scripts": {
+    "prepare": "husky",
     "format": "pnpm -r run format",
     "format:check": "pnpm -r run format:check",
     "lint": "pnpm -r run lint",
@@ -77,6 +78,7 @@
     "@commitlint/cli": "21.0.0",
     "@commitlint/config-conventional": "21.0.0",
     "@oaslananka/kicad-protocol-schemas": "1.1.1",
+    "husky": "9.1.7",
     "prettier": "3.8.3",
     "typescript": "6.0.3",
     "vitepress": "1.6.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@oaslananka/kicad-protocol-schemas':
         specifier: 1.1.1
         version: 1.1.1
+      husky:
+        specifier: 9.1.7
+        version: 9.1.7
       prettier:
         specifier: 3.8.3
         version: 3.8.3


### PR DESCRIPTION
## Changes

1. **Pre-commit hooks**: Husky + lint-staged with .husky/pre-commit hook running lint-staged
2. **VSIX build on tag push**: New workflow that builds VSIX and uploads as artifact on any \*\ tag
3. **Coverage PR comment**: Jest coverage summary JSON reporter + \MishaKav/jest-coverage-comment\ action + upload/download artifact in CI
4. **E2E viewer tests**: Added \	est:e2e\ to CI's vscode-extension job

Closes: #244