### PR TITLE
test(kicad-studio): raise coverage floors and cover untested helpers

### DIFF
--- a/apps/vscode-extension/jest.config.js
+++ b/apps/vscode-extension/jest.config.js
@@ -11,10 +11,10 @@ module.exports = {
   coverageReporters: ['json-summary', 'text', 'lcov'],
   coverageThreshold: {
     global: {
-      branches: 69,
-      functions: 85,
-      lines: 80,
-      statements: 80
+      branches: 70,
+      functions: 88,
+      lines: 83,
+      statements: 83
     },
     'src/mcp/mcpClient.ts': {
       branches: 70,

--- a/apps/vscode-extension/test/unit/compat.test.ts
+++ b/apps/vscode-extension/test/unit/compat.test.ts
@@ -1,0 +1,73 @@
+import {
+  MCP_COMPAT,
+  describeMcpCompatibility,
+  getMcpCompatStatus,
+  isMcpVersionSupported,
+  normalizeMcpVersion
+} from '../../src/mcp/compat';
+
+describe('mcp/compat', () => {
+  describe('normalizeMcpVersion', () => {
+    it('returns 0.0.0 for undefined', () => {
+      expect(normalizeMcpVersion(undefined)).toBe('0.0.0');
+    });
+
+    it('returns 0.0.0 for an empty string', () => {
+      expect(normalizeMcpVersion('')).toBe('0.0.0');
+    });
+
+    it('returns 0.0.0 for an uncoercible string', () => {
+      expect(normalizeMcpVersion('not-a-version')).toBe('0.0.0');
+    });
+
+    it('coerces a loose version', () => {
+      expect(normalizeMcpVersion('v3.9')).toBe('3.9.0');
+    });
+
+    it('passes through a clean version', () => {
+      expect(normalizeMcpVersion('3.9.2')).toBe('3.9.2');
+    });
+  });
+
+  describe('isMcpVersionSupported', () => {
+    it('is true for an in-range version', () => {
+      expect(isMcpVersionSupported('3.9.2')).toBe(true);
+    });
+
+    it('is false for a below-range version', () => {
+      expect(isMcpVersionSupported('3.0.0')).toBe(false);
+    });
+
+    it('is false when the version is missing', () => {
+      expect(isMcpVersionSupported(undefined)).toBe(false);
+    });
+  });
+
+  describe('getMcpCompatStatus', () => {
+    it('is ok for an in-range version', () => {
+      expect(getMcpCompatStatus('3.9.2')).toBe('ok');
+    });
+
+    it('is incompatible below the required range', () => {
+      expect(getMcpCompatStatus('3.0.0')).toBe('incompatible');
+    });
+
+    it('is incompatible at the upper bound', () => {
+      expect(getMcpCompatStatus('4.0.0')).toBe('incompatible');
+    });
+  });
+
+  describe('describeMcpCompatibility', () => {
+    it('describes a supported version', () => {
+      const message = describeMcpCompatibility('3.9.2');
+      expect(message).toContain('3.9.2');
+      expect(message).toContain('supported');
+    });
+
+    it('describes an incompatible version with the required range', () => {
+      const message = describeMcpCompatibility('3.0.0');
+      expect(message).toContain(MCP_COMPAT.required);
+      expect(message.toLowerCase()).toContain('outside');
+    });
+  });
+});

--- a/apps/vscode-extension/test/unit/i18n.test.ts
+++ b/apps/vscode-extension/test/unit/i18n.test.ts
@@ -1,0 +1,85 @@
+type I18nModule = typeof import('../../src/i18n');
+
+/**
+ * The locale is resolved once at module load from VSCODE_NLS_CONFIG, so each
+ * case re-imports the module in isolation with the env configured up front.
+ */
+function loadI18n(nlsConfig?: string): I18nModule {
+  jest.resetModules();
+  const previous = process.env['VSCODE_NLS_CONFIG'];
+  if (nlsConfig === undefined) {
+    delete process.env['VSCODE_NLS_CONFIG'];
+  } else {
+    process.env['VSCODE_NLS_CONFIG'] = nlsConfig;
+  }
+  let mod: I18nModule | undefined;
+  jest.isolateModules(() => {
+    // Module isolation requires a synchronous re-import; jest.isolateModules
+    // cannot use an async dynamic import().
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    mod = require('../../src/i18n') as I18nModule;
+  });
+  if (previous === undefined) {
+    delete process.env['VSCODE_NLS_CONFIG'];
+  } else {
+    process.env['VSCODE_NLS_CONFIG'] = previous;
+  }
+  return mod as I18nModule;
+}
+
+describe('i18n', () => {
+  describe('locale detection', () => {
+    it('defaults to English when VSCODE_NLS_CONFIG is absent', () => {
+      const { localize } = loadI18n(undefined);
+      expect(localize('restart')).toBe('Restart');
+    });
+
+    it('uses Turkish messages when the locale is tr', () => {
+      const { localize } = loadI18n('{"locale":"tr"}');
+      expect(localize('restart')).toBe('Yeniden Başlat');
+    });
+
+    it('falls back to English for a locale without translations', () => {
+      const { localize } = loadI18n('{"locale":"de"}');
+      expect(localize('restart')).toBe('Restart');
+    });
+
+    it('falls back to English when the config has no locale field', () => {
+      const { localize } = loadI18n('{"foo":"bar"}');
+      expect(localize('restart')).toBe('Restart');
+    });
+
+    it('falls back to English when the config is invalid JSON', () => {
+      const { localize } = loadI18n('not-json');
+      expect(localize('restart')).toBe('Restart');
+    });
+  });
+
+  describe('localize interpolation', () => {
+    it('returns the raw message when no args are given', () => {
+      const { localize } = loadI18n(undefined);
+      expect(localize('workspaceTrustRequired')).toContain('{feature}');
+    });
+
+    it('replaces a single placeholder', () => {
+      const { localize } = loadI18n(undefined);
+      expect(localize('runValidation', { label: 'DRC' })).toBe('Run DRC');
+    });
+
+    it('replaces multiple placeholders and coerces non-string args', () => {
+      const { localize } = loadI18n(undefined);
+      expect(
+        localize('diagnosticSummary', {
+          status: 'FAIL',
+          errors: 2,
+          warnings: 1
+        })
+      ).toBe('FAIL - 2 errors, 1 warnings');
+    });
+
+    it('interpolates into a Turkish message', () => {
+      const { localize } = loadI18n('{"locale":"tr"}');
+      expect(localize('runValidation', { label: 'DRC' })).toBe('DRC çalıştır');
+    });
+  });
+});

--- a/apps/vscode-extension/test/unit/kicadCodeActionProvider.test.ts
+++ b/apps/vscode-extension/test/unit/kicadCodeActionProvider.test.ts
@@ -33,4 +33,28 @@ describe('KiCadCodeActionProvider', () => {
       })
     );
   });
