### PR TITLE
refactor(kicad-studio): split activation composition root into focused controllers

### DIFF
--- a/apps/vscode-extension/jest.config.js
+++ b/apps/vscode-extension/jest.config.js
@@ -27,6 +27,7 @@ module.exports = {
     'src/**/*.ts',
     '!src/**/*.d.ts',
     '!src/extension.ts',
+    '!src/activation/**/*.ts',
     '!src/cli/exportCommands.ts',
     '!src/providers/baseKiCanvasEditorProvider.ts',
     '!src/providers/bomViewProvider.ts',

--- a/apps/vscode-extension/src/activation/activationState.ts
+++ b/apps/vscode-extension/src/activation/activationState.ts
@@ -1,0 +1,29 @@
+import type * as vscode from 'vscode';
+import type { DiagnosticSummary } from '../types';
+
+/**
+ * Mutable activation-scoped state that is shared between the activation
+ * controllers and the command/language-model layers. Before the controller
+ * split (#397) these lived as closure variables inside `activate()`; promoting
+ * them to a small holder keeps the exact same shared-state semantics while the
+ * logic moves into focused controllers.
+ */
+export interface LatestDrcRun {
+  file: string;
+  diagnostics: vscode.Diagnostic[];
+  summary: DiagnosticSummary;
+}
+
+export class ActivationState {
+  /**
+   * Tracks the last known AI provider health. `undefined` means "not yet
+   * probed" and is reset when AI-related configuration changes.
+   */
+  aiHealthy: boolean | undefined;
+
+  /**
+   * The most recent DRC run, used as a fallback when the per-project diagnostic
+   * store has no record yet.
+   */
+  latestDrcRun: LatestDrcRun | undefined;
+}

--- a/apps/vscode-extension/src/activation/mcpActivationController.ts
+++ b/apps/vscode-extension/src/activation/mcpActivationController.ts
@@ -1,0 +1,169 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { CONTEXT_KEYS, SETTINGS } from '../constants';
+import type { McpClient } from '../mcp/mcpClient';
+import type { McpDetector } from '../mcp/mcpDetector';
+import type { McpStateStore } from '../state/stateStores';
+import { isWorkspaceTrusted } from '../utils/workspaceTrust';
+import type { McpInstallStatus } from '../types';
+
+export interface McpActivationControllerDeps {
+  mcpClient: McpClient;
+  mcpState: McpStateStore;
+  mcpDetector: McpDetector;
+}
+
+/**
+ * Owns MCP connection probing and the MCP-related `setContext` keys. Extracted
+ * unchanged from `activate()` as part of the #397 composition-root split.
+ */
+export class McpActivationController {
+  constructor(private readonly deps: McpActivationControllerDeps) {}
+
+  async refreshMcpState(): Promise<void> {
+    const { mcpClient, mcpState } = this.deps;
+    if (!isWorkspaceTrusted()) {
+      await this.setRestrictedMcpContexts();
+      mcpState.update({
+        kind: 'Disconnected',
+        available: false,
+        connected: false,
+        message: 'MCP integration is disabled in Restricted Mode.'
+      });
+      return;
+    }
+
+    const state = await mcpClient.testConnection();
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpAvailable,
+      state.available
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpConnected,
+      state.connected
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpCompatible,
+      state.server?.compat === 'ok' || state.server?.compat === 'warn'
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpIncompatible,
+      state.kind === 'Incompatible'
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpDisconnected,
+      state.kind === 'Disconnected'
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpVsCodeStdio,
+      state.kind === 'VsCodeStdio'
+    );
+    const activeMode =
+      state.server?.capabilities.serverInfo?.operatingMode.active ?? 'unknown';
+    await this.setMcpOperatingModeContexts(activeMode);
+    mcpState.update(state);
+
+    if (
+      state.available &&
+      !state.connected &&
+      state.kind !== 'Incompatible' &&
+      vscode.workspace
+        .getConfiguration()
+        .get<boolean>(SETTINGS.mcpAutoDetect, true)
+    ) {
+      await this.maybeOfferMcpBootstrap(state.install);
+    }
+  }
+
+  private async setRestrictedMcpContexts(): Promise<void> {
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpAvailable,
+      false
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpConnected,
+      false
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpCompatible,
+      false
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpIncompatible,
+      false
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpDisconnected,
+      true
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpVsCodeStdio,
+      false
+    );
+    await this.setMcpOperatingModeContexts('unknown');
+  }
+
+  private async setMcpOperatingModeContexts(mode: string): Promise<void> {
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpOperatingMode,
+      mode
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpWriteMode,
+      mode === 'write' || mode === 'experimental'
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpManufacturingMode,
+      mode === 'manufacturing' || mode === 'experimental'
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpExperimentalMode,
+      mode === 'experimental'
+    );
+  }
+
+  private async maybeOfferMcpBootstrap(
+    installStatus: McpInstallStatus | undefined
+  ): Promise<void> {
+    if (!installStatus?.found) {
+      return;
+    }
+
+    const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!root) {
+      return;
+    }
+
+    const mcpJsonPath = path.join(root, '.vscode', 'mcp.json');
+    if (fs.existsSync(mcpJsonPath)) {
+      return;
+    }
+
+    const choice = await vscode.window.showInformationMessage(
+      'kicad-mcp-pro was detected. Create .vscode/mcp.json for this project?',
+      'Setup MCP',
+      'Later'
+    );
+    if (choice === 'Setup MCP') {
+      await this.deps.mcpDetector.generateMcpJson(root, installStatus);
+      await this.refreshMcpState();
+    }
+  }
+}

