### PR TITLE
ci(repo): enforce branch protection and required quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - run: corepack pnpm run check:compatibility-contract
       - run: corepack pnpm run check:governance
+      - run: corepack pnpm run check:branch-protection
       - run: corepack pnpm run check:agent-configs
       - run: corepack pnpm run check:extension-manifest
 

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -29,6 +29,36 @@ this document plus `.github/rulesets/main.json` together.
 
 Scorecard should stay enabled as a repository health signal. It can be required once the repository has stable branch protection and token permissions.
 
+The documented list above and `.github/rulesets/main.json` are kept in sync by
+`corepack pnpm run check:branch-protection`, which fails if they diverge.
+
+## Quality gate coverage
+
+Each required pull-request quality gate maps to one of the required checks above:
+
+| Quality gate | Enforced by |
+| --- | --- |
+| Lint, typecheck, unit tests, accessibility, package build + validate | `vscode-extension (*)` |
+| Version + release-surface drift, compatibility, governance, extension manifest | `metadata` |
+| Forbidden references / stale monorepo language | `forbidden-refs` |
+| Static analysis (CodeQL) | `analyze (javascript-typescript)`, `analyze (python)` |
+| Dependency audit + supply-chain controls | `security` |
+| Secret scanning | `scan` |
+| Cross-product and shared-package build | `build`, `real-pair-compatibility` |
+
+Generated documentation drift is validated by the `docs` workflow on every
+documentation change. Promote it to a required context here and in the ruleset
+once it reports on every pull request (today it is path-scoped to docs changes).
+
+## Check tiers
+
+- **Pull-request required checks (blocking):** the required contexts listed
+  above. These cover lint, typecheck, unit tests, integration smoke,
+  package build + validation, and version/generated-surface drift.
+- **Scheduled / nightly checks (health gates, non-blocking on a PR):** the full
+  KiCad compatibility matrix, large-project benchmarks, the regression corpus,
+  and the dependency dashboard audit.
+
 ## Review ownership
 
 Enable CODEOWNERS review. Path ownership is declared in `.github/CODEOWNERS`:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "check:supply-chain": "node scripts/check-pnpm-supply-chain.mjs && node --test scripts/check-pnpm-supply-chain.test.mjs",
     "check:repo-governance": "node scripts/check-repo-governance.mjs",
     "check:governance": "node scripts/sync-governance-project-items.mjs --self-test && pnpm run check:repo-governance",
+    "check:branch-protection": "node scripts/check-branch-protection-gates.mjs && node --test scripts/check-branch-protection-gates.test.mjs",
     "test:ci-lanes": "node --test scripts/check-ci-lanes.test.mjs",
     "check:ci-lanes": "node scripts/check-ci-lanes.mjs --all --json && pnpm run test:ci-lanes",
     "check:testing-strategy": "node scripts/check-testing-strategy.mjs",
@@ -75,7 +76,7 @@
     "docs:preview": "vitepress preview docs",
     "check:docs-site": "pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",

