### PR TITLE
deps(kicad-studio): add overrides for tmp, form-data, vite to suppress pnpm audit high findings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,10 @@ overrides:
   mocha>serialize-javascript: 7.0.5
   qs: 6.15.2
   test-exclude: 8.0.0
-  tmp: 0.2.6
+  form-data: 4.0.6
+  tmp: 0.2.7
   uuid: 14.0.0
-  vite: 6.4.2
+  vite: 6.4.3
 
 importers:
 
@@ -1925,7 +1926,7 @@ packages:
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: 6.4.2
+      vite: 6.4.3
       vue: ^3.2.25
 
   '@vscode/test-electron@2.5.2':
@@ -3108,8 +3109,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs-extra@11.3.5:
@@ -3230,6 +3231,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-html@9.0.5:
@@ -4787,8 +4792,8 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  tmp@0.2.6:
-    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -5008,8 +5013,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@6.4.2:
-    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -7162,9 +7167,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.4.2(@types/node@24.12.3)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.3(@types/node@24.12.3)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
-      vite: 6.4.2(@types/node@24.12.3)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@24.12.3)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0)
       vue: 3.5.34(typescript@6.0.3)
 
   '@vscode/test-electron@2.5.2':
@@ -7229,7 +7234,7 @@ snapshots:
       cheerio: 1.2.0
       cockatiel: 3.2.1
       commander: 12.1.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       glob: 13.0.6
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
@@ -7241,7 +7246,7 @@ snapshots:
       read: 1.0.7
       secretlint: 10.2.2
       semver: 7.8.0
-      tmp: 0.2.6
+      tmp: 0.2.7
       typed-rest-client: 1.8.11
       url-join: 4.0.1
       xml2js: 0.5.0
@@ -8314,7 +8319,7 @@ snapshots:
       jszip: 3.10.1
       readable-stream: 3.6.2
       saxes: 5.0.1
-      tmp: 0.2.6
+      tmp: 0.2.7
       unzipper: 0.12.3
       uuid: 14.0.0
     transitivePeerDependencies:
@@ -8457,12 +8462,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fs-extra@11.3.5:
@@ -8590,6 +8595,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -9624,7 +9633,7 @@ snapshots:
       is-ci: 2.0.0
       leven: 3.1.0
       semver: 7.8.0
-      tmp: 0.2.6
+      tmp: 0.2.7
       yauzl-promise: 4.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -10378,7 +10387,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tmp@0.2.6: {}
+  tmp@0.2.7: {}
 
   tmpl@1.0.5: {}
 
@@ -10597,7 +10606,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.2(@types/node@24.12.3)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0):
+  vite@6.4.3(@types/node@24.12.3)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -10621,7 +10630,7 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@6.4.2(@types/node@24.12.3)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@6.4.3(@types/node@24.12.3)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
       '@vue/devtools-api': 7.7.9
       '@vue/shared': 3.5.34
       '@vueuse/core': 12.8.2(typescript@6.0.3)
@@ -10630,7 +10639,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
-      vite: 6.4.2(@types/node@24.12.3)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@24.12.3)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0)
       vue: 3.5.34(typescript@6.0.3)
     optionalDependencies:
       postcss: 8.5.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,7 @@ overrides:
   mocha>serialize-javascript: 7.0.5
   qs: 6.15.2
   test-exclude: 8.0.0
-  tmp: 0.2.6
+  form-data: 4.0.6
+  tmp: 0.2.7
   uuid: 14.0.0
-  vite: 6.4.2
+  vite: 6.4.3


### PR DESCRIPTION
## Summary

Add targeted \pnpm.overrides\ in \pnpm-workspace.yaml\ to resolve 3 high-severity transitive dependency vulnerabilities reported by \pnpm audit --audit-level high\.

## Changes

| Override | From | To | Advisory |
|---|---|---|---|
| \	mp\ | 0.2.6 | 0.2.7 | GHSA-7c78-jf6q-g5cm (path traversal) |
| \orm-data\ | — | 4.0.6 | GHSA-hmw2-7cc7-3qxx (CRLF injection) |
| \ite\ | 6.4.2 | 6.4.3 | GHSA-fx2h-pf6j-xcff (fs.deny bypass) |

## Validation

- \pnpm audit --audit-level high\ now passes (0 high, 2 moderate remaining)
- All three packages are transitive dev-only deps (packaging, docs tooling, test fixtures)
- \itepress build docs\ — passes with vite@6.4.3

## Risk

Low. All changes are patch/minor bumps to already-pinned transitive overrides.

## Rollback

Revert this PR.

## Release impact

No release created.
No tag created.
No publish workflow triggered.
No VSIX published.

## KiCad compatibility impact

KiCad 10.0.x remains primary.
KiCad 11 was not promoted to primary support.

## MCP boundary impact

No MCP server implementation was moved into this repository.

## Security impact

Resolves all high-severity \pnpm audit\ findings that were blocking the Security CI check. The Security CI will now pass on future PRs.

## Prompt/instruction file check

No prompt, instruction, or temporary agent file was committed.