--- a/apps/vscode-extension/src/activation/saveCheckController.ts
+++ b/apps/vscode-extension/src/activation/saveCheckController.ts
@@ -1,0 +1,120 @@
+import * as vscode from 'vscode';
+import { COMMANDS, SETTINGS } from '../constants';
+import type { AIProviderRegistry } from '../ai/aiProvider';
+import type { KiCadCheckService } from '../cli/checkCommands';
+import type { QualityGateProvider } from '../providers/qualityGateProvider';
+import type {
+  DiagnosticStateStore,
+  ProjectStateStore
+} from '../state/stateStores';
+import type { Logger } from '../utils/logger';
+import { isWorkspaceTrusted } from '../utils/workspaceTrust';
+import type { DiagnosticSummary } from '../types';
+import type { ActivationState } from './activationState';
+import type { PushStudioContextReason } from './studioContextController';
+
+export interface SaveCheckControllerDeps {
+  checkService: KiCadCheckService;
+  diagnosticState: DiagnosticStateStore;
+  projectState: ProjectStateStore;
+  qualityGateProvider: QualityGateProvider;
+  aiProviders: AIProviderRegistry;
+  activationState: ActivationState;
+  logger: Logger;
+  pushStudioContext: (reason: PushStudioContextReason) => Promise<void>;
+}
+
+/**
+ * Runs configured auto-DRC/ERC checks on save and surfaces proactive AI
+ * analysis. Extracted unchanged from `activate()` as part of the #397
+ * composition-root split.
+ */
+export class SaveCheckController {
+  constructor(private readonly deps: SaveCheckControllerDeps) {}
+
+  async runConfiguredSaveChecks(document: vscode.TextDocument): Promise<void> {
+    const {
+      checkService,
+      diagnosticState,
+      projectState,
+      qualityGateProvider,
+      activationState,
+      logger,
+      pushStudioContext
+    } = this.deps;
+    const config = vscode.workspace.getConfiguration();
+    const shouldRunDrc =
+      document.fileName.endsWith('.kicad_pcb') &&
+      config.get<boolean>(SETTINGS.autoRunDRC, false);
+    const shouldRunErc =
+      document.fileName.endsWith('.kicad_sch') &&
+      config.get<boolean>(SETTINGS.autoRunERC, false);
+
+    if ((!shouldRunDrc && !shouldRunErc) || !isWorkspaceTrusted()) {
+      return;
+    }
+
+    try {
+      const result = shouldRunDrc
+        ? await checkService.runDRC(document.fileName)
+        : await checkService.runERC(document.fileName);
+      diagnosticState.applyValidationResult(
+        vscode.Uri.file(document.fileName),
+        result.diagnostics,
+        result.summary,
+        {
+          project: projectState.findProjectForResource(document.fileName)
+        }
+      );
+      if (shouldRunDrc) {
+        activationState.latestDrcRun = {
+          file: document.fileName,
+          diagnostics: result.diagnostics,
+          summary: result.summary
+        };
+        qualityGateProvider.scheduleDrcRefresh();
+        await this.maybeOfferProactiveDrc(
+          result.summary,
+          result.diagnostics.length
+        );
+        await pushStudioContext('drc');
+      }
+      if (result.diagnostics.length > 0) {
+        await vscode.commands.executeCommand('workbench.actions.view.problems');
+      }
+    } catch (error) {
+      diagnosticState.recordValidationFailure(
+        shouldRunDrc ? 'drc' : 'erc',
+        vscode.Uri.file(document.fileName),
+        error,
+        {
+          project: projectState.findProjectForResource(document.fileName)
+        }
+      );
+      logger.error('Auto DRC/ERC on save failed', error);
+      void vscode.window.showErrorMessage(
+        error instanceof Error
+          ? `KiCad Studio auto-check failed: ${error.message}`
+          : 'KiCad Studio auto-check failed. Confirm kicad-cli is configured and the file is valid.'
+      );
+    }
+  }
+
+  private async maybeOfferProactiveDrc(
+    summary: DiagnosticSummary,
+    diagnosticCount: number
+  ): Promise<void> {
+    const provider = await this.deps.aiProviders.getProvider();
+    if (!provider?.isConfigured() || diagnosticCount <= 0) {
+      return;
+    }
+    const choice = await vscode.window.showInformationMessage(
+      `DRC: ${summary.errors} errors found. Start AI analysis?`,
+      'Yes, analyze',
+      'No'
+    );
+    if (choice === 'Yes, analyze') {
+      await vscode.commands.executeCommand(COMMANDS.aiProactiveDRC);
+    }
+  }
+}

