### PR TITLE
fix(kicad-studio): make marketplace index check advisory, not a release gate

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -194,23 +194,34 @@ jobs:
 
           corepack pnpm --filter kicadstudiokit exec vsce "${publish_args[@]}"
       - name: Verify Visual Studio Marketplace publish status
+        id: marketplace_index
         shell: bash
         run: |
           set -euo pipefail
           version="$(node -p "require('./apps/vscode-extension/package.json').version")"
-          for attempt in $(seq 1 10); do
+          # The publish step above is the source of truth: a successful
+          # `vsce publish` means the version is published. Marketplace *indexing*
+          # is asynchronous and routinely takes longer than this poll window, so
+          # a timeout here is indexing lag, NOT a publish failure. Treat it as
+          # advisory: never fail the job (which would also skip the Open VSX
+          # publish), and record whether indexing was confirmed so the content
+          # verification below only runs when the version is actually served.
+          indexed=false
+          for attempt in $(seq 1 20); do
             if corepack pnpm --filter kicadstudiokit exec vsce show oaslananka.kicadstudiokit --json 2>/dev/null | grep -q "\"$version\""; then
               echo "VS Code Marketplace indexed version $version on attempt $attempt"
-              exit 0
+              indexed=true
+              break
             fi
-            if [ "$attempt" -eq 10 ]; then
-              echo "::error::VS Code Marketplace version $version not visible after 10 attempts"
-              exit 1
-            fi
-            echo "VS Code Marketplace index not updated yet (attempt $attempt/10), waiting 30s…"
-            sleep 30
+            echo "VS Code Marketplace index not updated yet (attempt $attempt/20), waiting 30s…"
+            [ "$attempt" -lt 20 ] && sleep 30
           done
+          echo "indexed=$indexed" >> "$GITHUB_OUTPUT"
+          if [ "$indexed" != "true" ]; then
+            echo "::warning::VS Code Marketplace did not surface $version within the polling window. The publish step reported success, so this is marketplace indexing lag rather than a publish failure; skipping content verification."
+          fi
       - name: Verify Visual Studio Marketplace published content
+        if: steps.marketplace_index.outputs.indexed == 'true'
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Root cause of the 1.8.1 publish 'failure'

The publish actually **succeeded** — the run log shows `Published oaslananka.kicadstudiokit v1.8.1.` and the version is **now live on the VS Code Marketplace**. What failed was the post-publish *verification* step: it polled the marketplace API for only **10×30s = 5 minutes** then `exit 1`. Marketplace indexing is asynchronous and routinely takes longer, so the timeout marked the job failed **even though the publish landed** — and that false failure **cascaded into skipping the Open VSX publish** (which `needs: publish_vscode`).

## Fix

A successful `vsce publish` is the source of truth; the index poll is best-effort:
- Polls up to **20×30s**, records an `indexed` output, and on timeout emits a `::warning::` and **exits 0** instead of failing — so indexing lag no longer fails the release or skips Open VSX.
- The deeper "published content" verification now runs **only when indexing was confirmed** (`if: steps.marketplace_index.outputs.indexed == 'true'`), since it must download the served VSIX.

Validated with `actionlint`. No change to the actual publish logic or credentials.

After this merges I'll re-dispatch the workflow for **Open VSX only** (`publish_vscode=false`) to bring it to 1.8.1 — VS Code Marketplace already has 1.8.1.