### PR TITLE
fix(kicad-studio): trigger publish-extension after release

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -5,6 +5,12 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: >-
+          Git tag for the release to publish. When set, the workflow checks out
+          and publishes assets from that tag. Overrides the default ref.
+        type: string
+        required: false
       publish_vscode:
         description: Publish to Visual Studio Marketplace.
         type: boolean
@@ -52,12 +58,13 @@ jobs:
         shell: bash
         env:
           WORKFLOW_DISPATCH_PRERELEASE: ${{ inputs.publish_prerelease || false }}
+          WORKFLOW_DISPATCH_TAG: ${{ inputs.release_tag || '' }}
           RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
 
-          release_tag="${RELEASE_TAG_NAME:-${GITHUB_REF_NAME:-}}"
+          release_tag="${WORKFLOW_DISPATCH_TAG:-${RELEASE_TAG_NAME:-${GITHUB_REF_NAME:-}}}"
           is_prerelease="false"
           if [[ "${RELEASE_IS_PRERELEASE:-false}" == "true" || "${WORKFLOW_DISPATCH_PRERELEASE:-false}" == "true" || "$release_tag" == *"-beta."* ]]; then
             is_prerelease="true"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      actions: write
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         id: release
@@ -51,3 +52,16 @@ jobs:
           git add -A
           git diff --cached --quiet || git commit -m "docs(repo): regenerate changelog and versions after release"
           git push
+
+      # Trigger extension publish to marketplaces after release
+      - if: ${{ steps.release.outputs.release_created }}
+        name: Publish extension to marketplaces
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.release.outputs.tag_name }}"
+          echo "Triggering publish-extension workflow for tag ${tag}…"
+          gh workflow run publish-extension.yml \
+            --ref "${tag}" \
+            -f release_tag="${tag}"


### PR DESCRIPTION
## Problem

\elease-please-action\ creates releases using \GITHUB_TOKEN\. GitHub [intentionally blocks](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) workflow events triggered by \GITHUB_TOKEN\ from cascading to other workflows — so the \elease: [published]\ event never fired the \publish-extension.yml\ workflow.

Result: marketplace deployments (\xtension-marketplaces\) remain permanently inactive after every release.

## Changes

### \.github/workflows/release-please.yml\
- Added \ctions: write\ permission to the release job (required for \gh workflow run\)
- Added conditional step that runs \gh workflow run publish-extension.yml\ when \steps.release.outputs.release_created == 'true'\ — called with the correct release tag via \--ref\ and \-f release_tag=\

### \.github/workflows/publish-extension.yml\
- Added \elease_tag\ workflow_dispatch input (string, optional) so callers can explicitly specify which tag to publish
- Updated \elease_tag\ resolution in the release-policy step: prefers explicit input first, then release event tag name, then \GITHUB_REF_NAME\ fallback

## Next release behavior

1. Release PR merged → release-please-action creates tag and GitHub Release
2. \docs:generate\ regenerates changelog docs and commits
3. \gh workflow run publish-extension.yml\ triggers publish with correct tag
4. Publish workflow checks out the tag, builds, packages, and publishes to VS Code Marketplace + Open VSX