### PR TITLE
feat(kicad-studio): add structural KiCad diff report for local and PR review

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1108,6 +1108,12 @@
         "command": "kicadstudio.exportStats",
         "title": "%kicadstudio.contributes.commands.106.title%",
         "category": "%kicadstudio.contributes.commands.106.category%"
+      },
+      {
+        "command": "kicadstudio.generateKicadDiffReport",
+        "title": "%kicadstudio.contributes.commands.diffReport.title%",
+        "category": "%kicadstudio.contributes.commands.diffReport.category%",
+        "icon": "$(diff)"
       }
     ],
     "menus": {
@@ -1331,6 +1337,10 @@
         {
           "command": "kicadstudio.exportStats",
           "when": "kicadstudio.workspaceTrusted && kicadstudio.pcbOpen"
+        },
+        {
+          "command": "kicadstudio.generateKicadDiffReport",
+          "when": "kicadstudio.workspaceTrusted && (kicadstudio.schematicOpen || kicadstudio.pcbOpen)"
         },
         {
           "command": "kicadstudio.exportGenCAD",

--- a/apps/vscode-extension/package.nls.json
+++ b/apps/vscode-extension/package.nls.json
@@ -395,5 +395,7 @@
   "kicadstudio.contributes.commands.105.category": "KiCad Export",
   "kicadstudio.contributes.commands.106.title": "KiCad: Export Board Statistics",
   "kicadstudio.contributes.commands.106.category": "KiCad Export",
+  "kicadstudio.contributes.commands.diffReport.title": "KiCad: Generate Diff Report",
+  "kicadstudio.contributes.commands.diffReport.category": "KiCad",
   "kicadstudio.contributes.languageModelChatProviders.0.displayName": "KiCad Studio"
 }

--- a/apps/vscode-extension/package.nls.tr.json
+++ b/apps/vscode-extension/package.nls.tr.json
@@ -395,5 +395,7 @@
   "kicadstudio.contributes.commands.105.category": "KiCad Dışa Aktarma",
   "kicadstudio.contributes.commands.106.title": "KiCad: Kart İstatistiklerini Dışa Aktar",
   "kicadstudio.contributes.commands.106.category": "KiCad Dışa Aktarma",
+  "kicadstudio.contributes.commands.diffReport.title": "KiCad: Fark Raporu Oluştur",
+  "kicadstudio.contributes.commands.diffReport.category": "KiCad",
   "kicadstudio.contributes.languageModelChatProviders.0.displayName": "KiCad Studio"
 }

