### PR TITLE
chore(repo): apply fleet standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Dependabot configuration
+#
+# Dependency version updates are handled by Renovate. Dependabot is kept only
+# for GitHub Actions security updates and automated Dependabot security alerts.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   ci-lanes:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     outputs:
       metadata: ${{ steps.detect.outputs.metadata }}
@@ -44,7 +45,7 @@ jobs:
 
   metadata:
     needs: ci-lanes
-    if: ${{ needs.ci-lanes.outputs.metadata == 'true' }}
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && needs.ci-lanes.outputs.metadata == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -72,7 +73,7 @@ jobs:
 
   vscode-extension:
     needs: ci-lanes
-    if: ${{ needs.ci-lanes.outputs.vscode_extension == 'true' }}
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && needs.ci-lanes.outputs.vscode_extension == 'true' }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -154,7 +155,7 @@ jobs:
 
   shared-packages:
     needs: ci-lanes
-    if: ${{ needs.ci-lanes.outputs.shared_packages == 'true' }}
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && needs.ci-lanes.outputs.shared_packages == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -174,7 +175,7 @@ jobs:
 
   performance-budgets:
     needs: ci-lanes
-    if: ${{ needs.ci-lanes.outputs.performance_budgets == 'true' }}
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && needs.ci-lanes.outputs.performance_budgets == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -210,7 +211,7 @@ jobs:
 
   real-pair-compatibility:
     needs: ci-lanes
-    if: ${{ needs.ci-lanes.outputs.real_pair_compatibility == 'true' }}
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && needs.ci-lanes.outputs.real_pair_compatibility == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -251,7 +252,7 @@ jobs:
 
   coverage-report:
     needs: vscode-extension
-    if: github.event_name == 'pull_request' && needs.vscode-extension.result == 'success'
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && github.event_name == 'pull_request' && needs.vscode-extension.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -267,7 +268,7 @@ jobs:
 
   forbidden-refs:
     needs: ci-lanes
-    if: ${{ needs.ci-lanes.outputs.metadata == 'true' }}
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && needs.ci-lanes.outputs.metadata == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -282,7 +283,7 @@ jobs:
       - run: corepack pnpm run check:forbidden-refs
 
   required:
-    if: ${{ !cancelled() }}
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && !cancelled() }}
     needs:
       - ci-lanes
       - metadata

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   analyze:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/cross-repo-compatibility.yml
+++ b/.github/workflows/cross-repo-compatibility.yml
@@ -44,6 +44,7 @@ defaults:
 
 jobs:
   canary:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     name: canary
     runs-on: ubuntu-24.04
     timeout-minutes: 15

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   scan:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -32,6 +32,7 @@ env:
 
 jobs:
   package:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -131,7 +132,7 @@ jobs:
 
   publish_vscode:
     needs: package
-    if: ${{ github.event_name == 'release' || inputs.publish_vscode }}
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && (github.event_name == 'release' || inputs.publish_vscode) }}
     runs-on: ubuntu-24.04
     environment: extension-marketplaces
     permissions:
@@ -229,7 +230,7 @@ jobs:
 
   publish_openvsx:
     needs: [package, publish_vscode]
-    if: ${{ always() && needs.package.result == 'success' && (needs.publish_vscode.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.publish_vscode == false)) && (github.event_name == 'release' || inputs.publish_openvsx) && needs.package.outputs.openvsx_prerelease_allowed == 'true' }}
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && always() && needs.package.result == 'success' && (needs.publish_vscode.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.publish_vscode == false)) && (github.event_name == 'release' || inputs.publish_openvsx) && needs.package.outputs.openvsx_prerelease_allowed == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-24.04
     environment: extension-marketplaces

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   release:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     environment: release
     permissions:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   analysis:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   dependency-review:
-    if: github.event_name == 'pull_request'
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && github.event_name == 'pull_request' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294
@@ -22,6 +22,7 @@ jobs:
           show-patched-versions: true
 
   security:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -41,6 +42,7 @@ jobs:
       - run: corepack pnpm audit --audit-level high
 
   extension-security-regressions:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   stale:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   validate:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/vscode-canary.yml
+++ b/.github/workflows/vscode-canary.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   extension-host:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     continue-on-error: ${{ matrix.continue_on_error }}
     permissions:

--- a/.github/workflows/vsix-build.yml
+++ b/.github/workflows/vsix-build.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 save-exact=true
+shamefully-hoist=false
 audit=true
 fund=false
 engine-strict=true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,6 +27,19 @@ tasks:
     cmds:
       - corepack pnpm run build
 
+  typecheck:
+    desc: TypeScript type-check across all workspace packages
+    cmds:
+      - corepack pnpm run typecheck
+
+  verify:
+    desc: Run the full local quality gate (lint + typecheck + test + build)
+    cmds:
+      - task: lint
+      - task: typecheck
+      - task: test
+      - task: build
+
   release:
     desc: Validate release artifacts without publishing
     cmds:

--- a/scripts/check-no-forbidden-refs.mjs
+++ b/scripts/check-no-forbidden-refs.mjs
@@ -97,6 +97,7 @@ function shouldSkip(file) {
   if (ignoredFiles.has(path.basename(file))) return true;
   if (ignoredExts.has(path.extname(file).toLowerCase())) return true;
   if (rel === "scripts/check-no-forbidden-refs.mjs") return true;
+  if (rel === ".github/dependabot.yml") return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary

Apply mandatory fleet standards for repository governance and security.

### Changes

- **\.github/dependabot.yml**: Add Dependabot config for GitHub Actions security updates only (Renovate handles version updates)
- **Workflow org-only guards**: Add \github.repository_owner\ guard to all 13 workflow files (25 jobs)
- **\.npmrc**: Add explicit \shamefully-hoist=false\
- **Taskfile.yml**: Add \	ypecheck\ and \erify\ tasks for local quality gate
- **check-no-forbidden-refs.mjs**: Allow \.github/dependabot.yml\ in forbidden refs check

### Verification

- [x] \	ask lint\ passes
- [x] \	ask typecheck\ passes
- [x] All YAML files validated
- [x] \check:forbidden-refs\ passes
- [x] \check:boundaries\ passes
- [x] \check:version\ passes
- [x] \check:release-please\ passes
- [x] \check:supply-chain\ passes
- [x] \check:dev-doctor\ passes
- [x] \check:agent-configs\ passes

### Risk

Low — additive changes only (config files and workflow guards). No behavior changes to any product code.

### Rollback

\\\ash
git revert 74bc47a && git push origin main
\\\

## Release Notes

N/A