### PR TITLE
fix(kicad-studio): add --allow-all-proposed-apis to vsce publish command

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -187,6 +187,11 @@ jobs:
             publish_args+=(--pre-release)
           fi
 
+          # --allow-all-proposed-apis: needed because enabledApiProposals
+          # includes mcpConfigurationProvider (proposed API).
+          # Remove once mcpConfigurationProvider graduates from proposed.
+          publish_args+=(--allow-all-proposed-apis)
+
           corepack pnpm --filter kicadstudiokit exec vsce "${publish_args[@]}"
       - name: Verify Visual Studio Marketplace publish status
         shell: bash


### PR DESCRIPTION
## Problem

VS Code Marketplace publish for v1.6.2 failed with:
\\\
Extensions using unallowed proposed API (enabledApiProposals: [mcpConfigurationProvider], allowed: []) can't be published to the Marketplace.
\\\

The \mcpConfigurationProvider\ is a proposed API needed for insiders/canary builds, but the Marketplace does not allow it by default in the allowed list.

## Fix

Add \--allow-all-proposed-apis\ to the \sce publish\ command, which bypasses this restriction. This is required as long as \nabledApiProposals\ contains any proposed APIs.

## Verification

- [x] CI will run on this branch
- [x] After merge, trigger publish workflow from \main\ to retry v1.6.2 VSCode Marketplace publish

Fixes the v1.6.2 VSCode Marketplace publish failure.