### PR TITLE
feat(kicad-studio): premium sidebar density, status colors, and onboarding

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -419,42 +419,49 @@
           "name": "%kicadstudio.contributes.views.kicadstudio-sidebar.3.name%",
           "type": "webview",
           "when": "kicadstudio.hasProject",
-          "icon": "assets/views/bom.svg"
+          "icon": "assets/views/bom.svg",
+          "visibility": "collapsed"
         },
         {
           "id": "kicadstudio.netlistView",
           "name": "%kicadstudio.contributes.views.kicadstudio-sidebar.4.name%",
           "type": "webview",
           "when": "kicadstudio.hasProject",
-          "icon": "assets/views/netlist.svg"
+          "icon": "assets/views/netlist.svg",
+          "visibility": "collapsed"
         },
         {
           "id": "kicadstudio.variants",
           "name": "%kicadstudio.contributes.views.kicadstudio-sidebar.5.name%",
           "when": "kicadstudio.hasProject && kicadstudio.kicad10Plus",
-          "icon": "assets/views/variants.svg"
+          "icon": "assets/views/variants.svg",
+          "visibility": "collapsed"
         },
         {
           "id": "kicadstudio.library",
           "name": "%kicadstudio.contributes.views.kicadstudio-sidebar.6.name%",
-          "icon": "assets/views/library.svg"
+          "icon": "assets/views/library.svg",
+          "visibility": "collapsed"
         },
         {
           "id": "kicadstudio.drcRules",
           "name": "%kicadstudio.contributes.views.kicadstudio-sidebar.7.name%",
           "when": "kicadstudio.hasProject",
-          "icon": "assets/views/drc-rules.svg"
+          "icon": "assets/views/drc-rules.svg",
+          "visibility": "collapsed"
         },
         {
           "id": "kicadstudio.fixQueue",
           "name": "%kicadstudio.contributes.views.kicadstudio-sidebar.8.name%",
           "when": "kicadstudio.mcpConnected",
-          "icon": "assets/views/fix-queue.svg"
+          "icon": "assets/views/fix-queue.svg",
+          "visibility": "collapsed"
         },
         {
           "id": "kicadstudio.componentSearch",
           "name": "%kicadstudio.contributes.views.kicadstudio-sidebar.9.name%",
-          "icon": "assets/views/component-search.svg"
+          "icon": "assets/views/component-search.svg",
+          "visibility": "collapsed"
         },
         {
           "id": "kicadstudio.mcpTools",

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -577,11 +577,23 @@ export async function activate(
     'kicadstudio.installed'
   );
   if (isFirstInstall) {
+    // One-time, dismissible welcome. Offer the guided tour instead of forcibly
+    // opening a tab, so the user stays in control on first activation.
     await context.globalState.update('kicadstudio.installed', true);
-    await vscode.commands.executeCommand(
-      'workbench.action.openWalkthrough',
-      `${EXTENSION_ID}#kicadstudio.gettingStarted`
-    );
+    void vscode.window
+      .showInformationMessage(
+        'Welcome to KiCad Studio. Take a short guided tour to set up KiCad CLI, the MCP server, and AI?',
+        'Open Walkthrough',
+        'Maybe Later'
+      )
+      .then((choice) => {
+        if (choice === 'Open Walkthrough') {
+          void vscode.commands.executeCommand(
+            'workbench.action.openWalkthrough',
+            `${EXTENSION_ID}#kicadstudio.gettingStarted`
+          );
+        }
+      });
   }
 
   logger.info('KiCad Studio activated successfully.');

--- a/apps/vscode-extension/src/providers/bomViewProvider.ts
+++ b/apps/vscode-extension/src/providers/bomViewProvider.ts
@@ -30,7 +30,9 @@ export class BomViewProvider
   ) {
     this.bomParser = new BomParser(parser);
     this.disposables.push(
-      vscode.window.onDidChangeActiveTextEditor(() => this.scheduleRefresh(200)),
+      vscode.window.onDidChangeActiveTextEditor(() =>
+        this.scheduleRefresh(200)
+      ),
       vscode.workspace.onDidSaveTextDocument((doc) => {
         if (doc.fileName.endsWith('.kicad_sch')) {
           this.scheduleRefresh(0);
@@ -100,7 +102,9 @@ export class BomViewProvider
     const file = await this.findSchematicFile();
     if (!file) {
       this.exportState?.complete('bom', undefined, 'No schematic opened.');
-      this.manager.setStatus('Open a .kicad_sch schematic file to load the Bill of Materials.');
+      this.manager.setStatus(
+        'Open a .kicad_sch schematic file to load the Bill of Materials.'
+      );
       return;
     }
     const uri = vscode.Uri.file(file);

--- a/apps/vscode-extension/src/providers/qualityGateProvider.ts
+++ b/apps/vscode-extension/src/providers/qualityGateProvider.ts
@@ -84,7 +84,7 @@ export class QualityGateProvider implements vscode.TreeDataProvider<QualityGateE
     item.description = descriptionForGate(gate);
     item.tooltip = tooltipForGate(gate);
     item.contextValue = `qualityGate-${gate.status.toLowerCase()}`;
-    item.iconPath = new vscode.ThemeIcon(iconForStatus(gate.status));
+    item.iconPath = iconForStatus(gate.status);
 
     // Intentionally removed item.command here to separate click action
     // from standard treeview expansion. We rely on package.json inline commands
@@ -344,19 +344,28 @@ function qualityGateDocsUrl(gate: QualityGateResult | undefined): string {
   return `${base}/extension/`;
 }
 
-function iconForStatus(status: QualityGateStatus): string {
+function iconForStatus(status: QualityGateStatus): vscode.ThemeIcon {
   switch (status) {
     case 'PASS':
-      return 'pass';
+      return new vscode.ThemeIcon(
+        'pass',
+        new vscode.ThemeColor('testing.iconPassed')
+      );
     case 'WARN':
-      return 'warning';
+      return new vscode.ThemeIcon(
+        'warning',
+        new vscode.ThemeColor('editorWarning.foreground')
+      );
     case 'FAIL':
     case 'BLOCKED':
-      return 'error';
+      return new vscode.ThemeIcon(
+        'error',
+        new vscode.ThemeColor('editorError.foreground')
+      );
     case 'EMPTY':
-      return 'info';
+      return new vscode.ThemeIcon('info');
     case 'PENDING':
-      return 'play-circle';
+      return new vscode.ThemeIcon('play-circle');
   }
 }
 


### PR DESCRIPTION
## Summary

Three low-risk premium UX improvements to the sidebar and first-run experience.

### 1. First-run density
Secondary views (BOM, netlist, variants, library, DRC rules, fix queue, component search) now default to **collapsed** (`visibility: collapsed`), so a fresh project opens focused on Project / Validation / Quality Gates / MCP instead of a stack of empty panels.

### 2. Quality Gates — scannable status colors
PASS/WARN/FAIL/BLOCKED icons now carry theme colors (green / amber / red) so gate status is readable at a glance.

### 3. Onboarding — gentle, dismissible
The first-install walkthrough is now **offered via a one-time, dismissible notification** instead of forcibly opening a tab.

## Scope note
The deeper netlist/BOM empty-state redesign (CTA buttons, hiding the empty table grid, concise no-schematic message) was explored but **deferred**: those changes invalidate the Windows-only visual-regression baselines (`test:visual`), which can't be regenerated reliably off the CI runner. They'll land in a focused follow-up that regenerates the baselines on the CI Windows image.

## Verification
All green locally + pre-push full check: `typecheck`, `eslint`, `check:extension-manifest`, `check:nls-parity`, `format:check`, `test:unit` (845), `test:a11y` (76). Status-bar consolidation was assessed and intentionally left unchanged (functional quick-actions; removing cosmetic separators would churn an index-coupled test suite for marginal gain).