### PR TITLE
test(kicad-studio): document the VS Code integration/e2e test matrix and cover multi-root discovery

### DIFF
--- a/apps/vscode-extension/test/unit/multiProjectWorkspace.test.ts
+++ b/apps/vscode-extension/test/unit/multiProjectWorkspace.test.ts
@@ -60,7 +60,10 @@ function createDiagnostic(message: string): vscode.Diagnostic {
   return diagnostic;
 }
 
-function byName(projects: readonly ProjectContext[], name: string): ProjectContext {
+function byName(
+  projects: readonly ProjectContext[],
+  name: string
+): ProjectContext {
   const project = projects.find((entry) => entry.name === name);
   if (!project) {
     throw new Error(`Missing project ${name}`);
@@ -107,27 +110,66 @@ describe('multi-project workspace state', () => {
     );
   });
 
+  it('aggregates KiCad projects discovered across multiple workspace roots', async () => {
+    // Mirrors the shipped `multi-root-workspace` fixture (controller + power-supply):
+    // a multi-root workspace hands discoverKiCadProjects more than one workspace
+    // folder, and discovery must aggregate projects from every distinct root.
+    const controllerRoot = writeProject(tempDir, 'controller');
+    const powerRoot = writeProject(tempDir, 'power-supply');
+
+    const projects = await discoverKiCadProjects([
+      { uri: Uri.file(controllerRoot) },
+      { uri: Uri.file(powerRoot) }
+    ] as never);
+
+    expect(projects.map((project) => project.name)).toEqual([
+      'controller',
+      'power-supply'
+    ]);
+    expect(
+      new Set(projects.map((project) => project.workspaceFolder)).size
+    ).toBe(2);
+    expect(
+      findProjectForResource(
+        projects,
+        path.join(powerRoot, 'power-supply.kicad_pcb')
+      )
+    ).toEqual(expect.objectContaining({ name: 'power-supply' }));
+  });
+
   it('resolves nested projects and firmware hardware folders to the nearest project', async () => {
     writeProject(tempDir, 'alpha');
     const nestedRoot = writeProject(tempDir, 'alpha/submodule/nested');
     const hardwareRoot = writeProject(tempDir, 'firmware/hardware');
     fs.mkdirSync(path.join(tempDir, 'firmware/src'), { recursive: true });
-    fs.writeFileSync(path.join(tempDir, 'firmware/src/main.c'), 'int main(){}', 'utf8');
+    fs.writeFileSync(
+      path.join(tempDir, 'firmware/src/main.c'),
+      'int main(){}',
+      'utf8'
+    );
 
     const projects = await discoverKiCadProjects([
       { uri: Uri.file(tempDir) }
     ] as never);
 
-    expect(findProjectForResource(projects, path.join(nestedRoot, 'nested.kicad_pcb'))).toEqual(
-      expect.objectContaining({ name: 'nested' })
-    );
+    expect(
+      findProjectForResource(
+        projects,
+        path.join(nestedRoot, 'nested.kicad_pcb')
+      )
+    ).toEqual(expect.objectContaining({ name: 'nested' }));
     expect(
       findProjectForResource(
         projects,
         path.join(hardwareRoot, 'hardware.kicad_sch')
       )
     ).toEqual(expect.objectContaining({ name: 'hardware' }));
-    expect(findProjectForResource(projects, path.join(tempDir, 'firmware/src/main.c'))).toBeUndefined();
+    expect(
+      findProjectForResource(
+        projects,
+        path.join(tempDir, 'firmware/src/main.c')
+      )
+    ).toBeUndefined();
   });
 
   it('targets the active project when live validation starts from another open project', async () => {
@@ -227,7 +269,9 @@ describe('multi-project workspace state', () => {
     ]);
 
     expect(diagnostics.getSnapshot().drc?.errors).toBe(2);
-    expect(diagnostics.getSnapshot({ projectId: alpha.id }).drc?.errors).toBe(2);
+    expect(diagnostics.getSnapshot({ projectId: alpha.id }).drc?.errors).toBe(
+      2
+    );
     expect(diagnostics.getSnapshot({ projectId: beta.id }).drc?.errors).toBe(7);
 
     diagnostics.setActiveProject(beta.id);

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,6 +4,12 @@ Before tagging or publishing a release candidate, a maintainer runs the
 [release candidate smoke-test checklist](release-candidate-checklist.md) against
 the packaged VSIX and records the results in the release PR or issue.
 
+Extension Host release confidence is tracked by the
+[VS Code integration and E2E test matrix](testing-strategy.md#vs-code-integration-and-e2e-test-matrix),
+which maps operating systems, VS Code versions, KiCad lines, Workspace Trust
+states, and single-root/multi-root workspace shapes to their covering tests and
+CI lanes.
+
 Current product versions are represented in:
 
 - `.release-please-manifest.json`

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -360,6 +360,54 @@ servers implicitly:
 corepack pnpm run test:fixtures
 ```
 
+## VS Code Integration and E2E Test Matrix
+
+This matrix records how the extension is validated inside the VS Code Extension
+Host across operating systems, VS Code versions, KiCad lines, Workspace Trust
+states, workspace shapes, and representative workflows. The reduced matrix runs
+on every pull request; the full matrix adds scheduled and canary lanes. A
+reduced PR matrix plus a full scheduled matrix is an intentional cost/coverage
+trade-off, not missing coverage.
+
+### Matrix dimensions
+
+| Dimension | Reduced matrix (every PR) | Full matrix (scheduled / canary) | Source of truth |
+| --- | --- | --- | --- |
+| Operating system | `ubuntu-24.04`, `windows-2025`, `macos-15` | Same three runners | `.github/workflows/ci.yml` `vscode-extension` job matrix |
+| VS Code version | Pinned `DEFAULT_VSCODE_TEST_VERSION` | `engines.vscode` floor and Insiders canary | `apps/vscode-extension/test/vscodeTestRuntime.ts`, `.github/workflows/vscode-canary.yml` |
+| KiCad line | Deterministic fixtures and mocked CLI probes (no `kicad-cli` required) | Real `kicad-cli` line from the canary host | `compatibility.yaml`, `.github/workflows/cross-repo-compatibility.yml`, `oaslananka/kicad-mcp` |
+| Workspace Trust | Restricted and trusted contracts | Same | `apps/vscode-extension/test/integration/extension.test.ts` |
+| Workspace shape | Single-root and multi-root | Same | `extension.test.ts` (single-root), `apps/vscode-extension/test/unit/multiProjectWorkspace.test.ts` (multi-root) |
+
+### Workflow coverage
+
+| Workflow | Covering test | Layer |
+| --- | --- | --- |
+| Activation when a `.kicad_pro` workspace opens | `extension.test.ts` — _activates when .kicad_pro workspace opened_ | Extension Host integration |
+| Core command registration smoke after activation | `extension.test.ts` — _registers every package.json command at runtime_ | Extension Host integration |
+| Command enablement and context keys | `extension.test.ts` — _gates command palette commands by file state and Workspace Trust_ | Extension Host integration |
+| Workspace Trust restricted and trusted behavior | `extension.test.ts` — _declares activation, empty-workspace welcome, and Workspace Trust contracts_ | Extension Host integration |
+| KiCad CLI discovery with valid, missing, and invalid paths | `apps/vscode-extension/test/unit/kicadCliDetector.test.ts` | Unit |
+| Project discovery — single-root | `extension.test.ts` — _renders project tree fixture files_ | Extension Host integration |
+| Project discovery — multi-root | `multiProjectWorkspace.test.ts` — _aggregates KiCad projects discovered across multiple workspace roots_ | Unit |
+| Viewer / webview activation smoke | `apps/vscode-extension/test/e2e/viewer.test.ts`; `extension.test.ts` registers custom editors | E2E / integration |
+| Diagnostics update and stale-clear behavior | `extension.test.ts` — _scopes Problems diagnostics to exact URIs and clears stale diagnostics after a clean save_ | Extension Host integration |
+| Real MCP pair quickstart, quality gate, and context-bridge flows | `apps/vscode-extension/test/integration/realServer/*.flow.test.ts` | Integration |
+
+### Reduced versus full matrix
+
+- **Reduced (every PR):** all three operating systems, the pinned VS Code
+  version, and deterministic KiCad fixtures with mocked CLI probes. This is the
+  release-blocking lane.
+- **Full (scheduled / nightly / canary):** adds the VS Code Insiders lane
+  (`vscode-canary.yml`), the real `kicad-cli` cross-repo compatibility canary,
+  and the real-pair host run. Multi-KiCad-line installation is not required on
+  every PR job; the reduced matrix uses fixtures and probes instead.
+
+Multi-root coverage exercises the shipped
+[`multi-root-workspace`](kicad-fixture-corpus.md#fixture-coverage) corpus shape:
+two KiCad projects and a `.code-workspace` file across separate folders.
+
 ## CI Ownership
 
 CI ownership follows product boundaries:


### PR DESCRIPTION
## Summary

Closes #410. The Extension Host suite already covered most of what #410 asks for;
this PR closes the two remaining gaps: an explicit **multi-root workspace** shape
and a **documented integration & E2E test matrix** linked from release docs.

## What changed

- **Multi-root discovery test** — `multiProjectWorkspace.test.ts` now hands
  `discoverKiCadProjects` two distinct workspace roots (`controller` +
  `power-supply`, mirroring the shipped `multi-root-workspace` fixture from #411)
  and asserts projects aggregate across every root. The existing tests only ever
  passed a single root, so the multi-folder discovery path was untested.
- **Documented test matrix** — a new _VS Code Integration and E2E Test Matrix_
  section in `docs/testing-strategy.md` maps every dimension (OS, VS Code
  version, KiCad line, Workspace Trust, single/multi-root) and representative
  workflow to its covering test and CI lane, with an explicit reduced-PR vs
  full-scheduled split.
- **Release linkage** — `docs/release.md` now links the matrix for Extension
  Host release confidence.

## Acceptance criteria (#410)

| Criterion | Status |
| --- | --- |
| Extension Host integration tests run in CI | ✅ already (`ci.yml` `vscode-extension`, 3 OS) |
| Core commands smoke-tested after activation | ✅ already (`extension.test.ts`) |
| KiCad CLI discovery: valid / missing / invalid paths | ✅ already (`kicadCliDetector.test.ts`) |
| Workspace Trust restricted + trusted | ✅ already (`extension.test.ts` contracts + gating) |
| Project discovery single-root **and multi-root** | ✅ single-root already; **multi-root this PR** |
| Viewer/webview activation smoke | ✅ already (`e2e/viewer.test.ts`, custom editors) |
| Diagnostics update integration test | ✅ already (`extension.test.ts` stale-clear) |
| **Matrix documented and linked from release docs** | ✅ **this PR** |

## Validation

- [x] `jest multiProjectWorkspace.test.ts` — 7 passed (incl. new multi-root test)
- [x] `check:testing-strategy` exit 0
- [x] `docs:check-generated` / `docs:lint` / `docs:links`
- [x] full `pnpm run check` pre-push gate green

## Notes

Docs-only matrix lives in the already-registered `testing-strategy.md` (no new
sidebar page); coverage is mapped to existing tests rather than duplicating them.