--- a/apps/vscode-extension/src/activation/studioContextController.ts
+++ b/apps/vscode-extension/src/activation/studioContextController.ts
@@ -1,0 +1,145 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import type { KiCadCliDetector } from '../cli/kicadCliDetector';
+import type { ContextBridge } from '../mcp/contextBridge';
+import type { McpClient } from '../mcp/mcpClient';
+import type { PcbEditorProvider } from '../providers/pcbEditorProvider';
+import type { SchematicEditorProvider } from '../providers/schematicEditorProvider';
+import type {
+  DiagnosticStateStore,
+  ProjectStateStore
+} from '../state/stateStores';
+import type { VariantProvider } from '../variants/variantProvider';
+import { getActiveResourceUri } from '../utils/workspaceUtils';
+import { isWorkspaceTrusted } from '../utils/workspaceTrust';
+import type { StudioContext } from '../types';
+import type { ActivationState } from './activationState';
+
+export interface StudioContextControllerDeps {
+  projectState: ProjectStateStore;
+  diagnosticState: DiagnosticStateStore;
+  pcbEditorProvider: PcbEditorProvider;
+  schematicEditorProvider: SchematicEditorProvider;
+  variantProvider: VariantProvider;
+  cliDetector: KiCadCliDetector;
+  mcpClient: McpClient;
+  contextBridge: ContextBridge;
+  activationState: ActivationState;
+}
+
+export type PushStudioContextReason =
+  | 'save'
+  | 'focus'
+  | 'cursor'
+  | 'drc'
+  | 'default';
+
+/**
+ * Builds and pushes the live "studio context" snapshot consumed by MCP, the
+ * language-model tools, and the chat provider. Extracted from `activate()`
+ * unchanged as part of the #397 composition-root split.
+ */
+export class StudioContextController {
+  constructor(private readonly deps: StudioContextControllerDeps) {}
+
+  async buildStudioContext(): Promise<StudioContext> {
+    const {
+      projectState,
+      diagnosticState,
+      pcbEditorProvider,
+      schematicEditorProvider,
+      variantProvider,
+      cliDetector,
+      mcpClient,
+      activationState
+    } = this.deps;
+    const activeUri = getActiveResourceUri();
+    const activeEditor = vscode.window.activeTextEditor;
+    const selectedProject = projectState.getActiveProject();
+    const resourceProject = activeUri
+      ? projectState.findProjectForResource(activeUri)
+      : undefined;
+    const activeProject = selectedProject ?? resourceProject;
+    const fileType = activeUri?.fsPath.endsWith('.kicad_sch')
+      ? 'schematic'
+      : activeUri?.fsPath.endsWith('.kicad_pcb')
+        ? 'pcb'
+        : 'other';
+    const viewerState =
+      fileType === 'pcb' && activeUri
+        ? pcbEditorProvider.getViewerState(activeUri)
+        : fileType === 'schematic' && activeUri
+          ? schematicEditorProvider.getViewerState(activeUri)
+          : undefined;
+    const mcpState = isWorkspaceTrusted() ? mcpClient.getState() : undefined;
+    const cli = isWorkspaceTrusted() ? await cliDetector.detect() : undefined;
+    const latestProjectDrcRun =
+      diagnosticState.getLatestDrcRun(activeProject?.id) ??
+      activationState.latestDrcRun;
+    return {
+      activeFile: activeUri?.fsPath,
+      fileType,
+      project: activeProject,
+      projectId: activeProject?.id,
+      projectName: activeProject?.name,
+      projectRoot: activeProject?.rootPath,
+      projectFile: activeProject?.projectFile,
+      drcErrors:
+        latestProjectDrcRun?.diagnostics
+          .map((diagnostic) => diagnostic.message)
+          .slice(0, 20) ?? [],
+      selectedReference: viewerState?.selectedReference,
+      selectedArea: viewerState?.selectedArea,
+      cursorPosition: activeEditor
+        ? {
+            line: activeEditor.selection.active.line,
+            character: activeEditor.selection.active.character
+          }
+        : undefined,
+      activeSheetPath:
+        fileType === 'schematic' && activeUri
+          ? path.relative(
+              activeProject?.rootPath ??
+                vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ??
+                '',
+              activeUri.fsPath
+            )
+          : undefined,
+      visibleLayers: viewerState?.activeLayers,
+      viewerEngine: viewerState?.engine,
+      activeVariant: await variantProvider.getActiveVariantName(),
+      mcpConnected: mcpState?.connected ?? false,
+      kicadVersion: cli?.version,
+      designBlocks: activeUri ? readDesignBlockNames(activeUri.fsPath) : []
+    };
+  }
+
+  async pushStudioContext(
+    reason: PushStudioContextReason = 'default'
+  ): Promise<void> {
+    if (!isWorkspaceTrusted()) {
+      return;
+    }
+    await this.deps.contextBridge.pushContext(
+      await this.buildStudioContext(),
+      reason
+    );
+  }
+}
+
+export function readDesignBlockNames(file: string): string[] {
+  try {
+    const text = fs.readFileSync(file, 'utf8');
+    return [
+      ...new Set(
+        Array.from(
+          text.matchAll(/\(\s*design_block\b[\s\S]*?\(\s*name\s+"([^"]+)"/g),
+          (match) => match[1]
+        ).filter((entry): entry is string => Boolean(entry))
+      )
+    ];
+  } catch {
+    return [];
+  }
+}

--- a/apps/vscode-extension/src/activation/workspaceContextController.ts
+++ b/apps/vscode-extension/src/activation/workspaceContextController.ts
@@ -1,0 +1,234 @@
+import * as vscode from 'vscode';
+import { CONTEXT_KEYS } from '../constants';
+import type { AIProviderRegistry } from '../ai/aiProvider';
+import type { KiCadCliDetector } from '../cli/kicadCliDetector';
+import type { KiCadImportService } from '../cli/importCommands';
+import { readConfiguredMcpProfile } from '../commands/mcpProfilePicker';
+import type { KiCadProjectTreeProvider } from '../providers/projectTreeProvider';
+import type {
+  DiagnosticStateStore,
+  ProjectStateStore
+} from '../state/stateStores';
+import type { KiCadStatusBar } from '../statusbar/kicadStatusBar';
+import type { VariantProvider } from '../variants/variantProvider';
+import type { Logger } from '../utils/logger';
+import {
+  getActiveResourceUri,
+  workspaceHasVariants
+} from '../utils/workspaceUtils';
+import { isWorkspaceTrusted } from '../utils/workspaceTrust';
+import type { ProjectContext } from '../types';
+import {
+  ACTIVE_PROJECT_STORAGE_KEY,
+  discoverKiCadProjects,
+  pickActiveProject
+} from '../workspace/projectContext';
+import type { ActivationState } from './activationState';
+import type { PushStudioContextReason } from './studioContextController';
+
+const REFRESH_PROJECTS_DEBOUNCE_MS = 500;
+
+export interface WorkspaceContextControllerDeps {
+  context: vscode.ExtensionContext;
+  logger: Logger;
+  projectState: ProjectStateStore;
+  diagnosticState: DiagnosticStateStore;
+  statusBar: KiCadStatusBar;
+  aiProviders: AIProviderRegistry;
+  cliDetector: KiCadCliDetector;
+  importService: KiCadImportService;
+  treeProvider: KiCadProjectTreeProvider;
+  variantProvider: VariantProvider;
+  activationState: ActivationState;
+  pushStudioContext: (reason: PushStudioContextReason) => Promise<void>;
+}
+
+/**
+ * Owns workspace/project discovery, the `setContext` keys that gate the UI, and
+ * the active-project selection. Also coalesces rapid `.kicad_pro` filesystem
+ * events into a single debounced refresh. Extracted unchanged from `activate()`
+ * as part of the #397 composition-root split.
+ */
+export class WorkspaceContextController implements vscode.Disposable {
+  private refreshProjectsTimer: NodeJS.Timeout | undefined;
+
+  constructor(private readonly deps: WorkspaceContextControllerDeps) {}
+
+  async refreshContexts(): Promise<void> {
+    const {
+      context,
+      projectState,
+      diagnosticState,
+      statusBar,
+      aiProviders,
+      cliDetector,
+      activationState
+    } = this.deps;
+    const activeUri = getActiveResourceUri();
+    const projects = await discoverKiCadProjects(
+      vscode.workspace.workspaceFolders
+    );
+    const hasProject =
+      projects.length > 0 ||
+      (
+        await vscode.workspace.findFiles(
+          '**/*.kicad_sch',
+          '**/node_modules/**',
+          1
+        )
+      ).length > 0 ||
+      (
+        await vscode.workspace.findFiles(
+          '**/*.kicad_pcb',
+          '**/node_modules/**',
+          1
+        )
+      ).length > 0;
+    const trusted = isWorkspaceTrusted();
+    const provider = await aiProviders.getProvider();
+    const cli = trusted ? await cliDetector.detect() : undefined;
+    const kicadVersionMajor = Number(cli?.version.split('.')[0] ?? '0');
+    const allegroImportSupported = await this.detectAllegroImportSupport(
+      trusted,
+      Boolean(cli)
+    );
+    const hasVariants = await workspaceHasVariants();
+    const mcpProfile = readConfiguredMcpProfile();
+    const persistedProjectId = context.workspaceState.get<string>(
+      ACTIVE_PROJECT_STORAGE_KEY
+    );
+    const activeProject = pickActiveProject(projects, {
+      previousActiveProjectId: projectState.getActiveProject()?.id,
+      persistedActiveProjectId: persistedProjectId,
+      activeResourcePath: activeUri?.fsPath
+    });
+    const projectSnapshot = projectState.update({
+      activeResource: activeUri,
+      projects,
+      activeProject,
+      hasProject,
+      hasVariants,
+      workspaceTrusted: trusted
+    });
+    diagnosticState.setActiveProject(projectSnapshot.activeProject?.id);
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.hasProject,
+      projectSnapshot.hasProject
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.schematicOpen,
+      activeUri?.fsPath.endsWith('.kicad_sch') ?? false
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.pcbOpen,
+      activeUri?.fsPath.endsWith('.kicad_pcb') ?? false
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.aiEnabled,
+      Boolean(provider?.isConfigured())
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.aiHealthy,
+      Boolean(provider?.isConfigured() && activationState.aiHealthy !== false)
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.kicad10Plus,
+      kicadVersionMajor >= 10
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.hasVariants,
+      projectSnapshot.hasVariants
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.allegroImportSupported,
+      allegroImportSupported
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.workspaceTrusted,
+      isWorkspaceTrusted()
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      CONTEXT_KEYS.mcpProfile,
+      mcpProfile ?? 'full'
+    );
+    statusBar.update({
+      aiConfigured: Boolean(provider?.isConfigured()),
+      aiHealthy: activationState.aiHealthy,
+      mcpProfile,
+      activeProjectName: projectSnapshot.activeProject?.name,
+      drc: diagnosticState.getSnapshot().drc,
+      erc: diagnosticState.getSnapshot().erc
+    });
+  }
+
+  private async detectAllegroImportSupport(
+    trusted: boolean,
+    cliDetected: boolean
+  ): Promise<boolean> {
+    if (!trusted || !cliDetected) {
+      return false;
+    }
+
+    try {
+      return await this.deps.importService.isImportFormatSupported('allegro');
+    } catch (error) {
+      this.deps.logger.error('Allegro import capability probe failed', error);
+      return false;
+    }
+  }
+
+  async selectActiveProject(
+    projectOrId: ProjectContext | string
+  ): Promise<void> {
+    const { context, projectState, diagnosticState, statusBar, treeProvider } =
+      this.deps;
+    const project =
+      typeof projectOrId === 'string'
+        ? projectState.findProjectById(projectOrId)
+        : projectOrId;
+    if (!project) {
+      return;
+    }
+    await context.workspaceState.update(ACTIVE_PROJECT_STORAGE_KEY, project.id);
+    const snapshot = projectState.update({ activeProject: project });
+    diagnosticState.setActiveProject(project.id);
+    const diagnostics = diagnosticState.getSnapshot();
+    statusBar.update({
+      activeProjectName: snapshot.activeProject?.name,
+      drc: diagnostics.drc,
+      erc: diagnostics.erc
+    });
+    treeProvider.refresh();
+    await this.deps.pushStudioContext('focus');
+  }
+
+  scheduleProjectRefresh(): void {
+    const { treeProvider, variantProvider } = this.deps;
+    if (this.refreshProjectsTimer) {
+      clearTimeout(this.refreshProjectsTimer);
+    }
+    this.refreshProjectsTimer = setTimeout(() => {
+      this.refreshProjectsTimer = undefined;
+      void this.refreshContexts();
+      treeProvider.refresh();
+      variantProvider.refresh();
+    }, REFRESH_PROJECTS_DEBOUNCE_MS);
+  }
+
+  dispose(): void {
+    if (this.refreshProjectsTimer) {
+      clearTimeout(this.refreshProjectsTimer);
+      this.refreshProjectsTimer = undefined;
+    }
+  }
+}

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -1,5 +1,3 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { ErrorAnalyzer } from './ai/errorAnalyzer';
 import { AIProviderRegistry } from './ai/aiProvider';
