### PR TITLE
chore(deps): update devcontainer Dockerfile syntax to 1.14 and UV to 0.11.21

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.14
 FROM mcr.microsoft.com/devcontainers/python:3.13-bookworm@sha256:bf253e8b9200ad2c159015e87b63dc68a7d185e89cd5a9a1fa9d0d4f4ba6ad76
 
 ARG ACTIONLINT_VERSION=1.7.12
-ARG UV_VERSION=0.11.16
+ARG UV_VERSION=0.11.21
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV KICAD_STUDIO_DEVCONTAINER=1 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "context": "..",
     "args": {
       "ACTIONLINT_VERSION": "1.7.12",
-      "UV_VERSION": "0.11.16"
+      "UV_VERSION": "0.11.21"
     }
   },
   "features": {


### PR DESCRIPTION
## Summary

Updates the devcontainer configuration to match the latest dependency versions used across the repository.

## Changes

- \.devcontainer/Dockerfile\: Dockerfile syntax 1.7 → 1.14, UV_VERSION 0.11.16 → 0.11.21
- \.devcontainer/devcontainer.json\: UV_VERSION 0.11.16 → 0.11.21

## Rationale

- Dockerfile syntax 1.14 adds support for newer Dockerfile features (hermetic builds, improved cache mounts) while maintaining backward compatibility
- UV_VERSION synced with the version being applied in PR #372 for cross-repo-compatibility.yml

## Validation

- Devcontainer configuration is CI-only; no code impacts
- Pre-existing security alert (1 high) unrelated