### PR TITLE
docs(kicad-studio): add GA UI/UX review and accessibility conformance evidence

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -72,6 +72,7 @@ export default defineConfig({
           { text: "BoardReadyOps", link: "/board-ready-ops" },
           { text: "Troubleshooting", link: "/extension/troubleshooting" },
           { text: "Accessibility", link: "/accessibility" },
+          { text: "UI/UX Review", link: "/ux-review-1.0" },
           { text: "Telemetry", link: "/telemetry" },
         ],
       },

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -127,6 +127,24 @@ Status key:
 | 4.1.2 Name, Role, Value                         | A     | Automated + Manual | Custom controls must expose accessible names, roles, values, and state. Prefer native controls.                                                                                                               |
 | 4.1.3 Status Messages                           | AA    | Automated + Manual | Async results, loading states, errors, and completion notices must use status/alert semantics or native VS Code status APIs.                                                                                  |
 
+## Conformance Evidence
+
+Automated baseline (updated 2026-06-18):
+
+- `test:a11y` runs **76 axe-core assertions** and passes with zero violations.
+- Coverage spans every extension-owned webview surface — Settings, AI Chat, BOM,
+  Netlist, Visual Diff, DRC Rule Editor, Quality Gate, Component Search details,
+  MCP Tools, the viewer fallback/error chrome, and the status bar — across the
+  dark, light, and high-contrast theme fixtures, with WCAG 2.0/2.1 A and AA rule
+  tags enabled.
+- The suite runs headless in Chromium and is wired into the extension `check`
+  and `check:ci` scripts and the `vscode-extension` CI job, so the baseline
+  cannot silently regress.
+
+Manual release evidence (keyboard-only navigation and the NVDA/VoiceOver pass
+described under the manual release gate) is recorded per release candidate and
+is not a CI gate.
+
 ## Tooling Policy
 
 - `axe-core` is the automated accessibility engine for extension-owned HTML UI.

