### PR TITLE
perf(kicad-studio): debounce and cache workspace context refreshes

### DIFF
--- a/apps/vscode-extension/src/activation/studioContextController.ts
+++ b/apps/vscode-extension/src/activation/studioContextController.ts
@@ -35,12 +35,23 @@ export type PushStudioContextReason =
   | 'drc'
   | 'default';
 
+// Cursor moves fire continuously while typing/navigating. Coalesce them so the
+// (relatively expensive) studio-context build runs at most once per idle window
+// instead of once per cursor event. The ContextBridge applies a further
+// reason-based send delay on top of this.
+const CURSOR_PUSH_DEBOUNCE_MS = 250;
+
 /**
  * Builds and pushes the live "studio context" snapshot consumed by MCP, the
- * language-model tools, and the chat provider. Extracted from `activate()`
- * unchanged as part of the #397 composition-root split.
+ * language-model tools, and the chat provider. Extracted from `activate()` as
+ * part of the #397 composition-root split; #398 adds an mtime-keyed design-block
+ * cache and cursor-push debouncing so the build avoids redundant synchronous
+ * file reads on hot paths.
  */
-export class StudioContextController {
+export class StudioContextController implements vscode.Disposable {
+  private readonly designBlockCache = new DesignBlockCache();
+  private cursorPushTimer: NodeJS.Timeout | undefined;
+
   constructor(private readonly deps: StudioContextControllerDeps) {}
 
   async buildStudioContext(): Promise<StudioContext> {
@@ -111,7 +122,9 @@ export class StudioContextController {
       activeVariant: await variantProvider.getActiveVariantName(),
       mcpConnected: mcpState?.connected ?? false,
       kicadVersion: cli?.version,
-      designBlocks: activeUri ? readDesignBlockNames(activeUri.fsPath) : []
+      designBlocks: activeUri
+        ? this.designBlockCache.read(activeUri.fsPath)
+        : []
     };
   }
 
@@ -125,6 +138,64 @@ export class StudioContextController {
       await this.buildStudioContext(),
       reason
     );
+  }
+
+  /**
+   * Debounce high-frequency cursor pushes; route all other reasons straight
+   * through so saves/focus/DRC stay responsive.
+   */
+  schedulePushStudioContext(reason: PushStudioContextReason = 'default'): void {
+    if (reason !== 'cursor') {
+      void this.pushStudioContext(reason);
+      return;
+    }
+    if (this.cursorPushTimer) {
+      clearTimeout(this.cursorPushTimer);
+    }
+    this.cursorPushTimer = setTimeout(() => {
+      this.cursorPushTimer = undefined;
+      void this.pushStudioContext('cursor');
+    }, CURSOR_PUSH_DEBOUNCE_MS);
+  }
+
+  dispose(): void {
+    if (this.cursorPushTimer) {
+      clearTimeout(this.cursorPushTimer);
+      this.cursorPushTimer = undefined;
+    }
+  }
+}
+
+/**
+ * Caches design-block name parsing keyed by file path and modification time, so
+ * a large board file is only re-read and re-parsed when it actually changes
+ * rather than on every cursor move.
+ */
+export class DesignBlockCache {
+  private readonly entries = new Map<
+    string,
+    { mtimeMs: number; names: string[] }
+  >();
+
+  constructor(
+    private readonly reader: (file: string) => string[] = readDesignBlockNames
+  ) {}
+
+  read(file: string): string[] {
+    let mtimeMs: number;
+    try {
+      mtimeMs = fs.statSync(file).mtimeMs;
+    } catch {
+      this.entries.delete(file);
+      return [];
+    }
+    const cached = this.entries.get(file);
+    if (cached && cached.mtimeMs === mtimeMs) {
+      return cached.names;
+    }
+    const names = this.reader(file);
+    this.entries.set(file, { mtimeMs, names });
+    return names;
   }
 }
 

