### PR TITLE
fix(kicad-studio): drop proposed MCP API and raise engine floor to 1.101 (#378)

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -192,11 +192,6 @@ jobs:
             publish_args+=(--pre-release)
           fi
 
-          # --allow-all-proposed-apis: needed because enabledApiProposals
-          # includes mcpConfigurationProvider (proposed API).
-          # Remove once mcpConfigurationProvider graduates from proposed.
-          publish_args+=(--allow-all-proposed-apis)
-
           corepack pnpm --filter kicadstudiokit exec vsce "${publish_args[@]}"
       - name: Verify Visual Studio Marketplace publish status
         shell: bash

--- a/.github/workflows/vscode-canary.yml
+++ b/.github/workflows/vscode-canary.yml
@@ -29,7 +29,7 @@ jobs:
         include:
           - id: minimum
             state: primary
-            version: 1.100.0
+            version: 1.101.0
             continue_on_error: false
           - id: stable
             state: primary

--- a/apps/vscode-extension/docs/AI_PROVIDERS.md
+++ b/apps/vscode-extension/docs/AI_PROVIDERS.md
@@ -72,7 +72,7 @@ Use `kicadstudio.ai.language` to control the response language independently fro
 
 ## Language Model Tools
 
-KiCad Studio 1.0.0 targets VS Code `^1.100.0` for Language Model Tool and chat-provider contribution metadata. When `kicadstudio.ai.allowTools` is enabled and the host VS Code build exposes the API, KiCad Studio registers tools for:
+KiCad Studio 1.0.0 targets VS Code `^1.101.0` for Language Model Tool and chat-provider contribution metadata. When `kicadstudio.ai.allowTools` is enabled and the host VS Code build exposes the API, KiCad Studio registers tools for:
 
 - DRC
 - ERC

--- a/apps/vscode-extension/docs/CONTRIBUTING.md
+++ b/apps/vscode-extension/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Development Setup
 
-1. Install Node.js `24.14.1`, pnpm `11.3.0`, and VS Code 1.100+.
+1. Install Node.js `24.14.1`, pnpm `11.3.0`, and VS Code 1.101+.
 2. Run `pnpm install --frozen-lockfile`.
 3. Press `F5` to launch the Extension Development Host.
 4. Let the Git hooks handle fast staged checks on commit and run `pnpm run check` before push.

--- a/apps/vscode-extension/docs/KICAD10_MIGRATION.md
+++ b/apps/vscode-extension/docs/KICAD10_MIGRATION.md
@@ -13,7 +13,7 @@ KiCad 10 introduces workflow changes that matter to extension users:
 ## Recommended Upgrade Path
 
 1. Update your local KiCad installation to KiCad 10.
-2. Update VS Code to 1.100 or newer before installing KiCad Studio 1.0.0.
+2. Update VS Code to 1.101 or newer before installing KiCad Studio 1.0.0.
 3. Re-run `KiCad: Detect kicad-cli` so the extension refreshes CLI capability detection.
 4. Open the project in KiCad 10 once and save it before testing in VS Code.
 5. Confirm that your `.kicad_pro` contains the expected variant data if you plan to use the Variants sidebar.

--- a/apps/vscode-extension/docs/dependency-upgrade-notes.md
+++ b/apps/vscode-extension/docs/dependency-upgrade-notes.md
@@ -8,7 +8,7 @@ This monorepo uses Renovate as the dependency maintenance bot. Repository-local 
 - Renovate lock-file maintenance refreshes `pnpm-lock.yaml` on the weekly maintenance window. (Python MCP server lock files are managed in [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp).)
 - GitHub Action references remain pinned to immutable commit SHAs.
 - `@types/node` stays below `25` while the workspace runtime is Node 24.
-- `@types/vscode` stays aligned with `engines.vscode: ^1.100.0`.
+- `@types/vscode` stays aligned with `engines.vscode: ^1.101.0`.
 - Python dependency updates are applied through `pyproject.toml` plus `uv.lock`.
 
 ## Applied Updates
@@ -23,7 +23,7 @@ This monorepo uses Renovate as the dependency maintenance bot. Repository-local 
 | `prettier`                         | `3.8.3`   |
 | `typescript`                       | `5.9.3`   |
 | `@types/node`                      | `24.12.3` |
-| `@types/vscode`                    | `1.100.0` |
+| `@types/vscode`                    | `1.101.0` |
 | `webpack-cli`                      | `7.0.2`   |
 | `c8`                               | `11.0.0`  |
 | `lint-staged`                      | `17.0.4`  |

--- a/apps/vscode-extension/docs/repository-operations.md
+++ b/apps/vscode-extension/docs/repository-operations.md
@@ -80,7 +80,7 @@ Renovate is the only dependency update bot for this repository. It covers npm, G
 Major runtime-aligned dependencies are constrained until the supported runtime changes:
 
 - `@types/node` remains below `25` while Node 24 is the supported runtime.
-- `@types/vscode` remains aligned with `engines.vscode: ^1.100.0`.
+- `@types/vscode` remains aligned with `engines.vscode: ^1.101.0`.
 
 ## Review Thread Control
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -5,12 +5,9 @@
   "version": "1.8.0",
   "publisher": "oaslananka",
   "engines": {
-    "vscode": "^1.100.0",
+    "vscode": "^1.101.0",
     "node": "24.x"
   },
-  "enabledApiProposals": [
-    "mcpConfigurationProvider"
-  ],
   "packageManager": "pnpm@11.6.0",
   "devEngines": {
     "runtime": {
@@ -2547,7 +2544,7 @@
     "@types/jest": "30.0.0",
     "@types/mocha": "10.0.10",
     "@types/node": "24.12.3",
-    "@types/vscode": "1.100.0",
+    "@types/vscode": "1.101.0",
     "@typescript-eslint/eslint-plugin": "8.61.0",
     "@typescript-eslint/parser": "8.61.0",
     "@vscode/test-electron": "2.5.2",

--- a/apps/vscode-extension/scripts/validate-package.js
+++ b/apps/vscode-extension/scripts/validate-package.js
@@ -83,7 +83,7 @@ function validateStaticMetadata({ root, repoRoot, pkg, fail }) {
     fail
   );
   check(
-    pkg.engines?.vscode === '^1.100.0',
+    pkg.engines?.vscode === '^1.101.0',
     'VS Code engine drifted unexpectedly',
     fail
   );

--- a/apps/vscode-extension/test/integration/canaryCompatibility.test.ts
+++ b/apps/vscode-extension/test/integration/canaryCompatibility.test.ts
@@ -52,9 +52,9 @@ suite('VS Code Canary Compatibility', () => {
     }
 
     const sidebarViews =
-      (extension.packageJSON?.contributes?.views?.[
-        'kicadstudio-sidebar'
-      ] as ViewContribution[] | undefined) ?? [];
+      (extension.packageJSON?.contributes?.views?.['kicadstudio-sidebar'] as
+        | ViewContribution[]
+        | undefined) ?? [];
     assert.ok(
       sidebarViews.some((view) => view.id === 'kicadstudio.projectTree'),
       'Missing projectTree view contribution.'
@@ -78,8 +78,38 @@ suite('VS Code Canary Compatibility', () => {
     );
   });
 
+  test('activates without depending on proposed VS Code APIs', async () => {
+    // Regression for #378. A published extension cannot use proposed APIs, so
+    // any enabledApiProposals entry hard-fails activation on a host where the
+    // proposal is not finalized (mcpConfigurationProvider on VS Code 1.100.x).
+    // The MCP server-definition API finalized in 1.101, the current engine
+    // floor, so this list must stay empty and activation must succeed cleanly.
+    await extension.activate();
+    assert.ok(extension.isActive, 'Expected the extension to be active.');
+
+    const proposals = (
+      extension.packageJSON as { enabledApiProposals?: string[] }
+    ).enabledApiProposals;
+    assert.ok(
+      !proposals || proposals.length === 0,
+      `Extension must not declare proposed APIs; found ${JSON.stringify(
+        proposals
+      )}`
+    );
+
+    const mcpProviders =
+      (extension.packageJSON?.contributes?.mcpServerDefinitionProviders as
+        | unknown[]
+        | undefined) ?? [];
+    assert.ok(
+      mcpProviders.length > 0,
+      'Expected the finalized MCP server definition provider contribution.'
+    );
+  });
+
   test('registers custom editors and bootstraps the schematic webview host', async () => {
-    const customEditors = extension.packageJSON?.contributes?.customEditors ?? [];
+    const customEditors =
+      extension.packageJSON?.contributes?.customEditors ?? [];
     assert.ok(
       customEditors.some(
         (item: { viewType?: string }) =>
@@ -103,7 +133,10 @@ suite('VS Code Canary Compatibility', () => {
     );
 
     const tab = await waitForCustomTab(resource, 'kicadstudio.schematicViewer');
-    assert.ok(tab.isActive, 'Expected the canary custom editor tab to activate.');
+    assert.ok(
+      tab.isActive,
+      'Expected the canary custom editor tab to activate.'
+    );
   });
 
   test('opens a KiCad document through the diagnostics lifecycle smoke path', async () => {

--- a/apps/vscode-extension/test/unit/extensionManifest.test.ts
+++ b/apps/vscode-extension/test/unit/extensionManifest.test.ts
@@ -9,12 +9,14 @@ describe('extensionManifest', () => {
     publisher: string;
     version: string;
     engines: { vscode: string };
+    enabledApiProposals?: string[];
     contributes?: {
       commands?: Array<{ command: string; title: string }>;
       views?: Record<string, unknown[]>;
       viewsContainers?: Record<string, unknown[]>;
       customEditors?: Array<{ viewType: string }>;
       viewsWelcome?: unknown[];
+      mcpServerDefinitionProviders?: Array<{ id: string; label: string }>;
     };
     activationEvents?: string[];
   };
@@ -28,9 +30,24 @@ describe('extensionManifest', () => {
     expect(packageJson.version).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
-  it('targets VS Code >= 1.100.0', () => {
+  it('targets VS Code >= 1.101.0', () => {
     const vsCodeEngine = packageJson.engines.vscode;
-    expect(vsCodeEngine).toMatch(/^\^1\.100\.0$/);
+    expect(vsCodeEngine).toMatch(/^\^1\.101\.0$/);
+  });
+
+  it('declares no proposed API dependencies', () => {
+    // A published extension cannot use proposed APIs, so declaring any in
+    // enabledApiProposals hard-fails activation on hosts where the proposal is
+    // not finalized (regression #378: mcpConfigurationProvider on 1.100.x). The
+    // MCP server-definition API finalized in 1.101, which is now the engine
+    // floor, so no proposal declaration is needed.
+    expect(packageJson.enabledApiProposals ?? []).toEqual([]);
+  });
+
+  it('contributes the finalized MCP server definition provider', () => {
+    const providers =
+      packageJson.contributes?.mcpServerDefinitionProviders ?? [];
+    expect(providers.length).toBeGreaterThan(0);
   });
 
   it('contributes exported command IDs in package.json', () => {

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -463,8 +463,8 @@ kicadIpcReadiness:
         evidence: []
 
 vscode:
-  minimum: "1.100.0"
-  enginesRange: "^1.100.0"
+  minimum: "1.101.0"
+  enginesRange: "^1.101.0"
   stable: "current"
   insiders: "current"
   nodeRuntime: "24.x"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ This guide walks you through your first KiCad Studio experience. It takes about 
 
 ## 1. Install VS Code and the Extension
 
-1. Install [VS Code](https://code.visualstudio.com/) (1.100.0 or later).
+1. Install [VS Code](https://code.visualstudio.com/) (1.101.0 or later).
 2. Open VS Code, go to the **Extensions** view (`Ctrl+Shift+X`).
 3. Search for **KiCad Studio Kit** and click **Install**.
 4. After installation, the KiCad Studio icon appears in the Activity Bar.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -15,7 +15,7 @@ Machine-maintained from `compatibility.yaml`. Refresh with
 | --- | --- |
 | KiCad primary | `10.0.x` |
 | KiCad latest verified | `10.0.3` |
-| VS Code minimum | `1.100.0` |
+| VS Code minimum | `1.101.0` |
 | Node | `>=24.11.0 <25` |
 | pnpm | `>=11.0.0 <12` |
 | Python | `>=3.13` |
@@ -155,7 +155,7 @@ Freshness sources checked on 2026-05-27:
 | Surface      | Primary    | Supported              | Deprecated | Gate                                     |
 | ------------ | ---------- | ---------------------- | ---------- | ---------------------------------------- |
 | KiCad        | 10.0.x     | none                   | 9.x, 8.x   | `compatibility.yaml` + release preflight |
-| VS Code      | current    | `engines.vscode` 1.100 | none       | extension manifest + VS Code canary      |
+| VS Code      | current    | `engines.vscode` 1.101 | none       | extension manifest + VS Code canary      |
 | MCP protocol | 2025-11-25 | 2025-11-25             | older      | well-known server card + matrix          |
 | Node         | 24.x       | `>=24.11.0 <25`        | older      | root and extension package metadata      |
 | pnpm         | 11.x       | `>=11.0.0 <12`         | older      | root package metadata                    |

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -8,7 +8,7 @@ Refresh with `corepack pnpm run docs:generate`.
 | Monorepo baseline | `1.0.0` |
 | KiCad Studio extension | `1.8.0` |
 | kicad-mcp-pro Python server | `3.9.2` |
-| VS Code engine | `^1.100.0` |
+| VS Code engine | `^1.101.0` |
 | Node | `>=24.11.0 <25` |
 | pnpm | `>=11.0.0 <12` |
 | Python | `>=3.13` |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: 24.12.3
         version: 24.12.3
       '@types/vscode':
-        specifier: 1.100.0
-        version: 1.100.0
+        specifier: 1.101.0
+        version: 1.101.0
       '@typescript-eslint/eslint-plugin':
         specifier: 8.61.0
         version: 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.5.0(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
@@ -1717,8 +1717,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/vscode@1.100.0':
-    resolution: {integrity: sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==}
+  '@types/vscode@1.101.0':
+    resolution: {integrity: sha512-ZWf0IWa+NGegdW3iU42AcDTFHWW7fApLdkdnBqwYEtHVIBGbTu0ZNQKP/kX3Ds/uMJXIMQNAojHR4vexCEEz5Q==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
@@ -6947,7 +6947,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/vscode@1.100.0': {}
+  '@types/vscode@1.101.0': {}
 
   '@types/web-bluetooth@0.0.21': {}
 


### PR DESCRIPTION
## Work item A1 — VS Code canary compatibility (#378)

Fixes the `release-blocker` canary `minimum` lane failure.

### Root cause (from the failing run's extension-host log)
```
Activating extension 'oaslananka.kicadstudiokit' failed:
CANNOT use API proposal: mcpConfigurationProvider.
```
The manifest declared `enabledApiProposals: ["mcpConfigurationProvider"]`. A **published** extension is never permitted to use a proposed API, so on any host where that proposal is not finalized VS Code **hard-fails activation** before any runtime guard runs. That host is exactly **1.100.x** — the engine floor. The `stable` and `insiders` lanes passed only because the MCP server-definition API was **finalized in VS Code 1.101** (proposed in 1.100, finalized in 1.101 — confirmed against the VS Code release notes).

The runtime already feature-detects `lm.registerMcpServerDefinitionProvider` and degrades gracefully (`src/lm/mcpServerDefinitionProvider.ts`), so the proposal declaration was pure liability.

### Fix
- **Remove** the `enabledApiProposals` declaration — rely on the finalized API + existing runtime guard.
- **Raise** `engines.vscode` and `@types/vscode` `^1.100.0 → ^1.101.0` (the release that finalized `lm.registerMcpServerDefinitionProvider` and the `contributes.mcpServerDefinitionProviders` contribution point). Justified per the issue ("update `engines.vscode` only with justification"): below 1.101 the contributed MCP feature cannot function for a published build.
- Propagate the floor to `compatibility.yaml`, the support matrix / versions / getting-started / migration / contributing / dependency docs, the `validate-package` guard, and the canary `minimum` lane (`1.100.0 → 1.101.0`). Refresh `pnpm-lock.yaml`.
- Drop the now-obsolete `vsce publish --allow-all-proposed-apis` flag.

### Regression coverage
- `extensionManifest` unit test now asserts **no** proposed APIs are declared and that the MCP provider contribution is present.
- The **canary integration suite** asserts the extension activates cleanly with no proposed-API dependency (the exact failure mode of #378).

### Verification
Local (all green): `typecheck`, `eslint`, `check:extension-manifest`, `check:compatibility-contract`, `check:version`, the manifest unit test (10 passed), and integration `compile-tests`. The canary extension-host lane needs xvfb + a downloaded VS Code, so it is validated by CI on this PR.

Closes #378.
