### PR TITLE
ci(repo): wire Stryker mutation testing into scheduled CI workflow

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,41 @@
+name: Mutation Testing
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - run: corepack enable
+      - run: corepack pnpm install --frozen-lockfile
+      - name: Run Stryker mutation testing
+        run: corepack pnpm --filter kicadstudiokit run test:mutation
+        continue-on-error: true
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: mutation-report
+          path: apps/vscode-extension/reports/mutation
+          if-no-files-found: ignore
+          retention-days: 30

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2504,6 +2504,7 @@
     "test:e2e": "playwright test test/e2e/",
     "test:webview": "playwright test --config playwright.webview.config.ts",
     "test:visual": "playwright test --config playwright.visual.config.ts",
+    "test:mutation": "stryker run",
     "test:e2e:real": "playwright test test/e2e/realPair.test.ts",
     "check:bundle-size": "node scripts/check-bundle-size.js",
     "bundle-kicanvas": "node scripts/bundle-kicanvas.js",


### PR DESCRIPTION
## Summary

Add Stryker mutation testing to CI on a weekly schedule with manual dispatch support.

## Changes

- `apps/vscode-extension/package.json`: Add `test:mutation` script that runs `stryker run` using the existing `stryker.config.json` and `@stryker-mutator/core` / `@stryker-mutator/jest-runner` dependencies.
- `.github/workflows/mutation.yml`: New workflow with weekly schedule (Monday 03:17 UTC) + `workflow_dispatch`, org guard, SHA-pinned actions, least-privilege permissions, Node setup from `.node-version`, corepack enable, frozen install, `test:mutation` with `continue-on-error: true` (advisory, non-blocking), and HTML mutation report artifact upload with 30-day retention.

## Acceptance Criteria (H2)

- [x] Extension `test:mutation` script runs the Stryker CLI
- [x] Workflow triggers on schedule (weekly) and `workflow_dispatch`
- [x] Org guard present (G9)
- [x] All actions pinned to full commit SHA (G9)
- [x] Least-privilege permissions declared (G9)
- [x] Stryker break threshold stays at 0 (non-blocking, advisory)
- [x] `check:ci-lanes` passes
- [x] `check:forbidden-refs` passes
- [x] PR merge path is not newly gated