### PR TITLE
docs(repo): regenerate changelog and versions after v1.6.2 release

### DIFF
--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -6,5 +6,5 @@ documentation site always follows the same release history as the repository.
 | Product | Version | Changelog |
 | --- | ---: | --- |
 | Monorepo | `1.0.0` | [Root changelog](root.md) |
-| KiCad Studio extension | `1.6.1` | [Extension changelog](kicad-studio.md) |
+| KiCad Studio extension | `1.6.2` | [Extension changelog](kicad-studio.md) |
 | kicad-mcp-pro Python server | `3.5.2` | [MCP server changelog](kicad-mcp-pro.md) |

--- a/docs/changelog/kicad-studio.md
+++ b/docs/changelog/kicad-studio.md
@@ -12,6 +12,13 @@ and this extension adheres to
 Comparison links will be added after the first public component tags are
 published.
 
+## [1.6.2](https://github.com/oaslananka/kicad-studio-kit/compare/vscode-extension-v1.6.1...vscode-extension-v1.6.2) (2026-06-09)
+
+
+### Bug Fixes
+
+* **kicad-studio:** declare mcpConfigurationProvider in enabledApiProposals ([#333](https://github.com/oaslananka/kicad-studio-kit/issues/333)) ([4f1018e](https://github.com/oaslananka/kicad-studio-kit/commit/4f1018ed3ac7592a0cc334b814c88b22ced42a1b))
+
 ## [1.6.1](https://github.com/oaslananka/kicad-studio-kit/compare/vscode-extension-v1.6.0...vscode-extension-v1.6.1) (2026-06-07)
 
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -6,7 +6,7 @@ Refresh with `corepack pnpm run docs:generate`.
 | Surface | Version or range |
 | --- | --- |
 | Monorepo baseline | `1.0.0` |
-| KiCad Studio extension | `1.6.1` |
+| KiCad Studio extension | `1.6.2` |
 | kicad-mcp-pro Python server | `3.5.2` |
 | VS Code engine | `^1.100.0` |
 | Node | `>=24.11.0 <25` |


### PR DESCRIPTION
Regenerate stale generated docs after v1.6.2 release commit.