### PR TITLE
security(kicad-studio): centralize guarded execution for write, export, import, and MCP operations

### DIFF
--- a/apps/vscode-extension/src/commands/manufacturingReleaseWizard.ts
+++ b/apps/vscode-extension/src/commands/manufacturingReleaseWizard.ts
@@ -9,6 +9,10 @@ import {
   troubleshootingUri
 } from '../utils/notifications';
 import { telemetry } from '../utils/telemetry';
+import {
+  assertWorkspaceTrusted,
+  resolveGuardedPath
+} from '../security/guardedOperations';
 import type { CommandServices } from './types';
 
 export async function runManufacturingReleaseWizard(
@@ -21,6 +25,9 @@ export async function runManufacturingReleaseWizard(
   }
 
   try {
+    // A manufacturing release writes a bundle to disk; gate it on workspace
+    // trust through the centralized guard rather than menu visibility alone.
+    assertWorkspaceTrusted('Manufacturing release');
     const gates = await services.mcpAdapter.runProjectQualityGate();
     const blocking = gates.filter((gate) =>
       ['FAIL', 'BLOCKED'].includes(gate.status)
@@ -49,11 +56,14 @@ export async function runManufacturingReleaseWizard(
     if (!outputDirInput) {
       return;
     }
-    const outputDir = path.isAbsolute(outputDirInput)
-      ? outputDirInput
-      : root
-        ? path.resolve(root, outputDirInput)
-        : path.resolve(outputDirInput);
+    // Resolve + canonicalize the user-supplied output folder and confine it to
+    // the workspace (defeats `..` traversal and symlink escape). Throws a safe
+    // GuardedOperationError on escape, handled by the catch below.
+    const outputDir = resolveGuardedPath({
+      requestedPath: outputDirInput,
+      workspaceRoot: root,
+      label: 'Manufacturing release output folder'
+    });
 
     let mcpResult: Record<string, unknown> | undefined;
     const filesGenerated: string[] = [];

--- a/apps/vscode-extension/src/security/guardedOperations.ts
+++ b/apps/vscode-extension/src/security/guardedOperations.ts
@@ -1,0 +1,164 @@
+import * as vscode from 'vscode';
+import { resolveSafeWorkspacePath } from '../utils/pathUtils';
+import { isWorkspaceTrusted } from '../utils/workspaceTrust';
+
+/**
+ * Centralized guard layer for state-changing operations (write, export, import,
+ * manufacturing, and MCP operations that can affect project state).
+ *
+ * Every such operation should flow through this module rather than re-checking
+ * trust and path safety ad hoc, and rather than relying only on hiding commands
+ * from menus. The guarantees provided here are:
+ *
+ * - workspace-trust gating (Restricted Mode cannot mutate project state);
+ * - path canonicalization + symlink-resolved workspace-boundary checks for any
+ *   user-supplied output path (defeats `..` traversal and symlink escape);
+ * - explicit user confirmation for risky operations;
+ * - an opt-in dry-run / preview that resolves and validates without executing;
+ * - safe, code-tagged error messages that do not leak host paths.
+ */
+
+export type GuardedOperationKind =
+  | 'write'
+  | 'export'
+  | 'import'
+  | 'manufacturing'
+  | 'mcp';
+
+export type GuardedOperationErrorCode =
+  | 'untrusted'
+  | 'no-workspace'
+  | 'path-escape';
+
+/** Error type whose `message` is always safe to surface to the user. */
+export class GuardedOperationError extends Error {
+  constructor(
+    message: string,
+    readonly code: GuardedOperationErrorCode
+  ) {
+    super(message);
+    this.name = 'GuardedOperationError';
+  }
+}
+
+/** Throw a {@link GuardedOperationError} when the workspace is not trusted. */
+export function assertWorkspaceTrusted(feature: string): void {
+  if (!isWorkspaceTrusted()) {
+    throw new GuardedOperationError(
+      `${feature} is disabled in Restricted Mode. Trust this workspace to continue.`,
+      'untrusted'
+    );
+  }
+}
+
+export interface GuardedPathOptions {
+  requestedPath: string;
+  /** Workspace root to confine the path to; defaults to the first folder. */
+  workspaceRoot?: string | undefined;
+  /** Human label used in the error message, e.g. "Output directory". */
+  label?: string | undefined;
+}
+
+/**
+ * Resolve a user-supplied path and assert it stays inside the workspace. Throws
+ * a {@link GuardedOperationError} (never a raw path-leaking error) on escape or
+ * when no workspace is open.
+ */
+export function resolveGuardedPath(options: GuardedPathOptions): string {
+  const workspaceRoot =
+    options.workspaceRoot ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const label = options.label ?? 'Path';
+  if (!workspaceRoot) {
+    throw new GuardedOperationError(
+      `${label} requires an open workspace folder.`,
+      'no-workspace'
+    );
+  }
+  try {
+    return resolveSafeWorkspacePath(
+      workspaceRoot,
+      options.requestedPath,
+      `${label} must stay inside the open workspace.`
+    );
+  } catch (error) {
+    throw new GuardedOperationError(
+      error instanceof Error
+        ? error.message
+        : `${label} must stay inside the open workspace.`,
+      'path-escape'
+    );
+  }
+}
+
+export interface ConfirmOptions {
+  message: string;
+  confirmLabel: string;
+  detail?: string | undefined;
+}
+
+/** Modal confirmation for a risky operation. Returns true only on confirm. */
+export async function confirmRiskyOperation(
+  options: ConfirmOptions
+): Promise<boolean> {
+  const messageOptions: vscode.MessageOptions = { modal: true };
+  if (options.detail !== undefined) {
+    messageOptions.detail = options.detail;
+  }
+  const choice = await vscode.window.showWarningMessage(
+    options.message,
+    messageOptions,
+    options.confirmLabel
+  );
+  return choice === options.confirmLabel;
+}
+
+export interface GuardedOperationOptions {
+  feature: string;
+  kind: GuardedOperationKind;
+  /** Defaults to true; set false only for read-only previews. */
+  requireTrust?: boolean;
+  /** When set, the path is resolved + boundary-checked before the action runs. */
+  outputPath?: GuardedPathOptions;
+  /** When set, the user must confirm before the action runs. */
+  confirm?: ConfirmOptions;
+  /** When true, validate everything but do not run the action. */
+  dryRun?: boolean;
+}
+
+export type GuardedOperationOutcome = 'completed' | 'dry-run' | 'cancelled';
+
+export interface GuardedOperationResult<T> {
+  outcome: GuardedOperationOutcome;
+  /** The validated, workspace-safe path, when `outputPath` was provided. */
+  safePath?: string | undefined;
+  value?: T | undefined;
+}
+
+/**
+ * Run `action` only after trust, path-safety, and confirmation guards pass.
+ * Throws {@link GuardedOperationError} when a guard fails; returns a
+ * discriminated result describing whether the action ran, was previewed
+ * (dry-run), or was cancelled at the confirmation step.
+ */
+export async function runGuardedOperation<T>(
+  options: GuardedOperationOptions,
+  action: (ctx: { safePath?: string | undefined }) => Promise<T>
+): Promise<GuardedOperationResult<T>> {
+  if (options.requireTrust !== false) {
+    assertWorkspaceTrusted(options.feature);
+  }
+  const safePath = options.outputPath
+    ? resolveGuardedPath(options.outputPath)
+    : undefined;
+  if (options.dryRun) {
+    return { outcome: 'dry-run', safePath };
+  }
+  if (options.confirm) {
+    const confirmed = await confirmRiskyOperation(options.confirm);
+    if (!confirmed) {
+      return { outcome: 'cancelled', safePath };
+    }
+  }
+  const value = await action({ safePath });
+  return { outcome: 'completed', safePath, value };
+}

--- a/apps/vscode-extension/src/utils/pathUtils.ts
+++ b/apps/vscode-extension/src/utils/pathUtils.ts
@@ -93,13 +93,18 @@ export function assertPathInside(
   }
 }
 
-export function resolveWorkspaceOutputDir(
-  filePath: string,
-  configuredOutputDir: string
+/**
+ * Resolve a user-supplied path against a workspace root, then assert — through
+ * symlink-resolved canonical paths — that it stays inside that root. Throws when
+ * the path escapes. Shared primitive behind {@link resolveWorkspaceOutputDir}
+ * and the centralized guarded-operation layer (src/security).
+ */
+export function resolveSafeWorkspacePath(
+  workspaceRoot: string,
+  requestedPath: string,
+  message?: string
 ): string {
-  const workspaceRoot =
-    getWorkspaceRoot(vscode.Uri.file(filePath)) ?? path.dirname(filePath);
-  const configured = normalizeUserPath(configuredOutputDir) || 'fab';
+  const configured = normalizeUserPath(requestedPath);
   const candidate = path.isAbsolute(configured)
     ? path.normalize(configured)
     : path.resolve(workspaceRoot, configured);
@@ -110,10 +115,24 @@ export function resolveWorkspaceOutputDir(
   assertPathInside(
     workspaceRealPath,
     candidateRealPath,
-    `Output directory must stay inside the workspace: ${configuredOutputDir}`
+    message ?? `Path must stay inside the workspace: ${requestedPath}`
   );
 
   return candidate;
+}
+
+export function resolveWorkspaceOutputDir(
+  filePath: string,
+  configuredOutputDir: string
+): string {
+  const workspaceRoot =
+    getWorkspaceRoot(vscode.Uri.file(filePath)) ?? path.dirname(filePath);
+  const configured = normalizeUserPath(configuredOutputDir) || 'fab';
+  return resolveSafeWorkspacePath(
+    workspaceRoot,
+    configured,
+    `Output directory must stay inside the workspace: ${configuredOutputDir}`
+  );
 }
 
 export function findSiblingProjectFile(filePath: string): string | undefined {

--- a/apps/vscode-extension/test/unit/guardedOperations.test.ts
+++ b/apps/vscode-extension/test/unit/guardedOperations.test.ts
@@ -1,0 +1,238 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  GuardedOperationError,
+  assertWorkspaceTrusted,
+  confirmRiskyOperation,
+  resolveGuardedPath,
+  runGuardedOperation
+} from '../../src/security/guardedOperations';
+import { window, workspace } from './vscodeMock';
+
+describe('guarded operations (#399)', () => {
+  let wsRoot: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    workspace.isTrusted = true;
+    wsRoot = fs.realpathSync.native(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'kicad-guard-'))
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(wsRoot, { recursive: true, force: true });
+  });
+
+  describe('assertWorkspaceTrusted', () => {
+    it('passes in a trusted workspace', () => {
+      expect(() => assertWorkspaceTrusted('Export')).not.toThrow();
+    });
+
+    it('throws an untrusted error in Restricted Mode', () => {
+      workspace.isTrusted = false;
+      try {
+        assertWorkspaceTrusted('Export');
+        throw new Error('expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GuardedOperationError);
+        expect((error as GuardedOperationError).code).toBe('untrusted');
+      }
+    });
+  });
+
+  describe('resolveGuardedPath', () => {
+    it('returns a resolved path that stays inside the workspace', () => {
+      const safe = resolveGuardedPath({
+        requestedPath: 'fab/out',
+        workspaceRoot: wsRoot,
+        label: 'Output directory'
+      });
+      expect(safe).toBe(path.resolve(wsRoot, 'fab/out'));
+    });
+
+    it('rejects parent-directory traversal', () => {
+      expect(() =>
+        resolveGuardedPath({
+          requestedPath: '../escape',
+          workspaceRoot: wsRoot,
+          label: 'Output directory'
+        })
+      ).toThrow(GuardedOperationError);
+    });
+
+    it('rejects an absolute path outside the workspace', () => {
+      const outside = fs.realpathSync.native(os.tmpdir());
+      try {
+        resolveGuardedPath({
+          requestedPath: path.join(outside, 'elsewhere'),
+          workspaceRoot: wsRoot
+        });
+        throw new Error('expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GuardedOperationError);
+        expect((error as GuardedOperationError).code).toBe('path-escape');
+      }
+    });
+
+    it('rejects a symlink that escapes the workspace', () => {
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kicad-out-'));
+      const link = path.join(wsRoot, 'link');
+      try {
+        fs.symlinkSync(outsideDir, link, 'dir');
+      } catch {
+        // Symlink creation can require privileges (e.g. Windows); the
+        // canonicalization behavior is covered by the traversal cases above.
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+        return;
+      }
+      try {
+        expect(() =>
+          resolveGuardedPath({
+            requestedPath: 'link/file.gbr',
+            workspaceRoot: wsRoot
+          })
+        ).toThrow(GuardedOperationError);
+      } finally {
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
+
+    it('throws a no-workspace error when no root is available', () => {
+      const wsMock = workspace as unknown as { workspaceFolders: unknown };
+      const previous = wsMock.workspaceFolders;
+      wsMock.workspaceFolders = undefined;
+      try {
+        resolveGuardedPath({ requestedPath: 'fab' });
+        throw new Error('expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GuardedOperationError);
+        expect((error as GuardedOperationError).code).toBe('no-workspace');
+      } finally {
+        wsMock.workspaceFolders = previous;
+      }
+    });
+  });
+
+  describe('confirmRiskyOperation', () => {
+    it('returns true when the user confirms', async () => {
+      (window.showWarningMessage as jest.Mock).mockResolvedValueOnce('Proceed');
+      await expect(
+        confirmRiskyOperation({
+          message: 'Overwrite?',
+          confirmLabel: 'Proceed'
+        })
+      ).resolves.toBe(true);
+    });
+
+    it('returns false when the user dismisses', async () => {
+      (window.showWarningMessage as jest.Mock).mockResolvedValueOnce(undefined);
+      await expect(
+        confirmRiskyOperation({
+          message: 'Overwrite?',
+          confirmLabel: 'Proceed'
+        })
+      ).resolves.toBe(false);
+    });
+  });
+
+  describe('runGuardedOperation', () => {
+    it('runs the action when all guards pass', async () => {
+      const action = jest.fn().mockResolvedValue('done');
+      const result = await runGuardedOperation(
+        {
+          feature: 'Export',
+          kind: 'export',
+          outputPath: { requestedPath: 'fab', workspaceRoot: wsRoot }
+        },
+        action
+      );
+      expect(result.outcome).toBe('completed');
+      expect(result.value).toBe('done');
+      expect(result.safePath).toBe(path.resolve(wsRoot, 'fab'));
+      expect(action).toHaveBeenCalledTimes(1);
+    });
+
+    it('refuses to run in Restricted Mode', async () => {
+      workspace.isTrusted = false;
+      const action = jest.fn();
+      await expect(
+        runGuardedOperation({ feature: 'Export', kind: 'export' }, action)
+      ).rejects.toBeInstanceOf(GuardedOperationError);
+      expect(action).not.toHaveBeenCalled();
+    });
+
+    it('previews without executing on dry-run', async () => {
+      const action = jest.fn();
+      const result = await runGuardedOperation(
+        {
+          feature: 'Export',
+          kind: 'export',
+          dryRun: true,
+          outputPath: { requestedPath: 'fab', workspaceRoot: wsRoot }
+        },
+        action
+      );
+      expect(result.outcome).toBe('dry-run');
+      expect(result.safePath).toBe(path.resolve(wsRoot, 'fab'));
+      expect(action).not.toHaveBeenCalled();
+    });
+
+    it('cancels when the confirmation is declined', async () => {
+      (window.showWarningMessage as jest.Mock).mockResolvedValueOnce(undefined);
+      const action = jest.fn();
+      const result = await runGuardedOperation(
+        {
+          feature: 'Export',
+          kind: 'manufacturing',
+          confirm: { message: 'Overwrite?', confirmLabel: 'Proceed' }
+        },
+        action
+      );
+      expect(result.outcome).toBe('cancelled');
+      expect(action).not.toHaveBeenCalled();
+    });
+
+    it('runs after the confirmation is accepted', async () => {
+      (window.showWarningMessage as jest.Mock).mockResolvedValueOnce('Proceed');
+      const action = jest.fn().mockResolvedValue(undefined);
+      const result = await runGuardedOperation(
+        {
+          feature: 'Export',
+          kind: 'manufacturing',
+          confirm: { message: 'Overwrite?', confirmLabel: 'Proceed' }
+        },
+        action
+      );
+      expect(result.outcome).toBe('completed');
+      expect(action).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects an escaping output path before running the action', async () => {
+      const action = jest.fn();
+      await expect(
+        runGuardedOperation(
+          {
+            feature: 'Export',
+            kind: 'export',
+            outputPath: { requestedPath: '../escape', workspaceRoot: wsRoot }
+          },
+          action
+        )
+      ).rejects.toBeInstanceOf(GuardedOperationError);
+      expect(action).not.toHaveBeenCalled();
+    });
+
+    it('can skip the trust gate for read-only previews', async () => {
+      workspace.isTrusted = false;
+      const action = jest.fn().mockResolvedValue('ok');
+      const result = await runGuardedOperation(
+        { feature: 'Preview', kind: 'write', requireTrust: false },
+        action
+      );
+      expect(result.outcome).toBe('completed');
+      expect(action).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `src/security/guardedOperations.ts` as the **single guard layer** for state-changing operations, replacing ad-hoc per-call-site checks and "hide the command from the menu" as the only protection.

Guarantees provided in one place:
- **Workspace-trust gating** — Restricted Mode cannot mutate project state.
- **Path canonicalization + symlink-resolved workspace-boundary checks** — defeats `..` traversal and symlink escape on any user-supplied output path.
- **Explicit confirmation** for risky operations + an opt-in **dry-run/preview**.
- **Safe, code-tagged errors** (`GuardedOperationError`) that never leak host paths.

### Real bug fixed

The **Manufacturing Release Wizard** previously resolved its user-supplied output folder with a plain `path.resolve` and **no workspace-boundary check** — a malicious or mistyped path (`../../...`, an absolute path, or a symlink) could write the release bundle outside the workspace. It now asserts trust and routes the path through `resolveGuardedPath`.

## Linked issues

Closes #399
Refs #413 (threat model + expanded guarded-operation test matrix to follow, stacked on this)

## Validation

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check`
- [x] `pnpm test:unit:coverage` — **95 suites / 762 tests**, `guardedOperations.ts` at **97% lines / 100% functions**, thresholds held
- [x] `pnpm test:security` (existing regression/fuzz suite) — passes
- [x] New `guardedOperations.test.ts`: trust gating, `..` traversal, absolute-outside, **symlink escape**, no-workspace, modal confirm, dry-run, cancel, trust-skip preview

## Risk

Medium (security-sensitive + touches the manufacturing write path). Mitigated: `resolveSafeWorkspacePath` is the same battle-tested canonicalization that already backed `resolveWorkspaceOutputDir` (existing path-regression/fuzz suites still pass); the wizard change only *tightens* behavior. The no-workspace case now errors instead of writing to an arbitrary resolved path — intentional hardening for a release-bundle write.

## Acceptance criteria mapping

- Central guarded layer for write/export/import/manufacturing/MCP ✔ (shared API; manufacturing migrated first as the highest-risk writer)
- Trust, path canonicalization, boundary + symlink-escape checks, confirmation, dry-run, safe errors ✔
- Not relying only on menu hiding ✔ (guard enforced in code)