### PR TITLE
fix(kicad-studio): default generated MCP config to least privilege

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1978,7 +1978,7 @@
         },
         "kicadstudio.mcp.profile": {
           "type": "string",
-          "default": "full",
+          "default": "analysis",
           "enum": [
             "full",
             "minimal",

--- a/apps/vscode-extension/src/activation/workspaceContextController.ts
+++ b/apps/vscode-extension/src/activation/workspaceContextController.ts
@@ -206,7 +206,7 @@ export class WorkspaceContextController implements vscode.Disposable {
     await vscode.commands.executeCommand(
       'setContext',
       CONTEXT_KEYS.mcpProfile,
-      mcpProfile ?? 'full'
+      mcpProfile ?? 'analysis'
     );
     statusBar.update({
       aiConfigured: Boolean(provider?.isConfigured()),

--- a/apps/vscode-extension/src/commands/mcpCommands.ts
+++ b/apps/vscode-extension/src/commands/mcpCommands.ts
@@ -78,15 +78,15 @@ export function registerMcpCommands(
         const detector = new McpDetector();
         const profile = await vscode.window.showQuickPick(
           [
-            'full',
-            'minimal',
+            'analysis',
             'pcb_only',
             'schematic_only',
+            'minimal',
             'manufacturing',
             'high_speed',
             'power',
             'simulation',
-            'analysis',
+            'full',
             'agent_full'
           ],
           {
@@ -128,15 +128,15 @@ export function registerMcpCommands(
         const detector = new McpDetector();
         const profile = await vscode.window.showQuickPick(
           [
-            'full',
-            'minimal',
+            'analysis',
             'pcb_only',
             'schematic_only',
+            'minimal',
             'manufacturing',
             'high_speed',
             'power',
             'simulation',
-            'analysis',
+            'full',
             'agent_full'
           ],
           {

--- a/apps/vscode-extension/src/commands/mcpProfilePicker.ts
+++ b/apps/vscode-extension/src/commands/mcpProfilePicker.ts
@@ -48,7 +48,7 @@ export function readConfiguredMcpProfile(): string | undefined {
   }
   return vscode.workspace
     .getConfiguration()
-    .get<string>(SETTINGS.mcpProfile, 'full');
+    .get<string>(SETTINGS.mcpProfile, 'analysis');
 }
 
 async function writeProfile(profile: KicadMcpProfileId): Promise<void> {

--- a/apps/vscode-extension/src/lm/mcpServerDefinitionProvider.ts
+++ b/apps/vscode-extension/src/lm/mcpServerDefinitionProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { readConfiguredMcpProfile } from '../commands/mcpProfilePicker';
 import { McpDetector } from '../mcp/mcpDetector';
 import type { McpInstallStatus } from '../types';
 import { Logger } from '../utils/logger';
@@ -60,7 +61,11 @@ export async function createKicadMcpServerDefinition(
     cwd: vscode.Uri.file(workspaceRoot),
     env: {
       KICAD_MCP_PROJECT_DIR: workspaceRoot,
-      KICAD_MCP_PROFILE: 'full'
+      // Default to a focused, read-only posture (least privilege). The profile
+      // honours the user's "Pick MCP Profile" choice; write/manufacturing tools
+      // require an explicit opt-in via KICAD_MCP_OPERATING_MODE.
+      KICAD_MCP_PROFILE: readConfiguredMcpProfile() ?? 'analysis',
+      KICAD_MCP_OPERATING_MODE: 'readonly'
     },
     ...(install.version ? { version: install.version } : {})
   });

--- a/apps/vscode-extension/src/mcp/mcpDetector.ts
+++ b/apps/vscode-extension/src/mcp/mcpDetector.ts
@@ -127,7 +127,7 @@ export class McpDetector {
   async generateMcpJson(
     projectDir: string,
     status: McpInstallStatus,
-    profile = 'full'
+    profile = 'analysis'
   ): Promise<void> {
     const root =
       vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? projectDir;
@@ -164,7 +164,10 @@ export class McpDetector {
           args,
           env: {
             KICAD_MCP_PROJECT_DIR: projectDir,
-            KICAD_MCP_PROFILE: profile
+            KICAD_MCP_PROFILE: profile,
+            // Least-privilege default: read-only until the user opts into
+            // write/manufacturing tools.
+            KICAD_MCP_OPERATING_MODE: 'readonly'
           }
         }
       }

--- a/apps/vscode-extension/test/unit/languageModelMcpProvider.test.ts
+++ b/apps/vscode-extension/test/unit/languageModelMcpProvider.test.ts
@@ -32,7 +32,8 @@ describe('language model MCP server definition provider', () => {
 
     expect(definition.value.command).toBe('uvx');
     expect(definition.value.args).toEqual(['kicad-mcp-pro']);
-    expect(definition.value.env['KICAD_MCP_PROFILE']).toBe('full');
+    expect(definition.value.env['KICAD_MCP_PROFILE']).toBe('analysis');
+    expect(definition.value.env['KICAD_MCP_OPERATING_MODE']).toBe('readonly');
   });
 
   it('falls back to the VS Code 1.115 positional stdio constructor', async () => {
@@ -76,7 +77,8 @@ describe('language model MCP server definition provider', () => {
 
       expect(definition.label).toBe('KiCad MCP Pro (detected)');
       expect(definition.command).toBe('kicad-mcp-pro');
-      expect(definition.env['KICAD_MCP_PROFILE']).toBe('full');
+      expect(definition.env['KICAD_MCP_PROFILE']).toBe('analysis');
+      expect(definition.env['KICAD_MCP_OPERATING_MODE']).toBe('readonly');
       expect(definition.cwd?.fsPath).toBe(
         workspace.workspaceFolders[0]?.uri.fsPath
       );

--- a/apps/vscode-extension/test/unit/mcpDetector.test.ts
+++ b/apps/vscode-extension/test/unit/mcpDetector.test.ts
@@ -64,6 +64,9 @@ describe('McpDetector.generateMcpJson', () => {
     expect(saved.servers.kicad.args).toEqual(['kicad-mcp-pro']);
     expect(saved.servers.kicad.env['KICAD_MCP_PROJECT_DIR']).toBe(tempDir);
     expect(saved.servers.kicad.env['KICAD_MCP_PROFILE']).toBe('analysis');
+    expect(saved.servers.kicad.env['KICAD_MCP_OPERATING_MODE']).toBe(
+      'readonly'
+    );
     expect(window.showInformationMessage).toHaveBeenCalled();
   });
 

--- a/apps/vscode-extension/test/unit/mcpProfilePicker.test.ts
+++ b/apps/vscode-extension/test/unit/mcpProfilePicker.test.ts
@@ -131,11 +131,11 @@ describe('mcpProfilePicker', () => {
       expect(readConfiguredMcpProfile()).toBe('manufacturing');
     });
 
-    it('returns the full default when nothing is configured', () => {
+    it('returns the analysis (least-privilege) default when nothing is configured', () => {
       existsSync.mockReturnValue(false);
       __setConfiguration({});
 
-      expect(readConfiguredMcpProfile()).toBe('full');
+      expect(readConfiguredMcpProfile()).toBe('analysis');
     });
 
     it('ignores an unparseable mcp.json and falls back to configuration', () => {

--- a/docs/extension/settings.md
+++ b/docs/extension/settings.md
@@ -46,7 +46,7 @@ Total settings: 47.
 | `kicadstudio.mcp.allowLegacySse` | boolean | `false` |  | Allow a best-effort fallback to the legacy /sse MCP transport when Streamable HTTP is unavailable. |
 | `kicadstudio.mcp.timeout` | number | `15` |  | MCP HTTP request timeout in seconds. |
 | `kicadstudio.mcp.pushContext` | boolean | `true` |  | Push active file, DRC summary, and lasso selection context to kicad-mcp-pro. |
-| `kicadstudio.mcp.profile` | string | `full` | `full`, `minimal`, `schematic_only`, `pcb_only`, `manufacturing`, `high_speed`, `power`, `simulation`, `analysis`, `agent_full` | Preferred kicad-mcp-pro profile when no workspace .vscode/mcp.json overrides it. |
+| `kicadstudio.mcp.profile` | string | `analysis` | `full`, `minimal`, `schematic_only`, `pcb_only`, `manufacturing`, `high_speed`, `power`, `simulation`, `analysis`, `agent_full` | Preferred kicad-mcp-pro profile when no workspace .vscode/mcp.json overrides it. |
 | `kicadstudio.mcp.logSize` | number | `200` |  | Number of recent MCP request/response log entries retained in memory. |
 | `kicadstudio.exportPresets` | array | `[]` |  | Saved export presets managed by the extension. |
 | `kicadstudio.telemetry.enabled` | boolean | `false` |  | Enable opt-in KiCad Studio usage and error telemetry. Disabled by default and capped by VS Code's telemetry.telemetryLevel setting. |


### PR DESCRIPTION
## Summary

Aligns the extension's **runtime** MCP defaults with the repository's documented least-privilege policy (AGENTS.md and the checked-in `.vscode/mcp.json`), closing a docs-vs-code inconsistency where generated configs were broader than the policy mandates.

### What changed
- **Operating mode pinned to `readonly`.** Generated MCP configs now set `KICAD_MCP_OPERATING_MODE=readonly`, so a freshly set-up server cannot mutate board files or trigger manufacturing exports until the user explicitly opts into a write/manufacturing mode. Applies to **both** generators: the VS Code stdio server definition (`mcpServerDefinitionProvider`) and detector-generated `.vscode/mcp.json` (`mcpDetector.generateMcpJson`).
- **Default profile `full` → `analysis`.** Matches the checked-in workspace config. The stdio server definition now honours the user's **Pick MCP Profile** choice via `readConfiguredMcpProfile()` instead of hardcoding a profile (previously the picker had no effect on the VS Code stdio server).
- **Setup quick-picks** list `analysis` first and `full` last, so the recommended choice is the least-privilege one.

### Why
Operating mode (read-only vs write) is the real safety lever; profile only governs which tool families load. Defaulting to `full` profile with an unpinned operating mode let a fresh install reach write/manufacturing tools without explicit opt-in — and contradicted the repo's own policy/checked-in config. This makes the safe posture the default and keeps elevation an explicit, discoverable action.

## Verification
All green locally + pre-push full check: `typecheck`, `eslint`, `check:extension-manifest`, `check:nls-parity`, `format:check`, `docs:lint`/`docs:links`/`docs:check-generated`, **`test:unit` (845 tests)**. Tests updated to assert the readonly mode and `analysis` default; generated `docs/extension/settings.md` refreshed.