### PR TITLE
fix(kicad-studio): tidy command palette gating and add editor context menu

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1579,18 +1579,6 @@
           "when": "kicadstudio.aiEnabled"
         },
         {
-          "command": "kicadstudio.searchLibrarySymbol",
-          "when": "kicadstudio.library"
-        },
-        {
-          "command": "kicadstudio.searchLibraryFootprint",
-          "when": "kicadstudio.library"
-        },
-        {
-          "command": "kicadstudio.reindexLibraries",
-          "when": "kicadstudio.library"
-        },
-        {
           "command": "kicadstudio.pcm.refresh",
           "when": "false"
         },

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -886,6 +886,7 @@
       },
       {
         "command": "kicadstudio.fixQueue.applyAll",
+        "icon": "$(check-all)",
         "title": "%kicadstudio.contributes.commands.63.title%",
         "category": "%kicadstudio.contributes.commands.63.category%"
       },
@@ -1009,11 +1010,13 @@
       },
       {
         "command": "kicadstudio.pcm.refresh",
+        "icon": "$(refresh)",
         "title": "%kicadstudio.contributes.commands.86.title%",
         "category": "%kicadstudio.contributes.commands.86.category%"
       },
       {
         "command": "kicadstudio.pcm.filter",
+        "icon": "$(filter)",
         "title": "%kicadstudio.contributes.commands.87.title%",
         "category": "%kicadstudio.contributes.commands.87.category%"
       },
@@ -1029,6 +1032,7 @@
       },
       {
         "command": "kicadstudio.pcm.updateAll",
+        "icon": "$(sync)",
         "title": "%kicadstudio.contributes.commands.90.title%",
         "category": "%kicadstudio.contributes.commands.90.category%"
       },
@@ -1141,6 +1145,23 @@
           "when": "activeCustomEditorId == kicadstudio.schematicViewer || activeCustomEditorId == kicadstudio.pcbViewer",
           "command": "kicadstudio.openInKiCad",
           "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "when": "resourceExtname == .kicad_sch",
+          "command": "kicadstudio.openSchematic",
+          "group": "kicadstudio@1"
+        },
+        {
+          "when": "resourceExtname == .kicad_pcb",
+          "command": "kicadstudio.openPCB",
+          "group": "kicadstudio@1"
+        },
+        {
+          "when": "resourceExtname =~ /\\.kicad_(sch|pcb|sym|mod|pro)/",
+          "command": "kicadstudio.openInKiCad",
+          "group": "kicadstudio@2"
         }
       ],
       "view/title": [
@@ -1416,14 +1437,16 @@
           "when": "kicadstudio.aiEnabled"
         },
         {
-          "command": "kicadstudio.searchComponent"
+          "command": "kicadstudio.searchComponent",
+          "when": "kicadstudio.hasProject"
         },
         {
           "command": "kicadstudio.showDiff",
           "when": "kicadstudio.hasProject"
         },
         {
-          "command": "kicadstudio.refreshProjectTree"
+          "command": "kicadstudio.refreshProjectTree",
+          "when": "kicadstudio.hasProject"
         },
         {
           "command": "kicadstudio.openSettings"
@@ -1443,7 +1466,8 @@
           "when": "kicadstudio.workspaceTrusted"
         },
         {
-          "command": "kicadstudio.mcp.retry"
+          "command": "kicadstudio.mcp.retry",
+          "when": "false"
         },
         {
           "command": "kicadstudio.mcp.openUpgradeGuide"
@@ -1555,19 +1579,24 @@
           "when": "kicadstudio.aiEnabled"
         },
         {
-          "command": "kicadstudio.searchLibrarySymbol"
+          "command": "kicadstudio.searchLibrarySymbol",
+          "when": "kicadstudio.library"
         },
         {
-          "command": "kicadstudio.searchLibraryFootprint"
+          "command": "kicadstudio.searchLibraryFootprint",
+          "when": "kicadstudio.library"
         },
         {
-          "command": "kicadstudio.reindexLibraries"
+          "command": "kicadstudio.reindexLibraries",
+          "when": "kicadstudio.library"
         },
         {
-          "command": "kicadstudio.pcm.refresh"
+          "command": "kicadstudio.pcm.refresh",
+          "when": "false"
         },
         {
-          "command": "kicadstudio.pcm.filter"
+          "command": "kicadstudio.pcm.filter",
+          "when": "false"
         },
         {
           "command": "kicadstudio.pcm.install",


### PR DESCRIPTION
## Work item K — Menu & command-surface hygiene

Cleans up the VS Code extension's contributed command/menu surface. No new strings, no behavior changes to existing commands — only **where** commands appear.

### Changes (`apps/vscode-extension/package.json`)
- **K1 — palette gating:** project/library commands no longer show in the Command Palette when irrelevant.
  - `searchComponent`, `refreshProjectTree` → `when: kicadstudio.hasProject`
  - `searchLibrarySymbol`, `searchLibraryFootprint`, `reindexLibraries` → `when: kicadstudio.library`
- **K2 — stop view actions leaking to the palette:** `mcp.retry`, `pcm.refresh`, `pcm.filter` get `when: false` in `commandPalette` (still reachable from their own view title/context menus).
- **K3 — title-bar icons:** `fixQueue.applyAll` (`$(check-all)`), `pcm.refresh` (`$(refresh)`), `pcm.filter` (`$(filter)`), `pcm.updateAll` (`$(sync)`) now render inline instead of in the overflow menu.
- **K4 — editor/context menu:** right-click in the editor on a KiCad file offers Open Schematic (`.kicad_sch`) / Open PCB (`.kicad_pcb`) / Open in KiCad (`kicad_*`), reusing existing file-action commands.

### Validation
- `check:extension-manifest` — 0 errors / 0 warnings
- `check:nls-parity` — ok (no new keys)
- `typecheck` — clean
- `packageJsonMenus.test.ts` — 1 passed
- root `pnpm run check` (pre-push gate) — green

Scope: `package.json` only (37 insertions, 8 deletions).
