### PR TITLE
security(repo): publish threat model and guarded-operation test suite

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,3 +5,12 @@ Report vulnerabilities through GitHub Security Advisories for the canonical repo
 https://github.com/oaslananka/kicad-studio-kit/security/advisories/new
 
 Do not open public issues for active vulnerabilities. Include the affected package, version, reproduction details, and any known exploitability constraints.
+
+## Threat Model
+
+The extension's assets, trust boundaries, modeled threats with their code/test
+evidence, and accepted residual risks are documented in
+[docs/security/threat-model.md](docs/security/threat-model.md). The guarded
+operation layer (`apps/vscode-extension/src/security/guardedOperations.ts`)
+centralizes workspace-trust, path-canonicalization, and boundary enforcement for
+write, export, import, and MCP operations.

--- a/apps/vscode-extension/test/security/threatModel.test.ts
+++ b/apps/vscode-extension/test/security/threatModel.test.ts
@@ -1,0 +1,76 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// Repo root is four levels up from apps/vscode-extension/test/security.
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const THREAT_MODEL = path.join(
+  REPO_ROOT,
+  'docs',
+  'security',
+  'threat-model.md'
+);
+
+function readThreatModel(): string {
+  return fs.readFileSync(THREAT_MODEL, 'utf8');
+}
+
+describe('threat model (#413)', () => {
+  it('exists and documents the required sections', () => {
+    const doc = readThreatModel();
+    for (const section of [
+      '# Threat Model',
+      '## Assets',
+      '## Trust Boundaries',
+      '## Threats and Mitigations',
+      '## Residual Risks',
+      '## Reporting'
+    ]) {
+      expect(doc).toContain(section);
+    }
+  });
+
+  it('covers each enumerated threat scenario', () => {
+    const doc = readThreatModel();
+    for (const id of ['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8']) {
+      expect(doc).toMatch(new RegExp(`\\|\\s*${id}\\s*\\|`, 'u'));
+    }
+  });
+
+  it('names the modeled attack classes', () => {
+    const doc = readThreatModel().toLowerCase();
+    for (const phrase of [
+      'path traversal',
+      'symlink',
+      'untrusted',
+      'kicad-cli',
+      'mcp endpoint',
+      'webview',
+      'secret'
+    ]) {
+      expect(doc).toContain(phrase);
+    }
+  });
+
+  it('every evidence file referenced in the model actually exists', () => {
+    const doc = readThreatModel();
+    const evidence = new Set<string>(
+      Array.from(
+        doc.matchAll(/`(apps\/vscode-extension\/[^`]+\.(?:ts|md))`/gu),
+        (match) => match[1]
+      ).filter((rel): rel is string => Boolean(rel))
+    );
+    // The model must cite real mitigations, not aspirational ones.
+    expect(evidence.size).toBeGreaterThanOrEqual(8);
+    const missing = [...evidence].filter(
+      (rel) => !fs.existsSync(path.join(REPO_ROOT, rel))
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('documents at least one accepted residual risk', () => {
+    const doc = readThreatModel();
+    const residual = doc.slice(doc.indexOf('## Residual Risks'));
+    // Bullet list under the residual-risks heading.
+    expect(residual).toMatch(/\n- /u);
+  });
+});

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -19,5 +19,6 @@ the Python MCP server, the npm launcher, shared protocol schemas, examples, and 
 
 - [KiCad Studio and MCP integration](../integration/kicad-studio-mcp.md)
 - [Support matrix](../support-matrix.md)
+- [Threat model](../security/threat-model.md)
 - [Reusable workflows](../reusable-workflows.md)
 - [Dependency lifecycle](../dependency-lifecycle.md)

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,67 @@
+# Threat Model
+
+This threat model covers the KiCad Studio VS Code extension (this repository).
+The MCP server is threat-modeled separately in
+[oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp); here we model
+only the extension-side surface and the client-side MCP integration.
+
+Each mitigation links to the code and tests that enforce it. The
+`threatModel.test.ts` suite parses the evidence column below and fails if any
+referenced file is missing, so this document cannot claim coverage that does not
+exist.
+
+## Assets
+
+- The user's KiCad project files and the workspace file tree.
+- Generated manufacturing/export artifacts (Gerbers, drill, BOM, release bundles).
+- Provider credentials (AI API keys, Octopart/Nexar keys) held in VS Code
+  SecretStorage.
+- The extension host process and its filesystem access.
+
+## Trust Boundaries
+
+- **Workspace trust.** An opened workspace may be untrusted (Restricted Mode).
+  Project content (file names, `.kicad_*` contents, configured paths) is
+  attacker-controlled input until the user trusts the workspace.
+- **User-supplied paths.** Output directories and import sources come from input
+  boxes and settings and must be confined to the workspace.
+- **External tooling.** The configured `kicad-cli` path and the MCP endpoint are
+  configuration the extension shells out to / connects to.
+- **Webviews.** Custom editors and panels render untrusted project-derived
+  content inside webviews.
+
+## Threats and Mitigations
+
+| ID | Threat | Mitigation | Evidence |
+| --- | --- | --- | --- |
+| T1 | Path traversal (`..`) in a user-supplied output or import path writes outside the workspace | All guarded paths are resolved and asserted inside the workspace root | `apps/vscode-extension/src/security/guardedOperations.ts`, `apps/vscode-extension/src/utils/pathUtils.ts`, `apps/vscode-extension/test/unit/guardedOperations.test.ts`, `apps/vscode-extension/test/unit/pathRegressionSuite.test.ts` |
+| T2 | A symlink inside the workspace points outside it, escaping the boundary | Boundary checks compare symlink-resolved canonical paths (`fs.realpathSync.native`) | `apps/vscode-extension/src/utils/pathUtils.ts`, `apps/vscode-extension/test/unit/guardedOperations.test.ts`, `apps/vscode-extension/test/security/securityRegression.test.ts` |
+| T3 | A state-changing operation runs in an untrusted (Restricted Mode) workspace | Trust gate enforced in code (not only menu visibility) before write/export/MCP operations | `apps/vscode-extension/src/security/guardedOperations.ts`, `apps/vscode-extension/src/utils/workspaceTrust.ts`, `apps/vscode-extension/test/unit/workspaceTrust.test.ts`, `apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts`, `apps/vscode-extension/test/unit/pcmCommandsTrust.test.ts` |
+| T4 | A malicious or mistyped manufacturing-release output folder writes a bundle outside the workspace | The wizard asserts trust and resolves the output folder through the central guard | `apps/vscode-extension/src/commands/manufacturingReleaseWizard.ts`, `apps/vscode-extension/test/unit/guardedOperations.test.ts` |
+| T5 | An unsafe or spoofed `kicad-cli` path is configured and executed | CLI path is canonicalized and capability-probed before use; commands stay gated by detected support | `apps/vscode-extension/src/cli/kicadCliDetector.ts`, `apps/vscode-extension/test/unit/kicadCliSupport.test.ts` |
+| T6 | The MCP endpoint fails or reports an unsafe operating mode | Connection results gate MCP context keys; restricted/disconnected states disable MCP-affecting actions | `apps/vscode-extension/src/mcp/mcpClient.ts`, `apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts` |
+| T7 | A webview escapes its boundary (script injection or arbitrary local resource read) | Webview HTML uses nonced CSP and restricted local resource roots; fuzz tests cover rendering of hostile content | `apps/vscode-extension/src/utils/nonce.ts`, `apps/vscode-extension/test/unit/securityFuzz.test.ts` |
+| T8 | Provider credentials leak through plaintext settings | Keys are migrated to and read from VS Code SecretStorage; plaintext runtime fallback is disabled | `apps/vscode-extension/src/utils/secrets.ts`, `apps/vscode-extension/test/unit/guardedOperations.test.ts` |
+
+## Residual Risks
+
+- **Trusted-workspace code execution.** Once a user trusts a workspace, the
+  extension shells out to `kicad-cli` with project paths. A user who trusts a
+  malicious project accepts the same risk as opening it in KiCad directly. This
+  is accepted; trust gating is the mitigation boundary.
+- **CLI/endpoint integrity.** The extension validates the configured `kicad-cli`
+  path and MCP endpoint shape but does not verify a code signature of the binary
+  or authenticate the MCP server beyond its reported compatibility metadata.
+- **Webview rendering depth.** CSP + nonce mitigate injection, but a future
+  rendering feature that introduces `eval`-like behavior would need its own
+  review. New or changed webviews must keep the accessibility and security
+  fixtures current.
+- **Symlink TOCTOU.** Boundary checks resolve canonical paths at validation
+  time; a path that is replaced with a symlink between validation and write is
+  not separately defended. Output directories are created and written inside the
+  same guarded flow to minimize the window.
+
+## Reporting
+
+Report suspected vulnerabilities through GitHub Security Advisories as described
+in `SECURITY.md`. Do not open public issues for active vulnerabilities.


### PR DESCRIPTION
## Summary

Publishes `docs/security/threat-model.md` and a completeness gate that keeps it honest.

> **Stacked on #399** ([#422](https://github.com/oaslananka/kicad-studio-kit/pull/422)). Base is `security/guarded-operations-399`; it will retarget to `main` once #399 merges.

- **Threat model doc**: assets, trust boundaries, and **8 modeled threats** (path traversal, symlink escape, untrusted workspace, malicious manufacturing output, unsafe `kicad-cli` path, MCP endpoint failure/unsafe mode, webview boundary escape, plaintext secret leakage), each citing the code and tests that mitigate it, plus accepted **residual risks**.
- **`test/security/threatModel.test.ts`**: parses the evidence column and **fails if any cited mitigation file is missing**, asserts all required sections + threat IDs are present, and requires a residual-risks entry — so the model can't claim coverage it doesn't have.
- Linked from `SECURITY.md` and the architecture index.

The underlying scenario tests live across `guardedOperations.test.ts` (#399), `securityRegression`, `securityFuzz`, `mcpCommandsTrust`, `pcmCommandsTrust`, `pathRegressionSuite`, and `kicadCliSupport`.

## Linked issues

Closes #413

## Validation

- [x] `pnpm test:security` — **2 suites / 12 tests** pass (regression + threat-model gate)
- [x] `pnpm typecheck` / `pnpm lint`
- [x] `pnpm docs:lint` / `docs:links` / `docs:check-generated`
- [x] Full `pnpm run check` (pre-push)

## Risk

Low — documentation + a meta-test. No runtime changes.

## Acceptance criteria mapping

- Written threat model ✔
- Tests for path traversal, symlink escape, untrusted workspace, malicious output path, unsafe CLI path, MCP endpoint failure, webview boundaries ✔ (mapped + enforced present)
- Documented residual risks ✔