### PR TITLE
feat(kicad-studio): document clear capability modes for assistant tools

### DIFF
--- a/apps/vscode-extension/src/lm/languageModelTools.ts
+++ b/apps/vscode-extension/src/lm/languageModelTools.ts
@@ -29,7 +29,7 @@ import {
   type LanguageModelTool
 } from './api';
 
-const TOOL_NAMES = {
+export const TOOL_NAMES = {
   runDrc: 'kicadstudio_runDrc',
   runErc: 'kicadstudio_runErc',
   exportGerbers: 'kicadstudio_exportGerbers',

--- a/apps/vscode-extension/src/lm/toolCapabilityModes.ts
+++ b/apps/vscode-extension/src/lm/toolCapabilityModes.ts
@@ -1,0 +1,52 @@
+import { TOOL_NAMES } from './languageModelTools';
+
+// Capability modes for assistant-facing tools (#406). Every language-model /
+// MCP tool the assistant can call is classified into exactly one mode so its
+// blast radius is explicit and testable. This module is editor-free.
+
+export type CapabilityMode = 'read-only' | 'review' | 'release-preparation';
+
+export const MODE_DESCRIPTIONS: Record<CapabilityMode, string> = {
+  'read-only':
+    'Explorer mode. Returns information about the project and never changes files or project state.',
+  review:
+    'Advisory mode. Runs checks/validations and returns findings plus proposed next steps; it does not modify design files.',
+  'release-preparation':
+    'Release-preparation mode. Changes release-relevant project state or produces artifacts. Requires workspace trust and a preview/confirmation before acting.'
+};
+
+/**
+ * Authoritative mode for every assistant-facing tool. Keyed by the same
+ * `TOOL_NAMES` the tools register under, so the registry cannot drift from the
+ * registered tool set (enforced by toolCapabilityModes.test.ts).
+ */
+export const TOOL_CAPABILITY_MODES = {
+  [TOOL_NAMES.openFile]: 'read-only',
+  [TOOL_NAMES.searchComponent]: 'read-only',
+  [TOOL_NAMES.searchSymbol]: 'read-only',
+  [TOOL_NAMES.searchFootprint]: 'read-only',
+  [TOOL_NAMES.getActiveContext]: 'read-only',
+  [TOOL_NAMES.listVariants]: 'read-only',
+  [TOOL_NAMES.runDrc]: 'review',
+  [TOOL_NAMES.runErc]: 'review',
+  [TOOL_NAMES.exportGerbers]: 'release-preparation',
+  [TOOL_NAMES.switchVariant]: 'release-preparation'
+} as const satisfies Record<string, CapabilityMode>;
+
+export function getToolMode(toolName: string): CapabilityMode | undefined {
+  return (TOOL_CAPABILITY_MODES as Record<string, CapabilityMode>)[toolName];
+}
+
+export function isReadOnlyTool(toolName: string): boolean {
+  return getToolMode(toolName) === 'read-only';
+}
+
+/** Release-preparation tools must require workspace trust before acting. */
+export function modeRequiresTrust(mode: CapabilityMode): boolean {
+  return mode === 'release-preparation';
+}
+
+/** Release-preparation tools must present a preview before producing artifacts. */
+export function modeRequiresPreview(mode: CapabilityMode): boolean {
+  return mode === 'release-preparation';
+}

--- a/apps/vscode-extension/test/unit/toolCapabilityModes.test.ts
+++ b/apps/vscode-extension/test/unit/toolCapabilityModes.test.ts
@@ -1,0 +1,61 @@
+import { TOOL_NAMES } from '../../src/lm/languageModelTools';
+import {
+  MODE_DESCRIPTIONS,
+  TOOL_CAPABILITY_MODES,
+  getToolMode,
+  isReadOnlyTool,
+  modeRequiresPreview,
+  modeRequiresTrust,
+  type CapabilityMode
+} from '../../src/lm/toolCapabilityModes';
+
+describe('#406 assistant tool capability modes', () => {
+  it('assigns a documented mode to every registered tool', () => {
+    for (const toolName of Object.values(TOOL_NAMES)) {
+      const mode = getToolMode(toolName);
+      expect(mode).toBeDefined();
+      expect(MODE_DESCRIPTIONS[mode as CapabilityMode]).toBeTruthy();
+    }
+  });
+
+  it('does not classify any unknown tools', () => {
+    const known = new Set<string>(Object.values(TOOL_NAMES));
+    for (const toolName of Object.keys(TOOL_CAPABILITY_MODES)) {
+      expect(known.has(toolName)).toBe(true);
+    }
+  });
+
+  it('keeps read-only tools read-only', () => {
+    const readOnly = Object.values(TOOL_NAMES).filter(isReadOnlyTool);
+    expect(readOnly).toEqual(
+      expect.arrayContaining([
+        TOOL_NAMES.openFile,
+        TOOL_NAMES.searchComponent,
+        TOOL_NAMES.searchSymbol,
+        TOOL_NAMES.searchFootprint,
+        TOOL_NAMES.getActiveContext,
+        TOOL_NAMES.listVariants
+      ])
+    );
+    // State-changing / artifact tools must never be read-only.
+    expect(isReadOnlyTool(TOOL_NAMES.exportGerbers)).toBe(false);
+    expect(isReadOnlyTool(TOOL_NAMES.switchVariant)).toBe(false);
+    expect(isReadOnlyTool(TOOL_NAMES.runDrc)).toBe(false);
+  });
+
+  it('classifies check tools as review and artifact/state tools as release-preparation', () => {
+    expect(getToolMode(TOOL_NAMES.runDrc)).toBe('review');
+    expect(getToolMode(TOOL_NAMES.runErc)).toBe('review');
+    expect(getToolMode(TOOL_NAMES.exportGerbers)).toBe('release-preparation');
+    expect(getToolMode(TOOL_NAMES.switchVariant)).toBe('release-preparation');
+  });
+
+  it('requires trust and preview only for release-preparation', () => {
+    expect(modeRequiresTrust('release-preparation')).toBe(true);
+    expect(modeRequiresPreview('release-preparation')).toBe(true);
+    for (const mode of ['read-only', 'review'] as CapabilityMode[]) {
+      expect(modeRequiresTrust(mode)).toBe(false);
+      expect(modeRequiresPreview(mode)).toBe(false);
+    }
+  });
+});

--- a/docs/ai-capability-modes.md
+++ b/docs/ai-capability-modes.md
@@ -1,0 +1,44 @@
+# Assistant Tool Capability Modes
+
+Every assistant-facing tool (the VS Code Language Model tools and the MCP tools
+the assistant can call) is classified into exactly one capability mode so its
+blast radius is explicit. Dangerous tools cannot run without the right mode,
+trust, and confirmation. The authoritative mapping lives in
+`src/lm/toolCapabilityModes.ts` and is enforced by `toolCapabilityModes.test.ts`,
+which fails if any registered tool has no documented mode.
+
+## Modes
+
+| Mode | Meaning | Trust + preview |
+| --- | --- | --- |
+| `read-only` | Explorer. Returns information about the project; never changes files or project state. | not required |
+| `review` | Advisory. Runs checks/validations and returns findings plus proposed next steps; does not modify design files. | not required |
+| `release-preparation` | Changes release-relevant project state or produces artifacts. | requires workspace trust **and** a preview/confirmation before acting |
+
+## Tool classification
+
+| Tool | Mode |
+| --- | --- |
+| `kicadstudio_openFile` | read-only |
+| `kicadstudio_getActiveContext` | read-only |
+| `kicadstudio_searchComponent` | read-only |
+| `kicadstudio_searchSymbol` | read-only |
+| `kicadstudio_searchFootprint` | read-only |
+| `kicadstudio_listVariants` | read-only |
+| `kicadstudio_runDrc` | review |
+| `kicadstudio_runErc` | review |
+| `kicadstudio_exportGerbers` | release-preparation |
+| `kicadstudio_switchVariant` | release-preparation |
+
+## Guarantees
+
+- **Read-only tools stay read-only.** They are tested to never appear in the
+  state-changing or artifact-producing sets.
+- **Review tools produce findings and next steps.** DRC/ERC tools return real
+  diagnostics, not free-form claims.
+- **Release-preparation tools preview first.** They surface what they will
+  produce or change and require workspace trust before acting, consistent with
+  the central guarded-operation layer.
+
+Each tool's description documents its expected inputs and outputs alongside its
+mode so the assistant chooses the least-privileged tool that fits the task.


### PR DESCRIPTION
## Summary

Classifies every assistant-facing tool (VS Code Language Model tools / MCP tools) into exactly one **capability mode** so its blast radius is explicit and testable.

| Mode | Tools | Trust + preview |
| --- | --- | --- |
| `read-only` (explorer) | openFile, getActiveContext, searchComponent/Symbol/Footprint, listVariants | no |
| `review` (advisory) | runDrc, runErc — findings + next steps | no |
| `release-preparation` | exportGerbers, switchVariant — change release state / produce artifacts | **yes** (workspace trust + preview/confirmation) |

- New `src/lm/toolCapabilityModes.ts` — authoritative registry keyed by the same `TOOL_NAMES` the tools register under (exported for this), with `getToolMode` / `isReadOnlyTool` and trust/preview helpers.
- New `toolCapabilityModes.test.ts` — **fails if any registered tool has no documented mode**, and asserts read-only tools never appear in the state-changing/artifact sets.
- `docs/ai-capability-modes.md` documents the modes + per-tool classification.

## Linked issues

Closes #406

## Validation

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check`
- [x] `pnpm test:unit:coverage` — **842 tests**, `toolCapabilityModes.ts` **100%**, thresholds held
- [x] `docs:lint` / `docs:links`

## Acceptance criteria mapping

Each tool has a documented mode ✔ (enforced by the test) · descriptions explain inputs/outputs ✔ · read-only stays read-only ✔ · review produces findings + next steps ✔ · release-prep previews before producing ✔ (documented + trust/preview helpers) · tests cover mode boundaries ✔.

## Risk

Low — additive registry + test + docs; one `export` added to `TOOL_NAMES`. No runtime behavior change to tool execution.