### PR TITLE
chore(kicad-studio): flag untranslated locale strings in nls-parity check

### DIFF
--- a/scripts/check-nls-parity.mjs
+++ b/scripts/check-nls-parity.mjs
@@ -9,6 +9,33 @@ const REPO_ROOT = path.resolve(SCRIPT_ROOT, '..');
 const EXTENSION_DIR = path.join(REPO_ROOT, 'apps', 'vscode-extension');
 const BASE_FILE = path.join(EXTENSION_DIR, 'package.nls.json');
 
+// Supported locales for GA are English (base) + Turkish. Beyond key parity, we
+// also guard against *new* user-facing strings that were copied into a locale
+// file but never translated (value identical to the base locale).
+//
+// A value that is legitimately identical across locales is allowed when it is a
+// proper noun, brand name, palette category label, or file-format alias. The
+// 57 currently-identical tr values were triaged and all fall into these
+// buckets, captured by the patterns below. Anything else identical to the base
+// is treated as a missed translation and fails the gate; if a new string is
+// genuinely meant to be identical, add it here with that justification.
+const IDENTICAL_ALLOWED_KEYS = new Set([
+  'kicadstudio.displayName', // "KiCad Studio Kit" (product name)
+  'kicadstudio.contributes.viewsContainers.activitybar.0.title', // "KiCad Studio"
+  'kicadstudio.contributes.views.kicadstudio-sidebar.4.name', // "Netlist" (accepted term)
+  'kicadstudio.contributes.configuration.title', // "KiCad Studio"
+  'kicadstudio.contributes.languageModelChatProviders.0.displayName' // "KiCad Studio"
+]);
+
+/** Whether a key may legitimately carry the same value in every locale. */
+function identicalValueAllowed(key) {
+  return (
+    key.endsWith('.category') || // command palette categories ("KiCad", "KiCad AI", …)
+    key.includes('.aliases.') || // language/file-format aliases ("kicad_sch", "Gerber RS-274X", …)
+    IDENTICAL_ALLOWED_KEYS.has(key)
+  );
+}
+
 let exitCode = 0;
 
 /** Parse a JSON file, returning the parsed object or null on failure. */
@@ -79,6 +106,27 @@ for (const file of localeFiles) {
 
   if (extra.length > 0) {
     console.error(`\x1b[31m✗ ${loc}\x1b[0m has ${extra.length} extra key(s): ${extra.join(', ')}`);
+    exitCode = 1;
+    fileOk = false;
+  }
+
+  // Flag user-facing strings that were copied verbatim from the base locale and
+  // never translated (excluding proper nouns / brand / category / aliases).
+  const untranslated = [];
+  for (const key of localeKeys) {
+    if (!baseKeys.has(key)) continue;
+    if (base[key] === localeData[key] && !identicalValueAllowed(key)) {
+      untranslated.push(key);
+    }
+  }
+
+  if (untranslated.length > 0) {
+    console.error(
+      `\x1b[31m✗ ${loc}\x1b[0m has ${untranslated.length} value(s) identical to the base locale (likely untranslated): ${untranslated.join(', ')}`
+    );
+    console.error(
+      '  If a value is intentionally identical (proper noun, brand, category, or alias), add the key to IDENTICAL_ALLOWED_KEYS in scripts/check-nls-parity.mjs.'
+    );
     exitCode = 1;
     fileOk = false;
   }

--- a/scripts/check-nls-parity.test.mjs
+++ b/scripts/check-nls-parity.test.mjs
@@ -79,6 +79,56 @@ describe('check-nls-parity', () => {
     }
   });
 