--- a/scripts/check-branch-protection-gates.mjs
+++ b/scripts/check-branch-protection-gates.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+// Keeps the documented branch-protection policy and the enforced ruleset in
+// sync (#414). The required status checks listed in
+// docs/architecture/branch-protection.md must exactly match the contexts in
+// .github/rulesets/main.json, so the policy doc can never silently drift from
+// what is actually enforced on `main`.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const RULESET_PATH = ".github/rulesets/main.json";
+const DOC_PATH = "docs/architecture/branch-protection.md";
+
+export function rulesetRequiredChecks(root = repoRoot) {
+  const ruleset = JSON.parse(
+    fs.readFileSync(path.join(root, RULESET_PATH), "utf8"),
+  );
+  const rule = (ruleset.rules ?? []).find(
+    (entry) => entry.type === "required_status_checks",
+  );
+  const checks = rule?.parameters?.required_status_checks ?? [];
+  return checks
+    .map((check) => check.context)
+    .filter((context) => typeof context === "string");
+}
+
+export function documentedRequiredChecks(root = repoRoot) {
+  const doc = fs.readFileSync(path.join(root, DOC_PATH), "utf8");
+  const lines = doc.split(/\r?\n/u);
+  const start = lines.findIndex((line) =>
+    /^##\s+Required status checks/u.test(line),
+  );
+  if (start === -1) {
+    throw new Error(
+      `${DOC_PATH}: missing a "## Required status checks" section`,
+    );
+  }
+  const checks = [];
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^##\s/u.test(line)) {
+      break;
+    }
+    const match = line.match(/^-\s+`([^`]+)`\s*$/u);
+    if (match) {
+      checks.push(match[1]);
+    }
+  }
+  return checks;
+}
+
+export function diffChecks(root = repoRoot) {
+  const ruleset = new Set(rulesetRequiredChecks(root));
+  const documented = new Set(documentedRequiredChecks(root));
+  const missingFromDoc = [...ruleset].filter((c) => !documented.has(c));
+  const missingFromRuleset = [...documented].filter((c) => !ruleset.has(c));
+  return { missingFromDoc, missingFromRuleset };
+}
+
+function main() {
+  const documented = documentedRequiredChecks();
+  if (documented.length === 0) {
+    console.error(
+      `${DOC_PATH}: no required status checks are documented under "## Required status checks".`,
+    );
+    process.exit(1);
+  }
+  const { missingFromDoc, missingFromRuleset } = diffChecks();
+  if (missingFromDoc.length > 0 || missingFromRuleset.length > 0) {
+    console.error(
+      "Branch-protection policy is out of sync with the enforced ruleset:",
+    );
+    for (const context of missingFromDoc) {
+      console.error(
+        `- ${context}: required by ${RULESET_PATH} but not documented in ${DOC_PATH}`,
+      );
+    }
+    for (const context of missingFromRuleset) {
+      console.error(
+        `- ${context}: documented in ${DOC_PATH} but not required by ${RULESET_PATH}`,
+      );
+    }
+    process.exit(1);
+  }
+  console.log(
+    `Branch-protection policy matches the ruleset (${documented.length} required checks).`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-branch-protection-gates.test.mjs
+++ b/scripts/check-branch-protection-gates.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  diffChecks,
+  documentedRequiredChecks,
+  rulesetRequiredChecks,
+} from "./check-branch-protection-gates.mjs";
+
+test("#414 the ruleset declares required status checks", () => {
+  const checks = rulesetRequiredChecks();
+  assert.ok(
+    checks.length > 0,
+    "ruleset must require at least one status check",
+  );
+  // Core quality gates must be present.
+  assert.ok(checks.includes("metadata"));
+  assert.ok(checks.includes("security"));
+  assert.ok(
+    checks.some((context) => context.startsWith("vscode-extension")),
+    "the extension build/test gate must be required",
+  );
+});
+
+test("#414 the policy doc lists required status checks", () => {
+  const documented = documentedRequiredChecks();
+  assert.ok(documented.length > 0);
+});
+
+test("#414 documented policy matches the enforced ruleset", () => {
+  const { missingFromDoc, missingFromRuleset } = diffChecks();
+  assert.deepEqual(
+    { missingFromDoc, missingFromRuleset },
+    { missingFromDoc: [], missingFromRuleset: [] },
+    "docs/architecture/branch-protection.md and .github/rulesets/main.json must list the same required checks",
+  );
+});


### PR DESCRIPTION
## Summary

The branch-protection policy doc and ruleset already exist; this PR makes the required quality gates **explicit and drift-proof**.

- **New `scripts/check-branch-protection-gates.mjs` (+ test):** asserts the required status checks documented in `docs/architecture/branch-protection.md` exactly match the contexts enforced by `.github/rulesets/main.json`. The policy can no longer silently diverge from what is actually enforced on `main`. Wired into the root `check` aggregate **and the CI `metadata` job** (itself a required PR gate).
- **Documented quality-gate coverage map** — which required check enforces lint, typecheck, unit tests, package build + validate, version/release-surface drift, CodeQL, dependency audit, and secret scanning — plus the **PR-required vs scheduled** check tiers.

## Linked issues

Closes #414

## Validation

- [x] `pnpm run check:branch-protection` — 11 required checks in sync (doc ↔ ruleset)
- [x] `node --test` guard tests (3) pass
- [x] `docs:lint` / `docs:links`
- [x] `check:testing-strategy` / `check:ci-lanes` still pass after the ci.yml step

## Acceptance criteria mapping

Required checks documented ✔ · default branch protection configured/documented (ruleset + doc) ✔ · required checks include lint/typecheck/tests/package build ✔ (coverage map) · version + generated-surface drift blocking ✔ (`metadata`) · release packaging smoke required ✔ (`vscode-extension` `package:validate`) · security/dependency in the gate strategy ✔ · linked from contributor docs ✔ (CONTRIBUTING already links it).

## Risk

Low — additive guard script + doc + one CI step. Generated-docs drift promotion to a required context is noted as a follow-up (it is path-scoped today).