### PR TITLE
chore(github-actions): update astral-sh/uv to v0.11.21

### DIFF
--- a/.github/workflows/cross-repo-compatibility.yml
+++ b/.github/workflows/cross-repo-compatibility.yml
@@ -96,7 +96,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           enable-cache: true
-          version: 0.11.16
+          version: 0.11.21
 
       - name: Smoke-test published kicad-mcp-pro from PyPI
         id: pypi-check


### PR DESCRIPTION
## Summary

Patch update for astral-sh/setup-uv action from v0.11.16 to v0.11.21 in the cross-repo compatibility workflow.

## Changes

- .github/workflows/cross-repo-compatibility.yml: bump uv tool version from 0.11.16 to 0.11.21

## Validation

- Single-line version bump — no semantic impact on the workflow
- The setup-uv action hash is unchanged (only the tool version parameter changed)

## Risk

Low. Patch-level change within the same minor version series.

## Rollback

Revert the single commit.

## Release impact

No release created.
No tag created.
No publish workflow triggered.
No VSIX published.

## KiCad compatibility impact

KiCad 10.0.x remains primary.
KiCad 11 was not promoted to primary support.

## MCP boundary impact

No MCP server implementation was moved into this repository.

## Security impact

None. The action pin commit hash is unchanged. Only the installed uv tool version is bumped.