+
+  it('falls back to the description and is not preferred for low-confidence fixes', () => {
+    const provider = new KiCadCodeActionProvider({
+      getFixesForUri: jest.fn().mockReturnValue([
+        {
+          id: 'fix-2',
+          description: 'Increase clearance on NET1',
+          severity: 'error'
+          // no title and no confidence
+        }
+      ])
+    } as never);
+
+    const actions = provider.provideCodeActions(
+      {
+        uri: vscode.Uri.file('/project/board.kicad_pcb')
+      } as never,
+      new vscode.Range(0, 0, 0, 1)
+    );
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.title).toBe('KiCad Fix: Increase clearance on NET1');
+    expect(actions[0]?.isPreferred).toBe(false);
+  });
 });

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -25,6 +25,26 @@ notes can add detail, but they should not weaken these gates.
 | Cross-repo canary    | Push, pull request, and manual workflow                              | Verify this repo consumes published `kicad-mcp` protocol schema and server artifacts.                  | `.github/workflows/cross-repo-compatibility.yml`      |
 | Manual smoke         | Release candidate only                                               | Final human inspection where automation is not practical.                                              | PR notes must name the exact manual check             |
 
+## Coverage and Mutation Thresholds
+
+Extension unit coverage is enforced by Jest (`apps/vscode-extension/jest.config.js`)
+and must not regress. The global floor is **statements 83 / branches 70 /
+functions 88 / lines 83**, set just below the measured suite so new uncovered
+code fails the gate rather than silently lowering the bar. Raise these floors as
+coverage improves; do not lower them to make a change pass.
+
+Branch coverage is the laggard metric: the remaining gap is concentrated in
+mocking-heavy command handlers (`src/commands/*`) and the AI/LM providers
+(`src/ai/*`, `src/lm/*`). Close it by exercising their error, empty, and
+guard-clause paths — that is the highest-value place to add tests, not the
+already-strong pure helpers.
+
+Mutation testing is configured in `stryker.config.json` (Jest runner, `perTest`
+analysis, thresholds high 80 / low 60). It currently runs with `break: 0` so it
+never fails the build. The next step is to run `pnpm exec stryker run` against
+the core modules, record the baseline mutation score here, and raise `break` to
+that baseline so mutation coverage cannot regress.
+
 ## Test Layers
 
 | Layer                                 | Scope                                                                                                                                                                                                      | Owner path                                                         | Runner or API                                                  | Gate                                              |


### PR DESCRIPTION
## Work item E — Test & coverage hardening

Branch coverage (70%) was the weak metric, and the Jest thresholds sat *below* the measured suite, so coverage could silently regress.

### Tests added
- **`src/mcp/compat.ts`** (previously untested): 56% → **81%** branch. Covers `normalizeMcpVersion` (undefined/empty/uncoercible/loose/clean), `isMcpVersionSupported`, `getMcpCompatStatus` (ok/incompatible), and `describeMcpCompatibility`. The two remaining branches are unreachable defensive code — `required === recommended` in the matrix means `'warn'` can't occur.
- **`src/i18n.ts`** (previously untested): 50% → **100%** branch. Exercises locale detection (absent / `tr` / untranslated locale / no-locale field / invalid JSON via isolated re-import) and placeholder interpolation (none / single / multiple / Turkish).
- **`KiCadCodeActionProvider`**: added the title→description fallback and low-confidence (not-preferred) path.

### Thresholds raised (lock-in, can't regress)
`jest.config.js` global floor → **statements 83 / branches 70 / functions 88 / lines 83** (from 80 / 69 / 80 / 85), just under the measured suite (84.05 / 70.24 / 88.43 / 84.02).

### Documentation
`docs/testing-strategy.md` gains a **Coverage and Mutation Thresholds** section: the policy, where the remaining branch gap lives (mocking-heavy `src/commands/*` and `src/ai|lm/*`), and the **Stryker mutation baseline as the explicit next step** (run + record + raise `break`). I did not run Stryker here — mutation testing the full extension is long-running and I won't record a baseline I can't honestly produce in this environment.

### Verification
**738** unit tests across **93** suites, all green; thresholds enforced by the gate; eslint + docs:lint clean.
