### PR TITLE
qa(repo): define release candidate smoke-test checklist

### DIFF
--- a/docs/release-candidate-checklist.md
+++ b/docs/release-candidate-checklist.md
@@ -1,0 +1,80 @@
+# Release Candidate Smoke-Test Checklist
+
+A maintainer runs this manual checklist against a packaged VSIX before tagging or
+publishing a release candidate. It complements — it does not replace — the
+automated CI gates ([branch protection](architecture/branch-protection.md)) and
+the [release runbook](release.md).
+
+Record the run by copying the tables below into the release PR or a release
+issue and filling in **Actual** / **Pass-Fail** / **Notes** for each step. Run on
+each target OS where practical (Windows, macOS, Linux) and note OS-specific
+differences.
+
+## Environment
+
+| Field | Value |
+| --- | --- |
+| Candidate version | |
+| VSIX file / SHA-256 | |
+| VS Code version | |
+| OS | |
+| KiCad CLI version (if installed) | |
+| MCP server version (if connected) | |
+| Date / tester | |
+
+## Install and activation
+
+| Step | Expected result | Actual | Pass/Fail | Notes |
+| --- | --- | --- | --- | --- |
+| Fresh install of the VSIX into a clean VS Code | Extension installs; activity-bar icon appears | | | |
+| Upgrade install over the previous version | Settings/secrets preserved; no duplicate views | | | |
+| Activation time on a sample project | Activates without error; under the perf budget | | | |
+| Getting-started walkthrough on first install | Walkthrough opens once | | | |
+
+## Project discovery and scoping
+
+| Step | Expected result | Actual | Pass/Fail | Notes |
+| --- | --- | --- | --- | --- |
+| Open a single-project workspace | Project tree shows the project | | | |
+| Open a multi-project / multi-root workspace | All projects discovered; active project shown in status bar | | | |
+| Switch active project (status bar / palette) | Tree, variants, diagnostics, and context update | | | |
+| Open a workspace with no KiCad project | No errors; project views stay empty | | | |
+
+## Diagnostics, viewer, and export
+
+| Step | Expected result | Actual | Pass/Fail | Notes |
+| --- | --- | --- | --- | --- |
+| View a schematic and a PCB in the built-in viewer | Both render and fit to screen | | | |
+| Run DRC and ERC (KiCad CLI installed) | Findings appear in Problems panel | | | |
+| Export Gerbers / BOM / PDF | Files produced in the output folder | | | |
+| Prepare Manufacturing Release — dry run | Preview shown; nothing written | | | |
+| Prepare Manufacturing Release — create | `release-manifest.json` + `RELEASE-SUMMARY.md` produced | | | |
+| BoardReadyOps / readiness scorecard | Scorecard reports per-dimension status | | | |
+| Generate KiCad Diff Report on a committed file | Structural diff report opens | | | |
+
+## Trust and failure paths
+
+| Step | Expected result | Actual | Pass/Fail | Notes |
+| --- | --- | --- | --- | --- |
+| Restricted (untrusted) workspace | Write/export/MCP actions are disabled with a clear reason | | | |
+| Grant workspace trust | Gated features become available | | | |
+| KiCad CLI **not** installed / wrong path | Capability-gated commands warn; no crash | | | |
+| MCP endpoint unavailable | MCP views show disconnected; no blocking errors | | | |
+| Malicious output path (`..`, absolute, symlink) | Guarded operation rejects it with a safe message | | | |
+
+## Marketplace and Open VSX
+
+| Step | Expected result | Actual | Pass/Fail | Notes |
+| --- | --- | --- | --- | --- |
+| VSIX identity / metadata | `oaslananka.kicadstudiokit` with the candidate version | | | |
+| Marketplace listing (after publish) | Version, icon, and README render correctly | | | |
+| Open VSX listing (after publish) | Same VSIX payload published | | | |
+| Marketplace/Open VSX indexing delay | Treated as advisory, not a publish failure | | | |
+
+## Sign-off
+
+| Field | Value |
+| --- | --- |
+| Overall result (pass / pass-with-notes / fail) | |
+| Blocking issues | |
+| Maintainer sign-off | |

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,5 +1,9 @@
 # Release
 
+Before tagging or publishing a release candidate, a maintainer runs the
+[release candidate smoke-test checklist](release-candidate-checklist.md) against
+the packaged VSIX and records the results in the release PR or issue.
+
 Current product versions are represented in:
 
 - `.release-please-manifest.json`


### PR DESCRIPTION
## Summary

Adds `docs/release-candidate-checklist.md` — a maintainer-run **manual smoke test** for a packaged VSIX before tagging/publishing, complementing the automated CI gates.

Covers, with **environment + step + expected + actual + pass/fail + notes** columns and a sign-off block:
- fresh + upgrade install, activation, getting-started
- single / multi-root project discovery and **active-project scoping**
- viewer, DRC/ERC, export, **manufacturing release wizard (dry-run + create)**, BoardReadyOps scorecard, diff report
- **trusted vs restricted** workspace behavior
- **failure paths** — missing KiCad CLI, MCP down, malicious output path
- **Marketplace / Open VSX** verification with advisory indexing

Linked from the [release runbook](https://github.com/oaslananka/kicad-studio-kit/blob/main/docs/release.md).

## Linked issues

Closes #416

## Validation

- [x] `docs:lint` / `docs:links`

## Acceptance criteria mapping

Checklist exists ✔ · linked from release instructions ✔ · covers install/activation/project discovery/diagnostics/viewer/export ✔ · trusted + restricted workspace ✔ · Marketplace + Open VSX steps ✔ · failure-path checks (missing KiCad CLI) ✔ · results recordable per candidate ✔.

## Risk

None — documentation only.