--- a/apps/vscode-extension/src/commands/viewerCommands.ts
+++ b/apps/vscode-extension/src/commands/viewerCommands.ts
@@ -15,7 +15,18 @@ import {
 import { resolveKiCadExecutable, launchDetached } from './kicadLauncher';
 import { buildStatusMenuItems } from './viewerStatusMenu';
 import type { CommandServices } from './types';
-import { findFirstWorkspaceFile, getWorkspaceRoot } from '../utils/pathUtils';
+import { GitDiffDetector } from '../git/gitDiffDetector';
+import { SExpressionParser } from '../language/sExpressionParser';
+import {
+  buildKicadDiffSummary,
+  classifyKicadFile,
+  renderDiffReport
+} from '../diff/kicadDiffSummary';
+import {
+  findFirstWorkspaceFile,
+  getWorkspaceRoot,
+  relativeToWorkspace
+} from '../utils/pathUtils';
 import type { KiCadVariant, ProjectContext, ProjectTreeNode } from '../types';
 import { unwrapPcmPackage } from '../library/pcmLibraryProvider';
 import type { PcmPackage } from '../library/pcmService';
@@ -135,6 +146,49 @@ export function registerViewerCommands(
     vscode.commands.registerCommand(
       COMMANDS.showDiff,
       (resource?: vscode.Uri) => services.diffEditorProvider.show(resource)
+    ),
+
+    registerTrustedCommand(
+      COMMANDS.generateDiffReport,
+      async (resource?: vscode.Uri) => {
+        const uri = resource ?? getActiveResourceUri();
+        const kind = uri ? classifyKicadFile(uri.fsPath) : 'unknown';
+        if (!uri || kind === 'unknown') {
+          void vscode.window.showWarningMessage(
+            'Open a .kicad_sch or .kicad_pcb file to generate a KiCad diff report.'
+          );
+          return;
+        }
+        try {
+          const detector = new GitDiffDetector(new SExpressionParser());
+          const file = relativeToWorkspace(uri.fsPath);
+          const summary =
+            kind === 'schematic'
+              ? buildKicadDiffSummary({
+                  kind,
+                  file,
+                  components: await detector.getChangedComponents(uri.fsPath)
+                })
+              : buildKicadDiffSummary({
+                  kind,
+                  file,
+                  ...detector.readFileVersions(uri.fsPath)
+                });
+          const document = await vscode.workspace.openTextDocument({
+            language: 'markdown',
+            content: renderDiffReport(summary)
+          });
+          await vscode.window.showTextDocument(document, { preview: true });
+        } catch (error) {
+          services.logger.error('KiCad diff report failed', error);
+          void vscode.window.showWarningMessage(
+            error instanceof Error
+              ? `Unable to generate the KiCad diff report: ${error.message}`
+              : 'Unable to generate the KiCad diff report. Confirm the file is committed and the workspace is a git repository.'
+          );
+        }
+      },
+      'Generate KiCad Diff Report'
     ),
 
     vscode.commands.registerCommand(COMMANDS.refreshProjectTree, () =>

--- a/apps/vscode-extension/src/constants.ts
+++ b/apps/vscode-extension/src/constants.ts
@@ -65,6 +65,7 @@ export const KICAD_FILE_EXTENSIONS = [
 export const COMMANDS = {
   showStatusMenu: 'kicadstudio.showStatusMenu',
   selectActiveProject: 'kicadstudio.selectActiveProject',
+  generateDiffReport: 'kicadstudio.generateKicadDiffReport',
   openSchematic: 'kicadstudio.openSchematic',
   openPCB: 'kicadstudio.openPCB',
   openInKiCad: 'kicadstudio.openInKiCad',

--- a/apps/vscode-extension/src/diff/kicadDiffSummary.ts
+++ b/apps/vscode-extension/src/diff/kicadDiffSummary.ts
@@ -1,0 +1,258 @@
+import type { ComponentDiff } from '../types';
+
+// KiCad-aware structural diff summary (#401). This module is intentionally free
+// of vscode/fs imports so the same logic can run inside the extension and in a
+// headless CI/PR context. It produces machine-readable summary data and a
+// human-readable Markdown report; it does not replace the Git text diff and
+// makes no electrical-correctness claims.
+
+/** Combined byte size above which the heavy PCB scan is skipped. */
+export const MAX_DIFF_SCAN_BYTES = 8 * 1024 * 1024;
+
+export type KicadDiffKind = 'schematic' | 'pcb' | 'unknown';
+
+export interface ComponentChangeSummary {
+  added: number;
+  removed: number;
+  changed: number;
+  valueChanges: number;
+  footprintChanges: number;
+  references: {
+    added: string[];
+    removed: string[];
+    changed: string[];
+  };
+}
+
+export interface PrimitiveDelta {
+  before: number;
+  after: number;
+  delta: number;
+}
+
+export interface PcbPrimitiveSummary {
+  footprints: PrimitiveDelta;
+  tracks: PrimitiveDelta;
+  vias: PrimitiveDelta;
+  zones: PrimitiveDelta;
+  /** Per-layer copper track (segment) counts, before and after. */
+  tracksByLayer: Record<string, { before: number; after: number }>;
+}
+
+export interface KicadDiffSummary {
+  kind: KicadDiffKind;
+  file?: string;
+  truncated: boolean;
+  components?: ComponentChangeSummary;
+  pcb?: PcbPrimitiveSummary;
+}
+
+export function classifyKicadFile(filePath: string): KicadDiffKind {
+  if (filePath.endsWith('.kicad_sch')) {
+    return 'schematic';
+  }
+  if (filePath.endsWith('.kicad_pcb')) {
+    return 'pcb';
+  }
+  return 'unknown';
+}
+
+export function summarizeComponents(
+  diffs: readonly ComponentDiff[]
+): ComponentChangeSummary {
+  const summary: ComponentChangeSummary = {
+    added: 0,
+    removed: 0,
+    changed: 0,
+    valueChanges: 0,
+    footprintChanges: 0,
+    references: { added: [], removed: [], changed: [] }
+  };
+
+  for (const diff of diffs) {
+    if (diff.type === 'added') {
+      summary.added += 1;
+      summary.references.added.push(diff.reference);
+    } else if (diff.type === 'removed') {
+      summary.removed += 1;
+      summary.references.removed.push(diff.reference);
+    } else {
+      summary.changed += 1;
+      summary.references.changed.push(diff.reference);
+      if ((diff.before?.['value'] ?? '') !== (diff.after?.['value'] ?? '')) {
+        summary.valueChanges += 1;
+      }
+      if (
+        (diff.before?.['footprint'] ?? '') !== (diff.after?.['footprint'] ?? '')
+      ) {
+        summary.footprintChanges += 1;
+      }
+    }
+  }
+
+  summary.references.added.sort();
+  summary.references.removed.sort();
+  summary.references.changed.sort();
+  return summary;
+}
+
+function countOccurrences(text: string, token: string): number {
+  let count = 0;
+  let index = text.indexOf(token);
+  while (index !== -1) {
+    count += 1;
+    index = text.indexOf(token, index + token.length);
+  }
+  return count;
+}
+
+function countTracksByLayer(text: string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  const pattern = /\(segment\b[\s\S]*?\(layer\s+"([^"]+)"/gu;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    const layer = match[1];
+    if (layer) {
+      counts[layer] = (counts[layer] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+
+export function summarizePcb(
+  beforeText: string,
+  afterText: string
+): PcbPrimitiveSummary {
+  const delta = (token: string): PrimitiveDelta => {
+    const before = countOccurrences(beforeText, token);
+    const after = countOccurrences(afterText, token);
+    return { before, after, delta: after - before };
+  };
+
+  const beforeLayers = countTracksByLayer(beforeText);
+  const afterLayers = countTracksByLayer(afterText);
+  const tracksByLayer: Record<string, { before: number; after: number }> = {};
+  for (const layer of new Set([
+    ...Object.keys(beforeLayers),
+    ...Object.keys(afterLayers)
+  ]).values()) {
+    tracksByLayer[layer] = {
+      before: beforeLayers[layer] ?? 0,
+      after: afterLayers[layer] ?? 0
+    };
+  }
+
+  return {
+    footprints: delta('(footprint '),
+    tracks: delta('(segment '),
+    vias: delta('(via '),
+    zones: delta('(zone '),
+    tracksByLayer
+  };
+}
+
+export interface BuildKicadDiffInput {
+  kind: KicadDiffKind;
+  file?: string | undefined;
+  beforeText?: string | undefined;
+  afterText?: string | undefined;
+  components?: readonly ComponentDiff[] | undefined;
+}
+
+export function buildKicadDiffSummary(
+  input: BuildKicadDiffInput
+): KicadDiffSummary {
+  const combinedSize =
+    Buffer.byteLength(input.beforeText ?? '', 'utf8') +
+    Buffer.byteLength(input.afterText ?? '', 'utf8');
+  const truncated = combinedSize > MAX_DIFF_SCAN_BYTES;
+
+  const summary: KicadDiffSummary = {
+    kind: input.kind,
+    truncated,
+    ...(input.file ? { file: input.file } : {})
+  };
+
+  if (input.components) {
+    summary.components = summarizeComponents(input.components);
+  }
+
+  if (
+    input.kind === 'pcb' &&
+    !truncated &&
+    typeof input.beforeText === 'string' &&
+    typeof input.afterText === 'string'
+  ) {
+    summary.pcb = summarizePcb(input.beforeText, input.afterText);
+  }
+
+  return summary;
+}
+
+function deltaCell(value: PrimitiveDelta): string {
+  const sign = value.delta > 0 ? `+${value.delta}` : `${value.delta}`;
+  return `${value.before} → ${value.after} (${sign})`;
+}
+
+export function renderDiffReport(summary: KicadDiffSummary): string {
+  const lines: string[] = [];
+  lines.push('# KiCad Diff Report', '');
+  if (summary.file) {
+    lines.push(`- File: \`${summary.file}\``);
+  }
+  lines.push(`- Type: ${summary.kind}`);
+  if (summary.truncated) {
+    lines.push(
+      '- Note: file exceeded the scan size limit; only a partial summary is available.'
+    );
+  }
+  lines.push('');
+
+  if (summary.components) {
+    const c = summary.components;
+    lines.push('## Components', '');
+    lines.push('| Change | Count |', '| --- | ---: |');
+    lines.push(`| Added | ${c.added} |`);
+    lines.push(`| Removed | ${c.removed} |`);
+    lines.push(`| Changed | ${c.changed} |`);
+    lines.push(`| — value changes | ${c.valueChanges} |`);
+    lines.push(`| — footprint changes | ${c.footprintChanges} |`);
+    lines.push('');
+    if (c.references.added.length) {
+      lines.push(`Added: ${c.references.added.join(', ')}`, '');
+    }
+    if (c.references.removed.length) {
+      lines.push(`Removed: ${c.references.removed.join(', ')}`, '');
+    }
+    if (c.references.changed.length) {
+      lines.push(`Changed: ${c.references.changed.join(', ')}`, '');
+    }
+  }
+
+  if (summary.pcb) {
+    const p = summary.pcb;
+    lines.push('## Board primitives', '');
+    lines.push('| Primitive | Before → After (Δ) |', '| --- | --- |');
+    lines.push(`| Footprints | ${deltaCell(p.footprints)} |`);
+    lines.push(`| Tracks | ${deltaCell(p.tracks)} |`);
+    lines.push(`| Vias | ${deltaCell(p.vias)} |`);
+    lines.push(`| Zones | ${deltaCell(p.zones)} |`);
+    lines.push('');
+    const layers = Object.keys(p.tracksByLayer).sort();
+    if (layers.length) {
+      lines.push('### Tracks by layer', '');
+      lines.push('| Layer | Before | After |', '| --- | ---: | ---: |');
+      for (const layer of layers) {
+        const entry = p.tracksByLayer[layer]!;
+        lines.push(`| ${layer} | ${entry.before} | ${entry.after} |`);
+      }
+      lines.push('');
+    }
+  }
+
+  lines.push(
+    '_This is a structural summary for review. It does not replace the Git text diff or assert electrical correctness._',
+    ''
+  );
+  return lines.join('\n');
+}

--- a/apps/vscode-extension/test/unit/kicadDiffSummary.test.ts
+++ b/apps/vscode-extension/test/unit/kicadDiffSummary.test.ts
@@ -1,0 +1,149 @@
+import {
+  buildKicadDiffSummary,
+  classifyKicadFile,
+  renderDiffReport,
+  summarizeComponents,
+  summarizePcb
+} from '../../src/diff/kicadDiffSummary';
+import type { ComponentDiff } from '../../src/types';
+
+const PCB_BEFORE = `(kicad_pcb
+  (footprint "R_0402" (layer "F.Cu"))
+  (segment (start 0 0) (end 1 0) (width 0.2) (layer "F.Cu") (net 1))
+  (via (at 1 1) (size 0.6) (layers "F.Cu" "B.Cu"))
+  (zone (net 1) (layer "F.Cu"))
+)`;
+
+const PCB_AFTER = `(kicad_pcb
+  (footprint "R_0402" (layer "F.Cu"))
+  (footprint "C_0402" (layer "F.Cu"))
+  (segment (start 0 0) (end 1 0) (width 0.2) (layer "F.Cu") (net 1))
+  (segment (start 0 0) (end 1 0) (width 0.2) (layer "B.Cu") (net 2))
+  (via (at 1 1) (size 0.6) (layers "F.Cu" "B.Cu"))
+)`;
+
+describe('#401 KiCad diff summary', () => {
+  describe('classifyKicadFile', () => {
+    it('classifies schematic, pcb, and unknown', () => {
+      expect(classifyKicadFile('/x/board.kicad_sch')).toBe('schematic');
+      expect(classifyKicadFile('/x/board.kicad_pcb')).toBe('pcb');
+      expect(classifyKicadFile('/x/notes.txt')).toBe('unknown');
+    });
+  });
+
+  describe('summarizeComponents', () => {
+    it('counts adds, removes, and field-level changes', () => {
+      const diffs: ComponentDiff[] = [
+        { uuid: '1', reference: 'R1', type: 'added', after: { value: '10k' } },
+        {
+          uuid: '2',
+          reference: 'C1',
+          type: 'removed',
+          before: { value: '100n' }
+        },
+        {
+          uuid: '3',
+          reference: 'R2',
+          type: 'changed',
+          before: { value: '1k', footprint: 'R_0402' },
+          after: { value: '2k', footprint: 'R_0402' }
+        },
+        {
+          uuid: '4',
+          reference: 'U1',
+          type: 'changed',
+          before: { value: 'MCU', footprint: 'A' },
+          after: { value: 'MCU', footprint: 'B' }
+        }
+      ];
+      const summary = summarizeComponents(diffs);
+      expect(summary.added).toBe(1);
+      expect(summary.removed).toBe(1);
+      expect(summary.changed).toBe(2);
+      expect(summary.valueChanges).toBe(1);
+      expect(summary.footprintChanges).toBe(1);
+      expect(summary.references).toEqual({
+        added: ['R1'],
+        removed: ['C1'],
+        changed: ['R2', 'U1']
+      });
+    });
+  });
+
+  describe('summarizePcb', () => {
+    it('counts primitives and per-layer tracks with deltas', () => {
+      const pcb = summarizePcb(PCB_BEFORE, PCB_AFTER);
+      expect(pcb.footprints).toEqual({ before: 1, after: 2, delta: 1 });
+      expect(pcb.tracks).toEqual({ before: 1, after: 2, delta: 1 });
+      expect(pcb.vias).toEqual({ before: 1, after: 1, delta: 0 });
+      expect(pcb.zones).toEqual({ before: 1, after: 0, delta: -1 });
+      expect(pcb.tracksByLayer['F.Cu']).toEqual({ before: 1, after: 1 });
+      expect(pcb.tracksByLayer['B.Cu']).toEqual({ before: 0, after: 1 });
+    });
+  });
+
+  describe('buildKicadDiffSummary', () => {
+    it('summarizes a schematic from component diffs', () => {
+      const summary = buildKicadDiffSummary({
+        kind: 'schematic',
+        file: 'board.kicad_sch',
+        components: [
+          { uuid: '1', reference: 'R1', type: 'added', after: { value: '1k' } }
+        ]
+      });
+      expect(summary.kind).toBe('schematic');
+      expect(summary.components?.added).toBe(1);
+      expect(summary.pcb).toBeUndefined();
+      expect(summary.truncated).toBe(false);
+    });
+
+    it('summarizes a pcb from before/after text', () => {
+      const summary = buildKicadDiffSummary({
+        kind: 'pcb',
+        file: 'board.kicad_pcb',
+        beforeText: PCB_BEFORE,
+        afterText: PCB_AFTER
+      });
+      expect(summary.pcb?.footprints.delta).toBe(1);
+    });
+
+    it('marks oversized inputs as truncated and skips the heavy scan', () => {
+      const huge = `(kicad_pcb ${'(segment )'.repeat(1_000_000)})`;
+      const summary = buildKicadDiffSummary({
+        kind: 'pcb',
+        beforeText: huge,
+        afterText: huge
+      });
+      expect(summary.truncated).toBe(true);
+      expect(summary.pcb).toBeUndefined();
+    });
+  });
+
+  describe('renderDiffReport', () => {
+    it('renders component and board tables with the review disclaimer', () => {
+      const report = renderDiffReport(
+        buildKicadDiffSummary({
+          kind: 'pcb',
+          file: 'board.kicad_pcb',
+          beforeText: PCB_BEFORE,
+          afterText: PCB_AFTER,
+          components: [
+            {
+              uuid: '1',
+              reference: 'R1',
+              type: 'added',
+              after: { value: '1k' }
+            }
+          ]
+        })
+      );
+      expect(report).toContain('# KiCad Diff Report');
+      expect(report).toContain('## Components');
+      expect(report).toContain('## Board primitives');
+      expect(report).toContain('### Tracks by layer');
+      expect(report).toContain('| Footprints | 1 → 2 (+1) |');
+      expect(report).toContain('| Zones | 1 → 0 (-1) |');
+      expect(report).toContain('does not replace the Git text diff');
+    });
+  });
+});

--- a/docs/extension/commands.md
+++ b/docs/extension/commands.md
@@ -3,7 +3,7 @@
 Machine-maintained from `apps/vscode-extension/package.json` and `package.nls.json`.
 Refresh with `corepack pnpm run docs:generate`.
 
-Total contributed commands: 107.
+Total contributed commands: 108.
 
 | Command ID | Title | Category |
 | --- | --- | --- |
@@ -114,3 +114,4 @@ Total contributed commands: 107.
 | `kicadstudio.exportPcbPs` | KiCad: Export PCB PostScript | KiCad Export |
 | `kicadstudio.exportSchPs` | KiCad: Export Schematic PostScript | KiCad Export |
 | `kicadstudio.exportStats` | KiCad: Export Board Statistics | KiCad Export |
+| `kicadstudio.generateKicadDiffReport` | KiCad: Generate Diff Report | KiCad |

--- a/docs/workflows/review-diff.md
+++ b/docs/workflows/review-diff.md
@@ -1,0 +1,37 @@
+# KiCad Review Diff
+
+Text diffs alone are hard to review for hardware changes. The **KiCad: Generate
+Diff Report** command produces a structural, KiCad-aware summary of what changed
+between the working file and its last committed (`HEAD`) version, for local
+review and PR workflows. It complements — and never replaces — the Git text diff,
+and it makes no electrical-correctness claims.
+
+## Using it
+
+1. Open a `.kicad_sch` or `.kicad_pcb` file from a project under git.
+2. Run **KiCad: Generate Diff Report** from the Command Palette (the command is
+   gated on workspace trust because it shells out to `git`).
+3. A Markdown report opens with the structural summary.
+
+## What the report covers
+
+- **Schematics:** components added, removed, and changed, including how many
+  changes touched the component **value** or **footprint**, with the affected
+  references listed.
+- **PCBs:** before/after counts (with deltas) for footprints, tracks, vias, and
+  zones, plus **per-layer track counts** so copper changes are distinguishable
+  by layer.
+
+## Headless / CI use
+
+The summary engine in `src/diff/kicadDiffSummary.ts` is free of editor APIs, so
+the same machine-readable summary and Markdown report can be produced in a
+headless CI/PR context from two file snapshots. Large files are guarded: inputs
+above the scan-size limit are reported as `truncated` instead of being parsed.
+
+## Scope
+
+This is the minimal-useful first iteration (issue #401). Rendered visual
+overlays (SVG/PNG screenshots of the board/schematic) and an optional
+AI risk summary grounded in those artifacts are tracked as follow-up work; the
+structural summary above is the grounding source any such summary must use.


### PR DESCRIPTION
## Summary

Adds a KiCad-aware **structural diff** that complements (never replaces) the Git text diff — the minimal-useful first iteration the issue invites.

- **`src/diff/kicadDiffSummary.ts`** — an editor-API-free engine producing:
  - **Schematic**: components added/removed/changed, with value/footprint change counts and the affected references.
  - **PCB**: before/after counts + deltas for footprints, tracks, vias, zones, plus **per-layer track counts** (copper changes distinguishable by layer).
  - A **Markdown report** renderer and an 8 MB scan guard (oversized inputs reported as `truncated`).
  - Because it's free of vscode/fs, the same machine-readable summary + report can be produced **headlessly in CI/PR**.
- **`KiCad: Generate Diff Report`** command (trust-gated; resolves working-vs-`HEAD` via the existing `GitDiffDetector`) opens the report as Markdown.

## Linked issues

Closes #401

## Validation

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check`
- [x] `pnpm test:unit:coverage` — **753 tests**, `kicadDiffSummary.ts` **97% lines**, thresholds held
- [x] `check:extension-manifest` (0 errors) + `check:nls-parity` (EN/TR) — the new command uses a descriptive nls key to avoid index collisions
- [x] `docs:lint` / `docs:links` / `docs:check-generated` (command catalog regenerated to 108)

## Acceptance criteria mapping

Compare two states ✔ (working vs HEAD) · machine-readable summary ✔ · human-readable artifact ✔ (Markdown) · layer-specific PCB changes ✔ · linked to changed file ✔ · CI/headless without UI ✔ (pure engine) · large-file timeout/guard ✔ · AI grounding source ✔ (summary is the grounding).

## Explicit follow-ups (noted, not in scope here)

Rendered SVG/PNG visual overlays and an artifact-grounded AI risk summary — the structural summary in this PR is their grounding source. Per the issue: does not replace Git diff; no electrical-correctness claims; AI not required for the core feature.

## Risk

Low — additive engine + one trust-gated, read-only command. No change to existing diff/editor behavior.