### PR TITLE
ci(repo): harden workflow permissions and release gates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,11 +10,13 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     strategy:

--- a/.github/workflows/cross-repo-compatibility.yml
+++ b/.github/workflows/cross-repo-compatibility.yml
@@ -35,6 +35,9 @@ on:
       - apps/vscode-extension/**
       - .github/workflows/cross-repo-compatibility.yml
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,9 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 concurrency:
   group: release-please-${{ github.ref }}
@@ -18,6 +16,10 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     environment: release
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         with:

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -9,7 +9,7 @@ KiCad Studio turns VS Code into a focused KiCad workspace for project navigation
 Canonical repository: https://github.com/oaslananka/kicad-studio-kit/tree/main/apps/vscode-extension
 
 - Extension ID: `oaslananka.kicadstudiokit`
-- Version: `1.3.0`
+- Version: `1.4.0`
 - Supported MCP: `kicad-mcp-pro >=3.5.2 <4.0.0`
 - Supported KiCad projects: KiCad 8.x, 9.x, and 10.x project, schematic, PCB, DRC, and jobset files
 
@@ -68,7 +68,7 @@ corepack pnpm --filter kicadstudiokit run package
 
 ## MCP Compatibility
 
-KiCad Studio 1.3.0 supports `kicad-mcp-pro >=3.5.2 <4.0.0` and was tested against `3.5.2`. If a connected server reports a version outside the required range, MCP-dependent commands are disabled while KiCad-only features continue to work.
+KiCad Studio 1.4.0 supports `kicad-mcp-pro >=3.5.2 <4.0.0` and was tested against `3.5.2`. If a connected server reports a version outside the required range, MCP-dependent commands are disabled while KiCad-only features continue to work.
 
 ## Marketplace Listing Copy
 

--- a/apps/vscode-extension/scripts/check-marketplace-assets.js
+++ b/apps/vscode-extension/scripts/check-marketplace-assets.js
@@ -239,11 +239,7 @@ function assertMarketplaceMarkdown() {
   ]) {
     assertMarkdownSection(readme, 'README.md', heading);
   }
-  for (const heading of [
-    'Manual Review Checklist',
-    'English Listing Copy',
-    'Turkish Listing Copy'
-  ]) {
+  for (const heading of ['Manual Review Checklist', 'English Listing Copy']) {
     assertMarkdownSection(listing, 'docs/marketplace-listing.md', heading);
   }
   if (/<details|<summary|<script|<style|<iframe/iu.test(readme)) {

--- a/scripts/check-beta-program.test.mjs
+++ b/scripts/check-beta-program.test.mjs
@@ -4,7 +4,7 @@ import { createBetaProgramChecks } from "./lib/beta-program-checks.mjs";
 
 test("beta program documentation and intake surfaces are wired", () => {
   const checks = createBetaProgramChecks();
-  assert.equal(checks.length, 28);
+  assert.equal(checks.length, 27);
   assert.deepEqual(
     checks.filter((item) => !item.ok),
     [],


### PR DESCRIPTION
## Problem
Scorecard reported workflow token-permission gaps, and the local pre-push gate exposed two stale post-release checks on main.

## Solution
- Scope Release Please and CodeQL write permissions to the jobs that need them.
- Add explicit read-only permissions to the cross-repo compatibility workflow.
- Align the beta-program regression test count with the English-only localization cleanup.
- Align the extension marketplace README and validator with the 1.4.0 English-only release state.

Fixes #318
Fixes #319
Fixes #320

## Verification
- `corepack pnpm run check:ci-lanes`
- `corepack pnpm --filter kicadstudiokit run workflows:lint`
- `corepack pnpm --filter kicadstudiokit run format:check`
- `yamllint .github/workflows .github/actionlint.yaml .github/labeler.yml .github/labels.yml .github/rulesets/main.json .pre-commit-config.yaml .repo-health.yaml .yamllint.yml`
- `corepack pnpm run check:repo-governance`
- `corepack pnpm run check:forbidden-refs`
- `corepack pnpm run check:supply-chain`
- `corepack pnpm run check:beta-program`
- `corepack pnpm --filter kicadstudiokit run marketplace:check`
- `pre-commit run --all-files`
- `corepack pnpm run check`