### PR TITLE
fix(repo): verify registry VSIX payload content

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -211,6 +211,21 @@ jobs:
             echo "VS Code Marketplace index not updated yet (attempt $attempt/10), waiting 30s…"
             sleep 30
           done
+      - name: Verify Visual Studio Marketplace published content
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./apps/vscode-extension/package.json').version")"
+          VSIX_DIR="$GITHUB_WORKSPACE/release-assets/vscode-extension"
+          VSIX_PATH="$(find "$VSIX_DIR" -type f -name '*.vsix' | sort | tail -n1)"
+          MARKETPLACE_VERIFY_DIR="$GITHUB_WORKSPACE/release-assets/marketplace-verify"
+          MARKETPLACE_VSIX="$MARKETPLACE_VERIFY_DIR/oaslananka.kicadstudiokit-$version.vsix"
+          mkdir -p "$MARKETPLACE_VERIFY_DIR"
+          curl --fail --location --retry 3 \
+            --output "$MARKETPLACE_VSIX" \
+            "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/oaslananka/vsextensions/kicadstudiokit/$version/vspackage"
+          corepack pnpm --filter kicadstudiokit exec node scripts/validate-vsix-metadata.js \
+            --compare-content "$VSIX_PATH" "$MARKETPLACE_VSIX"
 
   publish_openvsx:
     needs: [package, publish_vscode]
@@ -281,7 +296,7 @@ jobs:
           fi
 
           corepack pnpm --filter kicadstudiokit exec ovsx "${publish_args[@]}"
-      - name: Verify Open VSX published digest
+      - name: Verify Open VSX published content
         shell: bash
         run: |
           set -euo pipefail
@@ -307,10 +322,7 @@ jobs:
           corepack pnpm --filter kicadstudiokit exec ovsx get oaslananka.kicadstudiokit --versionRange "$version" --output "$OPENVSX_VERIFY_DIR"
           downloaded="$(find "$OPENVSX_VERIFY_DIR" -type f -name '*.vsix' | sort | tail -n1)"
           test -n "$downloaded"
-          expected="$(awk '{print $1}' release-assets/vscode-extension/SHA256SUMS.txt)"
-          actual="$(sha256sum "$downloaded" | awk '{print $1}')"
-          if [ "$expected" != "$actual" ]; then
-            echo "::error::Open VSX digest mismatch for version $version — expected $expected, got $actual"
-            exit 1
-          fi
-          echo "Open VSX digest verified: $actual"
+          VSIX_DIR="$GITHUB_WORKSPACE/release-assets/vscode-extension"
+          VSIX_PATH="$(find "$VSIX_DIR" -type f -name '*.vsix' | sort | tail -n1)"
+          corepack pnpm --filter kicadstudiokit exec node scripts/validate-vsix-metadata.js \
+            --compare-content "$VSIX_PATH" "$downloaded"

--- a/apps/vscode-extension/scripts/validate-vsix-metadata.js
+++ b/apps/vscode-extension/scripts/validate-vsix-metadata.js
@@ -4,6 +4,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const zlib = require('node:zlib');
+const crypto = require('node:crypto');
 
 const EXPECTED_PUBLISHER = 'oaslananka';
 const EXPECTED_NAME = 'kicadstudiokit';
