### PR TITLE
docs(kicad-studio): reconcile the 1.x-stable vs pre-1.0 version story

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ for the command catalog.
 ## Publishing
 
 Publishing is handled by GitHub Actions workflows under `.github/workflows`. External setup for environments, marketplace secrets, and trusted publishers is documented in [docs/publishing.md](docs/publishing.md).
-The structured pre-1.0 beta program and tester feedback loop are documented in [docs/beta-program.md](docs/beta-program.md).
+The structured preview (beta) program and tester feedback loop for the stable `1.x` line are documented in [docs/beta-program.md](docs/beta-program.md).
 
 ## Maintenance
 

--- a/docs/beta-program.md
+++ b/docs/beta-program.md
@@ -1,16 +1,19 @@
 # KiCad Studio Beta Program
 
-The beta program is the structured feedback loop for KiCad Studio before the
-`1.0.0` stable release. It is NDA-free, public by default, and designed to turn
-real project feedback into Linear issues without requiring maintainers to infer
-what happened from unstructured comments.
+KiCad Studio ships a stable `1.x` line on the VS Code Marketplace and Open VSX.
+The beta (preview) program is the structured feedback loop for **preview
+builds** of upcoming changes: an ongoing channel that validates work with real
+projects before it is promoted to the stable channel. It is NDA-free, public by
+default, and designed to turn real project feedback into Linear issues without
+requiring maintainers to infer what happened from unstructured comments.
 
 ## Goals
 
-- Recruit 10-20 beta testers before the first public beta cycle.
+- Recruit 10-20 beta testers before each preview cycle.
 - Cover Windows, macOS, and Linux with single-board, multi-board, classroom,
   embedded, and non-English KiCad workflows.
-- Complete at least two 2-week beta cycles before `1.0.0` stable.
+- Complete at least two 2-week preview cycles before promoting a preview build
+  to the stable channel.
 - Triage every actionable beta report into Linear with the `source:beta` label.
 - Keep telemetry and crash reporting opt-in, disabled by default, and bounded by
   the privacy model in [telemetry.md](telemetry.md).
@@ -18,7 +21,7 @@ what happened from unstructured comments.
 ## Beta Channel
 
 Beta builds use GitHub pre-release tags that end with `-beta.N`, for example
-`vscode-extension-v1.0.1-beta.1`.
+`vscode-extension-v1.9.0-beta.1` (a preview of the next `1.x` release).
 
 VS Code Marketplace and Open VSX publish these builds as pre-releases. The VSIX
 package version remains normal `major.minor.patch` because VS Code marketplace
@@ -33,7 +36,7 @@ pre-release. Stable release notes must use "KiCad Studio Stable" and must not
 refer to beta-only fixes as generally available until the stable release ships.
 
 Stable releases and beta releases must not share the same extension version. If
-`1.0.1` is used for a beta, the next stable release must be `1.0.2` or higher.
+`1.9.0` is used for a beta, the next stable release must be `1.9.1` or higher.
 Before publishing a stable release, publish the next beta version first so beta
 users are not silently moved to stable.
 
@@ -133,4 +136,5 @@ names, company names, or non-public design details.
 - Publish workflow packages beta tags with `--pre-release`.
 - Auto-update and release-note copy distinguishes beta from stable.
 - Weekly async email digest is sent during every active beta week.
-- At least two beta cycles are completed before `1.0.0` stable.
+- At least two preview cycles are completed before promoting a preview build to
+  the stable channel.


### PR DESCRIPTION
## Work item I — Versioning & messaging reconciliation

Resolves the 1.8.0-vs-"pre-1.0" contradiction the audit flagged.

The extension ships at **1.8.0** — a stable 1.x line by SemVer — yet `docs/beta-program.md` described the program as the loop "before the `1.0.0` stable release" and the README called it a "pre-1.0 beta program." Renumbering a published 1.8.0 *downward* to pre-release would be user-hostile, so the fact-aligned resolution (the audit's recommended option) is to declare the **1.x line stable** and reframe beta as an **ongoing preview/insiders channel** that feeds the stable line.

### Changes
- **`docs/beta-program.md`** — leads with the stable 1.x line; reframes the goals, readiness checklist, and version examples (`1.0.1` → `1.9.0` preview of the next 1.x) around *promoting preview builds to stable* instead of *reaching 1.0.0*.
- **`README.md`** — points to "the structured preview (beta) program … for the stable `1.x` line."

### Deliberately unchanged
The embedded beta identifiers stay as-is to avoid churn in CI/labels/templates: the `beta-feedback` discussion category, the `source:beta` label, and the `-beta.N` pre-release tags. Only the narrative is corrected. No code or CI changes; `check:version` is unaffected.