--- a/apps/vscode-extension/src/activation/workspaceContextController.ts
+++ b/apps/vscode-extension/src/activation/workspaceContextController.ts
@@ -27,6 +27,10 @@ import type { ActivationState } from './activationState';
 import type { PushStudioContextReason } from './studioContextController';
 
 const REFRESH_PROJECTS_DEBOUNCE_MS = 500;
+// Editor focus, tab, and config changes can fire in quick bursts. Coalescing the
+// (relatively expensive) context refresh keeps the extension host responsive on
+// large workspaces.
+const CONTEXT_REFRESH_DEBOUNCE_MS = 150;
 
 export interface WorkspaceContextControllerDeps {
   context: vscode.ExtensionContext;
@@ -46,15 +50,58 @@ export interface WorkspaceContextControllerDeps {
 /**
  * Owns workspace/project discovery, the `setContext` keys that gate the UI, and
  * the active-project selection. Also coalesces rapid `.kicad_pro` filesystem
- * events into a single debounced refresh. Extracted unchanged from `activate()`
- * as part of the #397 composition-root split.
+ * events into a single debounced refresh. Extracted from `activate()` as part of
+ * the #397 composition-root split; #398 adds context-refresh debouncing, an
+ * overlap guard, and a cached capability probe.
  */
 export class WorkspaceContextController implements vscode.Disposable {
   private refreshProjectsTimer: NodeJS.Timeout | undefined;
+  private contextRefreshTimer: NodeJS.Timeout | undefined;
+  private refreshInFlight = false;
+  private refreshQueued = false;
+  private allegroSupported: boolean | undefined;
 
   constructor(private readonly deps: WorkspaceContextControllerDeps) {}
 
+  /**
+   * Refresh all context keys and the status bar. Overlapping calls are coalesced
+   * into a single trailing run so bursts of events do not stampede the
+   * (async) discovery + capability probes.
+   */
   async refreshContexts(): Promise<void> {
+    if (this.refreshInFlight) {
+      this.refreshQueued = true;
+      return;
+    }
+    this.refreshInFlight = true;
+    try {
+      await this.doRefreshContexts();
+    } finally {
+      this.refreshInFlight = false;
+      if (this.refreshQueued) {
+        this.refreshQueued = false;
+        await this.refreshContexts();
+      }
+    }
+  }
+
+  /** Debounced entry point for high-frequency UI events. */
+  scheduleContextRefresh(): void {
+    if (this.contextRefreshTimer) {
+      clearTimeout(this.contextRefreshTimer);
+    }
+    this.contextRefreshTimer = setTimeout(() => {
+      this.contextRefreshTimer = undefined;
+      void this.refreshContexts();
+    }, CONTEXT_REFRESH_DEBOUNCE_MS);
+  }
+
+  /** Drop cached capability probes (e.g. after a CLI-path/config change). */
+  invalidateProbeCache(): void {
+    this.allegroSupported = undefined;
+  }
+
+  private async doRefreshContexts(): Promise<void> {
     const {
       context,
       projectState,
@@ -178,9 +225,14 @@ export class WorkspaceContextController implements vscode.Disposable {
     if (!trusted || !cliDetected) {
       return false;
     }
+    if (this.allegroSupported !== undefined) {
+      return this.allegroSupported;
+    }
 
     try {
-      return await this.deps.importService.isImportFormatSupported('allegro');
+      this.allegroSupported =
+        await this.deps.importService.isImportFormatSupported('allegro');
+      return this.allegroSupported;
     } catch (error) {
       this.deps.logger.error('Allegro import capability probe failed', error);
       return false;
@@ -229,6 +281,10 @@ export class WorkspaceContextController implements vscode.Disposable {
     if (this.refreshProjectsTimer) {
       clearTimeout(this.refreshProjectsTimer);
       this.refreshProjectsTimer = undefined;
+    }
+    if (this.contextRefreshTimer) {
+      clearTimeout(this.contextRefreshTimer);
+      this.contextRefreshTimer = undefined;
     }
   }
 }

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -290,6 +290,7 @@ export async function activate(
     netlistViewProvider,
     validationViewProvider,
     workspaceContext,
+    studioContext,
     diagnosticState.onDidChange((state) => {
       statusBar.update({ drc: state.drc, erc: state.erc });
     }),
@@ -398,7 +399,7 @@ export async function activate(
       treeProvider.refresh();
       variantProvider.refresh();
       drcRulesProvider.refresh();
-      void workspaceContext.refreshContexts();
+      workspaceContext.scheduleContextRefresh();
       void saveCheck.runConfiguredSaveChecks(document);
       void studioContext.pushStudioContext('save');
     }),
@@ -407,16 +408,16 @@ export async function activate(
       languageServer.invalidate(document.uri);
     }),
     vscode.window.onDidChangeActiveTextEditor(() => {
-      void workspaceContext.refreshContexts();
+      workspaceContext.scheduleContextRefresh();
       variantProvider.refresh();
       drcRulesProvider.refresh();
       void studioContext.pushStudioContext('focus');
     }),
     vscode.window.onDidChangeTextEditorSelection(() => {
-      void studioContext.pushStudioContext('cursor');
+      studioContext.schedulePushStudioContext('cursor');
     }),
     vscode.window.tabGroups.onDidChangeTabs(() => {
-      void workspaceContext.refreshContexts();
+      workspaceContext.scheduleContextRefresh();
     }),
     vscode.workspace.onDidChangeConfiguration((event) => {
       if (
@@ -432,8 +433,9 @@ export async function activate(
         event.affectsConfiguration(SETTINGS.pcmThirdPartyDir)
       ) {
         cliDetector.clearCache();
+        workspaceContext.invalidateProbeCache();
         activationState.aiHealthy = undefined;
-        void workspaceContext.refreshContexts();
+        workspaceContext.scheduleContextRefresh();
         void mcpActivation.refreshMcpState();
       }
       if (

--- a/apps/vscode-extension/test/unit/contextRefreshPerf.test.ts
+++ b/apps/vscode-extension/test/unit/contextRefreshPerf.test.ts
@@ -1,0 +1,156 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  DesignBlockCache,
+  StudioContextController,
+  type StudioContextControllerDeps
+} from '../../src/activation/studioContextController';
+import {
+  WorkspaceContextController,
+  type WorkspaceContextControllerDeps
+} from '../../src/activation/workspaceContextController';
+
+describe('#398 context refresh performance', () => {
+  describe('DesignBlockCache', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kicad-dbc-'));
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeBoard(file: string, blockName: string): void {
+      fs.writeFileSync(
+        file,
+        `(kicad_pcb (design_block (id "x") (name "${blockName}")))`,
+        'utf8'
+      );
+    }
+
+    it('parses the file once for repeated reads with an unchanged mtime', () => {
+      const file = path.join(tmpDir, 'board.kicad_pcb');
+      writeBoard(file, 'Power');
+      const reader = jest.fn(() => ['Power']);
+      const cache = new DesignBlockCache(reader);
+
+      expect(cache.read(file)).toEqual(['Power']);
+      expect(cache.read(file)).toEqual(['Power']);
+      expect(cache.read(file)).toEqual(['Power']);
+
+      // Only the first read parses the file; later reads are served from cache.
+      expect(reader).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-parses when the file mtime changes', () => {
+      const file = path.join(tmpDir, 'board.kicad_pcb');
+      writeBoard(file, 'Power');
+      const reader = jest.fn(() => ['Power']);
+      const cache = new DesignBlockCache(reader);
+      cache.read(file);
+
+      writeBoard(file, 'MCU');
+      // Force a distinct mtime so the change is detectable on fast filesystems.
+      const future = new Date(Date.now() + 5000);
+      fs.utimesSync(file, future, future);
+      cache.read(file);
+
+      expect(reader).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns an empty array and does not parse a missing file', () => {
+      const reader = jest.fn(() => ['Power']);
+      const cache = new DesignBlockCache(reader);
+
+      expect(cache.read(path.join(tmpDir, 'nope.kicad_pcb'))).toEqual([]);
+      expect(reader).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('StudioContextController.schedulePushStudioContext', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    function makeController() {
+      return new StudioContextController(
+        {} as unknown as StudioContextControllerDeps
+      );
+    }
+
+    it('debounces rapid cursor pushes into a single push', () => {
+      const controller = makeController();
+      const push = jest
+        .spyOn(controller, 'pushStudioContext')
+        .mockResolvedValue(undefined);
+
+      controller.schedulePushStudioContext('cursor');
+      controller.schedulePushStudioContext('cursor');
+      controller.schedulePushStudioContext('cursor');
+      expect(push).not.toHaveBeenCalled();
+
+      jest.runOnlyPendingTimers();
+      expect(push).toHaveBeenCalledTimes(1);
+      expect(push).toHaveBeenCalledWith('cursor');
+    });
+
+    it('passes non-cursor reasons straight through', () => {
+      const controller = makeController();
+      const push = jest
+        .spyOn(controller, 'pushStudioContext')
+        .mockResolvedValue(undefined);
+
+      controller.schedulePushStudioContext('save');
+      expect(push).toHaveBeenCalledWith('save');
+    });
+
+    it('dispose cancels a pending cursor push', () => {
+      const controller = makeController();
+      const push = jest
+        .spyOn(controller, 'pushStudioContext')
+        .mockResolvedValue(undefined);
+
+      controller.schedulePushStudioContext('cursor');
+      controller.dispose();
+      jest.runOnlyPendingTimers();
+      expect(push).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('WorkspaceContextController.scheduleContextRefresh', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    it('coalesces rapid schedule calls into a single refresh', () => {
+      const controller = new WorkspaceContextController(
+        {} as unknown as WorkspaceContextControllerDeps
+      );
+      const refresh = jest
+        .spyOn(controller, 'refreshContexts')
+        .mockResolvedValue(undefined);
+
+      controller.scheduleContextRefresh();
+      controller.scheduleContextRefresh();
+      controller.scheduleContextRefresh();
+      expect(refresh).not.toHaveBeenCalled();
+
+      jest.runOnlyPendingTimers();
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Cuts redundant work on hot UI paths by adding debouncing and caching to the activation controllers introduced in #397.

> **Stacked on #397** ([#420](https://github.com/oaslananka/kicad-studio-kit/pull/420)). Base is the `refactor/activation-controllers-397` branch so this PR shows only the perf diff; it will retarget to `main` automatically once #397 merges.

**Hot-path costs removed:**
- The Allegro import probe (a `kicad-cli` spawn) ran on **every** `refreshContexts()` — now cached and invalidated on config change.
- `readDesignBlockNames` did a **synchronous `readFileSync`** of the board on **every cursor move** (via `buildStudioContext`) — now mtime-cached, so a large board is re-parsed only when it actually changes.
- `refreshContexts()` fired in full on every editor-focus / tab / save / config event — now debounced + coalesced with an in-flight overlap guard.
- Cursor context pushes are debounced (the `ContextBridge` still applies its own reason-based send delay on top).

## Linked issues

Closes #398

## Validation

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check`
- [x] `pnpm test:unit:coverage` — **96 suites / 759 tests pass**, thresholds held
- [x] New `contextRefreshPerf.test.ts`: mtime cache hit/miss, cursor-push debounce + dispose, context-refresh coalescing
- [x] Integration test (activates the extension) via pre-push full `pnpm run check`

## Risk

Low–medium. Debounce intervals are short (150ms context, 250ms cursor) so UX is unchanged perceptually; the awaited activation refresh stays immediate. Caches invalidate on config change / mtime change. Rollback = revert the commit.

## Notes

The dedicated activation/context/large-project **benchmark** suite is intentionally scoped to #412; this PR delivers the debounce/cache behavior plus behavioral perf tests.