### PR TITLE
chore(deps): update astral-sh/uv to v0.11.21

### DIFF
--- a/.github/workflows/cross-repo-compatibility.yml
+++ b/.github/workflows/cross-repo-compatibility.yml
@@ -102,7 +102,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           enable-cache: true
-          version: 0.11.16
+          version: 0.11.21
 
       - name: Smoke-test published kicad-mcp-pro from PyPI
         id: pypi-check


### PR DESCRIPTION
## Summary

Patch update for astral-sh/setup-uv action from v0.11.16 to v0.11.21 in the cross-repo compatibility workflow. Supersedes #368 (scope validation failure).

## Changes

- .github/workflows/cross-repo-compatibility.yml: bump uv tool version from 0.11.16 to 0.11.21

## Validation

- Single-line version bump — no semantic impact on the workflow
- The setup-uv action hash is unchanged (only the tool version parameter changed)

## Supersedes

Closes #368 (Renovate-created PR with invalid conventional commit scope).

## Risk

Low. Patch-level change within the same minor version series.

## Release impact

No release created. No tag created. No publish workflow triggered. No VSIX published.