### PR TITLE
ci(repo): skip husky in release-please bot commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,8 +64,12 @@ jobs:
           git config user.name "kicad-studio-bot"
           git config user.email "kicad-studio-bot@users.noreply.github.com"
           git add -A
-          git diff --cached --quiet || git commit -m "chore(repo): sync release surfaces for the pending release"
-          git push
+          # --no-verify: this is an automated bot commit of deterministically
+          # generated surfaces. Skipping husky avoids running lint-staged on
+          # commit and the full `pnpm run check` pre-push hook inside this job;
+          # the release PR's own CI re-validates every surface.
+          git diff --cached --quiet || git commit --no-verify -m "chore(repo): sync release surfaces for the pending release"
+          git push --no-verify
 
       # Regenerate changelog docs after a release PR is merged
       - if: ${{ steps.release.outputs.release_created }}
@@ -91,8 +95,10 @@ jobs:
           git config user.name "kicad-studio-bot"
           git config user.email "kicad-studio-bot@users.noreply.github.com"
           git add -A
-          git diff --cached --quiet || git commit -m "docs(repo): regenerate changelog and versions after release"
-          git push
+          # --no-verify: automated bot commit of generated docs; skip husky so
+          # this job does not run lint-staged / the full pre-push check.
+          git diff --cached --quiet || git commit --no-verify -m "docs(repo): regenerate changelog and versions after release"
+          git push --no-verify
 
       # Release Please creates releases with GITHUB_TOKEN, which does not
       # recursively trigger release-event workflows. Dispatch the publish


### PR DESCRIPTION
## Problem

The follow-up to [#450](https://github.com/oaslananka/kicad-studio-kit/pull/450): the new release-please surface-sync step failed in CI. Its
`git commit` triggered husky's **pre-commit** hook (`lint-staged`) — installed on
the runner by `pnpm install` — which failed on the generated surfaces, and
`git push` would have triggered the **pre-push** hook (full `pnpm run check`)
inside the release job. Husky 9 hooks ignore `HUSKY=0` at runtime.

Net effect: release-please updated #431 to 1.9.0, but the surface-sync commit
never landed, so #431 stayed red. (No release/tag/publish was created.)

## Fix

Add `--no-verify` to both automated bot commits/pushes in `release-please.yml`
(the open-PR surface sync and the post-release docs regen). The content is
deterministically generated from validated sources and the release PR's own CI
re-validates every surface, so bypassing the local hooks in this job is safe and
correct.

## After merge

Merging re-triggers the Release Please workflow on `main`; the now-working sync
step commits the synced surfaces to #431's branch with `--no-verify`, and #431's
CI goes green. Publishing 1.9.0 (merging #431) remains a maintainer action.

Refs #431