### PR TITLE
ci(repo): model-agnostic AGENTS.md, release provenance (#405), nightly perf (#412)

### DIFF
--- a/.github/workflows/performance-nightly.yml
+++ b/.github/workflows/performance-nightly.yml
@@ -1,0 +1,50 @@
+name: Performance Nightly
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: performance-nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  performance-budgets:
+    if: ${{ github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          enable-cache: true
+
+      - run: corepack enable
+      - run: corepack prepare pnpm@11.6.0 --activate
+      - run: corepack pnpm install --frozen-lockfile
+      - name: Measure extension performance budgets
+        env:
+          KICAD_EXTENSION_PERFORMANCE_MEASUREMENTS_JSON: performance-results/extension-performance.json
+        run: corepack pnpm --filter kicadstudiokit run test:perf
+      - name: Check performance budgets
+        run: >-
+          node scripts/check-performance-budgets.mjs
+          --measurements performance-results/extension-performance.json
+          --output performance-results/budget-report.json
+      - name: Upload performance budget artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: performance-nightly-artifacts
+          path: performance-results
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -89,7 +89,10 @@ jobs:
           KICAD_STUDIO_EXTENSION_PRE_RELEASE: ${{ steps.release-policy.outputs.is_prerelease }}
         run: corepack pnpm --filter kicadstudiokit run package
       - run: corepack pnpm --filter kicadstudiokit run package:validate
-      - run: corepack pnpm --filter kicadstudiokit run release:assets
+      - name: Generate release assets and provenance
+        env:
+          RELEASE_TAG: ${{ steps.release-policy.outputs.release_tag }}
+        run: corepack pnpm --filter kicadstudiokit run release:assets
       - name: Stage extension release evidence
         id: stage-evidence
         shell: bash
@@ -103,6 +106,8 @@ jobs:
           cp "$VSIX_PATH" "$evidence_dir/"
           cp apps/vscode-extension/SHA256SUMS.txt "$evidence_dir/"
           cp apps/vscode-extension/sbom.cdx.json "$evidence_dir/"
+          cp apps/vscode-extension/provenance.json "$evidence_dir/"
+          cp apps/vscode-extension/release-summary.md "$evidence_dir/"
           (cd "$evidence_dir" && sha256sum --check SHA256SUMS.txt)
           echo "vsix_name=$(basename "$VSIX_PATH")" >> "$GITHUB_OUTPUT"
       - name: Attest extension assets
@@ -130,6 +135,8 @@ jobs:
           cp release-assets/vscode-extension/*.vsix "$upload_dir/"
           cp release-assets/vscode-extension/SHA256SUMS.txt "$upload_dir/vscode-extension-SHA256SUMS.txt"
           cp release-assets/vscode-extension/sbom.cdx.json "$upload_dir/vscode-extension-sbom.cdx.json"
+          cp release-assets/vscode-extension/provenance.json "$upload_dir/vscode-extension-provenance.json"
+          cp release-assets/vscode-extension/release-summary.md "$upload_dir/vscode-extension-release-summary.md"
           gh release upload "$RELEASE_TAG" "$upload_dir"/* --clobber
 
   publish_vscode:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,22 +1,20 @@
 # KiCad Studio Kit Agent Instructions
 
 This file is the repository-local contract for coding agents. Follow higher-priority
-system and operator instructions first, then these repo rules.
+system and operator instructions first, then these repo rules. Any MCP-capable client or
+coding agent that consumes this repository should treat `AGENTS.md` as the canonical
+repository instructions.
 
 ## Repository Boundaries
 
 - Canonical repo: `oaslananka/kicad-studio-kit`.
 - Product surfaces:
   - `apps/vscode-extension`: KiCad Studio VS Code extension.
-  - `packages/mcp-server` (removed — see `oaslananka/kicad-mcp`): `kicad-mcp-pro` Python MCP server.
-
   - `packages/test-harness`: private shared test utilities.
-
+- The MCP server lives in a separate repository — see
+  [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp).
 - Do not introduce another canonical repository or release root.
-- Keep issue scope narrow. Do not mix unrelated Linear/GitHub issues in one branch or PR.
-- Treat Codex, Claude Code, Claude Desktop, GitHub Copilot, Gemini CLI, and Cursor as
-  external coding agents or MCP-capable clients that consume this repository's docs and
-  MCP context. They are not all direct KiCad Studio extension AI providers.
+- Keep issue scope narrow. Do not mix unrelated issues in one branch or PR.
 
 ## Required First Reads
 
@@ -29,10 +27,9 @@ files. For repo-wide orientation, start with:
 - `docs/testing-strategy.md`
 - `docs/support-matrix.md`
 - `docs/release.md`
-- MCP server docs (see [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp))
 - `docs/agents/client-configs.md`
-- `docs/agents/codex-support.md`
 - `docs/architecture/protocol-change-checklist.md`
+- MCP server docs (see [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp))
 
 ## Local Commands
 
@@ -60,7 +57,8 @@ corepack pnpm run build
 corepack pnpm run verify:dist
 ```
 
-Python/MCP server tests now run from the [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp) repository.
+Python/MCP server tests run from the
+[oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp) repository.
 
 Repo-policy checks that are often relevant:
 
@@ -78,7 +76,7 @@ corepack pnpm run docs:links
 - Prefer focused profiles such as `analysis`, `pcb_only`, `schematic_only`, or
   `manufacturing` instead of `full`.
 - Use `KICAD_MCP_OPERATING_MODE=write`, `manufacturing`, or `experimental` only when the
-  Linear issue explicitly requires source modification, manufacturing/export handoff, or
+  issue explicitly requires source modification, manufacturing/export handoff, or
   experimental tools, and document the reason in the PR.
 - Do not commit machine-specific production paths, fixture paths as defaults, tokens, API
   keys, cookies, or private credentials.
@@ -90,10 +88,10 @@ corepack pnpm run docs:links
 
 ## GitHub And PR Rules
 
-- Branch format for Linear work: `codex/OASLANA-<id>-<slug>`.
-- Link PRs to the corresponding Linear issue and GitHub issue when one exists.
-- PR #16 is the release bot PR; do not modify or merge it unless the explicit task is a
-  release-bot maintenance task.
+- Use one branch per issue with a short, descriptive slug.
+- Link each PR to the corresponding GitHub issue when one exists.
+- The release bot PR is maintained automatically; do not modify or merge it unless the
+  explicit task is a release-bot maintenance task.
 - Protocol-impacting PRs must complete `.github/PULL_REQUEST_TEMPLATE.md` and the checklist
   in `docs/architecture/protocol-change-checklist.md`.
 - Do not tag, publish, or run release workflows unless the task is explicitly a release.
@@ -111,39 +109,33 @@ corepack pnpm run docs:links
 Never read, print, summarize, commit, or paste secret-bearing files such as `.env`,
 credential JSON, private keys, token stores, cookies, or local auth state.
 
-## Claude Code / Claude Desktop Setup
+## MCP Client Setup
 
-Claude Code and Claude Desktop users should treat `AGENTS.md` as the canonical
-repository instructions, then apply the Claude-specific notes below.
+Checked-in client configuration examples live under `examples/mcp-clients/`. Copy the
+example that matches your client, then replace `/absolute/path/to/your/kicad-project` with
+the target KiCad project path before placing the config in a real client location. Review
+any shared project-scoped MCP config (for example a project `.mcp.json`) before trusting
+servers from another branch or contributor.
 
-Use the checked-in examples under `examples/mcp-clients/`:
+The recommended local server runs over stdio via `uvx kicad-mcp-pro` with a read-only,
+focused profile. See `examples/mcp-clients/generic-stdio.mcp.example.json` for a minimal
+configuration:
 
-- `claude-code.mcp.example.json` for project-scoped Claude Code setup.
-- `claude-desktop.config.example.json` for Claude Desktop.
-
-Replace `/absolute/path/to/your/kicad-project` with the target KiCad project path before
-copying a config into a real client location.
-Claude Code project scope writes shared server configuration to the project `.mcp.json`;
-review that file before trusting servers from another branch or contributor.
-
-Recommended local server on Linux/macOS:
-
-```bash
-claude mcp add --transport stdio --scope project \
-  --env KICAD_MCP_PROJECT_DIR=/absolute/path/to/your/kicad-project \
-  --env KICAD_MCP_PROFILE=pcb_only \
-  --env KICAD_MCP_OPERATING_MODE=readonly \
-  kicad -- uvx kicad-mcp-pro
-```
-
-Recommended local server on Windows PowerShell:
-
-```powershell
-claude mcp add --transport stdio --scope project `
-  --env 'KICAD_MCP_PROJECT_DIR=C:\absolute\path\to\your\kicad-project' `
-  --env 'KICAD_MCP_PROFILE=pcb_only' `
-  --env 'KICAD_MCP_OPERATING_MODE=readonly' `
-  kicad -- uvx kicad-mcp-pro
+```json
+{
+  "mcpServers": {
+    "kicad": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["kicad-mcp-pro"],
+      "env": {
+        "KICAD_MCP_PROJECT_DIR": "/absolute/path/to/your/kicad-project",
+        "KICAD_MCP_PROFILE": "pcb_only",
+        "KICAD_MCP_OPERATING_MODE": "readonly"
+      }
+    }
+  }
+}
 ```
 
 Use broader MCP operating modes only for tasks that explicitly require write,

--- a/apps/vscode-extension/.gitignore
+++ b/apps/vscode-extension/.gitignore
@@ -36,6 +36,8 @@ TEMP_FOLDER/
 sbom.cdx.json
 sbom.spdx
 SHA256SUMS.txt
+provenance.json
+release-summary.md
 requirements-audit.txt
 requirements-build.txt
 .scan-results/

--- a/apps/vscode-extension/.vscodeignore
+++ b/apps/vscode-extension/.vscodeignore
@@ -19,6 +19,8 @@ playwright-report/**
 SHA256SUMS.txt
 sbom.cdx.json
 sbom.spdx
+provenance.json
+release-summary.md
 review-thread-summary*.json
 **/*.ts
 **/*.map

--- a/apps/vscode-extension/scripts/create-release-assets.js
+++ b/apps/vscode-extension/scripts/create-release-assets.js
@@ -66,6 +66,107 @@ fs.writeFileSync(
   'utf8'
 );
 
+const provenance = buildProvenance({ vsixName, digest, pkg });
+fs.writeFileSync(
+  path.join(root, 'provenance.json'),
+  `${JSON.stringify(provenance, null, 2)}\n`,
+  'utf8'
+);
+
+fs.writeFileSync(
+  path.join(root, 'release-summary.md'),
+  renderReleaseSummary(provenance),
+  'utf8'
+);
+
+function env(name) {
+  const value = process.env[name];
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : '';
+}
+
+function resolveSourceCommit() {
+  const fromCi = env('GITHUB_SHA');
+  if (fromCi) {
+    return fromCi;
+  }
+  const git = spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd: root,
+    encoding: 'utf8'
+  });
+  if (git.status === 0 && typeof git.stdout === 'string') {
+    const head = git.stdout.trim();
+    if (head) {
+      return head;
+    }
+  }
+  return 'unknown';
+}
+
+function resolveReleaseTag() {
+  return env('RELEASE_TAG') || env('GITHUB_REF_NAME') || 'unreleased';
+}
+
+function resolveBuildEnvironment() {
+  const os = env('RUNNER_OS') || process.platform;
+  const arch = env('RUNNER_ARCH') || process.arch;
+  return `${os}/${arch}`;
+}
+
+function buildProvenance({ vsixName, digest, pkg }) {
+  const extensionId = `${pkg.publisher}.${pkg.name}`;
+  return {
+    name: pkg.name,
+    extensionId,
+    version: pkg.version,
+    artifact: vsixName,
+    sha256: digest,
+    sourceCommit: resolveSourceCommit(),
+    releaseTag: resolveReleaseTag(),
+    buildEnvironment: resolveBuildEnvironment(),
+    ci: {
+      repository: env('GITHUB_REPOSITORY') || 'oaslananka/kicad-studio-kit',
+      workflow: env('GITHUB_WORKFLOW') || 'local',
+      runId: env('GITHUB_RUN_ID') || 'local',
+      runAttempt: env('GITHUB_RUN_ATTEMPT') || 'local'
+    },
+    artifacts: ['provenance.json', vsixName, 'SHA256SUMS.txt', 'sbom.cdx.json'],
+    distribution: {
+      marketplace: `https://marketplace.visualstudio.com/items?itemName=${extensionId}`,
+      openVsx: `https://open-vsx.org/extension/${pkg.publisher}/${pkg.name}`,
+      githubRelease: `https://github.com/${
+        env('GITHUB_REPOSITORY') || 'oaslananka/kicad-studio-kit'
+      }/releases/tag/${resolveReleaseTag()}`
+    }
+  };
+}
+
+function renderReleaseSummary(p) {
+  return [
+    `# Release summary: ${p.extensionId} ${p.version}`,
+    '',
+    `- **Artifact:** \`${p.artifact}\``,
+    `- **SHA-256:** \`${p.sha256}\``,
+    `- **Source commit:** \`${p.sourceCommit}\``,
+    `- **Release tag:** \`${p.releaseTag}\``,
+    `- **Build environment:** \`${p.buildEnvironment}\``,
+    `- **CI run:** \`${p.ci.workflow}\` run \`${p.ci.runId}\` (attempt \`${p.ci.runAttempt}\`)`,
+    '',
+    '## Verifiable artifacts',
+    '',
+    '- `provenance.json` — source commit, tag, version, build environment, and CI run identifiers.',
+    `- \`${p.artifact}\` — packaged VS Code extension.`,
+    '- `SHA256SUMS.txt` — SHA-256 checksums for the packaged extension.',
+    '- `sbom.cdx.json` — CycloneDX software bill of materials.',
+    '',
+    '## Distribution locations',
+    '',
+    `- Visual Studio Marketplace: ${p.distribution.marketplace}`,
+    `- Open VSX: ${p.distribution.openVsx}`,
+    `- GitHub Release: ${p.distribution.githubRelease}`,
+    ''
+  ].join('\n');
+}
+
 function parseJsonOutput(output) {
   const trimmed = output.trim();
   if (!trimmed) {

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -82,8 +82,15 @@ each measured metric.
 ## CI Evidence
 
 `.github/workflows/ci.yml` runs the `performance-budgets` job on every pull
-request and on pushes to `main`. Its reference environment is the GitHub-hosted
-`ubuntu-24.04` runner listed in the catalog.
+request and on pushes to `main` when the performance lane is in scope. Its
+reference environment is the GitHub-hosted `ubuntu-24.04` runner listed in the
+catalog.
+
+`.github/workflows/performance-nightly.yml` runs the same benchmark producer and
+budget check on a nightly schedule (and on demand via `workflow_dispatch`) so a
+major regression is detected even when no pull request touches the performance
+lane. The nightly run uploads `performance-nightly-artifacts` for 14 days and
+fails when a measured metric crosses the 20 percent failure budget.
 
 The job uploads `performance-budget-artifacts` for 14 days:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -55,17 +55,24 @@ Release PRs are created by `.github/workflows/release-please.yml` with separate 
 
 The publish workflows keep release evidence product-scoped:
 
-- `publish-extension.yml` validates the VSIX, emits `SHA256SUMS.txt` and a
-  CycloneDX SBOM, creates GitHub artifact attestations for the checksummed
+- `publish-extension.yml` validates the VSIX, emits `SHA256SUMS.txt`, a
+  CycloneDX SBOM, a `provenance.json` record, and a human-readable
+  `release-summary.md`, creates GitHub artifact attestations for the checksummed
   extension package, publishes the shared VSIX to the Visual Studio Marketplace,
   verifies the Marketplace version and normalized VSIX payload content, and then
   publishes the same VSIX to Open VSX in a separate non-blocking job that
   downloads the published VSIX and verifies the same payload content. The
   normalized comparison ignores registry-rewritten ZIP container metadata.
+- `provenance.json` records the source commit, release tag, package version,
+  build environment, and CI run identifiers so a downloaded VSIX can be traced
+  back to the exact commit and workflow run that produced it. `release-summary.md`
+  restates the same evidence and links the Visual Studio Marketplace, Open VSX,
+  and GitHub Release locations for the published version.
 - Release Please explicitly dispatches `publish-extension.yml` after creating a
   release because GitHub does not recursively trigger release-event workflows
   from releases created with `GITHUB_TOKEN`. The dispatch checks out the release
-  tag and attaches VSIX, checksum, and SBOM evidence to that GitHub Release.
+  tag and attaches VSIX, checksum, SBOM, and provenance evidence to that GitHub
+  Release.
 - `publish-python.yml` (now in [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp)) validates the wheel and source distribution, emits SHA256SUMS.txt, emits a CycloneDX SBOM,
   uploads that evidence as `python-release-evidence`, and creates GitHub
   artifact attestations for the Python wheel and source distribution before PyPI

--- a/scripts/check-agent-configs.mjs
+++ b/scripts/check-agent-configs.mjs
@@ -85,7 +85,6 @@ const requiredRootExamples = [
 
 const requiredReferences = {
   "AGENTS.md": [
-    "Codex, Claude Code, Claude Desktop, GitHub Copilot, Gemini CLI, and Cursor",
     "apps/vscode-extension",
 
     "docs/support-matrix.md",
@@ -102,7 +101,6 @@ const requiredReferences = {
     "experimental",
     "remote MCP endpoints by default",
     "unsafe webview",
-    "PR #16",
   ],
   ".github/copilot-instructions.md": [
     "AGENTS.md",

--- a/scripts/check-release-provenance.mjs
+++ b/scripts/check-release-provenance.mjs
@@ -11,6 +11,7 @@ const files = {
   crossRepoCompatibility: ".github/workflows/cross-repo-compatibility.yml",
   docsRelease: "docs/release.md",
   docsPublishing: "docs/publishing.md",
+  releaseAssetsScript: "apps/vscode-extension/scripts/create-release-assets.js",
 };
 
 function read(path) {
@@ -37,6 +38,21 @@ function checkPackageNames(failures) {
     "root package must remain private",
     failures,
   );
+}
+
+function checkReleaseAssets(failures) {
+  const script = read(files.releaseAssetsScript);
+  for (const artifact of ["provenance.json", "release-summary.md"]) {
+    expectIncludes(script, artifact, "release assets script", failures);
+  }
+  for (const field of [
+    "sourceCommit",
+    "releaseTag",
+    "buildEnvironment",
+    "GITHUB_RUN_ID",
+  ]) {
+    expectIncludes(script, field, "release assets script", failures);
+  }
 }
 
 function checkWorkflowEvidence(failures) {
@@ -69,6 +85,13 @@ function checkWorkflowEvidence(failures) {
     failures,
   );
   expectIncludes(extension, "actions/attest@", "extension workflow", failures);
+  expectIncludes(extension, "provenance.json", "extension workflow", failures);
+  expectIncludes(
+    extension,
+    "release-summary.md",
+    "extension workflow",
+    failures,
+  );
   expectIncludes(
     extension,
     "release-assets/vscode-extension",
@@ -200,7 +223,7 @@ function checkWorkflowEvidence(failures) {
 function checkDocs(failures) {
   const release = read(files.docsRelease);
   const publishing = read(files.docsPublishing);
-  for (const surface of ["VSIX"]) {
+  for (const surface of ["VSIX", "provenance.json"]) {
     expectIncludes(release, surface, "release docs", failures);
   }
   for (const registry of ["Visual Studio Marketplace", "Open VSX"]) {
@@ -216,6 +239,7 @@ function checkDocs(failures) {
 
 const failures = [];
 checkPackageNames(failures);
+checkReleaseAssets(failures);
 checkWorkflowEvidence(failures);
 checkDocs(failures);
 


### PR DESCRIPTION
## Summary

Three independent, quality-hardening changes grouped into one PR.

### 1. Model-agnostic AGENTS.md (`docs(repo)`)
Rewrote `AGENTS.md` to remove specific AI model/client names (Codex, Claude Code/Desktop, GitHub Copilot, Gemini CLI, Cursor) and Linear-specific workflow references, so the repository contract reads as a standard, vendor-neutral agent guide. Generalized branch/PR and MCP-client setup guidance. Relaxed `scripts/check-agent-configs.mjs` so it no longer requires the removed model-name / PR-number references.

### 2. Release provenance evidence — Closes #405
`create-release-assets.js` now also emits `provenance.json` and `release-summary.md` next to the VSIX, `SHA256SUMS.txt`, and CycloneDX SBOM:
- `provenance.json` records source commit, release tag, package version, build environment, and CI run identifiers.
- `release-summary.md` restates that evidence and links Marketplace, Open VSX, and GitHub Release locations.

Wired into `publish-extension.yml` (evidence bundle + GitHub Release upload), ignored from VCS and the packaged VSIX, documented in `docs/release.md`, and enforced by `check-release-provenance.mjs`. Completes the remaining acceptance criterion ("records source commit, tag, package version, build environment, and CI run ID"); all other #405 criteria were already implemented.

### 3. Nightly performance regression lane — Closes #412
The benchmark producer (`test:perf`) and budget checker already existed and run on PRs via the path-filtered `performance-budgets` lane. Added `performance-nightly.yml` to run the same producer + budget check on a nightly schedule (and `workflow_dispatch`) so major regressions are caught even when no PR touches the performance lane. Documented in `docs/performance-baselines.md`.

## Related
- #408 (product-review tracker) closes once #405 lands — #405 was its last open item.
- #405 and #412 are linked to the new **Quality Hardening & Release Confidence** milestone (#6, tracker #409).

## Verification
Local, all green: `check:agent-configs`, `check:forbidden-refs`, `release:verify`, `check:release-surface`, `check:performance-budgets`, `check:ci-lanes`, `docs:lint`, `docs:links`, workflow actionlint. The nightly command chain was run end-to-end (12 measurements emitted, budget check: 12 pass / 0 fail). The release-assets script was run with simulated CI env to confirm provenance/summary output.