### PR TITLE
feat(kicad-studio): downgrade vscode engine and improve mcp sidebar UX

### DIFF
--- a/.github/workflows/vscode-canary.yml
+++ b/.github/workflows/vscode-canary.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - id: minimum
             state: primary
-            version: 1.122.0
+            version: 1.100.0
             continue_on_error: false
           - id: stable
             state: primary

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CodeQL](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/codeql.yml/badge.svg)](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/codeql.yml)
 [![Security](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/security.yml/badge.svg)](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/security.yml)
 [![Open VSX](https://img.shields.io/open-vsx/v/oaslananka/kicadstudiokit?label=Open%20VSX)](https://open-vsx.org/extension/oaslananka/kicadstudiokit)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/oaslananka/kicad-studio-kit)
 
 Monorepo for:
 

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -9,7 +9,7 @@ KiCad Studio turns VS Code into a focused KiCad workspace for project navigation
 Canonical repository: https://github.com/oaslananka/kicad-studio-kit/tree/main/apps/vscode-extension
 
 - Extension ID: `oaslananka.kicadstudiokit`
-- Version: `1.2.0`
+- Version: `1.3.0`
 - Supported MCP: `kicad-mcp-pro >=3.5.2 <4.0.0`
 - Supported KiCad projects: KiCad 8.x, 9.x, and 10.x project, schematic, PCB, DRC, and jobset files
 
@@ -68,7 +68,7 @@ corepack pnpm --filter kicadstudiokit run package
 
 ## MCP Compatibility
 
-KiCad Studio 1.2.0 supports `kicad-mcp-pro >=3.5.2 <4.0.0` and was tested against `3.5.2`. If a connected server reports a version outside the required range, MCP-dependent commands are disabled while KiCad-only features continue to work.
+KiCad Studio 1.3.0 supports `kicad-mcp-pro >=3.5.2 <4.0.0` and was tested against `3.5.2`. If a connected server reports a version outside the required range, MCP-dependent commands are disabled while KiCad-only features continue to work.
 
 ## Marketplace Listing Copy
 

--- a/apps/vscode-extension/docs/AI_PROVIDERS.md
+++ b/apps/vscode-extension/docs/AI_PROVIDERS.md
@@ -72,7 +72,7 @@ Use `kicadstudio.ai.language` to control the response language independently fro
 
 ## Language Model Tools
 
-KiCad Studio 1.0.0 targets VS Code `^1.122.0` for Language Model Tool and chat-provider contribution metadata. When `kicadstudio.ai.allowTools` is enabled and the host VS Code build exposes the API, KiCad Studio registers tools for:
+KiCad Studio 1.0.0 targets VS Code `^1.100.0` for Language Model Tool and chat-provider contribution metadata. When `kicadstudio.ai.allowTools` is enabled and the host VS Code build exposes the API, KiCad Studio registers tools for:
 
 - DRC
 - ERC

--- a/apps/vscode-extension/docs/CONTRIBUTING.md
+++ b/apps/vscode-extension/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Development Setup
 
-1. Install Node.js `24.14.1`, pnpm `11.3.0`, and VS Code 1.122+.
+1. Install Node.js `24.14.1`, pnpm `11.3.0`, and VS Code 1.100+.
 2. Run `pnpm install --frozen-lockfile`.
 3. Press `F5` to launch the Extension Development Host.
 4. Let the Git hooks handle fast staged checks on commit and run `pnpm run check` before push.

--- a/apps/vscode-extension/docs/KICAD10_MIGRATION.md
+++ b/apps/vscode-extension/docs/KICAD10_MIGRATION.md
@@ -13,7 +13,7 @@ KiCad 10 introduces workflow changes that matter to extension users:
 ## Recommended Upgrade Path
 
 1. Update your local KiCad installation to KiCad 10.
-2. Update VS Code to 1.122 or newer before installing KiCad Studio 1.0.0.
+2. Update VS Code to 1.100 or newer before installing KiCad Studio 1.0.0.
 3. Re-run `KiCad: Detect kicad-cli` so the extension refreshes CLI capability detection.
 4. Open the project in KiCad 10 once and save it before testing in VS Code.
 5. Confirm that your `.kicad_pro` contains the expected variant data if you plan to use the Variants sidebar.

--- a/apps/vscode-extension/docs/dependency-upgrade-notes.md
+++ b/apps/vscode-extension/docs/dependency-upgrade-notes.md
@@ -8,7 +8,7 @@ This monorepo uses Renovate as the dependency maintenance bot. Repository-local 
 - Renovate lock-file maintenance refreshes `pnpm-lock.yaml` on the weekly maintenance window. (Python MCP server lock files are managed in [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp).)
 - GitHub Action references remain pinned to immutable commit SHAs.
 - `@types/node` stays below `25` while the workspace runtime is Node 24.
-- `@types/vscode` stays aligned with `engines.vscode: ^1.122.0`.
+- `@types/vscode` stays aligned with `engines.vscode: ^1.100.0`.
 - Python dependency updates are applied through `pyproject.toml` plus `uv.lock`.
 
 ## Applied Updates
@@ -23,7 +23,7 @@ This monorepo uses Renovate as the dependency maintenance bot. Repository-local 
 | `prettier`                         | `3.8.3`   |
 | `typescript`                       | `5.9.3`   |
 | `@types/node`                      | `24.12.3` |
-| `@types/vscode`                    | `1.122.0` |
+| `@types/vscode`                    | `1.100.0` |
 | `webpack-cli`                      | `7.0.2`   |
 | `c8`                               | `11.0.0`  |
 | `lint-staged`                      | `17.0.4`  |

--- a/apps/vscode-extension/docs/repository-operations.md
+++ b/apps/vscode-extension/docs/repository-operations.md
@@ -80,7 +80,7 @@ Renovate is the only dependency update bot for this repository. It covers npm, G
 Major runtime-aligned dependencies are constrained until the supported runtime changes:
 
 - `@types/node` remains below `25` while Node 24 is the supported runtime.
-- `@types/vscode` remains aligned with `engines.vscode: ^1.122.0`.
+- `@types/vscode` remains aligned with `engines.vscode: ^1.100.0`.
 
 ## Review Thread Control
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -5,7 +5,7 @@
   "version": "1.3.0",
   "publisher": "oaslananka",
   "engines": {
-    "vscode": "^1.122.0",
+    "vscode": "^1.100.0",
     "node": "24.x"
   },
   "packageManager": "pnpm@11.5.0",
@@ -2500,7 +2500,7 @@
     "@types/jest": "30.0.0",
     "@types/mocha": "10.0.10",
     "@types/node": "24.12.3",
-    "@types/vscode": "1.120.0",
+    "@types/vscode": "1.100.0",
     "@typescript-eslint/eslint-plugin": "8.59.2",
     "@typescript-eslint/parser": "8.59.2",
     "@vscode/test-electron": "2.5.2",

--- a/apps/vscode-extension/scripts/validate-package.js
+++ b/apps/vscode-extension/scripts/validate-package.js
@@ -83,7 +83,7 @@ function validateStaticMetadata({ root, repoRoot, pkg, fail }) {
     fail
   );
   check(
-    pkg.engines?.vscode === '^1.122.0',
+    pkg.engines?.vscode === '^1.100.0',
     'VS Code engine drifted unexpectedly',
     fail
   );

--- a/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
@@ -18,6 +18,7 @@ type McpToolsNode = {
   contextValue?: string | undefined;
   command?: vscode.Command | undefined;
   children?: McpToolsNode[] | undefined;
+  collapsedByDefault?: boolean | undefined;
 };
 
 type DashboardStatus =
@@ -137,7 +138,7 @@ export class McpToolsProvider implements vscode.TreeDataProvider<McpToolsNode> {
     }
 
     const cmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-    
+
     // First, run npx boardreadyops doctor --format json to get installation, version, and health status
     const runDoctor = (): Promise<{ stdout: string; stderr: string }> => {
       return new Promise((resolve, reject) => {
@@ -178,7 +179,7 @@ export class McpToolsProvider implements vscode.TreeDataProvider<McpToolsNode> {
       const { stdout: docStdout } = await runDoctor();
       const doc = JSON.parse(docStdout.trim());
       const version = doc.tool?.version ?? 'unknown';
-      
+
       let healthy = true;
       let message = 'BoardReadyOps is healthy.';
       if (Array.isArray(doc.checks)) {
@@ -187,7 +188,8 @@ export class McpToolsProvider implements vscode.TreeDataProvider<McpToolsNode> {
             for (const item of check.items) {
               if (item.severity === 'fail') {
                 healthy = false;
-                message = item.message || 'BoardReadyOps environment check failed.';
+                message =
+                  item.message || 'BoardReadyOps environment check failed.';
                 break;
               }
             }
@@ -262,12 +264,15 @@ export class McpToolsProvider implements vscode.TreeDataProvider<McpToolsNode> {
   }
 
   getTreeItem(element: McpToolsNode): vscode.TreeItem {
-    const item = new vscode.TreeItem(
-      element.label,
-      element.children?.length
-        ? vscode.TreeItemCollapsibleState.Expanded
-        : vscode.TreeItemCollapsibleState.None
-    );
+    let collapsibleState: vscode.TreeItemCollapsibleState;
+    if (!element.children?.length) {
+      collapsibleState = vscode.TreeItemCollapsibleState.None;
+    } else if (element.collapsedByDefault) {
+      collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+    } else {
+      collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+    }
+    const item = new vscode.TreeItem(element.label, collapsibleState);
     if (element.description !== undefined) {
       item.description = element.description;
     }
@@ -477,12 +482,13 @@ function compatibilityDashboardNode(
       `State: ${dashboard.stateLabel}`,
       `Server: ${dashboard.serverName} ${dashboard.serverVersion}`,
       `Transport: ${dashboard.transportMode}`,
-      `Missing required tools: ${dashboard.missingRequiredTools.length}`,
-      `Missing optional capabilities: ${dashboard.missingOptionalCapabilities.length}`,
+      `Unavailable tools: ${dashboard.missingRequiredTools.length}`,
+      `Unavailable capabilities: ${dashboard.missingOptionalCapabilities.length}`,
       `Last health check: ${dashboard.lastHealthCheck}`,
       `Remediation: ${dashboard.remediation}`
     ].join('\n'),
     icon: dashboardIcon(dashboard.status),
+    collapsedByDefault: dashboard.status !== 'incompatible',
     children: [
       dashboardField(
         'Compatibility state',
@@ -513,15 +519,17 @@ function compatibilityDashboardNode(
           countText(dashboard.resourceCount)
         ),
         dashboardField('Advertised prompts', countText(dashboard.promptCount)),
-        missingGroup(
-          'Missing required tools',
+        unavailableGroup(
+          'Unavailable tools',
           dashboard.missingRequiredTools,
-          'All required extension tools are advertised.'
+          'All required extension tools are advertised.',
+          'Connect to a kicad-mcp-pro server that advertises this tool.'
         ),
-        missingGroup(
-          'Missing optional capabilities',
+        unavailableGroup(
+          'Unavailable capabilities',
           dashboard.missingOptionalCapabilities,
-          'All optional capabilities are available.'
+          'All optional capabilities are available.',
+          'Launch KiCad with the target project or upgrade kicad-mcp-pro.'
         )
       ]),
       dashboardGroup('Health and remediation', [
@@ -542,20 +550,19 @@ function stateNode(
     const fileBackedDegraded =
       dashboard.fileBackedReadAvailable && dashboard.liveContextUnavailable;
     const degradedReason = dashboard.stateLabel.includes('context unavailable')
-      ? 'live KiCad context unavailable'
-      : 'live KiCad IPC unavailable';
+      ? 'live context unavailable'
+      : 'live IPC unavailable';
     return {
-      label: fileBackedDegraded
-        ? 'MCP connected; file-backed read-only features active'
-        : state.connected || state.kind === 'VsCodeStdio'
-          ? 'MCP connected with degraded capabilities'
-          : 'MCP degraded',
+      label: 'MCP Degraded',
       description: fileBackedDegraded
-        ? degradedReason
+        ? '📄 file-backed'
         : dashboard.serverVersion,
-      tooltip: fileBackedDegraded
-        ? `${sentenceCase(degradedReason)}; file-backed read-only features active.`
-        : dashboard.remediation,
+      tooltip: [
+        dashboard.stateLabel,
+        fileBackedDegraded
+          ? `${sentenceCase(degradedReason)}; file-backed read-only features active.`
+          : dashboard.remediation
+      ].join('\n'),
       icon: 'warning',
       command: {
         command: COMMANDS.retryMcp,
@@ -565,10 +572,10 @@ function stateNode(
   }
   if (state.kind === 'Incompatible') {
     return {
-      label: 'MCP incompatible',
+      label: 'MCP Incompatible',
       description: dashboard.serverVersion,
       tooltip:
-        'The detected kicad-mcp-pro version is outside the extension compatibility range.',
+        'The detected kicad-mcp-pro version is outside the extension compatibility range. Update kicad-mcp-pro to a compatible version.',
       icon: 'warning',
       command: {
         command: COMMANDS.openMcpUpgradeGuide,
@@ -578,8 +585,8 @@ function stateNode(
   }
   if (state.connected || state.kind === 'VsCodeStdio') {
     return {
-      label: 'MCP connected',
-      description: state.kind === 'VsCodeStdio' ? 'VS Code stdio' : 'HTTP',
+      label: 'MCP Connected',
+      description: state.kind === 'VsCodeStdio' ? 'stdio' : 'HTTP',
       tooltip:
         state.kind === 'VsCodeStdio'
           ? 'Connected through .vscode/mcp.json. HTTP-only Quality Gates and Fix Queue are unavailable in this transport.'
@@ -589,7 +596,7 @@ function stateNode(
   }
   if (state.kind === 'NotInstalled') {
     return {
-      label: 'MCP not installed',
+      label: 'MCP Not Installed',
       description: 'install required',
       icon: 'cloud-download',
       command: {
@@ -599,12 +606,14 @@ function stateNode(
     };
   }
   return {
-    label: dashboard.stateLabel,
-    description: state.available ? 'detected, not connected' : 'not detected',
-    tooltip:
+    label: 'MCP Disconnected',
+    description: state.available ? 'detected' : 'not detected',
+    tooltip: [
+      dashboard.stateLabel,
       dashboard.lastError === 'none'
         ? dashboard.remediation
-        : dashboard.lastError,
+        : dashboard.lastError
+    ].join('\n'),
     icon: state.available ? 'warning' : 'circle-slash',
     command: {
       command: state.available
@@ -630,42 +639,51 @@ function actionGroupNode(): McpToolsNode {
         'sync'
       ),
       actionNode(
-        'Refresh capabilities',
-        COMMANDS.retryMcp,
-        'Refresh server-info and advertised tools',
-        'refresh'
-      ),
-      actionNode('Open MCP log', COMMANDS.openMcpLog, 'Open MCP log', 'output'),
-      actionNode(
-        'Save diagnostic bundle',
-        COMMANDS.saveMcpLog,
-        'Save MCP diagnostic bundle',
-        'save'
-      ),
-      actionNode(
-        'Pick profile',
-        COMMANDS.pickMcpProfile,
-        'Pick MCP profile',
-        'settings'
-      ),
-      actionNode(
-        'Switch endpoint',
-        COMMANDS.setupMcpIntegration,
-        'Switch MCP endpoint or transport',
-        'plug'
-      ),
-      actionNode(
         'Launch local MCP server',
         COMMANDS.launchMcpHttp,
         'Launch local kicad-mcp-pro HTTP server',
         'server-process'
       ),
-      actionNode(
-        'Open compatibility docs',
-        COMMANDS.openMcpUpgradeGuide,
-        'Open MCP compatibility documentation',
-        'book'
-      )
+      actionNode('Open MCP log', COMMANDS.openMcpLog, 'Open MCP log', 'output'),
+      {
+        label: 'More actions',
+        description: '',
+        tooltip: 'Additional MCP setup and diagnostic actions.',
+        icon: 'ellipsis',
+        collapsedByDefault: true,
+        children: [
+          actionNode(
+            'Refresh capabilities',
+            COMMANDS.retryMcp,
+            'Refresh server-info and advertised tools',
+            'refresh'
+          ),
+          actionNode(
+            'Save diagnostic bundle',
+            COMMANDS.saveMcpLog,
+            'Save MCP diagnostic bundle',
+            'save'
+          ),
+          actionNode(
+            'Pick profile',
+            COMMANDS.pickMcpProfile,
+            'Pick MCP profile',
+            'settings'
+          ),
+          actionNode(
+            'Switch endpoint',
+            COMMANDS.setupMcpIntegration,
+            'Switch MCP endpoint or transport',
+            'plug'
+          ),
+          actionNode(
+            'Open compatibility docs',
+            COMMANDS.openMcpUpgradeGuide,
+            'Open MCP compatibility documentation',
+            'book'
+          )
+        ]
+      }
     ]
   };
 }
@@ -711,19 +729,23 @@ function dashboardField(
   };
 }
 
-function missingGroup(
+function unavailableGroup(
   label: string,
   values: string[],
-  emptyTooltip: string
+  emptyTooltip: string,
+  perItemHint: string
 ): McpToolsNode {
   return {
     label,
-    description: values.length ? `${values.length}` : 'none',
+    description: values.length ? `${values.length}` : '✓ none',
     tooltip: values.length ? values.join('\n') : emptyTooltip,
-    icon: values.length ? 'warning' : 'pass',
+    icon: values.length ? 'info' : 'pass',
+    collapsedByDefault: values.length === 0,
     children: values.map((value) => ({
       label: value,
-      icon: 'warning'
+      description: 'not connected',
+      tooltip: `${value} — ${perItemHint}`,
+      icon: 'info'
     }))
   };
 }
@@ -748,10 +770,11 @@ function capabilityNode(capabilities: McpCapabilityCard): McpToolsNode {
       ? `, ${diagnostics.length} diagnostic${diagnostics.length === 1 ? '' : 's'}`
       : ''
   }`;
+  // Operation modes kept here since it shows granular per-mode flags not in dashboard.
+  // KiCad runtime and diagnostics are already in the Compatibility Dashboard — avoid duplication.
   const details = capabilities.serverInfo
     ? [
         diagnosticsGroup(diagnostics),
-        kicadRuntimeNode(capabilities.serverInfo),
         operationModesNode(capabilities.serverInfo)
       ]
     : diagnostics.length
@@ -764,40 +787,13 @@ function capabilityNode(capabilities: McpCapabilityCard): McpToolsNode {
       ? diagnostics.join('\n')
       : 'Server-advertised MCP capability counts.',
     icon: 'symbol-namespace',
+    collapsedByDefault: true,
     children: [
       ...details,
       capabilityGroup('Tools', capabilities.tools),
       capabilityGroup('Resources', capabilities.resources),
       capabilityGroup('Prompts', capabilities.prompts)
     ]
-  };
-}
-
-function kicadRuntimeNode(
-  serverInfo: NonNullable<McpCapabilityCard['serverInfo']>
-): McpToolsNode {
-  const cliStatus = serverInfo.kicad.cliFound
-    ? (serverInfo.kicad.cliVersion ?? 'version unknown')
-    : 'CLI unavailable';
-  const fileBackedRead = hasFileBackedRead(serverInfo);
-  return {
-    label: 'KiCad runtime',
-    description: serverInfo.kicad.livePcbContext
-      ? 'live PCB'
-      : fileBackedRead
-        ? 'file-backed read available'
-        : 'degraded',
-    tooltip: [
-      `CLI: ${cliStatus}`,
-      `Path: ${serverInfo.kicad.cliPath}`,
-      `IPC: ${serverInfo.kicad.ipcAvailable ? 'available' : 'unavailable'}`,
-      `IPC version: ${serverInfo.kicad.ipcVersion ?? 'unknown'}`,
-      `IPC endpoint: ${serverInfo.kicad.ipcEndpointSource}`,
-      `Live PCB: ${serverInfo.kicad.livePcbContext ? 'available' : 'unavailable'}`,
-      `Live schematic: ${serverInfo.kicad.liveSchematicContext ? 'available' : 'unavailable'}`,
-      `File-backed read: ${fileBackedRead ? 'available' : 'unavailable'}`
-    ].join('\n'),
-    icon: serverInfo.kicad.livePcbContext ? 'circuit-board' : 'warning'
   };
 }
 
@@ -816,7 +812,7 @@ function operationModesNode(
       'Live PCB read',
       serverInfo.capabilities.livePcbRead,
       !serverInfo.capabilities.livePcbRead && fileBackedRead
-        ? 'unavailable; file-backed read available'
+        ? '✗ unavailable; 📄 file-backed read available'
         : undefined
     ),
     capabilityFlag('Live PCB write', serverInfo.capabilities.livePcbWrite),
@@ -839,10 +835,11 @@ function operationModesNode(
     tooltip: modes
       .map(
         (mode) =>
-          `${mode.label}: ${mode.description ?? (mode.enabled ? 'available' : 'unavailable')}`
+          `${mode.label}: ${mode.description ?? (mode.enabled ? '✓ available' : '✗ unavailable')}`
       )
       .join('\n'),
     icon: 'checklist',
+    collapsedByDefault: true,
     children: [
       {
         label: 'Active operating mode',
@@ -853,7 +850,7 @@ function operationModesNode(
       ...modes.map((mode) => ({
         label: mode.label,
         description:
-          mode.description ?? (mode.enabled ? 'available' : 'unavailable'),
+          mode.description ?? (mode.enabled ? '✓ available' : '✗ unavailable'),
         icon: mode.enabled ? 'pass' : 'circle-slash'
       }))
     ]
@@ -1123,64 +1120,120 @@ function isVersionDegraded(version: string): boolean {
   return false;
 }
 
-function boardReadyOpsNode(
-  status: {
-    installed: boolean;
-    version?: string;
-    healthy: boolean;
-    message?: string;
-    tools: string[];
-  }
-): McpToolsNode {
-  const enabled = vscode.workspace.getConfiguration().get<boolean>(SETTINGS.boardReadyOpsEnabled, false);
-  
+function boardReadyOpsNode(status: {
+  installed: boolean;
+  version?: string;
+  healthy: boolean;
+  message?: string;
+  tools: string[];
+}): McpToolsNode {
+  const enabled = vscode.workspace
+    .getConfiguration()
+    .get<boolean>(SETTINGS.boardReadyOpsEnabled, false);
+
   if (!status.installed) {
     return {
       label: 'BoardReadyOps',
       description: 'unavailable',
-      tooltip: status.message || 'BoardReadyOps CLI was not found. Install it to enable PCB preflight checks.',
+      tooltip:
+        status.message ||
+        'BoardReadyOps CLI was not found. Install it to enable PCB preflight checks.',
       icon: 'circle-slash',
+      collapsedByDefault: true,
       children: [
         dashboardField('CLI', 'not found', undefined, 'warning'),
-        actionNode('Configure Checks', COMMANDS.boardReadyOpsConfigure, 'Open BoardReadyOps extension settings', 'gear'),
-        actionNode('Open Documentation', COMMANDS.boardReadyOpsOpenDocs, 'Open BoardReadyOps documentation', 'book')
+        actionNode(
+          'Configure Checks',
+          COMMANDS.boardReadyOpsConfigure,
+          'Open BoardReadyOps extension settings',
+          'gear'
+        ),
+        actionNode(
+          'Open Documentation',
+          COMMANDS.boardReadyOpsOpenDocs,
+          'Open BoardReadyOps documentation',
+          'book'
+        )
       ]
     };
   }
 
   const isOld = isVersionDegraded(status.version ?? 'unknown');
   const healthy = status.healthy && !isOld;
-  const statusLabel = healthy ? 'healthy' : (isOld ? 'degraded (old version)' : 'degraded');
+  const statusLabel = healthy
+    ? 'healthy'
+    : isOld
+      ? 'degraded (old version)'
+      : 'degraded';
   const statusIcon = healthy ? 'pass' : 'warning';
-  
+
   const toolNodes = status.tools.map((tool) => ({
     label: tool,
-    description: healthy ? 'available' : 'degraded',
-    tooltip: `${tool} - BoardReadyOps rule check`,
+    description: healthy ? '✓ available' : 'degraded',
+    tooltip: `${tool} — BoardReadyOps rule check`,
     icon: healthy ? 'symbol-method' : 'warning'
   }));
 
   const children: McpToolsNode[] = [
-    dashboardField('CLI', `boardreadyops v${status.version}`, undefined, 'info'),
-    dashboardField('Health', statusLabel, status.message || (isOld ? 'Please upgrade BoardReadyOps to v1.2.0 or newer.' : undefined), statusIcon),
+    dashboardField(
+      'CLI',
+      `boardreadyops v${status.version}`,
+      undefined,
+      'info'
+    ),
+    dashboardField(
+      'Health',
+      statusLabel,
+      status.message ||
+        (isOld
+          ? 'Please upgrade BoardReadyOps to v1.2.0 or newer.'
+          : undefined),
+      statusIcon
+    ),
     {
       label: 'Advertised tools',
       description: `${status.tools.length}`,
       tooltip: 'BoardReadyOps preflight rules.',
       icon: 'list-tree',
+      collapsedByDefault: true,
       children: toolNodes
     },
-    actionNode('Check Board Readiness', COMMANDS.boardReadyOpsCheck, 'Run BoardReadyOps preflight checks on the active board', 'play'),
-    actionNode('Show Readiness Report', COMMANDS.boardReadyOpsShowReport, 'Show last BoardReadyOps run report', 'report'),
-    actionNode('Configure Checks', COMMANDS.boardReadyOpsConfigure, 'Open BoardReadyOps extension settings', 'gear'),
-    actionNode('Open Documentation', COMMANDS.boardReadyOpsOpenDocs, 'Open BoardReadyOps documentation', 'book')
+    actionNode(
+      'Check Board Readiness',
+      COMMANDS.boardReadyOpsCheck,
+      'Run BoardReadyOps preflight checks on the active board',
+      'play'
+    ),
+    actionNode(
+      'Show Readiness Report',
+      COMMANDS.boardReadyOpsShowReport,
+      'Show last BoardReadyOps run report',
+      'report'
+    ),
+    actionNode(
+      'Configure Checks',
+      COMMANDS.boardReadyOpsConfigure,
+      'Open BoardReadyOps extension settings',
+      'gear'
+    ),
+    actionNode(
+      'Open Documentation',
+      COMMANDS.boardReadyOpsOpenDocs,
+      'Open BoardReadyOps documentation',
+      'book'
+    )
   ];
 
   return {
     label: 'BoardReadyOps',
-    description: enabled ? (healthy ? `v${status.version}` : 'degraded') : 'disabled',
+    description: enabled
+      ? healthy
+        ? `v${status.version}`
+        : 'degraded'
+      : 'disabled',
     tooltip: `BoardReadyOps preflight checks: ${healthy ? 'active' : 'degraded'}`,
     icon: healthy ? 'verified' : 'warning',
+    collapsedByDefault: healthy,
     children
   };
 }

--- a/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
@@ -30,7 +30,7 @@ describe('McpToolsProvider', () => {
     const children = provider.getChildren();
 
     expect(children.map((item) => item.label)).toEqual([
-      'MCP connected with degraded capabilities',
+      'MCP Degraded',
       'Compatibility dashboard',
       'Actions',
       'Install',
@@ -74,26 +74,22 @@ describe('McpToolsProvider', () => {
       treeDescription(
         provider,
         provider.getChildren(advertisedSurface),
-        'Missing required tools'
+        'Unavailable tools'
       )
     ).toBe('6');
     expect(
       treeDescription(
         provider,
         provider.getChildren(advertisedSurface),
-        'Missing optional capabilities'
+        'Unavailable capabilities'
       )
-    ).toBe('none');
+    ).toBe('✓ none');
 
     expect(labels(provider.getChildren(child(children, 'Actions')))).toEqual([
       'Reconnect',
-      'Refresh capabilities',
-      'Open MCP log',
-      'Save diagnostic bundle',
-      'Pick profile',
-      'Switch endpoint',
       'Launch local MCP server',
-      'Open compatibility docs'
+      'Open MCP log',
+      'More actions'
     ]);
     expect(
       treeDescription(provider, children, 'Raw advertised capabilities')
@@ -129,9 +125,7 @@ describe('McpToolsProvider', () => {
     const dashboard = child(children, 'Compatibility dashboard');
     const runtime = child(provider.getChildren(dashboard), 'KiCad runtime');
 
-    expect(
-      child(children, 'MCP connected; file-backed read-only features active')
-    ).toBeDefined();
+    expect(child(children, 'MCP Degraded')).toBeDefined();
     expect(
       treeDescription(
         provider,
@@ -148,13 +142,6 @@ describe('McpToolsProvider', () => {
         'Live PCB context'
       )
     ).toBe('unavailable');
-    expect(
-      treeDescription(
-        provider,
-        provider.getChildren(child(children, 'Raw advertised capabilities')),
-        'KiCad runtime'
-      )
-    ).toBe('file-backed read available');
 
     const stdioProvider = providerForState({
       kind: 'VsCodeStdio',
@@ -174,9 +161,7 @@ describe('McpToolsProvider', () => {
       'Advertised surface'
     );
 
-    expect(
-      child(stdioChildren, 'MCP connected with degraded capabilities')
-    ).toBeDefined();
+    expect(child(stdioChildren, 'MCP Degraded')).toBeDefined();
     expect(
       treeDescription(
         stdioProvider,
@@ -188,7 +173,7 @@ describe('McpToolsProvider', () => {
       treeDescription(
         stdioProvider,
         stdioProvider.getChildren(stdioSurface),
-        'Missing optional capabilities'
+        'Unavailable capabilities'
       )
     ).toBe('3');
   });
@@ -271,7 +256,7 @@ describe('McpToolsProvider', () => {
 
     expect(flattenTree(provider)).toMatchInlineSnapshot(`
       [
-        "MCP connected with degraded capabilities :: 3.5.2",
+        "MCP Degraded :: 3.5.2",
         "Compatibility dashboard :: degraded",
         "Compatibility dashboard > Compatibility state :: Connected but degraded",
         "Compatibility dashboard > Server contract :: 8",
@@ -292,13 +277,13 @@ describe('McpToolsProvider', () => {
         "Compatibility dashboard > Advertised surface > Advertised tools :: 3",
         "Compatibility dashboard > Advertised surface > Advertised resources :: 1",
         "Compatibility dashboard > Advertised surface > Advertised prompts :: 1",
-        "Compatibility dashboard > Advertised surface > Missing required tools :: 3",
-        "Compatibility dashboard > Advertised surface > Missing required tools > project_get_design_intent ::",
-        "Compatibility dashboard > Advertised surface > Missing required tools > export_bom ::",
-        "Compatibility dashboard > Advertised surface > Missing required tools > export_netlist ::",
-        "Compatibility dashboard > Advertised surface > Missing optional capabilities :: 2",
-        "Compatibility dashboard > Advertised surface > Missing optional capabilities > stateless Streamable HTTP transport ::",
-        "Compatibility dashboard > Advertised surface > Missing optional capabilities > ChatGPT connector compatibility ::",
+        "Compatibility dashboard > Advertised surface > Unavailable tools :: 3",
+        "Compatibility dashboard > Advertised surface > Unavailable tools > project_get_design_intent :: not connected",
+        "Compatibility dashboard > Advertised surface > Unavailable tools > export_bom :: not connected",
+        "Compatibility dashboard > Advertised surface > Unavailable tools > export_netlist :: not connected",
+        "Compatibility dashboard > Advertised surface > Unavailable capabilities :: 2",
+        "Compatibility dashboard > Advertised surface > Unavailable capabilities > stateless Streamable HTTP transport :: not connected",
+        "Compatibility dashboard > Advertised surface > Unavailable capabilities > ChatGPT connector compatibility :: not connected",
         "Compatibility dashboard > Health and remediation :: 4",
         "Compatibility dashboard > Health and remediation > Last health check :: 2026-05-20T12:00:00.000Z",
         "Compatibility dashboard > Health and remediation > Last error :: none",
@@ -306,27 +291,27 @@ describe('McpToolsProvider', () => {
         "Compatibility dashboard > Health and remediation > Capability diagnostics :: none",
         "Actions :: MCP operations",
         "Actions > Reconnect ::",
-        "Actions > Refresh capabilities ::",
-        "Actions > Open MCP log ::",
-        "Actions > Save diagnostic bundle ::",
-        "Actions > Pick profile ::",
-        "Actions > Switch endpoint ::",
         "Actions > Launch local MCP server ::",
-        "Actions > Open compatibility docs ::",
+        "Actions > Open MCP log ::",
+        "Actions > More actions ::",
+        "Actions > More actions > Refresh capabilities ::",
+        "Actions > More actions > Save diagnostic bundle ::",
+        "Actions > More actions > Pick profile ::",
+        "Actions > More actions > Switch endpoint ::",
+        "Actions > More actions > Open compatibility docs ::",
         "Install :: uvx 3.5.2",
         "Raw advertised capabilities :: 3 tools, 1 resources, 1 prompts",
         "Raw advertised capabilities > Capability diagnostics :: none",
-        "Raw advertised capabilities > KiCad runtime :: live PCB",
         "Raw advertised capabilities > Operation modes :: readonly",
         "Raw advertised capabilities > Operation modes > Active operating mode :: readonly",
-        "Raw advertised capabilities > Operation modes > File-backed DRC :: available",
-        "Raw advertised capabilities > Operation modes > File-backed ERC :: available",
-        "Raw advertised capabilities > Operation modes > File-backed exports :: available",
-        "Raw advertised capabilities > Operation modes > Live PCB read :: available",
-        "Raw advertised capabilities > Operation modes > Live PCB write :: available",
-        "Raw advertised capabilities > Operation modes > Live schematic read :: available",
-        "Raw advertised capabilities > Operation modes > Live schematic write :: available",
-        "Raw advertised capabilities > Operation modes > ChatGPT connector :: unavailable",
+        "Raw advertised capabilities > Operation modes > File-backed DRC :: ✓ available",
+        "Raw advertised capabilities > Operation modes > File-backed ERC :: ✓ available",
+        "Raw advertised capabilities > Operation modes > File-backed exports :: ✓ available",
+        "Raw advertised capabilities > Operation modes > Live PCB read :: ✓ available",
+        "Raw advertised capabilities > Operation modes > Live PCB write :: ✓ available",
+        "Raw advertised capabilities > Operation modes > Live schematic read :: ✓ available",
+        "Raw advertised capabilities > Operation modes > Live schematic write :: ✓ available",
+        "Raw advertised capabilities > Operation modes > ChatGPT connector :: ✗ unavailable",
         "Raw advertised capabilities > Tools :: 3",
         "Raw advertised capabilities > Tools > kicad_get_version ::",
         "Raw advertised capabilities > Tools > run_drc ::",
@@ -345,10 +330,11 @@ describe('McpToolsProvider', () => {
 
   describe('BoardReadyOps integration', () => {
     it('handles absent CLI state', () => {
-      const provider = providerForState(
-        connectedState({ tools: [] }),
-        { installed: false, healthy: false, message: 'Not found' }
-      );
+      const provider = providerForState(connectedState({ tools: [] }), {
+        installed: false,
+        healthy: false,
+        message: 'Not found'
+      });
       const children = provider.getChildren();
       const broNode = child(children, 'BoardReadyOps');
       const item = provider.getTreeItem(broNode);
@@ -361,17 +347,21 @@ describe('McpToolsProvider', () => {
         'Configure Checks',
         'Open Documentation'
       ]);
-      expect(provider.getTreeItem(child(broChildren, 'CLI')).description).toBe('not found');
+      expect(provider.getTreeItem(child(broChildren, 'CLI')).description).toBe(
+        'not found'
+      );
     });
 
     it('handles disabled state', () => {
       __setConfiguration({
         'kicadstudio.boardReadyOps.enabled': false
       });
-      const provider = providerForState(
-        connectedState({ tools: [] }),
-        { installed: true, version: '1.2.3', healthy: true, tools: ['bom.missing-mpn'] }
-      );
+      const provider = providerForState(connectedState({ tools: [] }), {
+        installed: true,
+        version: '1.2.3',
+        healthy: true,
+        tools: ['bom.missing-mpn']
+      });
       const children = provider.getChildren();
       const broNode = child(children, 'BoardReadyOps');
       const item = provider.getTreeItem(broNode);
@@ -383,10 +373,12 @@ describe('McpToolsProvider', () => {
       __setConfiguration({
         'kicadstudio.boardReadyOps.enabled': true
       });
-      const provider = providerForState(
-        connectedState({ tools: [] }),
-        { installed: true, version: '1.2.3', healthy: true, tools: ['bom.missing-mpn'] }
-      );
+      const provider = providerForState(connectedState({ tools: [] }), {
+        installed: true,
+        version: '1.2.3',
+        healthy: true,
+        tools: ['bom.missing-mpn']
+      });
       const children = provider.getChildren();
       const broNode = child(children, 'BoardReadyOps');
       const item = provider.getTreeItem(broNode);
@@ -403,21 +395,27 @@ describe('McpToolsProvider', () => {
         'Configure Checks',
         'Open Documentation'
       ]);
-      expect(provider.getTreeItem(child(broChildren, 'Health')).description).toBe('healthy');
-      
+      expect(
+        provider.getTreeItem(child(broChildren, 'Health')).description
+      ).toBe('healthy');
+
       const toolsNode = child(broChildren, 'Advertised tools');
       expect(provider.getTreeItem(toolsNode).description).toBe('1');
-      expect(labels(provider.getChildren(toolsNode))).toEqual(['bom.missing-mpn']);
+      expect(labels(provider.getChildren(toolsNode))).toEqual([
+        'bom.missing-mpn'
+      ]);
     });
 
     it('handles degraded state due to old version', () => {
       __setConfiguration({
         'kicadstudio.boardReadyOps.enabled': true
       });
-      const provider = providerForState(
-        connectedState({ tools: [] }),
-        { installed: true, version: '1.1.0', healthy: true, tools: ['bom.missing-mpn'] }
-      );
+      const provider = providerForState(connectedState({ tools: [] }), {
+        installed: true,
+        version: '1.1.0',
+        healthy: true,
+        tools: ['bom.missing-mpn']
+      });
       const children = provider.getChildren();
       const broNode = child(children, 'BoardReadyOps');
       const item = provider.getTreeItem(broNode);
@@ -433,10 +431,13 @@ describe('McpToolsProvider', () => {
       __setConfiguration({
         'kicadstudio.boardReadyOps.enabled': true
       });
-      const provider = providerForState(
-        connectedState({ tools: [] }),
-        { installed: true, version: '1.2.3', healthy: false, message: 'Doctor failed', tools: ['bom.missing-mpn'] }
-      );
+      const provider = providerForState(connectedState({ tools: [] }), {
+        installed: true,
+        version: '1.2.3',
+        healthy: false,
+        message: 'Doctor failed',
+        tools: ['bom.missing-mpn']
+      });
       const children = provider.getChildren();
       const broNode = child(children, 'BoardReadyOps');
       const item = provider.getTreeItem(broNode);
@@ -452,7 +453,9 @@ describe('McpToolsProvider', () => {
 
 function providerForState(
   state: McpConnectionState,
-  broStatusOverride: Partial<McpToolsProvider['broStatus']> = { installed: false }
+  broStatusOverride: Partial<McpToolsProvider['broStatus']> = {
+    installed: false
+  }
 ): McpToolsProvider {
   return new McpToolsProvider(
     { getState: () => state } as never,

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -463,8 +463,8 @@ kicadIpcReadiness:
         evidence: []
 
 vscode:
-  minimum: "1.122.0"
-  enginesRange: "^1.122.0"
+  minimum: "1.100.0"
+  enginesRange: "^1.100.0"
   stable: "current"
   insiders: "current"
   nodeRuntime: "24.x"

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -7,4 +7,4 @@ documentation site always follows the same release history as the repository.
 | --- | ---: | --- |
 | Monorepo | `1.0.0` | [Root changelog](root.md) |
 | KiCad Studio extension | `1.3.0` | [Extension changelog](kicad-studio.md) |
-| kicad-mcp-pro Python server | `unknown` | [MCP server changelog](kicad-mcp-pro.md) |
+| kicad-mcp-pro Python server | `3.5.2` | [MCP server changelog](kicad-mcp-pro.md) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ This guide walks you through your first KiCad Studio experience. It takes about 
 
 ## 1. Install VS Code and the Extension
 
-1. Install [VS Code](https://code.visualstudio.com/) (1.122.0 or later).
+1. Install [VS Code](https://code.visualstudio.com/) (1.100.0 or later).
 2. Open VS Code, go to the **Extensions** view (`Ctrl+Shift+X`).
 3. Search for **KiCad Studio Kit** and click **Install**.
 4. After installation, the KiCad Studio icon appears in the Activity Bar.

--- a/docs/mcp/api-reference.md
+++ b/docs/mcp/api-reference.md
@@ -10,7 +10,7 @@ and `compatibility.yaml`. Refresh with `corepack pnpm run docs:generate`.
 | MCP protocol version | `2025-11-25` |
 | Tool schema version | `1.0` |
 | Registry schema version | `2025-12-11` |
-| Server package version | `unknown` |
+| Server package version | `3.5.2` |
 
 ## Server Info Fields
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -15,7 +15,7 @@ Machine-maintained from `compatibility.yaml`. Refresh with
 | --- | --- |
 | KiCad primary | `10.0.x` |
 | KiCad latest verified | `10.0.3` |
-| VS Code minimum | `1.122.0` |
+| VS Code minimum | `1.100.0` |
 | Node | `>=24.11.0 <25` |
 | pnpm | `>=11.0.0 <12` |
 | Python | `>=3.13` |
@@ -155,7 +155,7 @@ Freshness sources checked on 2026-05-27:
 | Surface      | Primary    | Supported              | Deprecated | Gate                                     |
 | ------------ | ---------- | ---------------------- | ---------- | ---------------------------------------- |
 | KiCad        | 10.0.x     | none                   | 9.x, 8.x   | `compatibility.yaml` + release preflight |
-| VS Code      | current    | `engines.vscode` 1.122 | none       | extension manifest + VS Code canary      |
+| VS Code      | current    | `engines.vscode` 1.100 | none       | extension manifest + VS Code canary      |
 | MCP protocol | 2025-11-25 | 2025-11-25             | older      | well-known server card + matrix          |
 | Node         | 24.x       | `>=24.11.0 <25`        | older      | root and extension package metadata      |
 | pnpm         | 11.x       | `>=11.0.0 <12`         | older      | root package metadata                    |

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -7,8 +7,8 @@ Refresh with `corepack pnpm run docs:generate`.
 | --- | --- |
 | Monorepo baseline | `1.0.0` |
 | KiCad Studio extension | `1.3.0` |
-| kicad-mcp-pro Python server | `unknown` |
-| VS Code engine | `^1.122.0` |
+| kicad-mcp-pro Python server | `3.5.2` |
+| VS Code engine | `^1.100.0` |
 | Node | `>=24.11.0 <25` |
 | pnpm | `>=11.0.0 <12` |
 | Python | `>=3.13` |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
         specifier: 24.12.3
         version: 24.12.3
       '@types/vscode':
-        specifier: 1.120.0
-        version: 1.120.0
+        specifier: 1.100.0
+        version: 1.100.0
       '@typescript-eslint/eslint-plugin':
         specifier: 8.59.2
         version: 8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
@@ -1714,8 +1714,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/vscode@1.120.0':
-    resolution: {integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==}
+  '@types/vscode@1.100.0':
+    resolution: {integrity: sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
@@ -6968,7 +6968,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/vscode@1.120.0': {}
+  '@types/vscode@1.100.0': {}
 
   '@types/web-bluetooth@0.0.21': {}
 

--- a/scripts/generate-docs-site.mjs
+++ b/scripts/generate-docs-site.mjs
@@ -89,10 +89,11 @@ function renderEnum(schema) {
 function productVersions() {
   const root = readJson("package.json");
   const extension = readJson("apps/vscode-extension/package.json");
+  const compatibility = readYaml("compatibility.yaml");
   return {
     root: root.version,
     extension: extension.version,
-    mcpServer: "unknown",
+    mcpServer: compatibility.products["kicad-studio"]?.compatibleMcpPro?.testedAgainst ?? "unknown",
   };
 }
 


### PR DESCRIPTION
This PR downgrades the VS Code engine requirement to 1.100.0 and refactors the MCP & Tools sidebar for a better, less cluttered UX. It dynamically expands nodes under degradation/error and resolves version drift checks.