### PR TITLE
test(kicad-studio): make e2e viewer command-palette check deterministic

### DIFF
--- a/apps/vscode-extension/test/e2e/viewer.test.ts
+++ b/apps/vscode-extension/test/e2e/viewer.test.ts
@@ -41,11 +41,23 @@ async function expectCommandPaletteEntry(
   page: import('@playwright/test').Page,
   query: string
 ) {
-  await page.keyboard.press('Control+Shift+P');
   const quickInput = page.locator('.quick-input-widget');
-  await expect(quickInput).toBeVisible();
-  await quickInput.locator('input').fill(`>${query}`);
-  await expect(quickInput).toContainText(query);
+  // The extension registers its commands during activation, which on slow CI
+  // runners can lag behind the first palette open. A single fill snapshots the
+  // command registry once; if the command is registered a moment later, the
+  // quick-open list never re-filters and the assertion times out (the Ubuntu
+  // viewer flake). Re-open and re-filter until the entry is present so we await
+  // a concrete readiness signal rather than a one-shot pre-activation snapshot.
+  await expect(async () => {
+    await page.keyboard.press('Control+Shift+P');
+    await expect(quickInput).toBeVisible({ timeout: 5000 });
+    const input = quickInput.locator('input');
+    // Clear before re-filling so VS Code recomputes the picks against the
+    // current registry even when the query text is unchanged between attempts.
+    await input.fill('');
+    await input.fill(`>${query}`);
+    await expect(quickInput).toContainText(query, { timeout: 2000 });
+  }).toPass({ timeout: 30000 });
   await page.keyboard.press('Escape');
   await expect(quickInput).toBeHidden();
 }

--- a/apps/vscode-extension/test/e2e/vscodeHarness.ts
+++ b/apps/vscode-extension/test/e2e/vscodeHarness.ts
@@ -91,6 +91,11 @@ export async function launchVsCodeWithFixtures(
       context.pages()[0] ??
       (await context.waitForEvent('page', { timeout: 30000 }));
     await page.waitForLoadState('domcontentloaded');
+    // Wait for the workbench shell to mount before handing the page to a test.
+    // `domcontentloaded` fires while VS Code is still booting; gating on the
+    // workbench root gives every test a deterministic ready state instead of
+    // racing the editor's first paint (a known source of slow-runner flake).
+    await page.waitForSelector('.monaco-workbench', { timeout: 60000 });
 
     return {
       browser,


### PR DESCRIPTION
## Work item A2 — Ubuntu e2e viewer flake (#380)

Fixes the command-registry race behind the Ubuntu-only viewer e2e flake.

### Root cause
`expectCommandPaletteEntry` opened the Command Palette and filled the query **once**. The quick-open list is computed from the command registry at fill time and does not re-filter on its own. When the extension finished registering `KiCad: Setup MCP` *after* that fill — likely on the slower Ubuntu CPU runner — the entry never appeared and the assertion timed out. macOS/Windows were fast enough to win the race, which is exactly the "passes on re-run, no deterministic regression" signature in the issue.

### Fix (test-only, no production code)
- **`viewer.test.ts`** — `expectCommandPaletteEntry` now re-opens and re-filters the palette inside `expect(...).toPass()` until the entry is present, clearing the input between attempts so VS Code recomputes the picks against the *current* registry. This awaits a concrete readiness signal instead of a single pre-activation snapshot (per the issue's "await a concrete readiness signal, not a timeout").
- **`vscodeHarness.ts`** — waits for `.monaco-workbench` after `domcontentloaded` so every test starts from a mounted workbench rather than racing the first paint.

### Verification & honesty
- `typecheck` + `eslint` clean on both files.
- I **cannot reproduce the Ubuntu-only flake on this Windows host** (it is xvfb/CDP-timing specific). The change is a deterministic-waiting improvement validated by the affected CI lane; the acceptance ("Ubuntu lane stable across consecutive runs") must be confirmed in CI.

Closes #380 once the Ubuntu lane is observed stable.
