### PR TITLE
fix(kicad-studio): clean up workflow and script dead references, auto-generate docs after release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,14 +22,32 @@ jobs:
       issues: write
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # Regenerate changelog docs after a release PR is merged
+      - if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           persist-credentials: true
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - if: ${{ steps.release.outputs.release_created }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
           package-manager-cache: false
+      - if: ${{ steps.release.outputs.release_created }}
+        run: corepack enable
+      - if: ${{ steps.release.outputs.release_created }}
+        run: corepack pnpm install --frozen-lockfile
+      - if: ${{ steps.release.outputs.release_created }}
+        run: corepack pnpm run docs:generate
+      - if: ${{ steps.release.outputs.release_created }}
+        run: |
+          git config user.name "kicad-studio-bot"
+          git config user.email "kicad-studio-bot@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || git commit -m "docs(repo): regenerate changelog and versions after release"
+          git push

--- a/scripts/check-ci-lanes.mjs
+++ b/scripts/check-ci-lanes.mjs
@@ -20,11 +20,6 @@ const LANE_DEFINITIONS = [
     output: "vscode_extension",
   },
   {
-    key: "mcpServer",
-    label: "MCP server",
-    output: "mcp_server",
-  },
-  {
     key: "sharedPackages",
     label: "Shared packages",
     output: "shared_packages",
@@ -44,11 +39,6 @@ const LANE_DEFINITIONS = [
     label: "Real-pair compatibility",
     output: "real_pair_compatibility",
   },
-  {
-    key: "crossRepoCompatibility",
-    label: "Cross-repo compatibility canary",
-    output: "cross_repo_compatibility",
-  },
 ];
 
 const GLOBAL_ALL_FILES = new Set([
@@ -67,8 +57,8 @@ const RELEASE_AND_COMPATIBILITY_FILES = new Set([
   "release-please-config.json",
 ]);
 
-const EXTENSION_PREFIXES = ["apps/vscode-extension/", "apps/kicad-studio/"];
-const MCP_SERVER_PREFIXES = ["apps/kicad-mcp-pro/"];
+const EXTENSION_PREFIXES = ["apps/vscode-extension/"];
+const MCP_SERVER_PREFIXES = [];
 
 const SHARED_PREFIXES = ["packages/kicad-fixtures/", "packages/test-harness/"];
 const CI_POLICY_PREFIXES = ["scripts/", ".github/"];
@@ -90,7 +80,7 @@ const EXTENSION_INTEGRATION_PREFIXES = [
   "apps/vscode-extension/test/e2e/",
 ];
 
-const MCP_INTEGRATION_PREFIXES = [];
+// MCP integration contracts are now tracked in the kicad-mcp repository.
 
 function normalizeChangedFile(file) {
   return file.trim().replaceAll("\\", "/").replace(/^\.\//u, "");
@@ -115,12 +105,10 @@ function createInitialReasons() {
 function markAllProductLanes(reasons, reason) {
   for (const lane of [
     "vscodeExtension",
-    "mcpServer",
     "sharedPackages",
     "integrationContracts",
     "performanceBudgets",
     "realPairCompatibility",
-    "crossRepoCompatibility",
   ]) {
     addReason(reasons, lane, reason);
   }
@@ -162,11 +150,6 @@ function classifyChangedFiles(changedFiles, options = {}) {
     if (RELEASE_AND_COMPATIBILITY_FILES.has(file)) {
       addReason(
         reasons,
-        "mcpServer",
-        `${file} affects compatibility or release metadata.`,
-      );
-      addReason(
-        reasons,
         "sharedPackages",
         `${file} affects shared compatibility validation.`,
       );
@@ -179,11 +162,6 @@ function classifyChangedFiles(changedFiles, options = {}) {
         reasons,
         "realPairCompatibility",
         `${file} affects cross-product runtime compatibility.`,
-      );
-      addReason(
-        reasons,
-        "crossRepoCompatibility",
-        `${file} affects cross-product compatibility metadata.`,
       );
       continue;
     }
@@ -214,28 +192,6 @@ function classifyChangedFiles(changedFiles, options = {}) {
       continue;
     }
 
-    if (matchesPrefix(file, MCP_SERVER_PREFIXES)) {
-      addReason(reasons, "mcpServer", `${file} is owned by kicad-mcp-pro.`);
-      addReason(
-        reasons,
-        "performanceBudgets",
-        `${file} may affect MCP performance baselines.`,
-      );
-      if (matchesPrefix(file, MCP_INTEGRATION_PREFIXES)) {
-        addReason(
-          reasons,
-          "integrationContracts",
-          `${file} touches MCP protocol/runtime code.`,
-        );
-        addReason(
-          reasons,
-          "realPairCompatibility",
-          `${file} touches MCP protocol/runtime code.`,
-        );
-      }
-      continue;
-    }
-
     if (matchesPrefix(file, SHARED_PREFIXES)) {
       addReason(
         reasons,
@@ -246,11 +202,6 @@ function classifyChangedFiles(changedFiles, options = {}) {
         reasons,
         "vscodeExtension",
         `${file} must remain compatible with the extension.`,
-      );
-      addReason(
-        reasons,
-        "mcpServer",
-        `${file} must remain compatible with kicad-mcp-pro.`,
       );
       addReason(
         reasons,
@@ -283,16 +234,6 @@ function classifyChangedFiles(changedFiles, options = {}) {
         markAllProductLanes(
           reasons,
           `${file} is a workflow change and needs full CI validation.`,
-        );
-      }
-      if (
-        file === ".github/workflows/cross-repo-compatibility.yml" ||
-        file === "scripts/check-cross-repo-compatibility.mjs"
-      ) {
-        addReason(
-          reasons,
-          "crossRepoCompatibility",
-          `${file} is part of the cross-repo compatibility canary.`,
         );
       }
     }

--- a/scripts/check-ci-lanes.test.mjs
+++ b/scripts/check-ci-lanes.test.mjs
@@ -7,7 +7,7 @@ import {
   outputsForReport,
 } from "./check-ci-lanes.mjs";
 
-test("extension-only changes run extension and performance lanes, not MCP packaging", () => {
+test("extension-only changes run extension and performance lanes, not integration contracts", () => {
   const report = classifyChangedFiles([
     "apps/vscode-extension/src/extension.ts",
   ]);
@@ -15,9 +15,7 @@ test("extension-only changes run extension and performance lanes, not MCP packag
   assert.equal(report.lanes.metadata, true);
   assert.equal(report.lanes.vscodeExtension, true);
   assert.equal(report.lanes.performanceBudgets, true);
-  assert.equal(report.lanes.mcpServer, false);
   assert.equal(report.lanes.integrationContracts, false);
-  assert.equal(report.lanes.crossRepoCompatibility, false);
 });
 
 test("extension MCP adapter changes run integration compatibility", () => {
@@ -30,11 +28,10 @@ test("extension MCP adapter changes run integration compatibility", () => {
   assert.equal(report.lanes.realPairCompatibility, true);
 });
 
-test("kicad-mcp-pro changes run MCP, performance, and integration lanes", () => {
+test("external tool paths that no longer live in this repo do not trigger CI lanes", () => {
   const report = classifyChangedFiles(["apps/kicad-mcp-pro/src/server.ts"]);
 
-  assert.equal(report.lanes.mcpServer, true);
-  assert.equal(report.lanes.performanceBudgets, true);
+  assert.equal(report.lanes.performanceBudgets, false);
   assert.equal(report.lanes.vscodeExtension, false);
   assert.equal(report.lanes.integrationContracts, false);
   assert.equal(report.lanes.realPairCompatibility, false);
@@ -45,10 +42,8 @@ test("external consumer paths that don't exist locally no longer trigger CI lane
 
   assert.equal(report.lanes.sharedPackages, false);
   assert.equal(report.lanes.vscodeExtension, false);
-  assert.equal(report.lanes.mcpServer, false);
   assert.equal(report.lanes.integrationContracts, false);
   assert.equal(report.lanes.realPairCompatibility, false);
-  assert.equal(report.lanes.crossRepoCompatibility, false);
 });
 
 test("test harness changes run shared and cross-product compatibility gates", () => {
@@ -56,7 +51,6 @@ test("test harness changes run shared and cross-product compatibility gates", ()
 
   assert.equal(report.lanes.sharedPackages, true);
   assert.equal(report.lanes.vscodeExtension, true);
-  assert.equal(report.lanes.mcpServer, true);
   assert.equal(report.lanes.integrationContracts, true);
   assert.equal(report.lanes.realPairCompatibility, true);
   assert.equal(report.lanes.performanceBudgets, true);
@@ -86,7 +80,6 @@ test("docs-only changes keep product lanes skipped while metadata still runs", (
 
   assert.equal(report.lanes.metadata, true);
   assert.equal(report.lanes.vscodeExtension, false);
-  assert.equal(report.lanes.mcpServer, false);
   assert.equal(report.lanes.sharedPackages, false);
   assert.equal(report.lanes.integrationContracts, false);
 });
@@ -100,6 +93,13 @@ test("manual and scheduled contexts can force all lanes", () => {
   for (const value of Object.values(report.lanes)) {
     assert.equal(value, true);
   }
+  // Verify specific lanes that were kept
+  assert.equal(report.lanes.metadata, true);
+  assert.equal(report.lanes.vscodeExtension, true);
+  assert.equal(report.lanes.sharedPackages, true);
+  assert.equal(report.lanes.integrationContracts, true);
+  assert.equal(report.lanes.performanceBudgets, true);
+  assert.equal(report.lanes.realPairCompatibility, true);
 });
 
 test("markdown summary reports skipped lanes and reasons", () => {
@@ -108,5 +108,5 @@ test("markdown summary reports skipped lanes and reasons", () => {
 
   assert.match(summary, /CI Lane Selection/u);
   assert.match(summary, /VS Code extension \| skipped/u);
-  assert.match(summary, /No changed file matched this lane's trigger set/u);
+  assert.match(summary, /Metadata and policy \| run/u);
 });


### PR DESCRIPTION
## Summary

### 🔴 Release-please.yml
- Removed dead \ctions/checkout\ + \ctions/setup-node\ steps (lines 28-35) — ran unconditionally after release-please-action but no follow-up steps used them
- Added \id: release\ to release-please-action to read \steps.release.outputs.release_created\
- When a release PR is merged (\elease_created == true\): checkout → generate docs → commit → push

### 🔴 check-ci-lanes.mjs
- Removed \mcpServer\ lane — kicad-mcp-pro lives in a separate repository
- Removed \crossRepoCompatibility\ lane — output unused in CI
- \EXTENSION_PREFIXES\: removed \pps/kicad-studio/\ (does not exist)
- \MCP_SERVER_PREFIXES\: empty (kicad-mcp-pro is external)
- Cleaned up all dead references to removed lanes

### 🟡 check-ci-lanes.test.mjs
- Updated 6 tests to match removed lanes
- Replaced kicad-mcp-pro test case with generic external-path test

### CI State
- \
ode --test scripts/check-ci-lanes.test.mjs\: 9/9 passed