@@ -18,9 +16,7 @@ import { LcscClient } from './components/lcscClient';
 import { OctopartClient } from './components/octopartClient';
 import {
   BOM_VIEW_ID,
-  COMMANDS,
   COMPONENT_SEARCH_VIEW_ID,
-  CONTEXT_KEYS,
   DIAGNOSTIC_COLLECTION_NAME,
   KICAD_S_EXPRESSION_LANGUAGES,
   DRC_RULES_VIEW_ID,
@@ -89,32 +85,17 @@ import {
   isAiSecretProvider,
   migratePlaintextSettingToSecret
 } from './utils/secrets';
-import {
-  getActiveResourceUri,
-  workspaceHasVariants
-} from './utils/workspaceUtils';
 import { isWorkspaceTrusted } from './utils/workspaceTrust';
-import type {
-  DiagnosticSummary,
-  McpInstallStatus,
-  ProjectContext,
-  StudioContext
-} from './types';
-import {
-  ACTIVE_PROJECT_STORAGE_KEY,
-  discoverKiCadProjects,
-  pickActiveProject
-} from './workspace/projectContext';
+import type { ProjectContext } from './types';
+import { ActivationState } from './activation/activationState';
+import { McpActivationController } from './activation/mcpActivationController';
+import { SaveCheckController } from './activation/saveCheckController';
+import { StudioContextController } from './activation/studioContextController';
+import { WorkspaceContextController } from './activation/workspaceContextController';
 
 let extensionLogger: Logger | undefined;
 let extensionMcpClient: McpClient | undefined;
 const S_EXPRESSION_LANGUAGE_IDS = new Set<string>(KICAD_S_EXPRESSION_LANGUAGES);
-
-// Debounced project re-scan — coalesces rapid file-system events into a single
-// refresh so that externally-created or deleted .kicad_pro files are picked up
-// without overwhelming the extension host.
-let refreshProjectsTimer: NodeJS.Timeout | undefined;
-const REFRESH_PROJECTS_DEBOUNCE_MS = 500;
 
 export async function activate(
   context: vscode.ExtensionContext
@@ -125,14 +106,10 @@ export async function activate(
   logger.info('Activating KiCad Studio...');
   await runSettingsMigrations(context, logger);
   await migrateDeprecatedSecretSettings(context, logger);
-  let latestDrcRun:
-    | {
-        file: string;
-        diagnostics: vscode.Diagnostic[];
-        summary: DiagnosticSummary;
-      }
-    | undefined;
-  let aiHealthy: boolean | undefined;
+
+  // Activation-scoped shared state (previously closure variables in this
+  // function). The focused controllers below read and write it.
+  const activationState = new ActivationState();
 
   const parser = new SExpressionParser();
   const languageServer = new KiCadDocumentStore(parser);
@@ -240,6 +217,50 @@ export async function activate(
     logger
   );
   const pcmLibraryProvider = new PcmLibraryProvider(pcmService);
+
+  // Focused activation controllers (#397). They own the activation logic that
+  // previously lived as nested closures in this function.
+  const studioContext = new StudioContextController({
+    projectState,
+    diagnosticState,
+    pcbEditorProvider,
+    schematicEditorProvider,
+    variantProvider,
+    cliDetector,
+    mcpClient,
+    contextBridge,
+    activationState
+  });
+  const mcpActivation = new McpActivationController({
+    mcpClient,
+    mcpState,
+    mcpDetector
+  });
+  const workspaceContext = new WorkspaceContextController({
+    context,
+    logger,
+    projectState,
+    diagnosticState,
+    statusBar,
+    aiProviders,
+    cliDetector,
+    importService,
+    treeProvider,
+    variantProvider,
+    activationState,
+    pushStudioContext: (reason) => studioContext.pushStudioContext(reason)
+  });
+  const saveCheck = new SaveCheckController({
+    checkService,
+    diagnosticState,
+    projectState,
+    qualityGateProvider,
+    aiProviders,
+    activationState,
+    logger,
+    pushStudioContext: (reason) => studioContext.pushStudioContext(reason)
+  });
+
   const componentSearch = new ComponentSearchService(
     new OctopartClient(context.secrets),
     new LcscClient(),
@@ -247,7 +268,7 @@ export async function activate(
     libraryIndexer,
     pcmService,
     context,
-    () => buildStudioContext()
+    () => studioContext.buildStudioContext()
   );
 
   context.subscriptions.push(
@@ -268,6 +289,7 @@ export async function activate(
     bomViewProvider,
     netlistViewProvider,
     validationViewProvider,
+    workspaceContext,
     diagnosticState.onDidChange((state) => {
       statusBar.update({ drc: state.drc, erc: state.erc });
     }),
@@ -376,25 +398,25 @@ export async function activate(
       treeProvider.refresh();
       variantProvider.refresh();
       drcRulesProvider.refresh();
-      void refreshContexts();
-      void runConfiguredSaveChecks(document);
-      void pushStudioContext('save');
+      void workspaceContext.refreshContexts();
+      void saveCheck.runConfiguredSaveChecks(document);
+      void studioContext.pushStudioContext('save');
     }),
     vscode.workspace.onDidCloseTextDocument((document) => {
       diagnosticsCollection.delete(document.uri);
       languageServer.invalidate(document.uri);
     }),
     vscode.window.onDidChangeActiveTextEditor(() => {
-      void refreshContexts();
+      void workspaceContext.refreshContexts();
       variantProvider.refresh();
       drcRulesProvider.refresh();
-      void pushStudioContext('focus');
+      void studioContext.pushStudioContext('focus');
     }),
     vscode.window.onDidChangeTextEditorSelection(() => {
-      void pushStudioContext('cursor');
+      void studioContext.pushStudioContext('cursor');
     }),
     vscode.window.tabGroups.onDidChangeTabs(() => {
-      void refreshContexts();
+      void workspaceContext.refreshContexts();
     }),
     vscode.workspace.onDidChangeConfiguration((event) => {
       if (
@@ -410,9 +432,9 @@ export async function activate(
         event.affectsConfiguration(SETTINGS.pcmThirdPartyDir)
       ) {
         cliDetector.clearCache();
-        aiHealthy = undefined;
-        void refreshContexts();
-        void refreshMcpState();
+        activationState.aiHealthy = undefined;
+        void workspaceContext.refreshContexts();
+        void mcpActivation.refreshMcpState();
       }
       if (
         event.affectsConfiguration(SETTINGS.pcmRepositoryUrls) ||
@@ -447,19 +469,17 @@ export async function activate(
 
   // Watch for externally-created/deleted .kicad_pro files so that the project
   // tree, status bar, and context keys stay current without requiring a tab
-  // switch or editor focus change.
+  // switch or editor focus change. The controller debounces the refresh.
   const projectFileWatcher =
     vscode.workspace.createFileSystemWatcher('**/*.kicad_pro');
   context.subscriptions.push(
     projectFileWatcher,
-    projectFileWatcher.onDidCreate(refreshProjectsScheduled),
-    projectFileWatcher.onDidDelete(refreshProjectsScheduled),
-    new vscode.Disposable(() => {
-      if (refreshProjectsTimer) {
-        clearTimeout(refreshProjectsTimer);
-        refreshProjectsTimer = undefined;
-      }
-    })
+    projectFileWatcher.onDidCreate(() =>
+      workspaceContext.scheduleProjectRefresh()
+    ),
+    projectFileWatcher.onDidDelete(() =>
+      workspaceContext.scheduleProjectRefresh()
+    )
   );
 
   registerAllCommands(context, {
@@ -492,17 +512,18 @@ export async function activate(
     logger,
     getLatestDrcRun: () =>
       diagnosticState.getLatestDrcRun(projectState.getActiveProject()?.id) ??
-      latestDrcRun,
+      activationState.latestDrcRun,
     setLatestDrcRun: (value) => {
-      latestDrcRun = value;
+      activationState.latestDrcRun = value;
     },
     setAiHealthy: (value) => {
-      aiHealthy = value;
+      activationState.aiHealthy = value;
     },
-    pushStudioContext: () => pushStudioContext('default'),
-    selectActiveProject,
-    refreshContexts,
-    refreshMcpState
+    pushStudioContext: () => studioContext.pushStudioContext('default'),
+    selectActiveProject: (projectOrId) =>
+      workspaceContext.selectActiveProject(projectOrId),
+    refreshContexts: () => workspaceContext.refreshContexts(),
+    refreshMcpState: () => mcpActivation.refreshMcpState()
   });
 
   context.subscriptions.push(
@@ -517,14 +538,16 @@ export async function activate(
       diagnosticsCollection,
       diagnosticState,
       projectState,
-      getStudioContext: buildStudioContext,
+      getStudioContext: () => studioContext.buildStudioContext(),
       setLatestDrcRun: (value) => {
-        latestDrcRun = value;
+        activationState.latestDrcRun = value;
       }
     })
   );
   registerMcpServerDefinitionProvider(context, mcpDetector, logger);
-  registerLanguageModelChatProvider(context, logger, buildStudioContext);
+  registerLanguageModelChatProvider(context, logger, () =>
+    studioContext.buildStudioContext()
+  );
 
   if (isWorkspaceTrusted()) {
     void cliDetector.detect().then((cli) => {
@@ -537,16 +560,16 @@ export async function activate(
         void cliDetector.detect().then((cli) => {
           statusBar.update({ cli });
         });
-        void refreshContexts();
-        void refreshMcpState();
+        void workspaceContext.refreshContexts();
+        void mcpActivation.refreshMcpState();
       })
     );
   }
-  void refreshMcpState();
+  void mcpActivation.refreshMcpState();
   variantProvider.refresh();
   drcRulesProvider.refresh();
 
-  await refreshContexts();
+  await workspaceContext.refreshContexts();
 
   const isFirstInstall = !context.globalState.get<boolean>(
     'kicadstudio.installed'
@@ -564,472 +587,6 @@ export async function activate(
   logger.info(`KiCad Studio activated in ${activationDurationMs}ms`);
   if (activationDurationMs > 500) {
     logger.warn(`Activation exceeded 500ms (${activationDurationMs}ms).`);
-  }
-
-  async function refreshContexts(): Promise<void> {
-    const activeUri = getActiveResourceUri();
-    const projects = await discoverKiCadProjects(
-      vscode.workspace.workspaceFolders
-    );
-    const hasProject =
-      projects.length > 0 ||
-      (
-        await vscode.workspace.findFiles(
-          '**/*.kicad_sch',
-          '**/node_modules/**',
-          1
-        )
-      ).length > 0 ||
-      (
-        await vscode.workspace.findFiles(
-          '**/*.kicad_pcb',
-          '**/node_modules/**',
-          1
-        )
-      ).length > 0;
-    const trusted = isWorkspaceTrusted();
-    const provider = await aiProviders.getProvider();
-    const cli = trusted ? await cliDetector.detect() : undefined;
-    const kicadVersionMajor = Number(cli?.version.split('.')[0] ?? '0');
-    const allegroImportSupported = await detectAllegroImportSupport(
-      trusted,
-      Boolean(cli)
-    );
-    const hasVariants = await workspaceHasVariants();
-    const mcpProfile = readConfiguredMcpProfile();
-    const persistedProjectId = context.workspaceState.get<string>(
-      ACTIVE_PROJECT_STORAGE_KEY
-    );
-    const activeProject = pickActiveProject(projects, {
-      previousActiveProjectId: projectState.getActiveProject()?.id,
-      persistedActiveProjectId: persistedProjectId,
-      activeResourcePath: activeUri?.fsPath
-    });
-    const projectSnapshot = projectState.update({
-      activeResource: activeUri,
-      projects,
-      activeProject,
-      hasProject,
-      hasVariants,
-      workspaceTrusted: trusted
-    });
-    diagnosticState.setActiveProject(projectSnapshot.activeProject?.id);
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.hasProject,
-      projectSnapshot.hasProject
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.schematicOpen,
-      activeUri?.fsPath.endsWith('.kicad_sch') ?? false
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.pcbOpen,
-      activeUri?.fsPath.endsWith('.kicad_pcb') ?? false
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.aiEnabled,
-      Boolean(provider?.isConfigured())
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.aiHealthy,
-      Boolean(provider?.isConfigured() && aiHealthy !== false)
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.kicad10Plus,
-      kicadVersionMajor >= 10
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.hasVariants,
-      projectSnapshot.hasVariants
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.allegroImportSupported,
-      allegroImportSupported
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.workspaceTrusted,
-      isWorkspaceTrusted()
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpProfile,
-      mcpProfile ?? 'full'
-    );
-    statusBar.update({
-      aiConfigured: Boolean(provider?.isConfigured()),
-      aiHealthy,
-      mcpProfile,
-      activeProjectName: projectSnapshot.activeProject?.name,
-      drc: diagnosticState.getSnapshot().drc,
-      erc: diagnosticState.getSnapshot().erc
-    });
-  }
-
-  async function detectAllegroImportSupport(
-    trusted: boolean,
-    cliDetected: boolean
-  ): Promise<boolean> {
-    if (!trusted || !cliDetected) {
-      return false;
-    }
-
-    try {
-      return await importService.isImportFormatSupported('allegro');
-    } catch (error) {
-      logger.error('Allegro import capability probe failed', error);
-      return false;
-    }
-  }
-
-  async function selectActiveProject(
-    projectOrId: ProjectContext | string
-  ): Promise<void> {
-    const project =
-      typeof projectOrId === 'string'
-        ? projectState.findProjectById(projectOrId)
-        : projectOrId;
-    if (!project) {
-      return;
-    }
-    await context.workspaceState.update(ACTIVE_PROJECT_STORAGE_KEY, project.id);
-    const snapshot = projectState.update({ activeProject: project });
-    diagnosticState.setActiveProject(project.id);
-    const diagnostics = diagnosticState.getSnapshot();
-    statusBar.update({
-      activeProjectName: snapshot.activeProject?.name,
-      drc: diagnostics.drc,
-      erc: diagnostics.erc
-    });
-    treeProvider.refresh();
-    await pushStudioContext('focus');
-  }
-
-  async function runConfiguredSaveChecks(
-    document: vscode.TextDocument
-  ): Promise<void> {
-    const config = vscode.workspace.getConfiguration();
-    const shouldRunDrc =
-      document.fileName.endsWith('.kicad_pcb') &&
-      config.get<boolean>(SETTINGS.autoRunDRC, false);
-    const shouldRunErc =
-      document.fileName.endsWith('.kicad_sch') &&
-      config.get<boolean>(SETTINGS.autoRunERC, false);
-
-    if ((!shouldRunDrc && !shouldRunErc) || !isWorkspaceTrusted()) {
-      return;
-    }
-
-    try {
-      const result = shouldRunDrc
-        ? await checkService.runDRC(document.fileName)
-        : await checkService.runERC(document.fileName);
-      diagnosticState.applyValidationResult(
-        vscode.Uri.file(document.fileName),
-        result.diagnostics,
-        result.summary,
-        {
-          project: projectState.findProjectForResource(document.fileName)
-        }
-      );
-      if (shouldRunDrc) {
-        latestDrcRun = {
-          file: document.fileName,
-          diagnostics: result.diagnostics,
-          summary: result.summary
-        };
-        qualityGateProvider.scheduleDrcRefresh();
-        await maybeOfferProactiveDrc(result.summary, result.diagnostics.length);
-        await pushStudioContext('drc');
-      }
-      if (result.diagnostics.length > 0) {
-        await vscode.commands.executeCommand('workbench.actions.view.problems');
-      }
-    } catch (error) {
-      diagnosticState.recordValidationFailure(
-        shouldRunDrc ? 'drc' : 'erc',
-        vscode.Uri.file(document.fileName),
-        error,
-        {
-          project: projectState.findProjectForResource(document.fileName)
-        }
-      );
-      logger.error('Auto DRC/ERC on save failed', error);
-      void vscode.window.showErrorMessage(
-        error instanceof Error
-          ? `KiCad Studio auto-check failed: ${error.message}`
-          : 'KiCad Studio auto-check failed. Confirm kicad-cli is configured and the file is valid.'
-      );
-    }
-  }
-
-  async function maybeOfferProactiveDrc(
-    summary: DiagnosticSummary,
-    diagnosticCount: number
-  ): Promise<void> {
-    const provider = await aiProviders.getProvider();
-    if (!provider?.isConfigured() || diagnosticCount <= 0) {
-      return;
-    }
-    const choice = await vscode.window.showInformationMessage(
-      `DRC: ${summary.errors} errors found. Start AI analysis?`,
-      'Yes, analyze',
-      'No'
-    );
-    if (choice === 'Yes, analyze') {
-      await vscode.commands.executeCommand(COMMANDS.aiProactiveDRC);
-    }
-  }
-
-  async function refreshMcpState(): Promise<void> {
-    if (!isWorkspaceTrusted()) {
-      await setRestrictedMcpContexts();
-      mcpState.update({
-        kind: 'Disconnected',
-        available: false,
-        connected: false,
-        message: 'MCP integration is disabled in Restricted Mode.'
-      });
-      return;
-    }
-
-    const state = await mcpClient.testConnection();
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpAvailable,
-      state.available
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpConnected,
-      state.connected
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpCompatible,
-      state.server?.compat === 'ok' || state.server?.compat === 'warn'
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpIncompatible,
-      state.kind === 'Incompatible'
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpDisconnected,
-      state.kind === 'Disconnected'
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpVsCodeStdio,
-      state.kind === 'VsCodeStdio'
-    );
-    const activeMode =
-      state.server?.capabilities.serverInfo?.operatingMode.active ?? 'unknown';
-    await setMcpOperatingModeContexts(activeMode);
-    mcpState.update(state);
-
-    if (
-      state.available &&
-      !state.connected &&
-      state.kind !== 'Incompatible' &&
-      vscode.workspace
-        .getConfiguration()
-        .get<boolean>(SETTINGS.mcpAutoDetect, true)
-    ) {
-      await maybeOfferMcpBootstrap(state.install);
-    }
-  }
-
-  function refreshProjectsScheduled(): void {
-    if (refreshProjectsTimer) {
-      clearTimeout(refreshProjectsTimer);
-    }
-    refreshProjectsTimer = setTimeout(() => {
-      refreshProjectsTimer = undefined;
-      void refreshContexts();
-      treeProvider.refresh();
-      variantProvider.refresh();
-    }, REFRESH_PROJECTS_DEBOUNCE_MS);
-  }
-
-  async function setRestrictedMcpContexts(): Promise<void> {
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpAvailable,
-      false
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpConnected,
-      false
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpCompatible,
-      false
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpIncompatible,
-      false
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpDisconnected,
-      true
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpVsCodeStdio,
-      false
-    );
-    await setMcpOperatingModeContexts('unknown');
-  }
-
-  async function setMcpOperatingModeContexts(mode: string): Promise<void> {
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpOperatingMode,
-      mode
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpWriteMode,
-      mode === 'write' || mode === 'experimental'
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpManufacturingMode,
-      mode === 'manufacturing' || mode === 'experimental'
-    );
-    await vscode.commands.executeCommand(
-      'setContext',
-      CONTEXT_KEYS.mcpExperimentalMode,
-      mode === 'experimental'
-    );
-  }
-
-  async function maybeOfferMcpBootstrap(
-    installStatus: McpInstallStatus | undefined
-  ): Promise<void> {
-    if (!installStatus?.found) {
-      return;
-    }
-
-    const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    if (!root) {
-      return;
-    }
-
-    const mcpJsonPath = path.join(root, '.vscode', 'mcp.json');
-    if (fs.existsSync(mcpJsonPath)) {
-      return;
-    }
-
-    const choice = await vscode.window.showInformationMessage(
-      'kicad-mcp-pro was detected. Create .vscode/mcp.json for this project?',
-      'Setup MCP',
-      'Later'
-    );
-    if (choice === 'Setup MCP') {
-      await mcpDetector.generateMcpJson(root, installStatus);
-      await refreshMcpState();
-    }
-  }
-
-  async function buildStudioContext(): Promise<StudioContext> {
-    const activeUri = getActiveResourceUri();
-    const activeEditor = vscode.window.activeTextEditor;
-    const selectedProject = projectState.getActiveProject();
-    const resourceProject = activeUri
-      ? projectState.findProjectForResource(activeUri)
-      : undefined;
-    const activeProject = selectedProject ?? resourceProject;
-    const fileType = activeUri?.fsPath.endsWith('.kicad_sch')
-      ? 'schematic'
-      : activeUri?.fsPath.endsWith('.kicad_pcb')
-        ? 'pcb'
-        : 'other';
-    const viewerState =
-      fileType === 'pcb' && activeUri
-        ? pcbEditorProvider.getViewerState(activeUri)
-        : fileType === 'schematic' && activeUri
-          ? schematicEditorProvider.getViewerState(activeUri)
-          : undefined;
-    const mcpState = isWorkspaceTrusted() ? mcpClient.getState() : undefined;
-    const cli = isWorkspaceTrusted() ? await cliDetector.detect() : undefined;
-    const latestProjectDrcRun =
-      diagnosticState.getLatestDrcRun(activeProject?.id) ?? latestDrcRun;
-    return {
-      activeFile: activeUri?.fsPath,
-      fileType,
-      project: activeProject,
-      projectId: activeProject?.id,
-      projectName: activeProject?.name,
-      projectRoot: activeProject?.rootPath,
-      projectFile: activeProject?.projectFile,
-      drcErrors:
-        latestProjectDrcRun?.diagnostics
-          .map((diagnostic) => diagnostic.message)
-          .slice(0, 20) ?? [],
-      selectedReference: viewerState?.selectedReference,
-      selectedArea: viewerState?.selectedArea,
-      cursorPosition: activeEditor
-        ? {
-            line: activeEditor.selection.active.line,
-            character: activeEditor.selection.active.character
-          }
-        : undefined,
-      activeSheetPath:
-        fileType === 'schematic' && activeUri
-          ? path.relative(
-              activeProject?.rootPath ??
-                vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ??
-                '',
-              activeUri.fsPath
-            )
-          : undefined,
-      visibleLayers: viewerState?.activeLayers,
-      viewerEngine: viewerState?.engine,
-      activeVariant: await variantProvider.getActiveVariantName(),
-      mcpConnected: mcpState?.connected ?? false,
-      kicadVersion: cli?.version,
-      designBlocks: activeUri ? readDesignBlockNames(activeUri.fsPath) : []
-    };
-  }
-
-  async function pushStudioContext(
-    reason: 'save' | 'focus' | 'cursor' | 'drc' | 'default' = 'default'
-  ): Promise<void> {
-    if (!isWorkspaceTrusted()) {
-      return;
-    }
-    await contextBridge.pushContext(await buildStudioContext(), reason);
-  }
-}
-
-function readDesignBlockNames(file: string): string[] {
-  try {
-    const text = fs.readFileSync(file, 'utf8');
-    return [
-      ...new Set(
-        Array.from(
-          text.matchAll(/\(\s*design_block\b[\s\S]*?\(\s*name\s+"([^"]+)"/g),
-          (match) => match[1]
-        ).filter((entry): entry is string => Boolean(entry))
-      )
-    ];
-  } catch {
-    return [];
   }
 }
 

--- a/apps/vscode-extension/test/unit/activationControllers.test.ts
+++ b/apps/vscode-extension/test/unit/activationControllers.test.ts
@@ -1,0 +1,120 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ActivationState } from '../../src/activation/activationState';
+import { readDesignBlockNames } from '../../src/activation/studioContextController';
+import {
+  WorkspaceContextController,
+  type WorkspaceContextControllerDeps
+} from '../../src/activation/workspaceContextController';
+
+describe('#397 activation controllers', () => {
+  describe('readDesignBlockNames', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kicad-design-blocks-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('extracts unique design block names from a board file', () => {
+      const file = path.join(tmpDir, 'board.kicad_pcb');
+      fs.writeFileSync(
+        file,
+        [
+          '(kicad_pcb',
+          '  (design_block (id "a") (name "Power Supply"))',
+          '  (design_block (id "b") (name "MCU Block"))',
+          '  (design_block (id "c") (name "Power Supply"))',
+          ')'
+        ].join('\n'),
+        'utf8'
+      );
+
+      const names = readDesignBlockNames(file);
+      expect(names).toEqual(['Power Supply', 'MCU Block']);
+    });
+
+    it('returns an empty array for a missing file', () => {
+      expect(readDesignBlockNames(path.join(tmpDir, 'nope.kicad_pcb'))).toEqual(
+        []
+      );
+    });
+
+    it('returns an empty array when there are no design blocks', () => {
+      const file = path.join(tmpDir, 'plain.kicad_pcb');
+      fs.writeFileSync(file, '(kicad_pcb (general))', 'utf8');
+      expect(readDesignBlockNames(file)).toEqual([]);
+    });
+  });
+
+  describe('ActivationState', () => {
+    it('starts with unset fields and is mutable', () => {
+      const state = new ActivationState();
+      expect(state.aiHealthy).toBeUndefined();
+      expect(state.latestDrcRun).toBeUndefined();
+      state.aiHealthy = true;
+      state.latestDrcRun = {
+        file: 'a.kicad_pcb',
+        diagnostics: [],
+        summary: {} as never
+      };
+      expect(state.aiHealthy).toBe(true);
+      expect(state.latestDrcRun?.file).toBe('a.kicad_pcb');
+    });
+  });
+
+  describe('WorkspaceContextController project-refresh debounce', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    function makeController(refresh: jest.Mock, variantRefresh: jest.Mock) {
+      const deps = {
+        treeProvider: { refresh },
+        variantProvider: { refresh: variantRefresh }
+      } as unknown as WorkspaceContextControllerDeps;
+      return new WorkspaceContextController(deps);
+    }
+
+    it('coalesces rapid schedule calls into a single tree refresh', () => {
+      const refresh = jest.fn();
+      const variantRefresh = jest.fn();
+      const controller = makeController(refresh, variantRefresh);
+      // Stub out the expensive context refresh so the timer callback is cheap.
+      jest.spyOn(controller, 'refreshContexts').mockResolvedValue(undefined);
+
+      controller.scheduleProjectRefresh();
+      controller.scheduleProjectRefresh();
+      controller.scheduleProjectRefresh();
+      expect(refresh).not.toHaveBeenCalled();
+
+      jest.runOnlyPendingTimers();
+      expect(refresh).toHaveBeenCalledTimes(1);
+      expect(variantRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispose cancels a pending refresh', () => {
+      const refresh = jest.fn();
+      const variantRefresh = jest.fn();
+      const controller = makeController(refresh, variantRefresh);
+      const refreshContexts = jest
+        .spyOn(controller, 'refreshContexts')
+        .mockResolvedValue(undefined);
+
+      controller.scheduleProjectRefresh();
+      controller.dispose();
+      jest.runOnlyPendingTimers();
+
+      expect(refresh).not.toHaveBeenCalled();
+      expect(refreshContexts).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`extension.ts` was a 1111-line composition root with ~450 lines of nested activation closures sharing mutable state. This extracts that logic into focused, dependency-injected controllers under `src/activation/`, leaving a slim composition root that instantiates services and wires controllers together. **Behavior is preserved exactly** — the logic moved unchanged.

New controllers:

| Controller | Responsibility (moved verbatim from `activate()`) |
| --- | --- |
| `StudioContextController` | `buildStudioContext` / `pushStudioContext` + the pure `readDesignBlockNames` helper |
| `McpActivationController` | `refreshMcpState` and all MCP `setContext` keys / bootstrap offer |
| `WorkspaceContextController` | `refreshContexts`, active-project selection, debounced `.kicad_pro` rescan (now `Disposable`) |
| `SaveCheckController` | auto DRC/ERC on save + proactive AI offer |
| `ActivationState` | shared `aiHealthy` / `latestDrcRun` (previously closure vars) |

`extension.ts` drops from 1111 → ~620 lines and now reads as: instantiate services → construct controllers → register subscriptions/commands → delegate.

## Linked issues

Closes #397

## Validation

- [x] `pnpm typecheck` (no errors)
- [x] `pnpm lint` (clean, no unused imports)
- [x] `pnpm test:unit:coverage` — **95 suites / 752 tests pass**, thresholds held
- [x] **Integration test** (activates the real extension and asserts every contributed command is registered) — passes in the pre-push full `pnpm run check`
- [x] `pnpm build` + `pnpm package` (VSIX) via pre-push aggregate

## Coverage policy

`src/activation/**` is excluded from unit-coverage thresholds, consistent with the existing `!src/extension.ts` exclusion — these are VS Code-API orchestration modules covered by the integration suite. A new `activationControllers.test.ts` unit-tests the genuinely unit-testable parts (the pure `readDesignBlockNames`, `ActivationState`, and the debounce/dispose lifecycle).

## Risk

Medium (touches the flagship activation path) but mitigated: the extraction is mechanical (no logic changes), fully typechecked, and verified by the existing integration test that boots the extension host and checks command registration. Rollback = revert the commit.

## Acceptance criteria mapping

- Composition root split into focused controllers (bootstrap/workspace/context/CLI/MCP/AI/viewer/diagnostics intent) ✔
- Behavior preserved ✔
- Tests around command registration & activation behavior ✔ (integration + new unit tests)
- No giant rewrite without tests ✔