### PR TITLE
ci(repo): auto-dispatch publish on release and tolerate marketplace serving lag

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -237,18 +237,38 @@ jobs:
         if: steps.marketplace_index.outputs.indexed == 'true'
         shell: bash
         run: |
-          set -euo pipefail
+          # Not `set -e`: the vspackage *binary* is served behind the gallery
+          # metadata index, so right after publish the download can still 404
+          # even though `vsce show` already lists the version. That serving lag
+          # is not a publish failure (the publish step is the source of truth)
+          # and must not fail the job, which would also skip the Open VSX publish.
+          set -uo pipefail
           version="$(node -p "require('./apps/vscode-extension/package.json').version")"
           VSIX_DIR="$GITHUB_WORKSPACE/release-assets/vscode-extension"
           VSIX_PATH="$(find "$VSIX_DIR" -type f -name '*.vsix' | sort | tail -n1)"
           MARKETPLACE_VERIFY_DIR="$GITHUB_WORKSPACE/release-assets/marketplace-verify"
           MARKETPLACE_VSIX="$MARKETPLACE_VERIFY_DIR/oaslananka.kicadstudiokit-$version.vsix"
           mkdir -p "$MARKETPLACE_VERIFY_DIR"
-          curl --fail --location --retry 3 \
-            --output "$MARKETPLACE_VSIX" \
-            "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/oaslananka/vsextensions/kicadstudiokit/$version/vspackage"
-          corepack pnpm --filter kicadstudiokit exec node scripts/validate-vsix-metadata.js \
-            --compare-content "$VSIX_PATH" "$MARKETPLACE_VSIX"
+          url="https://marketplace.visualstudio.com/_apis/public/gallery/publishers/oaslananka/vsextensions/kicadstudiokit/$version/vspackage"
+          downloaded=false
+          for attempt in $(seq 1 10); do
+            if curl --fail --location --retry 3 --retry-all-errors \
+              --output "$MARKETPLACE_VSIX" "$url"; then
+              downloaded=true
+              break
+            fi
+            echo "Marketplace vspackage for $version not downloadable yet (attempt $attempt/10), waiting 30s…"
+            [ "$attempt" -lt 10 ] && sleep 30
+          done
+          if [ "$downloaded" != "true" ]; then
+            echo "::warning::Marketplace did not serve the $version vspackage within the verification window. The publish step reported success, so this is serving lag rather than a publish failure; skipping content comparison."
+            exit 0
+          fi
+          if ! corepack pnpm --filter kicadstudiokit exec node scripts/validate-vsix-metadata.js \
+            --compare-content "$VSIX_PATH" "$MARKETPLACE_VSIX"; then
+            echo "::error::Published Marketplace content does not match the release VSIX for $version."
+            exit 1
+          fi
 
   publish_openvsx:
     needs: [package, publish_vscode]

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,25 +72,25 @@ jobs:
           git push --no-verify
 
       # Regenerate changelog docs after a release PR is merged
-      - if: ${{ steps.release.outputs.release_created }}
+      - if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           persist-credentials: true
-      - if: ${{ steps.release.outputs.release_created }}
+      - if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
           package-manager-cache: false
-      - if: ${{ steps.release.outputs.release_created }}
+      - if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: corepack enable
-      - if: ${{ steps.release.outputs.release_created }}
+      - if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: corepack prepare pnpm@11.6.0 --activate
-      - if: ${{ steps.release.outputs.release_created }}
+      - if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: corepack pnpm install --frozen-lockfile
-      - if: ${{ steps.release.outputs.release_created }}
+      - if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: corepack pnpm run docs:generate
-      - if: ${{ steps.release.outputs.release_created }}
+      - if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: |
           git config user.name "kicad-studio-bot"
           git config user.email "kicad-studio-bot@users.noreply.github.com"
@@ -103,13 +103,21 @@ jobs:
       # Release Please creates releases with GITHUB_TOKEN, which does not
       # recursively trigger release-event workflows. Dispatch the publish
       # workflow explicitly so packaging, evidence, and marketplaces run.
-      - if: ${{ steps.release.outputs.release_created }}
+      - if: ${{ steps.release.outputs.releases_created == 'true' }}
         name: Publish extension to marketplaces
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          tag="${{ steps.release.outputs.tag_name }}"
+          # Derive the tag from the released version rather than a Release Please
+          # output: in manifest mode the per-package outputs are path-prefixed
+          # (e.g. apps/vscode-extension--tag_name) and the bare tag_name output is
+          # unset, which previously left this dispatch with an empty ref. The
+          # component tag is component-name + "-v" + version, and this step runs
+          # on the checked-out main where package.json already holds the new
+          # version.
+          version="$(node -p "require('./apps/vscode-extension/package.json').version")"
+          tag="vscode-extension-v${version}"
           echo "Triggering publish-extension workflow for tag ${tag}…"
           gh workflow run publish-extension.yml \
             --ref "${tag}" \


### PR DESCRIPTION
## Why

Two release-pipeline gaps surfaced while publishing **1.9.0** (both worked around
manually then):

1. **Auto-publish never fired.** release-please runs in manifest mode, where the
   release-created output is **`releases_created`** (top-level), not
   `release_created`. Every post-release step gated on
   `steps.release.outputs.release_created` was silently skipped, so the GitHub
   release was created but `publish-extension.yml` was never dispatched.
2. **Marketplace content-verify failed on serving lag.** The vspackage *binary*
   is served behind the gallery metadata index, so the download can 404 for a
   short window after `vsce show` already lists the version. The verify step used
   `curl --fail` under `set -e`, failing the `publish_vscode` job — which also
   **skipped the Open VSX publish**.

## Changes

- `release-please.yml`: all post-release conditions →
  `releases_created == 'true'`; the publish dispatch derives the tag from the
  released `package.json` version (`vscode-extension-v<version>`) instead of the
  unset `tag_name` output (manifest per-package outputs are path-prefixed).
- `publish-extension.yml`: the Marketplace content-verify retries the download
  (10×30s, `--retry-all-errors`) and, if still not served, warns and exits 0
  (advisory) — matching the existing `marketplace_index` step. A genuine content
  mismatch still hard-fails the job.

## Effect

The next release publishes to **both** Marketplace and Open VSX automatically,
with no manual `workflow run` dispatch and no false failure on indexing/serving
lag.

## Validation

- [x] `actionlint` on both workflows
- [x] no remaining `outputs.release_created` references
- [x] full `pnpm run check` pre-push gate green
- Note: the publish path itself is exercised by the *next* real release; this PR
  only changes CI conditions/retry logic (no app/runtime code).