### PR TITLE
chore(kicad-studio): add CI gate job, fix release-please script, enable branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,3 +280,43 @@ jobs:
       - run: corepack enable
       - run: corepack pnpm install --frozen-lockfile
       - run: corepack pnpm run check:forbidden-refs
+
+  required:
+    if: ${{ !cancelled() }}
+    needs:
+      - ci-lanes
+      - metadata
+      - forbidden-refs
+      - shared-packages
+      - vscode-extension
+      - performance-budgets
+      - real-pair-compatibility
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Job result summary
+        shell: bash
+        run: |
+          echo "| Job | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| ci-lanes | ${{ needs.ci-lanes.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| metadata | ${{ needs.metadata.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| forbidden-refs | ${{ needs.forbidden-refs.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| shared-packages | ${{ needs.shared-packages.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| vscode-extension | ${{ needs.vscode-extension.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| performance-budgets | ${{ needs.performance-budgets.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| real-pair-compatibility | ${{ needs.real-pair-compatibility.result }} |" >> $GITHUB_STEP_SUMMARY
+      - name: Fail on critical job failure
+        if: >
+          ${{
+               needs.ci-lanes.result == 'failure'
+            || needs.metadata.result == 'failure'
+            || needs.forbidden-refs.result == 'failure'
+            || needs.shared-packages.result == 'failure'
+            || needs.vscode-extension.result == 'failure'
+            || needs.performance-budgets.result == 'failure'
+            || needs.real-pair-compatibility.result == 'failure'
+          }}
+        shell: bash
+        run: |
+          echo "::error::One or more required CI jobs failed"
+          exit 1

--- a/scripts/check-release-please-monorepo.mjs
+++ b/scripts/check-release-please-monorepo.mjs
@@ -500,7 +500,14 @@ function gitCommitExists(repoRoot, sha) {
 }
 
 function listLocalBranchCommits(repoRoot) {
-  const mergeBase = git(repoRoot, ["merge-base", "HEAD", "origin/main"]);
+  const mergeBase = git(
+    repoRoot,
+    ["merge-base", "HEAD", "origin/main"],
+    { allowFailure: true },
+  );
+  if (!mergeBase) {
+    return [];
+  }
   return listCommits(repoRoot, `${mergeBase.trim()}..HEAD`);
 }
 


### PR DESCRIPTION
## Summary

Three infrastructure improvements:

1. **Add equired gate job to CI workflow** — A final job that depends on all critical CI jobs (ci-lanes, metadata, shared-packages, vscode-extension, etc.) and fails if any of them failed. This serves as the single required status check in branch protection, avoiding per-job path-filtering issues.

2. **Fix check-release-please-monorepo.mjs for release-please branches** — The listLocalBranchCommits function called git merge-base HEAD origin/main, which crashes on release-please branches triggered via workflow_dispatch because origin/main ref doesn't exist in the shallow clone. Now returns empty array gracefully when origin/main is unreachable.

3. **Enable branch protection on main**:
   - Required checks: equired (gate job), metadata (always runs)
   - Required 1 approving PR review with stale review dismissal
   - Enforce for admins
   - Disable force pushes and branch deletions

## Type of change

- [x] type:chore

## Test evidence

- Pre-push hooks pass: Release Please monorepo policy is valid. (tests 12/12 pass)
- Branch protection confirmed via API: {checks: [{context:"required"},{context:"metadata"}], enforce_admins: true, force_pushes: false, deletions: false, reviews: 1}

## Protocol / MCP impact

- [x] Not applicable; reason: CI workflow and branch protection changes only, no protocol or MCP surface affected.

## Automation evidence

- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally (pre-push hooks passed except pre-existing test-harness DLL init issue unrelated to this change)