@@ -79,6 +80,10 @@ function readVsixPackageJson(vsixPath) {
 function readZipEntry(zipPath, entryName) {
   const buffer = fs.readFileSync(zipPath);
   const entry = findCentralDirectoryEntry(buffer, entryName);
+  return readCentralDirectoryEntry(buffer, entry, entryName);
+}
+
+function readCentralDirectoryEntry(buffer, entry, entryName) {
   const localOffset = entry.localHeaderOffset;
   if (buffer.readUInt32LE(localOffset) !== ZIP_LOCAL_FILE_HEADER_SIGNATURE) {
     throw new Error(`Invalid ZIP local header for ${entryName}`);
@@ -101,6 +106,91 @@ function readZipEntry(zipPath, entryName) {
   throw new Error(
     `Unsupported ZIP compression method ${entry.compressionMethod}`
   );
+}
+
+function readZipEntries(zipPath) {
+  const buffer = fs.readFileSync(zipPath);
+  const endOffset = findEndOfCentralDirectory(buffer);
+  const entryCount = buffer.readUInt16LE(
+    endOffset + ZIP_END_ENTRY_COUNT_OFFSET
+  );
+  let offset = buffer.readUInt32LE(endOffset + ZIP_END_CENTRAL_OFFSET_OFFSET);
+  const entries = new Map();
+
+  for (let index = 0; index < entryCount; index += 1) {
+    if (buffer.readUInt32LE(offset) !== ZIP_CENTRAL_DIRECTORY_SIGNATURE) {
+      throw new Error('Invalid ZIP central directory header');
+    }
+    const nameLength = buffer.readUInt16LE(
+      offset + ZIP_CENTRAL_NAME_LENGTH_OFFSET
+    );
+    const extraLength = buffer.readUInt16LE(
+      offset + ZIP_CENTRAL_EXTRA_LENGTH_OFFSET
+    );
+    const commentLength = buffer.readUInt16LE(
+      offset + ZIP_CENTRAL_COMMENT_LENGTH_OFFSET
+    );
+    const name = buffer
+      .subarray(
+        offset + ZIP_CENTRAL_HEADER_SIZE,
+        offset + ZIP_CENTRAL_HEADER_SIZE + nameLength
+      )
+      .toString();
+    if (!name.endsWith('/')) {
+      if (entries.has(name)) {
+        throw new Error(`Duplicate ZIP entry: ${name}`);
+      }
+      entries.set(
+        name,
+        readCentralDirectoryEntry(
+          buffer,
+          centralDirectoryEntry(buffer, offset),
+          name
+        )
+      );
+    }
+    offset +=
+      ZIP_CENTRAL_HEADER_SIZE + nameLength + extraLength + commentLength;
+  }
+  return entries;
+}
+
+function compareVsixContent(expectedPath, actualPath) {
+  const expected = readZipEntries(expectedPath);
+  const actual = readZipEntries(actualPath);
+  const missing = [...expected.keys()].filter((name) => !actual.has(name));
+  const unexpected = [...actual.keys()].filter((name) => !expected.has(name));
+  const changed = [...expected.keys()].filter(
+    (name) => actual.has(name) && !expected.get(name).equals(actual.get(name))
+  );
+  const failures = [];
+
+  if (missing.length > 0)
+    failures.push(`missing entries: ${missing.join(', ')}`);
+  if (unexpected.length > 0) {
+    failures.push(`unexpected entries: ${unexpected.join(', ')}`);
+  }
+  if (changed.length > 0)
+    failures.push(`changed entries: ${changed.join(', ')}`);
+  if (failures.length > 0) {
+    throw new Error(`VSIX content mismatch:\n- ${failures.join('\n- ')}`);
+  }
+
+  return {
+    contentDigest: computeContentDigest(expected),
+    entryCount: expected.size
+  };
+}
+
+function computeContentDigest(entries) {
+  const digest = crypto.createHash('sha256');
+  for (const name of [...entries.keys()].sort()) {
+    digest.update(name);
+    digest.update('\0');
+    digest.update(entries.get(name));
+    digest.update('\0');
+  }
+  return digest.digest('hex');
 }
 
 function findCentralDirectoryEntry(buffer, entryName) {
@@ -170,10 +260,17 @@ function readJson(filePath) {
 
 if (require.main === module) {
   try {
-    const result = validateVsixMetadata({ vsixPath: process.argv[2] });
-    console.log(
-      `VSIX metadata validation passed: ${result.extensionId}@${result.version}`
-    );
+    if (process.argv[2] === '--compare-content') {
+      const result = compareVsixContent(process.argv[3], process.argv[4]);
+      console.log(
+        `VSIX content validation passed: ${result.entryCount} entries, normalized SHA-256 ${result.contentDigest}`
+      );
+    } else {
+      const result = validateVsixMetadata({ vsixPath: process.argv[2] });
+      console.log(
+        `VSIX metadata validation passed: ${result.extensionId}@${result.version}`
+      );
+    }
   } catch (error) {
     console.error(error.message);
     process.exit(1);
@@ -181,6 +278,8 @@ if (require.main === module) {
 }
 
 module.exports = {
+  compareVsixContent,
   readZipEntry,
+  readZipEntries,
   validateVsixMetadata
 };

--- a/apps/vscode-extension/scripts/validate-vsix-metadata.test.mjs
+++ b/apps/vscode-extension/scripts/validate-vsix-metadata.test.mjs
@@ -7,6 +7,7 @@ import test from 'node:test';
 
 const require = createRequire(import.meta.url);
 const {
+  compareVsixContent,
   readZipEntry,
   validateVsixMetadata
 } = require('./validate-vsix-metadata.js');
@@ -78,6 +79,58 @@ test('readZipEntry extracts a stored VSIX package manifest', () => {
 
       assert.equal(entry.publisher, 'oaslananka');
       assert.equal(entry.name, 'kicadstudiokit');
+    }
+  );
+});
+
+test('#344 compareVsixContent ignores mutable ZIP container metadata', () => {
+  withFixtureVsix(
+    {
+      publisher: 'oaslananka',
+      name: 'kicadstudiokit',
+      version: '1.0.0'
+    },
+    ({ root, vsixPath }) => {
+      const registryPath = path.join(root, 'registry.vsix');
+      const registryArchive = Buffer.from(fs.readFileSync(vsixPath));
+      registryArchive.writeUInt16LE(0x1234, 10);
+      fs.writeFileSync(registryPath, registryArchive);
+
+      assert.notDeepEqual(
+        fs.readFileSync(vsixPath),
+        fs.readFileSync(registryPath)
+      );
+      const result = compareVsixContent(vsixPath, registryPath);
+      assert.equal(result.entryCount, 1);
+      assert.match(result.contentDigest, /^[a-f0-9]{64}$/);
+    }
+  );
+});
+
+test('#344 compareVsixContent rejects registry payload changes', () => {
+  withFixtureVsix(
+    {
+      publisher: 'oaslananka',
+      name: 'kicadstudiokit',
+      version: '1.0.0'
+    },
+    ({ root, vsixPath }) => {
+      const registryPath = path.join(root, 'registry.vsix');
+      fs.writeFileSync(
+        registryPath,
+        createStoredZip({
+          'extension/package.json': JSON.stringify({
+            publisher: 'oaslananka',
+            name: 'kicadstudiokit',
+            version: '1.0.1'
+          })
+        })
+      );
+
+      assert.throws(
+        () => compareVsixContent(vsixPath, registryPath),
+        /changed entries: extension\/package\.json/
+      );
     }
   );
 });

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -73,9 +73,11 @@ Open VSX:
 - the packaged README points Open VSX users to `apps/vscode-extension/CHANGELOG.md` for release notes.
 
 The Visual Studio Marketplace job is release-blocking and its post-publish
-visibility check fails closed. Open VSX remains a separate non-blocking job, but
-it runs only after Marketplace succeeds and records a failed job when indexing
-or digest verification does not complete successfully.
+visibility and normalized VSIX payload checks fail closed. Open VSX remains a
+separate non-blocking job, but it runs only after Marketplace succeeds and
+records a failed job when indexing or payload verification does not complete
+successfully. Registry-rewritten ZIP container metadata is ignored while every
+packaged file name and byte is compared.
 
 VS Code Marketplace:
 
@@ -149,7 +151,7 @@ records when a GitHub Release triggers the workflow.
 
 | Product                | Release assets                                                                    | Publish verification                                                                                 |
 | ---------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| VSIX                   | `kicadstudiokit-<version>.vsix`, `vscode-extension-SHA256SUMS.txt`, SBOM evidence | Verify checksum before Marketplace/Open VSX publish; verify Marketplace version and Open VSX digest. |
+| VSIX                   | `kicadstudiokit-<version>.vsix`, `vscode-extension-SHA256SUMS.txt`, SBOM evidence | Verify checksum before publish; verify Marketplace/Open VSX version and normalized VSIX payload.      |
 | Python wheel and sdist | wheel, sdist, `kicad-mcp-pro-python-SHA256SUMS.txt`, SBOM evidence                | Verify local checksums before publish; verify PyPI/TestPyPI SHA-256 digests after publish.           |
 
 Local release policy verification:

--- a/docs/release.md
+++ b/docs/release.md
@@ -16,9 +16,10 @@ The publish workflows keep release evidence product-scoped:
 - `publish-extension.yml` validates the VSIX, emits `SHA256SUMS.txt` and a
   CycloneDX SBOM, creates GitHub artifact attestations for the checksummed
   extension package, publishes the shared VSIX to the Visual Studio Marketplace,
-  verifies the Marketplace version, and then publishes the same VSIX to Open VSX
-  in a separate non-blocking job that downloads the published VSIX and compares
-  its digest with the release checksum.
+  verifies the Marketplace version and normalized VSIX payload content, and then
+  publishes the same VSIX to Open VSX in a separate non-blocking job that
+  downloads the published VSIX and verifies the same payload content. The
+  normalized comparison ignores registry-rewritten ZIP container metadata.
 - Release Please explicitly dispatches `publish-extension.yml` after creating a
   release because GitHub does not recursively trigger release-event workflows
   from releases created with `GITHUB_TOKEN`. The dispatch checks out the release

--- a/scripts/check-no-forbidden-refs.mjs
+++ b/scripts/check-no-forbidden-refs.mjs
@@ -76,7 +76,8 @@ function isOfficialVscodeHostHit(line) {
     hosts.every(
       (host) =>
         host === "update.code.visualstudio.com" ||
-        host === "code.visualstudio.com",
+        host === "code.visualstudio.com" ||
+        host === "marketplace.visualstudio.com",
     )
   );
 }

--- a/scripts/check-release-provenance.mjs
+++ b/scripts/check-release-provenance.mjs
@@ -95,6 +95,29 @@ function checkWorkflowEvidence(failures) {
   );
   expectIncludes(
     extension,
+    'MARKETPLACE_VERIFY_DIR="$GITHUB_WORKSPACE/release-assets/marketplace-verify"',
+    "extension workflow",
+    failures,
+  );
+  expectIncludes(
+    extension,
+    '--compare-content "$VSIX_PATH" "$MARKETPLACE_VSIX"',
+    "extension workflow",
+    failures,
+  );
+  expectIncludes(
+    extension,
+    '--compare-content "$VSIX_PATH" "$downloaded"',
+    "extension workflow",
+    failures,
+  );
+  expect(
+    !extension.includes('sha256sum "$downloaded"'),
+    "registry verification must compare VSIX payload content instead of mutable ZIP container digests",
+    failures,
+  );
+  expectIncludes(
+    extension,
     "vsce show oaslananka.kicadstudiokit --json",
     "extension workflow",
     failures,


### PR DESCRIPTION
## Summary

- verify Marketplace and Open VSX packages by normalized VSIX entry names and bytes
- ignore registry-rewritten ZIP container metadata while still failing closed on payload changes
- add Marketplace package-content verification and retain Open VSX verification without false raw-digest failures
- document the registry verification model and allow only the official Marketplace API host

## Linked issue

Closes #344

## Type of change

- [x] type:bug
- [x] type:docs

## Test evidence

- `KICADSTUDIO_PLAYWRIGHT_CHANNEL=chrome corepack pnpm run check` passed
- `corepack pnpm --filter kicadstudiokit exec node --test scripts/validate-vsix-metadata.test.mjs` passed
- `corepack pnpm run release:verify` passed
- live `1.6.2` Marketplace and Open VSX downloads both matched the GitHub VSIX normalized payload: 101 entries, SHA-256 `173aa8876dc86c1f616c7920d15157261e28e72e01a507eeae6cc411f80dc938`
- Regression tests `#344 compareVsixContent ignores mutable ZIP container metadata` and `#344 compareVsixContent rejects registry payload changes`

## Protocol / MCP impact

- [x] Not applicable; reason: release verification only; no protocol, MCP, compatibility metadata, or adapter changes

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean (full local gate passed before ready PR)
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval (not applicable)
- [x] CHANGELOG entry (not user-visible; no product release required)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts