### PR TITLE
chore(kicad-studio): sync version-derived surfaces for the 1.8.1 release

### DIFF
--- a/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
+++ b/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
@@ -11,7 +11,7 @@ export const COMPATIBILITY_MATRIX = {
   },
   products: {
     kicadStudio: {
-      version: '1.8.0',
+      version: '1.8.1',
       compatibleMcpPro: {
         required: '>=3.5.2 <4.0.0',
         recommended: '>=3.5.2 <4.0.0',
@@ -22,7 +22,7 @@ export const COMPATIBILITY_MATRIX = {
       version: '3.9.2',
       compatibleExtension: {
         required: '>=1.0.0 <2.0.0',
-        testedAgainst: '1.8.0'
+        testedAgainst: '1.8.1'
       }
     }
   }

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -511,7 +511,7 @@ mcp:
 products:
   kicad-studio:
     packagePath: "apps/vscode-extension/package.json"
-    version: "1.8.0"
+    version: "1.8.1"
     compatibleMcpPro:
       required: ">=3.5.2 <4.0.0"
       recommended: ">=3.5.2 <4.0.0"

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -6,5 +6,5 @@ documentation site always follows the same release history as the repository.
 | Product | Version | Changelog |
 | --- | ---: | --- |
 | Monorepo | `1.0.0` | [Root changelog](root.md) |
-| KiCad Studio extension | `1.8.0` | [Extension changelog](kicad-studio.md) |
+| KiCad Studio extension | `1.8.1` | [Extension changelog](kicad-studio.md) |
 | kicad-mcp-pro Python server | `3.9.2` | [MCP server changelog](kicad-mcp-pro.md) |

--- a/docs/changelog/kicad-studio.md
+++ b/docs/changelog/kicad-studio.md
@@ -12,6 +12,14 @@ and this extension adheres to
 Comparison links will be added after the first public component tags are
 published.
 
+## [1.8.1](https://github.com/oaslananka/kicad-studio-kit/compare/vscode-extension-v1.8.0...vscode-extension-v1.8.1) (2026-06-18)
+
+
+### Bug Fixes
+
+* **kicad-studio:** drop proposed MCP API and raise engine floor to 1.101 ([#385](https://github.com/oaslananka/kicad-studio-kit/issues/385)) ([e08dd3a](https://github.com/oaslananka/kicad-studio-kit/commit/e08dd3aca373866cc84db19a6c1e46789f34a7a9))
+* **kicad-studio:** tidy command palette gating and add editor context menu ([#383](https://github.com/oaslananka/kicad-studio-kit/issues/383)) ([76e94d7](https://github.com/oaslananka/kicad-studio-kit/commit/76e94d7d8a4d8726a2d269e0a6f3d05d04b96c2b))
+
 ## [1.8.0](https://github.com/oaslananka/kicad-studio-kit/compare/vscode-extension-v1.7.0...vscode-extension-v1.8.0) (2026-06-14)
 
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -34,7 +34,7 @@ Machine-maintained from `compatibility.yaml`. Refresh with
 
 | Product | Version | Manifest | Compatibility range |
 | --- | --- | --- | --- |
-| kicad-studio | 1.8.0 | apps/vscode-extension/package.json | &gt;=3.5.2 &lt;4.0.0 |
+| kicad-studio | 1.8.1 | apps/vscode-extension/package.json | &gt;=3.5.2 &lt;4.0.0 |
 
 ### Release Gate Inputs
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -6,7 +6,7 @@ Refresh with `corepack pnpm run docs:generate`.
 | Surface | Version or range |
 | --- | --- |
 | Monorepo baseline | `1.0.0` |
-| KiCad Studio extension | `1.8.0` |
+| KiCad Studio extension | `1.8.1` |
 | kicad-mcp-pro Python server | `3.9.2` |
 | VS Code engine | `^1.101.0` |
 | Node | `>=24.11.0 <25` |

--- a/scripts/check-compatibility-contract.test.mjs
+++ b/scripts/check-compatibility-contract.test.mjs
@@ -30,7 +30,7 @@ test("embedded extension compatibility matrix matches compatibility metadata", (
 
 test("embedded extension compatibility matrix rejects product-version drift", () => {
   const driftedSource = matrixSource.replace(
-    "version: '1.8.0'",
+    "version: '1.8.1'",
     "version: '0.0.0'",
   );
 


### PR DESCRIPTION
## Fixes the red CI on `main` after cutting 1.8.1

release-please bumps `package.json` + `CHANGELOG.md` but **has no `extra-files`** in `release-please-config.json`, so it never touches the repo-root version-derived surfaces. Cutting 1.8.1 therefore left `main` failing the **Docs** and **version/compatibility** gates. This syncs them all:

- `compatibility.yaml` `products.kicad-studio.version` 1.8.0 → 1.8.1
- `src/mcp/compatibilityMatrix.ts` `kicadStudio.version` + `compatibleExtension.testedAgainst` → 1.8.1
- regenerated `docs/versions.md`, `docs/changelog/*`, `docs/support-matrix.md` via `pnpm run docs:generate`
- updated the hardcoded drift-injection version in `check-compatibility-contract.test.mjs`

Full `pnpm run check` is green locally (version, compatibility-contract, docs-site incl. vitepress build, and the per-package checks).

### Follow-up (intentionally not in this PR)
Add these surfaces to release-please `extra-files` (or a post-release `docs:generate` step) so future version bumps stay in sync automatically. I left it out to avoid an untestable release-config change that could break the next release PR — flagging it for a deliberate pass.