### PR TITLE
ci(repo): sync derived version surfaces onto the open release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,41 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # When Release Please has an OPEN release PR, sync the version surfaces it
+      # does not bump itself (compatibility metadata + the generated docs tables)
+      # onto its branch. Release Please only updates package.json, the manifest,
+      # and the changelog, so without this the release PR's own CI fails on
+      # compatibility.yaml / compatibilityMatrix.ts / generated-docs version
+      # drift and the release can never be merged.
+      - if: ${{ steps.release.outputs.pr }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          fetch-depth: 0
+          persist-credentials: true
+      - if: ${{ steps.release.outputs.pr }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - if: ${{ steps.release.outputs.pr }}
+        run: corepack enable
+      - if: ${{ steps.release.outputs.pr }}
+        run: corepack prepare pnpm@11.6.0 --activate
+      - if: ${{ steps.release.outputs.pr }}
+        run: corepack pnpm install --frozen-lockfile
+      - if: ${{ steps.release.outputs.pr }}
+        run: corepack pnpm run release:surface
+      - if: ${{ steps.release.outputs.pr }}
+        run: corepack pnpm run docs:generate
+      - if: ${{ steps.release.outputs.pr }}
+        run: |
+          git config user.name "kicad-studio-bot"
+          git config user.email "kicad-studio-bot@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || git commit -m "chore(repo): sync release surfaces for the pending release"
+          git push
+
       # Regenerate changelog docs after a release PR is merged
       - if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ node_modules/
 dist/
 out/
 site/
+docs/.vitepress/dist/
+docs/.vitepress/cache/
+docs/.vitepress/.temp/
 coverage/
 htmlcov/
 coverage.xml

--- a/docs/release.md
+++ b/docs/release.md
@@ -28,6 +28,8 @@ repeats the version is derived from it:
   `<!-- release-surface:start -->` / `<!-- release-surface:end -->` markers);
 - `apps/vscode-extension/CHANGELOG.md` (owned by Release Please);
 - `compatibility.yaml` `products.kicad-studio.version`;
+- `apps/vscode-extension/src/mcp/compatibilityMatrix.ts` `products.kicadStudio.version`
+  and `products.kicadMcpPro.compatibleExtension.testedAgainst`;
 - the generated `docs/support-matrix.md` and `docs/versions.md` tables (owned by
   `corepack pnpm run docs:generate`).
 
@@ -37,12 +39,24 @@ Verify every surface in one command before tagging or publishing:
 corepack pnpm run check:release-surface
 ```
 
-It fails with a per-file diff when any surface is stale. The README block is the
-only hand-editable surface; regenerate it with:
+It fails with a per-file diff when any surface is stale. Regenerate the surfaces
+this repo owns directly (README block, `compatibility.yaml` version, and the
+`compatibilityMatrix.ts` version fields) with:
 
 ```bash
 corepack pnpm run release:surface
+corepack pnpm run docs:generate
 ```
+
+`release:surface` rewrites the README/compatibility/matrix versions from
+`apps/vscode-extension/package.json`; `docs:generate` refreshes the generated
+docs tables. Release Please owns the changelog and manifest.
+
+Because Release Please only bumps `package.json`, the manifest, and the
+changelog, `.github/workflows/release-please.yml` runs `release:surface` +
+`docs:generate` on the open release pull request and commits the result to its
+branch, so the release PR's own CI stays green and the release is mergeable
+without a manual surface bump.
 
 `check:release-surface` also runs inside `corepack pnpm run check:version`, so CI
 fails on README or release-surface drift on every pull request. Marketplace and

--- a/scripts/check-release-surface.mjs
+++ b/scripts/check-release-surface.mjs
@@ -6,7 +6,8 @@
 // a stale version.
 //
 //   node scripts/check-release-surface.mjs           # check, exit 1 on drift
-//   node scripts/check-release-surface.mjs --write    # regenerate the README block
+//   node scripts/check-release-surface.mjs --write    # rewrite the surfaces this
+//                                                      # module owns directly
 //
 // The authoritative version is apps/vscode-extension/package.json, which is
 // itself pinned to .release-please-manifest.json by check-version-consistency.
@@ -16,7 +17,7 @@ import {
   REFRESH_COMMAND,
   collectDrift,
   readAuthoritativeVersion,
-  writeReadmeBaseline,
+  writeOwnedReleaseSurfaces,
 } from "./lib/release-surface.mjs";
 
 function main() {
@@ -25,11 +26,18 @@ function main() {
   const version = readAuthoritativeVersion();
 
   if (write) {
-    const changed = writeReadmeBaseline(undefined, version);
+    const changed = writeOwnedReleaseSurfaces(undefined, version);
+    if (changed.length > 0) {
+      console.log(
+        `Regenerated release surfaces for version ${version}: ${changed.join(", ")}.`,
+      );
+    } else {
+      console.log(
+        `Owned release surfaces already match version ${version}.`,
+      );
+    }
     console.log(
-      changed
-        ? `Regenerated README release surface for version ${version}.`
-        : `README release surface already matches version ${version}.`,
+      "Run `corepack pnpm run docs:generate` to refresh the generated docs tables.",
     );
     return;
   }

--- a/scripts/check-release-surface.test.mjs
+++ b/scripts/check-release-surface.test.mjs
@@ -6,11 +6,36 @@ import {
   RELEASE_SURFACES,
   README_MARKER_END,
   README_MARKER_START,
+  applyCompatibilityMatrixStudioVersion,
+  applyCompatibilityMatrixTestedAgainst,
+  applyCompatibilityProductVersion,
   applyReadmeBaseline,
   collectDrift,
   readAuthoritativeVersion,
   renderReadmeBaseline,
 } from "./lib/release-surface.mjs";
+
+const COMPATIBILITY_YAML = fs.readFileSync("compatibility.yaml", "utf8");
+const COMPATIBILITY_MATRIX_TS = fs.readFileSync(
+  "apps/vscode-extension/src/mcp/compatibilityMatrix.ts",
+  "utf8",
+);
+
+function compatibilityProductVersion(content) {
+  return content.match(
+    /packagePath: "apps\/vscode-extension\/package\.json"\n\s*version: "([^"]+)"/u,
+  )?.[1];
+}
+
+function matrixStudioVersion(content) {
+  return content.match(/kicadStudio: \{\s*\n\s*version: '([^']+)'/u)?.[1];
+}
+
+function matrixTestedAgainst(content) {
+  return content.match(
+    /compatibleExtension: \{[\s\S]*?testedAgainst: '([^']+)'/u,
+  )?.[1];
+}
 
 test("#395 every known release surface matches the authoritative version", () => {
   const version = readAuthoritativeVersion();
@@ -60,6 +85,49 @@ test("#395 drift is detected when a surface goes stale", () => {
   // Sanity: re-rendering with the bogus version changes the file, proving the
   // README block is genuinely generated rather than incidentally matching.
   assert.notEqual(applyReadmeBaseline(readme, bogus), readme);
+});
+
+test("#431 compatibility.yaml writer bumps only the kicad-studio version", () => {
+  const next = applyCompatibilityProductVersion(COMPATIBILITY_YAML, "9.9.9");
+  assert.equal(compatibilityProductVersion(next), "9.9.9");
+  // The kicad-mcp-pro testedAgainst field shares the block but must be left alone.
+  assert.ok(
+    next.includes('testedAgainst: "3.9.2"'),
+    "compatibility writer must not touch the kicad-mcp-pro testedAgainst version",
+  );
+});
+
+test("#431 compatibilityMatrix.ts writer bumps both extension version fields only", () => {
+  let next = applyCompatibilityMatrixStudioVersion(
+    COMPATIBILITY_MATRIX_TS,
+    "9.9.9",
+  );
+  next = applyCompatibilityMatrixTestedAgainst(next, "9.9.9");
+  assert.equal(matrixStudioVersion(next), "9.9.9");
+  assert.equal(matrixTestedAgainst(next), "9.9.9");
+  // kicadMcpPro.version must remain the MCP server version, not the extension's.
+  assert.match(next, /kicadMcpPro: \{\s*\n\s*version: '3\.9\.2'/u);
+});
+
+test("#431 version writers are idempotent at the authoritative version", () => {
+  const version = readAuthoritativeVersion();
+  assert.equal(
+    applyCompatibilityProductVersion(COMPATIBILITY_YAML, version),
+    COMPATIBILITY_YAML,
+  );
+  let matrix = applyCompatibilityMatrixStudioVersion(
+    COMPATIBILITY_MATRIX_TS,
+    version,
+  );
+  matrix = applyCompatibilityMatrixTestedAgainst(matrix, version);
+  assert.equal(matrix, COMPATIBILITY_MATRIX_TS);
+});
+
+test("#431 version writers refuse to rewrite when the anchor is missing", () => {
+  assert.throws(
+    () => applyCompatibilityProductVersion("nothing to anchor on", "9.9.9"),
+    /could not locate/u,
+  );
 });
 
 test("#395 release surface list is non-empty and well-formed", () => {

--- a/scripts/lib/release-surface.mjs
+++ b/scripts/lib/release-surface.mjs
@@ -199,3 +199,116 @@ export function writeReadmeBaseline(root = repoRoot, version = undefined) {
   }
   return false;
 }
+
+// Surgical text rewriters for the two version fields that mirror the extension
+// version but have no generator of their own. We intentionally do not parse and
+// re-serialize compatibility.yaml / compatibilityMatrix.ts: a targeted,
+// anchored replacement preserves comments, ordering, and formatting, and only
+// touches the kicad-studio extension version — never the kicad-mcp-pro
+// "3.9.2"-style fields that live in the same blocks.
+
+function replaceAnchored(content, regex, version, file, label) {
+  const matches = content.match(new RegExp(regex.source, regex.flags + "g"));
+  if (!matches || matches.length === 0) {
+    throw new Error(`${file}: could not locate ${label} to rewrite`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `${file}: ${label} matched ${matches.length} times; refusing to rewrite ambiguously`,
+    );
+  }
+  return content.replace(regex, (_full, prefix, _old, suffix) => {
+    return `${prefix}${version}${suffix}`;
+  });
+}
+
+// compatibility.yaml products.kicad-studio.version — anchored on the
+// packagePath line that uniquely precedes it inside the kicad-studio block.
+export function applyCompatibilityProductVersion(content, version) {
+  return replaceAnchored(
+    content,
+    /(packagePath: "apps\/vscode-extension\/package\.json"\n\s*version: ")([^"]+)(")/u,
+    version,
+    "compatibility.yaml",
+    "products.kicad-studio.version",
+  );
+}
+
+// compatibilityMatrix.ts products.kicadStudio.version — anchored on the
+// kicadStudio object opener so it never matches kicadMcpPro.version.
+export function applyCompatibilityMatrixStudioVersion(content, version) {
+  return replaceAnchored(
+    content,
+    /(kicadStudio: \{\s*\n\s*version: ')([^']+)(')/u,
+    version,
+    "compatibilityMatrix.ts",
+    "products.kicadStudio.version",
+  );
+}
+
+// compatibilityMatrix.ts products.kicadMcpPro.compatibleExtension.testedAgainst
+// records the extension version the MCP server is tested against — anchored on
+// the compatibleExtension block.
+export function applyCompatibilityMatrixTestedAgainst(content, version) {
+  return replaceAnchored(
+    content,
+    /(compatibleExtension: \{[\s\S]*?testedAgainst: ')([^']+)(')/u,
+    version,
+    "compatibilityMatrix.ts",
+    "products.kicadMcpPro.compatibleExtension.testedAgainst",
+  );
+}
+
+function writeFileIfChanged(filePath, current, next) {
+  if (next !== current) {
+    fs.writeFileSync(filePath, next, "utf8");
+    return true;
+  }
+  return false;
+}
+
+export function writeCompatibilityVersion(root = repoRoot, version = undefined) {
+  const expected = version ?? readAuthoritativeVersion(root);
+  const filePath = path.join(root, "compatibility.yaml");
+  const current = fs.readFileSync(filePath, "utf8");
+  return writeFileIfChanged(
+    filePath,
+    current,
+    applyCompatibilityProductVersion(current, expected),
+  );
+}
+
+export function writeCompatibilityMatrixVersion(
+  root = repoRoot,
+  version = undefined,
+) {
+  const expected = version ?? readAuthoritativeVersion(root);
+  const filePath = path.join(
+    root,
+    "apps/vscode-extension/src/mcp/compatibilityMatrix.ts",
+  );
+  const current = fs.readFileSync(filePath, "utf8");
+  let next = applyCompatibilityMatrixStudioVersion(current, expected);
+  next = applyCompatibilityMatrixTestedAgainst(next, expected);
+  return writeFileIfChanged(filePath, current, next);
+}
+
+// Rewrites every version surface this module owns directly (README +
+// compatibility.yaml + compatibilityMatrix.ts). The generated docs
+// (docs/support-matrix.md, docs/versions.md) and the changelog remain owned by
+// `docs:generate` and Release Please respectively, so callers should run those
+// alongside this for a complete release-surface sync.
+export function writeOwnedReleaseSurfaces(root = repoRoot, version = undefined) {
+  const expected = version ?? readAuthoritativeVersion(root);
+  const changed = [];
+  if (writeReadmeBaseline(root, expected)) {
+    changed.push("README.md");
+  }
+  if (writeCompatibilityVersion(root, expected)) {
+    changed.push("compatibility.yaml");
+  }
+  if (writeCompatibilityMatrixVersion(root, expected)) {
+    changed.push("apps/vscode-extension/src/mcp/compatibilityMatrix.ts");
+  }
+  return changed;
+}


### PR DESCRIPTION
## Problem

Release Please only bumps `package.json`, `.release-please-manifest.json`, and
`CHANGELOG.md`. It does **not** touch the other surfaces that mirror the
extension version, so every release PR (e.g. [#431](https://github.com/oaslananka/kicad-studio-kit/pull/431) for 1.9.0) left these stale at
the previous version and failed its own CI:

| Drifted surface | Failing gate |
| --- | --- |
| `compatibility.yaml` `products.kicad-studio.version` | `metadata` / `check:version` |
| `compatibilityMatrix.ts` `version` + `compatibleExtension.testedAgainst` | `canary` / `check:compatibility-contract` |
| generated `docs/support-matrix.md`, `docs/versions.md` | `build` / `docs:check-generated` |

A red release PR can never be merged → no tag → `publish-extension.yml` never
runs. **This is why a release cannot currently be published.**

## Fix

- **`release:surface` (`--write`) now owns the missing surfaces.** It rewrites
  `compatibility.yaml` `products.kicad-studio.version` and the two
  `compatibilityMatrix.ts` fields (`products.kicadStudio.version`,
  `products.kicadMcpPro.compatibleExtension.testedAgainst`) from the
  authoritative `package.json` version. Rewrites are **anchored single-match**
  (throw on ambiguity), preserve comments/formatting, and never touch the
  kicad-mcp-pro `3.9.x` fields in the same blocks. Idempotent at the current
  version (no-op on `main`).
- **`release-please.yml` self-heals the open release PR.** Whenever Release
  Please has an open release PR, a new step checks out its branch, runs
  `release:surface` + `docs:generate`, and commits the synced surfaces — so the
  release PR's own CI goes green with no manual bump. (Verified the action's
  `pr` output is set on PR open/update and exposes `headBranchName`.)
- Tests for the new writers (`#431` cases), docs in `docs/release.md`, and the
  VitePress build scratch dirs are gitignored.

## Validation

- [x] `check:release-surface` — 9 tests (incl. anchored-writer + idempotence + ambiguity-guard)
- [x] `check:version`, `check:compatibility-contract` green on `main`
- [x] `release:surface` is a no-op at 1.8.1 (idempotent); writers verified against a fake 9.9.9 bump
- [x] `docs:check-generated` / `docs:lint` / `docs:links`; `actionlint` on the workflow
- [x] full `pnpm run check` pre-push gate green

## After this merges

Release Please re-runs on `main`, regenerates #431 at 1.9.0, and the new step
syncs its surfaces → **#431 goes green and becomes mergeable.** Publishing 1.9.0
(merging #431) remains a maintainer action and still needs `VSCE_PAT` / `OVSX_PAT`.

Refs #431