### PR TITLE
fix(kicad-studio): make sidebar MCP UX project-aware and actionable

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -459,7 +459,8 @@
         {
           "id": "kicadstudio.mcpTools",
           "name": "%kicadstudio.contributes.views.kicadstudio-sidebar.10.name%",
-          "icon": "assets/views/mcp-tools.svg"
+          "icon": "assets/views/mcp-tools.svg",
+          "when": "kicadstudio.hasProject"
         }
       ]
     },

--- a/apps/vscode-extension/src/activation/mcpActivationController.ts
+++ b/apps/vscode-extension/src/activation/mcpActivationController.ts
@@ -6,6 +6,7 @@ import type { McpClient } from '../mcp/mcpClient';
 import type { McpDetector } from '../mcp/mcpDetector';
 import type { McpStateStore } from '../state/stateStores';
 import { isWorkspaceTrusted } from '../utils/workspaceTrust';
+import { discoverKiCadProjects } from '../workspace/projectContext';
 import type { McpInstallStatus } from '../types';
 
 export interface McpActivationControllerDeps {
@@ -148,6 +149,16 @@ export class McpActivationController {
 
     const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     if (!root) {
+      return;
+    }
+
+    // Only offer MCP setup when the workspace actually contains a KiCad project.
+    // kicad-mcp-pro is project-scoped, so prompting in a folder that merely
+    // happens to hold a stray KiCad file (and activated the extension) is noise.
+    const projects = await discoverKiCadProjects(
+      vscode.workspace.workspaceFolders
+    );
+    if (projects.length === 0) {
       return;
     }
 

--- a/apps/vscode-extension/src/providers/qualityGateProvider.ts
+++ b/apps/vscode-extension/src/providers/qualityGateProvider.ts
@@ -97,11 +97,14 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
   getChildren(element?: QualityGateElement): QualityGateElement[] {
     if (!element) {
       const state = this.mcpState?.getState();
-      const gates =
-        state && !supportsHttpQualityGates(state)
-          ? blockedGates(this.gates, state)
-          : this.gates;
-      return orderGates(gates).map((gate) => ({ kind: 'gate', gate }));
+      // When MCP cannot serve HTTP quality gates, return no children so the
+      // view's welcome content (Connect / Setup MCP / Switch to HTTP) is shown
+      // instead of a wall of identical "BLOCKED — connect kicad-mcp-pro" rows.
+      // The welcome CTAs are the single, discoverable way to fix the blocker.
+      if (state && !supportsHttpQualityGates(state)) {
+        return [];
+      }
+      return orderGates(this.gates).map((gate) => ({ kind: 'gate', gate }));
     }
     if (element.kind === 'gate') {
       return element.gate.violations.map((violation) => ({
@@ -290,19 +293,6 @@ function pendingGateSummary(id: string): string {
     default:
       return localize('qualityGatePendingDefault');
   }
-}
-
-function blockedGates(
-  gates: QualityGateResult[],
-  state: McpConnectionState
-): QualityGateResult[] {
-  const summary = qualityGateBlockMessage(state);
-  return gates.map((gate) => ({
-    ...gate,
-    status: 'BLOCKED',
-    summary: state.message ? `${summary} ${state.message}` : summary,
-    violations: []
-  }));
 }
 
 function qualityGateBlockMessage(state: McpConnectionState): string {

--- a/apps/vscode-extension/test/unit/qualityGateProvider.test.ts
+++ b/apps/vscode-extension/test/unit/qualityGateProvider.test.ts
@@ -26,7 +26,7 @@ describe('QualityGateProvider', () => {
     );
   });
 
-  it('blocks cached gates while MCP is outside the HTTP connected state', () => {
+  it('renders no gate rows while MCP is outside the HTTP connected state so the welcome CTA is shown', () => {
     const mcpState = new McpStateStore();
     mcpState.update({
       kind: 'VsCodeStdio',
@@ -40,17 +40,25 @@ describe('QualityGateProvider', () => {
       mcpState
     );
 
-    const children = provider.getChildren();
+    // Empty children → VS Code shows the view's welcome content (Connect /
+    // Setup MCP / Switch to HTTP) instead of a wall of BLOCKED rows.
+    expect(provider.getChildren()).toHaveLength(0);
+  });
 
-    expect(children).toHaveLength(5);
-    expect(
-      children.every(
-        (item) => item.kind === 'gate' && item.gate.status === 'BLOCKED'
-      )
-    ).toBe(true);
-    expect(provider.getTreeItem(children[0] as never).description).toContain(
-      'BLOCKED'
+  it('still renders gate rows when MCP serves HTTP quality gates', () => {
+    const mcpState = new McpStateStore();
+    mcpState.update({
+      kind: 'Connected',
+      available: true,
+      connected: true
+    });
+    const provider = new QualityGateProvider(
+      createExtensionContextMock() as never,
+      {} as never,
+      mcpState
     );
+
+    expect(provider.getChildren()).toHaveLength(5);
   });
 
   it('blocks run actions while HTTP quality gates are unavailable', async () => {

--- a/docs/extension/views.md
+++ b/docs/extension/views.md
@@ -17,7 +17,7 @@ Refresh with `corepack pnpm run docs:generate`.
 | `kicadstudio.drcRules` | DRC Rules | `kicadstudio-sidebar` | tree | `kicadstudio.hasProject` |
 | `kicadstudio.fixQueue` | AI Fix Queue | `kicadstudio-sidebar` | tree | `kicadstudio.mcpConnected` |
 | `kicadstudio.componentSearch` | Component Search | `kicadstudio-sidebar` | tree |  |
-| `kicadstudio.mcpTools` | MCP &amp; Tools | `kicadstudio-sidebar` | tree |  |
+| `kicadstudio.mcpTools` | MCP &amp; Tools | `kicadstudio-sidebar` | tree | `kicadstudio.hasProject` |
 
 ## Custom Editors
 


### PR DESCRIPTION
## Summary

Professionalizes the sidebar so MCP-related prompts are **context-aware, meaningful, and actionable** instead of nagging and dead-ending. Three connected fixes.

### 1. Quality Gates: dead-end "BLOCKED" wall → one-click fix
Previously the Quality Gates section rendered five identical *"BLOCKED — Connect kicad-mcp-pro before running…"* rows whenever MCP wasn't serving HTTP gates. The rows weren't clickable (by design) and offered no way to actually connect — the fix lived in a different section.

Now the provider returns **no children** in that state, so VS Code shows the view's existing welcome content with real CTAs:
- not connected → **Setup MCP Integration** / **Install kicad-mcp-pro**
- connected via stdio → **Switch to HTTP Mode**

### 2. No MCP nag outside a real KiCad project
The *"kicad-mcp-pro was detected. Create .vscode/mcp.json?"* bootstrap toast fired whenever a workspace root existed and the server was installed — even in a folder that merely held a stray KiCad file and happened to activate the extension. It now only fires when `discoverKiCadProjects` finds an actual project.

### 3. MCP & TOOLS view gated on `hasProject`
The MCP section (Install/Connect surface) was `when: (always)`. It's now gated behind `kicadstudio.hasProject`, consistent with the other product views, so it's hidden in non-project workspaces. Generated `docs/extension/views.md` refreshed via `docs:generate`.

## Net effect
- Non-KiCad / project-less workspaces: no MCP install nagging.
- Project open + MCP disconnected: a clean **Connect / Setup** CTA instead of a wall of BLOCKED rows.
- The "describe the problem but don't offer the fix" loop is closed.

## Verification
All green locally + pre-push full check: `typecheck`, `eslint`, `check:extension-manifest`, `check:nls-parity`, `format:check`, `docs:check-generated`, **`test:unit` (845 tests)**, **`test:a11y` (76 tests)**. Removed the now-unused `blockedGates` helper and updated the provider unit test to assert the welcome-driven (empty children) behavior.