--- a/docs/ux-review-1.0.md
+++ b/docs/ux-review-1.0.md
@@ -1,0 +1,52 @@
+# UI/UX Review for GA (1.x)
+
+A per-surface review of the KiCad Studio extension UI against the GA bar in
+[GA Readiness](/ga-readiness). The product was already strong going in; this
+records the state of each surface, what changed this review cycle, and what is
+deferred (and why).
+
+Status key: ✅ meets the bar · 🟡 met with a deferred follow-up · ⏭️ deferred to
+an environment this review could not exercise.
+
+## Cross-cutting foundations
+
+| Concern | State | Evidence |
+| --- | --- | --- |
+| Theming | ✅ | All colors derive from `--vscode-*` tokens with fallbacks (`media/styles/{bom,viewer}.css`). The two literal hex values are *fallbacks* for `--vscode-testing-iconPassed` / `--vscode-editorWarning-foreground`, not hardcoded colors. |
+| Reduced motion | ✅ | Both stylesheets carry `@media (prefers-reduced-motion: reduce)` (universal transition/animation/scroll reset + spinner stop). |
+| High contrast | ✅ | Both stylesheets carry `@media (forced-colors: active)` focus outlines using `CanvasText`. |
+| Focus visibility | ✅ | `:focus-visible` styling present; tab order and accessible names asserted by the axe suite. |
+| Keyboard operability | ✅ | `table-wrapper[tabindex=0]` reference pattern in BOM; axe suite checks deterministic tab traversal and no focus traps. |
+| Status semantics | ✅ | `role="status"`/`role="alert"` + `aria-live` on loading/empty/error regions. |
+| Localization | ✅ | en/tr parity (397/397) with a guardrail that fails on new untranslated strings (`check:nls-parity`). |
+| Command surface | ✅ | Palette gating, inline title icons, and an editor context menu landed this cycle (menu hygiene). |
+
+## Per-surface review
+
+| Surface | Empty | Loading | Error | Notes |
+| --- | --- | --- | --- | --- |
+| BOM webview | ✅ `#bom-empty` | ✅ `#loading-row` | ✅ | Reference implementation for the others. |
+| Netlist webview | ✅ summary "No schematic opened." / "0 net entries" | ✅ provider-driven `status` ("Loading netlist…") | ✅ `#error-card` (`role="alert"`) | States are driven by the provider `status` payload rather than webview-local elements; all three are visual-snapshot locked (`netlist-loading/success/error`). |
+| Visual Diff webview | ✅ | ✅ | ✅ | Empty/error handling present in `diff.js`. |
+| Viewer (KiCanvas PCB/Schematic) | n/a (canvas) | ✅ | ✅ | Canvas content has documented keyboard-accessible alternatives per [Accessibility](/accessibility); loading + error states snapshot-locked. |
+| Quality Gate view | ✅ | ✅ | ✅ | Project-gated (`kicadstudio.hasProject`); axe-covered. |
+| Validation / DRC views | ✅ | ✅ | ✅ | `viewsWelcome` empty states for tree views; DRC Rule Editor axe-covered. |
+| Sidebar tree views (11) | ✅ | — | ✅ | `viewsWelcome` provides first-run/empty guidance per view. |
+
+## Changed this review cycle
+
+- **Menu & command-surface hygiene** — palette gating, inline `view/title` icons, editor context menu; removed an always-false `when` clause that hid library commands.
+- **i18n guardrail** — `check:nls-parity` now fails on newly-untranslated user-facing strings.
+- **Versioning story** — reframed the beta program as an ongoing preview channel for the stable 1.x line.
+- **Accessibility evidence** — recorded the automated axe baseline in [Accessibility](/accessibility#conformance-evidence).
+
+## Deferred (environment-bound)
+
+- ⏭️ **Visual-snapshot refresh.** The webview baselines (`test/visual/__screenshots__`) are platform-specific; regenerating them off the Linux CI runner would produce mismatching images. Any pixel-affecting UI change must regenerate on the CI platform.
+- ⏭️ **Manual screen-reader pass.** NVDA (Windows) / VoiceOver (macOS) verification is a documented release gate that needs a screen reader and a human; it is not a CI gate.
+
+## Conclusion
+
+Every in-scope surface meets the GA bar for states, theming, motion, contrast,
+keyboard operability, and localization. The two deferred items are release-time
+verification steps that require a specific environment, not outstanding defects.


### PR DESCRIPTION
## Work items C + D — GA UI/UX review and accessibility conformance evidence

The display-independent documentation deliverables of the UI/UX (C) and accessibility (D) work items. The CSS/state/a11y *implementation* was already strong in-repo; this records the review and the evidence.

### `docs/ux-review-1.0.md` (C)
Per-surface review of the 11 sidebar views and the webviews against the GA bar, with concrete evidence per surface:
- Theming via `--vscode-*` tokens (the two literal hex values are token *fallbacks*, not hardcoded colors).
- `@media (prefers-reduced-motion: reduce)` + `@media (forced-colors: active)` present in both stylesheets.
- `:focus-visible`, deterministic tab order, `role="status"`/`role="alert"` live regions.
- Empty/loading/error states per webview (BOM element-driven; netlist/diff/viewer provider-`status`-driven; all visual-snapshot locked).

Two deferrals documented as **release-time steps, not defects**: visual-snapshot refresh (platform-specific baselines must regenerate on the CI runner) and the manual NVDA/VoiceOver pass.

### `docs/accessibility.md` → Conformance Evidence (D)
Records the automated baseline: **76 axe-core assertions, zero violations**, across every webview surface and the dark/light/high-contrast fixtures, wired into `check`/`check:ci` and CI so it can't regress. (D's automated coverage was already comprehensive; this documents it. The manual screen-reader pass remains a release gate requiring a screen reader + human.)

Both pages linked from the docs nav. `docs:lint` and `docs:links` (incl. the `#conformance-evidence` anchor) pass.
