### PR TITLE
feat(kicad-studio): add a Fabrication Release Wizard with validated manufacturing bundles

### DIFF
--- a/apps/vscode-extension/src/commands/manufacturingReleaseWizard.ts
+++ b/apps/vscode-extension/src/commands/manufacturingReleaseWizard.ts
@@ -13,10 +13,22 @@ import {
   assertWorkspaceTrusted,
   resolveGuardedPath
 } from '../security/guardedOperations';
+import {
+  buildReleaseManifest,
+  collectGitMetadata,
+  renderReleaseSummary,
+  type GitMetadata,
+  type KiCadSnapshot,
+  type ReleaseGateSummary,
+  type ReleaseManifestFileEntry
+} from './releaseManifest';
 import type { CommandServices } from './types';
 
 export async function runManufacturingReleaseWizard(
-  services: Pick<CommandServices, 'variantProvider' | 'mcpAdapter' | 'context'>
+  services: Pick<
+    CommandServices,
+    'variantProvider' | 'mcpAdapter' | 'context' | 'cliDetector'
+  >
 ): Promise<void> {
   telemetry.trackEvent('wizard.start');
   const variant = await chooseVariant(services);
@@ -24,6 +36,7 @@ export async function runManufacturingReleaseWizard(
     return;
   }
 
+  let outputDir: string | undefined;
   try {
     // A manufacturing release writes a bundle to disk; gate it on workspace
     // trust through the centralized guard rather than menu visibility alone.
@@ -35,6 +48,32 @@ export async function runManufacturingReleaseWizard(
     if (blocking.length) {
       telemetry.trackEvent('wizard.blocked');
       void vscode.window.showWarningMessage(formatBlockedMessage(blocking));
+      return;
+    }
+
+    const gateSummaries: ReleaseGateSummary[] = gates.map((gate) => ({
+      label: gate.label,
+      status: gate.status,
+      summary: gate.summary
+    }));
+
+    const mode = await vscode.window.showQuickPick(
+      [
+        {
+          label: '$(rocket) Create release bundle',
+          detail:
+            'Export artifacts and write the release manifest and summary.',
+          dryRun: false
+        },
+        {
+          label: '$(eye) Preview (dry run)',
+          detail: 'Show the release plan without exporting or writing files.',
+          dryRun: true
+        }
+      ],
+      { title: 'Manufacturing release mode' }
+    );
+    if (!mode) {
       return;
     }
 
@@ -59,11 +98,51 @@ export async function runManufacturingReleaseWizard(
     // Resolve + canonicalize the user-supplied output folder and confine it to
     // the workspace (defeats `..` traversal and symlink escape). Throws a safe
     // GuardedOperationError on escape, handled by the catch below.
-    const outputDir = resolveGuardedPath({
+    outputDir = resolveGuardedPath({
       requestedPath: outputDirInput,
       workspaceRoot: root,
       label: 'Manufacturing release output folder'
     });
+
+    // Capability/version snapshot and source-control metadata for the manifest.
+    const capabilitySnapshot =
+      await services.cliDetector.getCapabilitySnapshot();
+    const kicadSnapshot: KiCadSnapshot | undefined = capabilitySnapshot
+      ? {
+          version:
+            typeof capabilitySnapshot.version === 'string'
+              ? capabilitySnapshot.version
+              : undefined,
+          capabilities: Object.entries(capabilitySnapshot)
+            .filter(([, value]) => value === true)
+            .map(([key]) => key)
+            .sort()
+        }
+      : undefined;
+    const git = root ? collectGitMetadata(root) : undefined;
+
+    if (mode.dryRun) {
+      telemetry.trackEvent('wizard.dryRun');
+      await showDryRunPreview({
+        outputDir,
+        variant,
+        gateSummaries,
+        kicadSnapshot,
+        git
+      });
+      return;
+    }
+
+    if (!kicadSnapshot) {
+      const proceed = await vscode.window.showWarningMessage(
+        'No kicad-cli was detected locally. The release will rely on the MCP server for exports. Continue?',
+        { modal: true },
+        'Continue'
+      );
+      if (proceed !== 'Continue') {
+        return;
+      }
+    }
 
     let mcpResult: Record<string, unknown> | undefined;
     const filesGenerated: string[] = [];
@@ -116,11 +195,14 @@ export async function runManufacturingReleaseWizard(
       }
     }
 
-    // Generate manifest.json
-    await generateManifest(outputDir, {
+    // Write release-manifest.json and a human-readable summary report.
+    await writeReleaseEvidence(outputDir, {
       ...(variant ? { variant } : {}),
       files: filesGenerated,
-      mcpResult
+      mcpResult,
+      gateSummaries,
+      ...(kicadSnapshot ? { kicadSnapshot } : {}),
+      ...(git ? { git } : {})
     });
 
     telemetry.trackEvent('wizard.success');
@@ -131,6 +213,9 @@ export async function runManufacturingReleaseWizard(
       );
     }
   } catch (error) {
+    if (outputDir) {
+      await markReleaseIncomplete(outputDir, error);
+    }
     const structured = structuredErrorFromUnknown(error);
     const message = error instanceof Error ? error.message : String(error);
     telemetry.trackEvent('wizard.failure', {
@@ -154,30 +239,15 @@ export async function runManufacturingReleaseWizard(
   }
 }
 
-interface ManifestEntry {
-  extensionVersion: string;
-  timestamp: string;
-  variant?: string;
-  projectFile?: string;
-  boardFile?: string;
-  schematicFile?: string;
-  files: ManifestFileEntry[];
-  qualityGates: boolean;
-  mcpServerVersion?: string;
-}
-
-interface ManifestFileEntry {
-  path: string;
-  size: number;
-  sha256: string;
-}
-
-async function generateManifest(
+async function writeReleaseEvidence(
   outputDir: string,
   options: {
     variant?: string;
     files: string[];
     mcpResult?: Record<string, unknown> | undefined;
+    gateSummaries: ReleaseGateSummary[];
+    kicadSnapshot?: KiCadSnapshot;
+    git?: GitMetadata;
   }
 ): Promise<void> {
   if (!fs.existsSync(outputDir)) {
@@ -213,7 +283,7 @@ async function generateManifest(
   }
 
   // Compute checksums for generated files
-  const fileEntries: ManifestFileEntry[] = [];
+  const fileEntries: ReleaseManifestFileEntry[] = [];
   const seenPaths = new Set<string>();
   for (const filePath of options.files) {
     try {
@@ -245,12 +315,17 @@ async function generateManifest(
     }
   }
 
-  const manifest: ManifestEntry = {
+  const mcpServerVersion = options.mcpResult?.['serverVersion'] as
+    | string
+    | undefined;
+
+  const manifest = buildReleaseManifest({
     extensionVersion,
     timestamp: new Date().toISOString(),
-    ...(options.variant !== undefined && options.variant !== ''
-      ? { variant: options.variant }
-      : {}),
+    ...(options.variant ? { variant: options.variant } : {}),
+    ...(options.git ? { git: options.git } : {}),
+    ...(options.kicadSnapshot ? { kicad: options.kicadSnapshot } : {}),
+    ...(mcpServerVersion ? { mcpServerVersion } : {}),
     ...(projectFile
       ? { projectFile: path.relative(outputDir, projectFile) }
       : {}),
@@ -258,23 +333,86 @@ async function generateManifest(
     ...(schematicFile
       ? { schematicFile: path.relative(outputDir, schematicFile) }
       : {}),
-    files: fileEntries,
-    qualityGates: true,
-    ...((options.mcpResult?.['serverVersion'] as string | undefined)
-      ? {
-          mcpServerVersion: options.mcpResult?.['serverVersion'] as string
-        }
-      : {})
-  };
+    qualityGates: options.gateSummaries,
+    files: fileEntries
+  });
 
-  const manifestPath = path.join(outputDir, 'manifest.json');
-  const manifestBytes = new TextEncoder().encode(
-    JSON.stringify(manifest, null, 2)
+  await writeOutputFile(
+    outputDir,
+    'release-manifest.json',
+    `${JSON.stringify(manifest, null, 2)}\n`
   );
+  await writeOutputFile(
+    outputDir,
+    'RELEASE-SUMMARY.md',
+    renderReleaseSummary(manifest)
+  );
+}
+
+async function writeOutputFile(
+  outputDir: string,
+  name: string,
+  content: string
+): Promise<void> {
   await vscode.workspace.fs.writeFile(
-    vscode.Uri.file(manifestPath),
-    manifestBytes
+    vscode.Uri.file(path.join(outputDir, name)),
+    new TextEncoder().encode(content)
   );
+}
+
+async function showDryRunPreview(plan: {
+  outputDir: string;
+  variant?: string;
+  gateSummaries: ReleaseGateSummary[];
+  kicadSnapshot?: KiCadSnapshot | undefined;
+  git?: GitMetadata | undefined;
+}): Promise<void> {
+  const detail = [
+    `Output folder: ${plan.outputDir}`,
+    `Variant: ${plan.variant || 'default'}`,
+    `KiCad CLI: ${plan.kicadSnapshot?.version ?? 'not detected'}`,
+    plan.git?.shortCommit
+      ? `Source: ${plan.git.shortCommit}${plan.git.dirty ? ' (uncommitted changes)' : ''}`
+      : 'Source: not a git repository',
+    `Quality gates: ${
+      plan.gateSummaries
+        .map((gate) => `${gate.label}=${gate.status}`)
+        .join(', ') || 'none'
+    }`,
+    '',
+    'No files were written (dry run).'
+  ].join('\n');
+  await vscode.window.showInformationMessage(
+    'Manufacturing release preview',
+    { modal: true, detail },
+    'OK'
+  );
+}
+
+async function markReleaseIncomplete(
+  outputDir: string,
+  error: unknown
+): Promise<void> {
+  try {
+    if (!fs.existsSync(outputDir)) {
+      return;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    await writeOutputFile(
+      outputDir,
+      'RELEASE-INCOMPLETE.txt',
+      [
+        'This manufacturing release did not complete successfully.',
+        'Artifacts in this folder may be partial and must not be used for fabrication.',
+        '',
+        `Failure: ${message}`,
+        `Time: ${new Date().toISOString()}`,
+        ''
+      ].join('\n')
+    );
+  } catch {
+    // Best-effort marker; never mask the original failure.
+  }
 }
 
 async function chooseVariant(

--- a/apps/vscode-extension/src/commands/releaseManifest.ts
+++ b/apps/vscode-extension/src/commands/releaseManifest.ts
@@ -133,6 +133,7 @@ export function renderReleaseSummary(manifest: ReleaseManifest): string {
 
 function escapeCell(value: string): string {
   return String(value ?? '')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/\r?\n/g, ' ');
 }

--- a/apps/vscode-extension/src/commands/releaseManifest.ts
+++ b/apps/vscode-extension/src/commands/releaseManifest.ts
@@ -1,0 +1,197 @@
+import { execFileSync } from 'node:child_process';
+
+// Pure builders for the Fabrication Release Wizard (#400). Keeping the manifest,
+// summary, and git-metadata logic free of vscode/fs side effects makes the
+// release evidence deterministic and unit-testable.
+
+export interface ReleaseManifestFileEntry {
+  path: string;
+  size: number;
+  sha256: string;
+}
+
+export interface ReleaseGateSummary {
+  label: string;
+  status: string;
+  summary: string;
+}
+
+export interface GitMetadata {
+  commit?: string;
+  shortCommit?: string;
+  branch?: string;
+  tag?: string;
+  dirty?: boolean;
+}
+
+export interface KiCadSnapshot {
+  version?: string | undefined;
+  capabilities?: string[] | undefined;
+}
+
+export interface ReleaseManifest {
+  schema: 'kicad-studio-release/1';
+  generatedBy: string;
+  extensionVersion: string;
+  timestamp: string;
+  variant?: string;
+  git?: GitMetadata;
+  kicad?: KiCadSnapshot;
+  mcpServerVersion?: string;
+  projectFile?: string;
+  boardFile?: string;
+  schematicFile?: string;
+  qualityGates: ReleaseGateSummary[];
+  files: ReleaseManifestFileEntry[];
+}
+
+export interface BuildReleaseManifestInput {
+  extensionVersion: string;
+  timestamp: string;
+  variant?: string | undefined;
+  git?: GitMetadata | undefined;
+  kicad?: KiCadSnapshot | undefined;
+  mcpServerVersion?: string | undefined;
+  projectFile?: string | undefined;
+  boardFile?: string | undefined;
+  schematicFile?: string | undefined;
+  qualityGates: ReleaseGateSummary[];
+  files: ReleaseManifestFileEntry[];
+}
+
+export function buildReleaseManifest(
+  input: BuildReleaseManifestInput
+): ReleaseManifest {
+  return {
+    schema: 'kicad-studio-release/1',
+    generatedBy: 'KiCad Studio Kit',
+    extensionVersion: input.extensionVersion,
+    timestamp: input.timestamp,
+    ...(input.variant ? { variant: input.variant } : {}),
+    ...(input.git ? { git: input.git } : {}),
+    ...(input.kicad ? { kicad: input.kicad } : {}),
+    ...(input.mcpServerVersion
+      ? { mcpServerVersion: input.mcpServerVersion }
+      : {}),
+    ...(input.projectFile ? { projectFile: input.projectFile } : {}),
+    ...(input.boardFile ? { boardFile: input.boardFile } : {}),
+    ...(input.schematicFile ? { schematicFile: input.schematicFile } : {}),
+    qualityGates: input.qualityGates,
+    files: input.files
+  };
+}
+
+/** Render a human-readable Markdown summary of a release manifest. */
+export function renderReleaseSummary(manifest: ReleaseManifest): string {
+  const lines: string[] = [];
+  lines.push('# Manufacturing Release Summary', '');
+  lines.push(`- Generated: ${manifest.timestamp}`);
+  lines.push(`- KiCad Studio Kit: ${manifest.extensionVersion}`);
+  if (manifest.variant) {
+    lines.push(`- Variant: ${manifest.variant}`);
+  }
+  if (manifest.kicad?.version) {
+    lines.push(`- KiCad CLI: ${manifest.kicad.version}`);
+  }
+  if (manifest.mcpServerVersion) {
+    lines.push(`- MCP server: ${manifest.mcpServerVersion}`);
+  }
+  if (manifest.git?.shortCommit) {
+    const dirty = manifest.git.dirty ? ' (uncommitted changes)' : '';
+    const branch = manifest.git.branch ? ` on ${manifest.git.branch}` : '';
+    const tag = manifest.git.tag ? ` [${manifest.git.tag}]` : '';
+    lines.push(`- Source: ${manifest.git.shortCommit}${branch}${tag}${dirty}`);
+  }
+
+  lines.push('', '## Quality Gates', '');
+  if (manifest.qualityGates.length === 0) {
+    lines.push('No quality gate results were recorded.');
+  } else {
+    lines.push('| Gate | Status | Summary |', '| --- | --- | --- |');
+    for (const gate of manifest.qualityGates) {
+      lines.push(
+        `| ${escapeCell(gate.label)} | ${escapeCell(gate.status)} | ${escapeCell(gate.summary)} |`
+      );
+    }
+  }
+
+  lines.push('', `## Artifacts (${manifest.files.length})`, '');
+  if (manifest.files.length === 0) {
+    lines.push('No artifacts were generated.');
+  } else {
+    lines.push('| File | Size (bytes) | SHA-256 |', '| --- | ---: | --- |');
+    for (const file of manifest.files) {
+      lines.push(
+        `| ${escapeCell(file.path)} | ${file.size} | ${file.sha256} |`
+      );
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function escapeCell(value: string): string {
+  return String(value ?? '')
+    .replace(/\|/g, '\\|')
+    .replace(/\r?\n/g, ' ');
+}
+
+export type GitRunner = (args: string[]) => string;
+
+function defaultGitRunner(root: string): GitRunner {
+  return (args) =>
+    execFileSync('git', args, {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+}
+
+/**
+ * Best-effort git metadata for the release manifest. Returns undefined when the
+ * workspace is not a git repository (or git is unavailable); never throws.
+ */
+export function collectGitMetadata(
+  root: string,
+  runner?: GitRunner
+): GitMetadata | undefined {
+  const run = runner ?? defaultGitRunner(root);
+  let commit: string;
+  try {
+    commit = run(['rev-parse', 'HEAD']);
+  } catch {
+    return undefined;
+  }
+  if (!commit) {
+    return undefined;
+  }
+
+  const metadata: GitMetadata = {
+    commit,
+    shortCommit: commit.slice(0, 12)
+  };
+  try {
+    const branch = run(['rev-parse', '--abbrev-ref', 'HEAD']);
+    if (branch && branch !== 'HEAD') {
+      metadata.branch = branch;
+    }
+  } catch {
+    // branch is optional
+  }
+  try {
+    const tag = run(['describe', '--tags', '--exact-match']);
+    if (tag) {
+      metadata.tag = tag;
+    }
+  } catch {
+    // no exact tag on HEAD
+  }
+  try {
+    const status = run(['status', '--porcelain']);
+    metadata.dirty = status.length > 0;
+  } catch {
+    // dirty flag is optional
+  }
+  return metadata;
+}

--- a/apps/vscode-extension/test/unit/manufacturingReleaseWizard.test.ts
+++ b/apps/vscode-extension/test/unit/manufacturingReleaseWizard.test.ts
@@ -30,6 +30,10 @@ describe('runManufacturingReleaseWizard', () => {
         exportManufacturingPackage:
           overrides?.exportManufacturingPackage ??
           jest.fn().mockResolvedValue(undefined)
+      },
+      cliDetector: {
+        detect: jest.fn().mockResolvedValue(undefined),
+        getCapabilitySnapshot: jest.fn().mockResolvedValue(undefined)
       }
     };
   }
@@ -49,6 +53,50 @@ describe('runManufacturingReleaseWizard', () => {
       'quality gate failed',
       'Open Output Channel',
       'Re-run Wizard'
+    );
+    expect(
+      services.mcpAdapter.exportManufacturingPackage
+    ).not.toHaveBeenCalled();
+  });
+
+  it('previews the release in dry-run mode without exporting or writing', async () => {
+    const services = createServices();
+    (window.showQuickPick as jest.Mock).mockResolvedValueOnce({
+      label: 'Preview (dry run)',
+      dryRun: true
+    });
+    (window.showInputBox as jest.Mock).mockResolvedValueOnce('release-out');
+
+    await expect(
+      runManufacturingReleaseWizard(services as never)
+    ).resolves.toBeUndefined();
+
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      'Manufacturing release preview',
+      expect.objectContaining({ modal: true }),
+      'OK'
+    );
+    expect(
+      services.mcpAdapter.exportManufacturingPackage
+    ).not.toHaveBeenCalled();
+  });
+
+  it('blocks the release when a quality gate fails', async () => {
+    const services = createServices({
+      runProjectQualityGate: jest.fn().mockResolvedValue([
+        {
+          label: 'DRC',
+          status: 'FAIL',
+          summary: '2 errors',
+          violations: []
+        }
+      ])
+    });
+
+    await runManufacturingReleaseWizard(services as never);
+
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('blocked by quality gates')
     );
     expect(
       services.mcpAdapter.exportManufacturingPackage

--- a/apps/vscode-extension/test/unit/releaseManifest.test.ts
+++ b/apps/vscode-extension/test/unit/releaseManifest.test.ts
@@ -1,0 +1,157 @@
+import {
+  buildReleaseManifest,
+  collectGitMetadata,
+  renderReleaseSummary,
+  type BuildReleaseManifestInput
+} from '../../src/commands/releaseManifest';
+
+function baseInput(
+  overrides: Partial<BuildReleaseManifestInput> = {}
+): BuildReleaseManifestInput {
+  return {
+    extensionVersion: '1.8.1',
+    timestamp: '2026-06-20T00:00:00.000Z',
+    qualityGates: [],
+    files: [],
+    ...overrides
+  };
+}
+
+describe('#400 release manifest', () => {
+  describe('buildReleaseManifest', () => {
+    it('emits the schema and required fields', () => {
+      const manifest = buildReleaseManifest(baseInput());
+      expect(manifest.schema).toBe('kicad-studio-release/1');
+      expect(manifest.generatedBy).toBe('KiCad Studio Kit');
+      expect(manifest.extensionVersion).toBe('1.8.1');
+      expect(manifest.qualityGates).toEqual([]);
+      expect(manifest.files).toEqual([]);
+    });
+
+    it('omits optional fields that are not provided', () => {
+      const manifest = buildReleaseManifest(baseInput());
+      expect('variant' in manifest).toBe(false);
+      expect('git' in manifest).toBe(false);
+      expect('kicad' in manifest).toBe(false);
+      expect('mcpServerVersion' in manifest).toBe(false);
+    });
+
+    it('includes provided git, kicad, variant, and artifact data', () => {
+      const manifest = buildReleaseManifest(
+        baseInput({
+          variant: 'assembly',
+          git: { commit: 'abcdef0123456789', shortCommit: 'abcdef012345' },
+          kicad: { version: '10.0.3', capabilities: ['gerbers', 'drill'] },
+          mcpServerVersion: '3.9.2',
+          qualityGates: [{ label: 'DRC', status: 'PASS', summary: '0 errors' }],
+          files: [{ path: 'gerbers.zip', size: 1024, sha256: 'deadbeef' }]
+        })
+      );
+      expect(manifest.variant).toBe('assembly');
+      expect(manifest.git?.shortCommit).toBe('abcdef012345');
+      expect(manifest.kicad?.capabilities).toContain('gerbers');
+      expect(manifest.mcpServerVersion).toBe('3.9.2');
+      expect(manifest.qualityGates[0]?.status).toBe('PASS');
+      expect(manifest.files[0]?.sha256).toBe('deadbeef');
+    });
+  });
+
+  describe('renderReleaseSummary', () => {
+    it('renders gates and artifacts as tables', () => {
+      const summary = renderReleaseSummary(
+        buildReleaseManifest(
+          baseInput({
+            variant: 'assembly',
+            kicad: { version: '10.0.3' },
+            git: {
+              commit: 'abcdef0123456789',
+              shortCommit: 'abcdef012345',
+              branch: 'main',
+              dirty: true
+            },
+            qualityGates: [
+              { label: 'DRC', status: 'PASS', summary: '0 errors' }
+            ],
+            files: [{ path: 'gerbers.zip', size: 2048, sha256: 'cafe' }]
+          })
+        )
+      );
+      expect(summary).toContain('# Manufacturing Release Summary');
+      expect(summary).toContain('Variant: assembly');
+      expect(summary).toContain('KiCad CLI: 10.0.3');
+      expect(summary).toContain('abcdef012345');
+      expect(summary).toContain('uncommitted changes');
+      expect(summary).toContain('| DRC | PASS | 0 errors |');
+      expect(summary).toContain('| gerbers.zip | 2048 | cafe |');
+    });
+
+    it('states when there are no gates or artifacts', () => {
+      const summary = renderReleaseSummary(buildReleaseManifest(baseInput()));
+      expect(summary).toContain('No quality gate results were recorded.');
+      expect(summary).toContain('No artifacts were generated.');
+    });
+
+    it('escapes pipe characters in cell values', () => {
+      const summary = renderReleaseSummary(
+        buildReleaseManifest(
+          baseInput({
+            qualityGates: [
+              { label: 'ERC', status: 'WARN', summary: 'a | b mismatch' }
+            ]
+          })
+        )
+      );
+      expect(summary).toContain('a \\| b mismatch');
+    });
+  });
+
+  describe('collectGitMetadata', () => {
+    it('returns undefined when HEAD cannot be resolved', () => {
+      const runner = () => {
+        throw new Error('not a git repository');
+      };
+      expect(collectGitMetadata('/ws', runner)).toBeUndefined();
+    });
+
+    it('collects commit, branch, tag, and dirty flag', () => {
+      const responses: Record<string, string> = {
+        'rev-parse HEAD': 'abcdef0123456789abcdef',
+        'rev-parse --abbrev-ref HEAD': 'main',
+        'describe --tags --exact-match': 'v1.8.1',
+        'status --porcelain': ' M file.kicad_pcb'
+      };
+      const metadata = collectGitMetadata('/ws', (args) => {
+        const key = args.join(' ');
+        if (key in responses) {
+          return responses[key]!;
+        }
+        throw new Error(`unexpected git args: ${key}`);
+      });
+      expect(metadata).toEqual({
+        commit: 'abcdef0123456789abcdef',
+        shortCommit: 'abcdef012345',
+        branch: 'main',
+        tag: 'v1.8.1',
+        dirty: true
+      });
+    });
+
+    it('omits branch HEAD and reports a clean tree', () => {
+      const responses: Record<string, string> = {
+        'rev-parse HEAD': '0123456789abcdef',
+        'rev-parse --abbrev-ref HEAD': 'HEAD',
+        'status --porcelain': ''
+      };
+      const metadata = collectGitMetadata('/ws', (args) => {
+        const key = args.join(' ');
+        if (key in responses) {
+          return responses[key]!;
+        }
+        throw new Error('no tag');
+      });
+      expect(metadata?.branch).toBeUndefined();
+      expect(metadata?.tag).toBeUndefined();
+      expect(metadata?.dirty).toBe(false);
+    });
+  });
+});

--- a/docs/workflows/manufacturing-export.md
+++ b/docs/workflows/manufacturing-export.md
@@ -14,3 +14,31 @@ When live KiCad IPC is unavailable, read-only file-backed capabilities can still
 surface diagnostics, BOM, netlist, and export-readiness evidence. Write or apply
 actions remain disabled until the MCP server advertises the required live/write
 capability.
+
+## Prepare Manufacturing Release
+
+The **KiCad Studio: Prepare Manufacturing Release** wizard turns the separate
+export and quality-gate actions into one auditable, evidence-backed release
+bundle.
+
+1. Pick a variant (or the default), then choose **Create release bundle** or
+   **Preview (dry run)**. Dry-run reports the planned output folder, KiCad CLI
+   version, source commit, and quality-gate status without exporting or writing
+   any files.
+2. Blocking quality gates (`FAIL`/`BLOCKED`) stop the release before any
+   artifacts are produced.
+3. The output folder is validated through the central guarded-operation layer, so
+   it cannot escape the workspace (no `..` traversal or symlink escape).
+4. A successful release writes the manufacturing artifacts plus two evidence
+   files:
+   - `release-manifest.json` — schema-versioned record of the KiCad Studio
+     extension version, KiCad CLI version and capability snapshot, MCP server
+     version (when connected), git commit/branch/tag and dirty state, project
+     files, per-artifact SHA-256 hashes, and the DRC/ERC quality-gate summaries.
+   - `RELEASE-SUMMARY.md` — a human-readable summary of the same evidence.
+5. If the release fails partway, the folder is marked with
+   `RELEASE-INCOMPLETE.txt` so partial artifacts are never mistaken for a
+   finished bundle.
+
+Unsupported outputs are never skipped silently; the export step surfaces the
+KiCad CLI capabilities that were available when the bundle was produced.


### PR DESCRIPTION
## Summary

Turns the manufacturing-release command into an auditable, evidence-backed release workflow.

> **Stacked on #399** ([#422](https://github.com/oaslananka/kicad-studio-kit/pull/422)) for the guarded output-path layer. Base is `security/guarded-operations-399`; retargets to `main` once #399 merges.

- **Dry-run / preview mode** — reports the planned output folder, KiCad CLI version, source commit, and quality-gate status with **no exports or writes**.
- **CLI capability + version snapshot** and best-effort **git commit/branch/tag/dirty** metadata.
- **`release-manifest.json`** (schema `kicad-studio-release/1`): extension/CLI/MCP versions, git metadata, project files, per-artifact **SHA-256** hashes, and **DRC/ERC gate summaries**.
- **`RELEASE-SUMMARY.md`** — human-readable summary of the same evidence.
- **`RELEASE-INCOMPLETE.txt`** marker on failure so partial artifacts are never mistaken for a finished bundle.
- Output folder confined to the workspace via the central guard (#399); blocking quality gates still stop the release.

## Linked issues

Closes #400

## Design

The manifest/summary/git logic is extracted into a pure, side-effect-free `releaseManifest.ts` module (fully unit-tested), so the release evidence is deterministic. The vscode/fs orchestration stays in the wizard.

## Validation

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check`
- [x] `pnpm test:unit:coverage` — **96 suites / 773 tests**, `releaseManifest.ts` 96% lines, thresholds held
- [x] New `releaseManifest.test.ts` (9: manifest shape, summary tables/escaping, git metadata via injected runner) + extended wizard test (error, dry-run, blocked-gate)
- [x] `docs:lint` / `docs:links`

## Acceptance criteria mapping

Dry-run ✔ · CLI capability validation ✔ (snapshot + warn when absent) · block/warn on gates ✔ · `release-manifest.json` ✔ · manifest records tool versions/commit/files/hashes/DRC-ERC ✔ · variant outputs ✔ · output via guard ✔ · summary report ✔ · failure marker ✔

## Risk

Medium — extends the release write path. The pure manifest logic is fully tested; the guard and quality-gate blocking are unchanged. Rollback = revert.