### PR TITLE
ci(repo): add concurrency controls, fail-closed gate, and visual diff artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,14 @@ jobs:
         if: runner.os == 'Windows'
         timeout-minutes: 15
         run: corepack pnpm --filter kicadstudiokit run test:visual
+      - name: Upload visual regression diffs on failure
+        if: ${{ failure() && runner.os == 'Windows' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: visual-regression-results
+          path: apps/vscode-extension/test-results
+          if-no-files-found: ignore
+          retention-days: 14
       - run: corepack pnpm --filter kicadstudiokit run test:a11y
       - run: corepack pnpm --filter kicadstudiokit run build
       - if: runner.os == 'Linux'
@@ -321,15 +329,17 @@ jobs:
           echo "| performance-budgets | ${{ needs.performance-budgets.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| real-pair-compatibility | ${{ needs.real-pair-compatibility.result }} |" >> $GITHUB_STEP_SUMMARY
       - name: Fail on critical job failure
+        # Fail closed on both failure and cancellation of a required job: a
+        # cancelled (e.g. timed-out) required lane must block merge, not pass.
         if: >
           ${{
-               needs.ci-lanes.result == 'failure'
-            || needs.metadata.result == 'failure'
-            || needs.forbidden-refs.result == 'failure'
-            || needs.shared-packages.result == 'failure'
-            || needs.vscode-extension.result == 'failure'
-            || needs.performance-budgets.result == 'failure'
-            || needs.real-pair-compatibility.result == 'failure'
+               needs.ci-lanes.result == 'failure' || needs.ci-lanes.result == 'cancelled'
+            || needs.metadata.result == 'failure' || needs.metadata.result == 'cancelled'
+            || needs.forbidden-refs.result == 'failure' || needs.forbidden-refs.result == 'cancelled'
+            || needs.shared-packages.result == 'failure' || needs.shared-packages.result == 'cancelled'
+            || needs.vscode-extension.result == 'failure' || needs.vscode-extension.result == 'cancelled'
+            || needs.performance-budgets.result == 'failure' || needs.performance-budgets.result == 'cancelled'
+            || needs.real-pair-compatibility.result == 'failure' || needs.real-pair-compatibility.result == 'cancelled'
           }}
         shell: bash
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'

--- a/.github/workflows/cross-repo-compatibility.yml
+++ b/.github/workflows/cross-repo-compatibility.yml
@@ -38,6 +38,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: cross-repo-compatibility-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # pnpm 11+ enforces packageManager version match. Prevents nested pnpm calls in scripts
   # from failing when runner pnpm differs from package.json constraint.

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
     if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -27,6 +27,12 @@ on:
 permissions:
   contents: read
 
+# Serialize publishes per release tag and never cancel an in-flight publish:
+# interrupting mid-upload could leave a registry partially updated.
+concurrency:
+  group: publish-extension-${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
+  cancel-in-progress: false
+
 env:
   OPENVSX_PRERELEASE_TAG_SUFFIX: -openvsx
   pnpm_config_pm_on_fail: ignore

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   pnpm_config_pm_on_fail: ignore
 

--- a/.github/workflows/vsix-build.yml
+++ b/.github/workflows/vsix-build.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: vsix-build-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   pnpm_config_pm_on_fail: ignore
 


### PR DESCRIPTION
## Summary

Addresses the CI/CD robustness gaps surfaced in review. No behavioral change to what is tested — these harden *how* the pipeline runs.

### 1. Concurrency on PR/push workflows
`codeql`, `gitleaks`, `security`, `vsix-build`, and `cross-repo-compatibility` lacked concurrency groups, so rapid pushes piled up redundant runs. Added `concurrency: { group: <wf>-${{ github.ref }}, cancel-in-progress: true }` to each (matching ci.yml).

### 2. Serialized release publishing
`publish-extension.yml` had no concurrency. Added a **tag-keyed** group with `cancel-in-progress: false`, so two release events can't publish concurrently and an in-flight publish is never interrupted mid-upload.

### 3. Fail-closed aggregate gate
The `required` gate only failed on `result == 'failure'`. It now also fails on `'cancelled'`, so a cancelled (e.g. timed-out) required lane blocks merge instead of passing.

### 4. Visual-regression diff artifacts
The Windows-only `test:visual` job is the one fragile spot (baselines locked to the CI runner, no way to retrieve actuals). Added an `upload-artifact` step (`if: failure() && runner.os == 'Windows'`) that uploads `apps/vscode-extension/test-results` (Playwright actual/diff PNGs), so intentional UI changes can be diffed and baselines refreshed from the runner's own output. This unblocks the deferred netlist/BOM empty-state redesign.

## Verification
All 7 changed workflows parse as valid YAML, `actionlint` clean, `check:ci-lanes` (9 tests), `release:verify` / release-provenance policy pass. `cross-repo-compatibility` was confirmed already path-gated, so only concurrency was added (triggers unchanged to preserve PR coverage).