### PR TITLE
security(deps): override undici to 7.28.0 to resolve high-severity advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   tmp: 0.2.7
   uuid: 14.0.0
   vite: 6.4.3
+  undici: 7.28.0
 
 importers:
 
@@ -4907,8 +4908,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.26.0:
-    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -7807,7 +7808,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.26.0
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -10449,7 +10450,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.26.0: {}
+  undici@7.28.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,3 +35,4 @@ overrides:
   tmp: 0.2.7
   uuid: 14.0.0
   vite: 6.4.3
+  undici: 7.28.0


### PR DESCRIPTION
## Summary

Pins `undici` to **7.28.0** via the existing pnpm `overrides` to clear a batch of advisories (vulnerable `>=7.23.0 <7.28.0`, patched `>=7.28.0`).

`undici@7.26.0` is pulled in **only by dev tooling** — `@vscode/vsce` and `ovsx` (the packaging/publish tools) → `cheerio` → `undici` — so it is **not shipped in the VSIX** and has no end-user runtime exposure. However it was failing the repo-wide `security` job (`pnpm audit --audit-level high`), which is why the `security` check is red on every open PR.

Advisories resolved (all fixed in 7.28.0):
- High: TLS cert validation bypass via dropped `requestTls` in SOCKS5 ProxyAgent (GHSA-vmh5-mc38-953g)
- High: WebSocket DoS via fragment-count bypass (GHSA-vxpw-j846-p89q)
- High: cross-origin request routing via SOCKS5 proxy pool reuse
- Moderate/Low: Set-Cookie header injection, cache whitespace disclosure, SameSite downgrade, keep-alive response-queue poisoning

## Linked issues

Refs #415 (continuous security scanning / dependency gates), #244 (dependency dashboard)

## Validation

- [x] `pnpm install` regenerates the lockfile (undici 7.26.0 → 7.28.0); supply-chain policy passes
- [x] `pnpm audit --audit-level high` → **No known vulnerabilities found**
- [x] `pnpm run check:supply-chain` passes
- [x] Full `pnpm run check` aggregate (pre-push) — passes, incl. extension build/package via vsce/cheerio/undici

## Risk

Very low — a patch-level bump of a dev-only transitive dependency within the `^7` range cheerio expects. Rollback = revert the override.

## Note on the other alerts

The remaining open Dependabot alerts (starlette, pyjwt, python-multipart, cryptography, pydantic-settings) are all in `packages/mcp-server/uv.lock`, a path that was **removed from this repo** (ADR-0009; MCP server lives in [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp)). They are stale here and should be remediated/dismissed in that repo, not this one.