### PR TITLE
fix(repo): pin devcontainer base image digest for Scorecard compliance

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM mcr.microsoft.com/devcontainers/python:3.13-bookworm
+FROM mcr.microsoft.com/devcontainers/python:3.13-bookworm@sha256:bf253e8b9200ad2c159015e87b63dc68a7d185e89cd5a9a1fa9d0d4f4ba6ad76
 
 ARG ACTIONLINT_VERSION=1.7.12
 ARG UV_VERSION=0.11.16

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -6,5 +6,5 @@ documentation site always follows the same release history as the repository.
 | Product | Version | Changelog |
 | --- | ---: | --- |
 | Monorepo | `1.0.0` | [Root changelog](root.md) |
-| KiCad Studio extension | `1.5.0` | [Extension changelog](kicad-studio.md) |
+| KiCad Studio extension | `1.6.0` | [Extension changelog](kicad-studio.md) |
 | kicad-mcp-pro Python server | `3.5.2` | [MCP server changelog](kicad-mcp-pro.md) |

--- a/docs/changelog/kicad-studio.md
+++ b/docs/changelog/kicad-studio.md
@@ -12,6 +12,18 @@ and this extension adheres to
 Comparison links will be added after the first public component tags are
 published.
 
+## [1.6.0](https://github.com/oaslananka/kicad-studio-kit/compare/vscode-extension-v1.5.0...vscode-extension-v1.6.0) (2026-06-07)
+
+
+### Features
+
+* **kicad-studio:** complete prompt spec - Phase A-E, screenshots, manifest, CI gates, security hardening ([a43e305](https://github.com/oaslananka/kicad-studio-kit/commit/a43e30505ca8151c312cf4047396a0d1e796fe93))
+
+
+### Bug Fixes
+
+* **kicad-studio:** address 6 Gemini code review issues ([aed0572](https://github.com/oaslananka/kicad-studio-kit/commit/aed0572453c3cdcb9223742ebbb97cd8df6b6d47))
+
 ## [1.5.0](https://github.com/oaslananka/kicad-studio-kit/compare/vscode-extension-v1.4.1...vscode-extension-v1.5.0) (2026-06-06)
 
 ### Features

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -11,7 +11,7 @@ The container follows the repository support matrix:
 | ----------------- | ----------------------------------------------------------------------------------------------- |
 | Node 24           | official `ghcr.io/devcontainers/features/node:1` feature with `version: "24"`                   |
 | pnpm 11           | root `packageManager` through Corepack, with the Node feature not installing a global pnpm      |
-| Python 3.13       | official `mcr.microsoft.com/devcontainers/python:3.13-bookworm` base image                      |
+| Python 3.13       | official `mcr.microsoft.com/devcontainers/python:3.13-bookworm@sha256:bf253e8b9200ad2c159015e87b63dc68a7d185e89cd5a9a1fa9d0d4f4ba6ad76` base image |
 | uv 0.11.16        | pinned Python package install, matching the MCP container policy                                |
 | actionlint 1.7.12 | pinned upstream release archive with SHA-256 verification                                       |
 | shellcheck        | Debian package                                                                                  |

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -6,7 +6,7 @@ Refresh with `corepack pnpm run docs:generate`.
 | Surface | Version or range |
 | --- | --- |
 | Monorepo baseline | `1.0.0` |
-| KiCad Studio extension | `1.5.0` |
+| KiCad Studio extension | `1.6.0` |
 | kicad-mcp-pro Python server | `3.5.2` |
 | VS Code engine | `^1.100.0` |
 | Node | `>=24.11.0 <25` |

--- a/scripts/check-devcontainer.mjs
+++ b/scripts/check-devcontainer.mjs
@@ -156,7 +156,7 @@ export function validateDevcontainerRepository(repoRoot = DEFAULT_REPO_ROOT) {
   requireExecutable(errors, repoRoot, ".devcontainer/postCreateCommand.sh");
 
   for (const phrase of [
-    "FROM mcr.microsoft.com/devcontainers/python:3.13-bookworm",
+    "FROM mcr.microsoft.com/devcontainers/python:3.13-bookworm@sha256:",
     "ARG ACTIONLINT_VERSION=1.7.12",
     "ARG UV_VERSION=0.11.16",
     "shellcheck",


### PR DESCRIPTION
## Summary

Pins the devcontainer base image \mcr.microsoft.com/devcontainers/python:3.13-bookworm\ by its multi-arch SHA-256 digest to satisfy the Scorecard/DCI pinning requirement (Scorecard alert #14).

## Changes

- \.devcontainer/Dockerfile\: \FROM\ now uses \@sha256:bf253e8b...\
- \docs/devcontainer.md\: updated Python 3.13 row to show pinned digest
- \scripts/check-devcontainer.mjs\: updated \FROM\ string check to accept \@sha256:\ suffix

## Verification

- \pnpm run check:devcontainer\ passes (7/7)