+  it('detects a new user-facing string left untranslated', () => {
+    const basePath = path.join(EXTENSION_DIR, 'package.nls.json');
+    const trPath = path.join(EXTENSION_DIR, 'package.nls.tr.json');
+    const baseOriginal = fs.readFileSync(basePath, 'utf8');
+    const trOriginal = fs.readFileSync(trPath, 'utf8');
+    try {
+      // Add a matching key to both locales with an identical, non-allowlisted
+      // value (a real sentence, not a proper noun / category / alias).
+      const baseData = JSON.parse(baseOriginal);
+      const trData = JSON.parse(trOriginal);
+      baseData['__test_untranslated__'] = 'Run the design rule check now';
+      trData['__test_untranslated__'] = 'Run the design rule check now';
+      fs.writeFileSync(basePath, JSON.stringify(baseData, null, 2) + '\n', 'utf8');
+      fs.writeFileSync(trPath, JSON.stringify(trData, null, 2) + '\n', 'utf8');
+
+      const result = runScriptExpectFail();
+      assert.ok(result !== null, 'Script should have failed');
+      assert.ok(
+        result.stderr.includes('untranslated') ||
+          result.stdout.includes('untranslated')
+      );
+      assert.notEqual(result.status, 0);
+    } finally {
+      fs.writeFileSync(basePath, baseOriginal, 'utf8');
+      fs.writeFileSync(trPath, trOriginal, 'utf8');
+    }
+  });
+
+  it('allows identical values for brand names, categories, and aliases', () => {
+    const basePath = path.join(EXTENSION_DIR, 'package.nls.json');
+    const trPath = path.join(EXTENSION_DIR, 'package.nls.tr.json');
+    const baseOriginal = fs.readFileSync(basePath, 'utf8');
+    const trOriginal = fs.readFileSync(trPath, 'utf8');
+    try {
+      const baseData = JSON.parse(baseOriginal);
+      const trData = JSON.parse(trOriginal);
+      // A *.category key is an allowed identical value.
+      baseData['kicadstudio.contributes.commands.test.category'] = 'KiCad';
+      trData['kicadstudio.contributes.commands.test.category'] = 'KiCad';
+      fs.writeFileSync(basePath, JSON.stringify(baseData, null, 2) + '\n', 'utf8');
+      fs.writeFileSync(trPath, JSON.stringify(trData, null, 2) + '\n', 'utf8');
+
+      const result = runScript();
+      assert.ok(result.includes('✓'));
+    } finally {
+      fs.writeFileSync(basePath, baseOriginal, 'utf8');
+      fs.writeFileSync(trPath, trOriginal, 'utf8');
+    }
+  });
+
   it('fails when no locale files exist', () => {
     const trPath = path.join(EXTENSION_DIR, 'package.nls.tr.json');
     const original = fs.readFileSync(trPath, 'utf8');


### PR DESCRIPTION
## Work item F — i18n completeness guardrail

`check:nls-parity` validated **key** parity (en/tr both 397/397) but not translation **quality** — a new user-facing string copied into `package.nls.tr.json` and left in English would pass silently.

### Triage of the 57 identical tr values
All 57 are legitimately untranslatable, in four buckets:
- **Command palette categories** (`*.category`): "KiCad", "KiCad AI", "KiCad MCP", "KiCad DRC", "KiCad BoardReadyOps", "KiCad Studio".
- **Language / file-format aliases** (`*.aliases.*`): "kicad_sch", "KiCad PCB", "Gerber RS-274X", "SPICE Netlist", …
- **Brand / product names**: "KiCad Studio", "KiCad Studio Kit".
- **Accepted technical term**: "Netlist".

None were genuinely-missed translations.

### Guardrail
The check now also fails when a key shared by a locale has a value **identical to the base locale**, unless the key matches an allowed pattern (`*.category`, `*.aliases.*`) or a small explicit allowlist (brand/title keys + the Netlist view name). A new untranslated string therefore fails the gate until it is translated or justified in the allowlist. The script header documents **en + tr** as the supported GA locale set.

### Tests
Two new cases added — a new untranslated string fails; an allowed identical `*.category` value passes. All **6** nls-parity tests green; the current locale files pass unchanged.
