### PR TITLE
chore(repo): harden scorecard and best practices evidence

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1.14
+FROM ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 AS uv-bin
 FROM mcr.microsoft.com/devcontainers/python:3.13-bookworm@sha256:bf253e8b9200ad2c159015e87b63dc68a7d185e89cd5a9a1fa9d0d4f4ba6ad76
 
 ARG ACTIONLINT_VERSION=1.7.12
@@ -63,8 +64,9 @@ RUN apt-get update \
     fi \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --no-cache-dir "uv==${UV_VERSION}" \
-    && uv --version \
+COPY --from=uv-bin /uv /uvx /usr/local/bin/
+
+RUN uv --version \
     && python --version
 
 RUN set -eux; \

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -41,22 +41,7 @@
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
           {
-            "context": "metadata"
-          },
-          {
-            "context": "forbidden-refs"
-          },
-          {
-            "context": "vscode-extension (ubuntu-24.04)"
-          },
-          {
-            "context": "vscode-extension (windows-2025-vs2026)"
-          },
-          {
-            "context": "vscode-extension (macos-15)"
-          },
-          {
-            "context": "real-pair-compatibility"
+            "context": "required"
           },
           {
             "context": "analyze (javascript-typescript)"
@@ -69,9 +54,6 @@
           },
           {
             "context": "scan"
-          },
-          {
-            "context": "build"
           }
         ]
       }

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,36 @@
+# Governance
+
+KiCad Studio Kit is governed through repository-local policy files, Architecture Decision Records, CODEOWNERS review, and GitHub project tracking.
+
+## Roles and responsibilities
+
+| Role               | Responsibility                                                                                       | Evidence                                      |
+| ------------------ | ---------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Maintainer         | Release approval, branch protection, marketplace credentials, security triage, final merge decisions | `CODEOWNERS`, branch ruleset, release runbook |
+| Code owner         | Review path-specific changes and enforce product boundaries                                          | `.github/CODEOWNERS`                          |
+| Contributor        | Keep changes single-purpose, add regression coverage, follow contribution and security policy        | `CONTRIBUTING.md`, pull request template      |
+| Security responder | Triage private vulnerability reports, coordinate fixes, request CVE/advisory handling when needed    | `SECURITY.md`, `docs/security.md`             |
+
+## Decision process
+
+Architecture, release, security, compatibility, and product-boundary decisions are recorded as ADRs under `docs/adr/`. Routine bug fixes and documentation corrections do not need an ADR unless they change policy or public compatibility.
+
+## Access continuity
+
+Maintainers should keep repository access, marketplace publish tokens, and release credentials limited to the minimum required people. Administrative access must use strong authentication, and token rotation should happen after maintainer changes or suspected exposure.
+
+## Bus-factor policy
+
+Critical release and security procedures must be documented well enough that a second maintainer can execute them from repository evidence. The release runbook, branch protection policy, and Best Practices evidence page are part of this continuity model.
+
+## Review policy
+
+Human changes to `main` should go through pull requests with CODEOWNERS review once the branch ruleset is active. Direct pushes to `main` should be reserved for emergency recovery and documented afterward.
+
+## Related documents
+
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [SECURITY.md](SECURITY.md)
+- [ROADMAP.md](ROADMAP.md)
+- [docs/architecture/governance-board.md](docs/architecture/governance-board.md)
+- [docs/architecture/branch-protection.md](docs/architecture/branch-protection.md)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://github.com/oaslananka/kicad-studio-kit/actions/workflows/codeql.yml"><img src="https://github.com/oaslananka/kicad-studio-kit/actions/workflows/codeql.yml/badge.svg" alt="CodeQL"></a>
   <a href="https://github.com/oaslananka/kicad-studio-kit/actions/workflows/security.yml"><img src="https://github.com/oaslananka/kicad-studio-kit/actions/workflows/security.yml/badge.svg" alt="Security"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/oaslananka/kicad-studio-kit"><img src="https://api.scorecard.dev/projects/github.com/oaslananka/kicad-studio-kit/badge" alt="OpenSSF Scorecard"></a>
+  <a href="https://www.bestpractices.dev/projects/13405"><img src="https://www.bestpractices.dev/projects/13405/badge" alt="OpenSSF Best Practices"></a>
 </p>
 
 <p align="center">
@@ -41,6 +42,8 @@ container image, and MCP Registry listing — lives in
 
 Canonical repository: https://github.com/oaslananka/kicad-studio-kit
 Searchable documentation: https://oaslananka.github.io/kicad-studio-kit/
+OpenSSF Best Practices evidence: [docs/best-practices-evidence.md](docs/best-practices-evidence.md)
+Governance: [GOVERNANCE.md](GOVERNANCE.md) · Roadmap: [ROADMAP.md](ROADMAP.md) · Support: [SUPPORT.md](SUPPORT.md)
 
 ## Version Baseline
 
@@ -69,6 +72,7 @@ coverage level, and feature gates are maintained in
 corepack enable
 corepack pnpm run dev:doctor
 corepack pnpm install --frozen-lockfile
+corepack pnpm --dir apps/vscode-extension exec playwright install chromium
 corepack pnpm run check:forbidden-refs
 corepack pnpm run check:version
 corepack pnpm --filter kicadstudiokit run check

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,26 @@
+# Roadmap
+
+KiCad Studio Kit is the VS Code extension surface for KiCad-focused EDA workflows. The roadmap is intentionally evidence-driven: every milestone should leave tests, documentation, release evidence, or governance records that can be audited later.
+
+## Current priorities
+
+1. **Repository trust hardening** — activate the versioned branch ruleset, complete the OpenSSF Best Practices questionnaire, and clear stale Scorecard alerts after the next scan.
+2. **Release evidence maturity** — keep VSIX checksums, SBOM, provenance, and GitHub artifact attestations attached to every marketplace release.
+3. **Compatibility reliability** — keep KiCad, VS Code, Node, Python, MCP integration, and protocol-schema compatibility documented and tested.
+4. **Premium user experience** — continue reducing viewer, diagnostics, status, and workflow friction with regression tests for every fixed user-facing bug.
+
+## Milestones
+
+| Milestone | Theme                                        | Exit evidence                                                                                     |
+| --------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| M0        | Repository foundation and product boundaries | ADRs, product-boundary docs, compatibility matrix, branch policy                                  |
+| M1        | Test foundation                              | Unit, fixture, contract, accessibility, visual, integration, and package validation gates         |
+| M2        | MCP compatibility                            | Versioned compatibility metadata, real-pair tests, tool and transport docs                        |
+| M3        | Premium UI/UX reliability                    | Viewer, diagnostics, sidebar, status, and workflow regressions covered by tests                   |
+| M4        | Release, security, and lifecycle hardening   | SBOM/provenance, release runbooks, dependency lifecycle, security policy, Best Practices evidence |
+
+The detailed execution board is documented in [docs/architecture/governance-board.md](docs/architecture/governance-board.md). Release readiness is tracked in [docs/ga-readiness.md](docs/ga-readiness.md), and beta workflow maturity is tracked in [docs/beta-program.md](docs/beta-program.md).
+
+## Update policy
+
+Roadmap changes should be made through reviewed pull requests. Any roadmap item that changes the release model, product boundary, security policy, or compatibility contract must also update the matching ADR, policy document, or test gate.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,3 +14,17 @@ evidence, and accepted residual risks are documented in
 operation layer (`apps/vscode-extension/src/security/guardedOperations.ts`)
 centralizes workspace-trust, path-canonicalization, and boundary enforcement for
 write, export, import, and MCP operations.
+
+## Private vulnerability handling
+
+Use the GitHub Security Advisory flow for private reports. The project aims to acknowledge active vulnerability reports within 7 calendar days and provide a coordinated fix plan, mitigation, or status update within 14 calendar days when the report is reproducible and in scope.
+
+Security reports should include:
+
+- affected version or commit;
+- operating system and VS Code/KiCad versions when relevant;
+- reproduction steps or proof of concept;
+- expected impact and exploitability constraints;
+- whether public credit is requested after disclosure.
+
+The project will coordinate public disclosure after a fix, mitigation, or maintainer-approved advisory is ready. Reporter credit is supported when requested and when disclosure is coordinated responsibly.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,31 @@
+# Support
+
+Use GitHub Issues for product support, bug reports, compatibility regressions, feature requests, and documentation corrections.
+
+## Public reports
+
+Open a GitHub issue with:
+
+- KiCad Studio Kit version.
+- VS Code version.
+- KiCad version when relevant.
+- Operating system.
+- Reproduction steps or a minimal KiCad project when possible.
+- Logs, screenshots, or failing command output when available.
+
+Compatibility regressions should use the compatibility regression issue template and include the old and new versions that changed behavior.
+
+## Security reports
+
+Do not open public issues for active vulnerabilities. Use the private advisory flow documented in [SECURITY.md](SECURITY.md).
+
+## Expected handling
+
+| Report type                 | Expected first triage | Target follow-up                                                |
+| --------------------------- | --------------------- | --------------------------------------------------------------- |
+| Active vulnerability        | 7 calendar days       | Coordinated fix plan or status update within 14 calendar days   |
+| Critical product regression | 7 calendar days       | Fix, workaround, or milestone assignment when reproducible      |
+| General bug report          | Best effort           | Reproduction request, backlog triage, or closure with rationale |
+| Feature request             | Best effort           | Backlog classification or rationale if out of scope             |
+
+These targets are not a paid support SLA. They are maintainer operating goals for the open source project.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -129,23 +129,56 @@ export default defineConfig({
           { text: "Testing Strategy", link: "/testing-strategy" },
           { text: "Governance Board", link: "/architecture/governance-board" },
           { text: "Migration Phases", link: "/architecture/migration-phases" },
-          { text: "M0 Completion Audit", link: "/architecture/m0-completion-audit" },
-          { text: "Protocol Change Checklist", link: "/architecture/protocol-change-checklist" },
+          {
+            text: "M0 Completion Audit",
+            link: "/architecture/m0-completion-audit",
+          },
+          {
+            text: "Protocol Change Checklist",
+            link: "/architecture/protocol-change-checklist",
+          },
         ],
       },
       {
         text: "Decision Records",
         items: [
           { text: "Overview", link: "/adr/" },
-          { text: "ADR 01: Monorepo Two Products", link: "/adr/0001-monorepo-two-products" },
-          { text: "ADR 02: MCP Contract-First", link: "/adr/0002-mcp-contract-first-integration" },
-          { text: "ADR 03: Independent Release Model", link: "/adr/0003-independent-release-model" },
-          { text: "ADR 04: No Direct Cross-Product Imports", link: "/adr/0004-no-direct-cross-product-imports" },
-          { text: "ADR 05: KiCad Version Support Policy", link: "/adr/0005-kicad-version-support-policy" },
-          { text: "ADR 06: VS Code Web Compatibility", link: "/adr/0006-vscode-web-compatibility" },
-          { text: "ADR 07: Agent Onboarding Config Pack", link: "/adr/0007-agent-onboarding-config-pack" },
-          { text: "ADR 08: MCP 2026-07-28 Protocol Upgrade", link: "/adr/0008-mcp-2026-07-28-protocol-upgrade" },
-          { text: "ADR 09: Split kicad-mcp-pro into Separate Repo", link: "/adr/0009-split-kicad-mcp-pro-into-separate-repository" },
+          {
+            text: "ADR 01: Monorepo Two Products",
+            link: "/adr/0001-monorepo-two-products",
+          },
+          {
+            text: "ADR 02: MCP Contract-First",
+            link: "/adr/0002-mcp-contract-first-integration",
+          },
+          {
+            text: "ADR 03: Independent Release Model",
+            link: "/adr/0003-independent-release-model",
+          },
+          {
+            text: "ADR 04: No Direct Cross-Product Imports",
+            link: "/adr/0004-no-direct-cross-product-imports",
+          },
+          {
+            text: "ADR 05: KiCad Version Support Policy",
+            link: "/adr/0005-kicad-version-support-policy",
+          },
+          {
+            text: "ADR 06: VS Code Web Compatibility",
+            link: "/adr/0006-vscode-web-compatibility",
+          },
+          {
+            text: "ADR 07: Agent Onboarding Config Pack",
+            link: "/adr/0007-agent-onboarding-config-pack",
+          },
+          {
+            text: "ADR 08: MCP 2026-07-28 Protocol Upgrade",
+            link: "/adr/0008-mcp-2026-07-28-protocol-upgrade",
+          },
+          {
+            text: "ADR 09: Split kicad-mcp-pro into Separate Repo",
+            link: "/adr/0009-split-kicad-mcp-pro-into-separate-repository",
+          },
         ],
       },
       {
@@ -170,6 +203,11 @@ export default defineConfig({
           { text: "Contributors", link: "/contributors" },
           { text: "Fixture Corpus", link: "/kicad-fixture-corpus" },
           { text: "Performance Baselines", link: "/performance-baselines" },
+          { text: "Best Practices Evidence", link: "/best-practices-evidence" },
+          {
+            text: "Best Practices Questionnaire",
+            link: "/best-practices-questionnaire",
+          },
           { text: "Protocol Schemas", link: "/protocol-schemas" },
           { text: "Reusable Workflows", link: "/reusable-workflows" },
         ],

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -6,28 +6,26 @@ checks are available. The importable ruleset lives in
 
 ## Required status checks
 
-The ruleset uses the check-run contexts reported by the current monorepo
-workflows:
+The ruleset uses stable check-run contexts reported by always-on repository
+workflows. The CI workflow exposes one aggregate `required` check so optional or
+path-scoped matrix lanes can be skipped without leaving branch protection waiting
+for a context that was never created.
 
-- `metadata`
-- `forbidden-refs`
-- `vscode-extension (ubuntu-24.04)`
-- `vscode-extension (windows-2025-vs2026)`
-- `vscode-extension (macos-15)`
-- `real-pair-compatibility`
+- `required`
 - `analyze (javascript-typescript)`
 - `analyze (python)`
 - `security`
 - `scan`
-- `build`
 
 Every required check above must keep reporting on every pull request. Do not add
 path filters, branch filters, or commit-message skip behavior to a workflow that
-owns one of these required contexts. If product CI later becomes path-filtered,
-keep an always-on required gate that reports for every pull request and update
-this document plus `.github/rulesets/main.json` together.
+owns one of these required contexts. If product CI later changes its internal
+matrix, keep the aggregate `required` job always-on and update this document plus
+`.github/rulesets/main.json` together.
 
-Scorecard should stay enabled as a repository health signal. It can be required once the repository has stable branch protection and token permissions.
+Scorecard should stay enabled as a repository health signal. It can be required
+once the repository has stable branch protection, token permissions, and no
+new-repository grace-period alerts.
 
 The documented list above and `.github/rulesets/main.json` are kept in sync by
 `corepack pnpm run check:branch-protection`, which fails if they diverge.
@@ -36,15 +34,15 @@ The documented list above and `.github/rulesets/main.json` are kept in sync by
 
 Each required pull-request quality gate maps to one of the required checks above:
 
-| Quality gate | Enforced by |
-| --- | --- |
-| Lint, typecheck, unit tests, accessibility, package build + validate | `vscode-extension (*)` |
-| Version + release-surface drift, compatibility, governance, extension manifest | `metadata` |
-| Forbidden references / stale monorepo language | `forbidden-refs` |
-| Static analysis (CodeQL) | `analyze (javascript-typescript)`, `analyze (python)` |
-| Dependency audit + supply-chain controls | `security` |
-| Secret scanning | `scan` |
-| Cross-product and shared-package build | `build`, `real-pair-compatibility` |
+| Quality gate                                                                   | Enforced by                                           |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| Lint, typecheck, unit tests, accessibility, package build + validate           | `required` aggregate CI gate                          |
+| Version + release-surface drift, compatibility, governance, extension manifest | `required` aggregate CI gate                          |
+| Forbidden references / stale repository language                               | `required` aggregate CI gate                          |
+| Static analysis (CodeQL)                                                       | `analyze (javascript-typescript)`, `analyze (python)` |
+| Dependency audit + supply-chain controls                                       | `security`                                            |
+| Secret scanning                                                                | `scan`                                                |
+| Cross-product and shared-package build                                         | `required` aggregate CI gate                          |
 
 Generated documentation drift is validated by the `docs` workflow on every
 documentation change. Promote it to a required context here and in the ruleset
@@ -53,8 +51,8 @@ once it reports on every pull request (today it is path-scoped to docs changes).
 ## Check tiers
 
 - **Pull-request required checks (blocking):** the required contexts listed
-  above. These cover lint, typecheck, unit tests, integration smoke,
-  package build + validation, and version/generated-surface drift.
+  above. The `required` aggregate covers CI lane success/failure while CodeQL,
+  security, and secret scanning remain independently visible.
 - **Scheduled / nightly checks (health gates, non-blocking on a PR):** the full
   KiCad compatibility matrix, large-project benchmarks, the regression corpus,
   and the dependency dashboard audit.

--- a/docs/best-practices-evidence.md
+++ b/docs/best-practices-evidence.md
@@ -1,0 +1,77 @@
+# OpenSSF Best Practices Evidence
+
+This page is the evidence register for the OpenSSF Best Practices project at
+<https://www.bestpractices.dev/projects/13405>.
+
+Last reviewed: 2026-06-30.
+
+## Current badge status
+
+| Field                    | Value                                                                  |
+| ------------------------ | ---------------------------------------------------------------------- |
+| Best Practices project   | `13405`                                                                |
+| Repository URL           | `https://github.com/oaslananka/kicad-studio-kit`                       |
+| Product represented here | VS Code extension: `oaslananka.kicadstudiokit`                         |
+| Current priority         | Reach Passing, then Silver                                             |
+| Main blockers            | Unanswered project fields, GitHub ruleset not active, Scorecard alerts |
+
+## Evidence matrix
+
+| Area                  | Claim                                                                                  | Repository evidence                                                                                                                                                      | Follow-up                                                                    |
+| --------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| Project identity      | The repository has a clear product boundary and canonical URL.                         | `README.md`, `CANONICAL.md`, `docs/architecture/repo-structure.md`, `docs/architecture/product-boundaries.md`                                                            | Keep this repo scoped to the VS Code extension.                              |
+| License               | The project uses a recognized FLOSS license.                                           | `LICENSE`, `README.md`                                                                                                                                                   | Keep release artifacts carrying the MIT license file.                        |
+| Contribution process  | Contributors have documented contribution requirements.                                | `CONTRIBUTING.md`, `.github/pull_request_template.md`, `.github/CODEOWNERS`, `GOVERNANCE.md`, `SUPPORT.md`                                                               | Reference these files in the badge form.                                     |
+| Code of conduct       | Contributor behavior is documented.                                                    | `CODE_OF_CONDUCT.md`                                                                                                                                                     | Link the file in the badge form.                                             |
+| Security policy       | Vulnerability reporting is documented.                                                 | `SECURITY.md`, `docs/security.md`, `docs/security/threat-model.md`                                                                                                       | Keep reporting instructions current.                                         |
+| Issue tracking        | Issues, release blockers, and regressions are tracked in GitHub.                       | `.github/ISSUE_TEMPLATE/`, `SUPPORT.md`, `docs/RELEASE-COORDINATION.md`, `docs/release-candidate-checklist.md`                                                           | Document expected response timing if the badge form requires it.             |
+| Build                 | The extension has reproducible local build commands.                                   | `package.json`, `apps/vscode-extension/package.json`, `docs/getting-started.md`, `docs/devcontainer.md`                                                                  | Keep `corepack pnpm --filter kicadstudiokit run check` as the product gate.  |
+| Tests                 | Unit, security, accessibility, integration, fixture, and package checks exist.         | `apps/vscode-extension/test/`, `packages/test-harness/`, `packages/kicad-fixtures/`, `docs/testing-strategy.md`, `apps/vscode-extension/jest.config.js`                  | Keep test counts and strategy current after refactors.                       |
+| Coverage policy       | Extension unit coverage enforces at least 80% global statements, lines, and functions. | `apps/vscode-extension/jest.config.js` `coverageThreshold.global.statements >= 80`, checked by `corepack pnpm run check:best-practices`                                  | Keep thresholds above the Best Practices 80% statement coverage claim.       |
+| CI                    | Pull requests and default-branch changes are validated by GitHub Actions.              | `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, `.github/workflows/security.yml`, `.github/workflows/vsix-build.yml`, `.github/workflows/docs.yml`           | Activate the repository ruleset so CI gates are enforced.                    |
+| Static analysis       | CodeQL, ESLint, TypeScript, actionlint, and package validation are part of the gates.  | `.github/workflows/codeql.yml`, `.github/workflows/security.yml`, `eslint.config.cjs`, `scripts/check-ci-lanes.mjs`, `apps/vscode-extension/scripts/validate-package.js` | Resolve the Scorecard SAST alert by confirming all sampled commits run SAST. |
+| Dependency management | Dependency updates and supply-chain checks are automated.                              | `renovate.json`, `scripts/check-pnpm-supply-chain.mjs`, `pnpm-lock.yaml`                                                                                                 | Keep lockfile-only installs enforced.                                        |
+| Local secret hygiene  | Repository scanning and tests cover secret leakage risks.                              | `.github/workflows/gitleaks.yml`, `apps/vscode-extension/test/security/`, `scripts/check-pnpm-supply-chain.mjs`                                                          | Keep GitHub alert count at zero.                                             |
+| Release notes         | Releases are generated and documented.                                                 | `.github/workflows/release-please.yml`, `docs/changelog/`, `docs/release.md`, `apps/vscode-extension/CHANGELOG.md`                                                       | Call out security fixes explicitly.                                          |
+| Provenance            | Release evidence includes checksums, SBOM, and attestation steps.                      | `.github/workflows/publish-extension.yml`, `apps/vscode-extension/scripts/create-release-assets.js`, `scripts/check-release-provenance.mjs`, `docs/release.md`           | Re-check Scorecard Signed-Releases after the next attested release.          |
+| Branch protection     | A strict main-branch ruleset with stable required checks is versioned in the repo.     | `.github/rulesets/main.json`, `docs/architecture/branch-protection.md`, `scripts/check-branch-protection-gates.mjs`                                                      | Apply the ruleset through GitHub settings/API.                               |
+| Review process        | CODEOWNERS and PR templates exist, but recent history lacks approved reviews.          | `.github/CODEOWNERS`, `.github/pull_request_template.md`, `docs/architecture/branch-protection.md`                                                                       | Require PR review for all future human changes.                              |
+| Documentation         | User, extension, integration, release, security, and architecture docs are maintained. | `docs/`, `docs/.vitepress/config.mts`, `scripts/check-docs-site.mjs`                                                                                                     | Keep links validated by `corepack pnpm run check:docs-site`.                 |
+| Accessibility         | Webview accessibility tests are present and run under the extension check.             | `apps/vscode-extension/test/a11y/`, `docs/accessibility.md`, `scripts/dev-doctor.mjs`                                                                                    | Keep Playwright browser cache covered by `dev-doctor`.                       |
+| Internationalization  | UI string parity is validated.                                                         | `apps/vscode-extension/package.nls.json`, `scripts/check-nls-parity.mjs`, `apps/vscode-extension/src/webviewI18n.ts`                                                     | Fill the corresponding badge field with NLS parity evidence.                 |
+
+## Questionnaire fill guide
+
+Use [Best Practices Questionnaire Fill Guide](best-practices-questionnaire.md) when updating the web form. It separates evidence-backed fields from fields that should remain Partial, Not Applicable, or unclaimed until more evidence exists.
+
+## Local evidence gate
+
+Repository-controlled Best Practices and Scorecard hardening anchors are
+validated by:
+
+```bash
+corepack pnpm run check:best-practices
+```
+
+This keeps the README badge, VitePress entry, evidence page, digest-pinned uv
+devcontainer install, Playwright browser-cache doctor check, and stable branch
+ruleset contexts from drifting.
+
+## Scorecard remediation mapping
+
+| Low score / alert   | Evidence already present                                                                      | Required action                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Branch-Protection   | `.github/rulesets/main.json`, `docs/architecture/branch-protection.md`                        | Apply the ruleset in GitHub and re-run Scorecard.                                                 |
+| Code-Review         | `.github/CODEOWNERS`, PR template, branch policy doc                                          | Use reviewed PRs for all future human changes.                                                    |
+| CII-Best-Practices  | This page plus existing policy docs                                                           | Fill the Best Practices project fields and keep the badge in README.                              |
+| Signed-Releases     | `publish-extension.yml`, `create-release-assets.js`, release docs                             | Confirm that the next release exposes attestations in a detectable way.                           |
+| SAST                | CodeQL workflow and security workflow                                                         | Confirm CodeQL runs on every default-branch/PR path Scorecard samples.                            |
+| Pinned-Dependencies | Devcontainer pins the base image, the official uv image digest, and downloaded tool checksums | Re-run Scorecard/code scanning after the next default-branch scan to clear stale line references. |
+| Maintained          | Active commits and releases                                                                   | This improves automatically as the repository ages.                                               |
+| Packaging           | `publish-extension.yml`, Marketplace/Open VSX publication                                     | Keep publish workflow names and release assets obvious to automated detectors.                    |
+
+## Ruleset verification
+
+The versioned ruleset is `.github/rulesets/main.json`. After applying it in GitHub,
+verify that it is active and that the Branch-Protection Scorecard alert has
+cleared in the repository security tab.

--- a/docs/best-practices-questionnaire.md
+++ b/docs/best-practices-questionnaire.md
@@ -1,0 +1,101 @@
+# Best Practices Questionnaire Fill Guide
+
+This file is a maintainer-facing guide for completing the OpenSSF Best Practices questionnaire for project `13405`.
+
+Use these answers as evidence-backed starting points. Do not mark an item as Met in the web form unless the referenced repository evidence is already merged on the default branch.
+
+Before editing the web form, refresh the remote status report:
+
+```bash
+corepack pnpm run best-practices:status
+corepack pnpm run best-practices:status:write
+```
+
+The first command prints a dry-run report. The second writes `docs/best-practices-status.md` for maintainer review.
+
+## High-impact Passing fields
+
+| Field                                    | Suggested value                                  | Evidence                                                                                                 |
+| ---------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `homepage_url`                           | `https://oaslananka.github.io/kicad-studio-kit/` | `README.md`, docs site config                                                                            |
+| `description_good`                       | Met                                              | README describes the extension scope, product boundary, install links, and compatibility baseline.       |
+| `interact`                               | Met                                              | GitHub Issues, pull requests, `CONTRIBUTING.md`, `SUPPORT.md`                                            |
+| `contribution_requirements`              | Met                                              | `CONTRIBUTING.md`, PR template, CODEOWNERS, branch protection policy                                     |
+| `documentation_interface`                | Met                                              | `docs/`, VitePress config, command/settings/view docs                                                    |
+| `repo_interim`                           | Met                                              | Canonical repository is `https://github.com/oaslananka/kicad-studio-kit`; releases and docs point to it. |
+| `version_unique`                         | Met                                              | `apps/vscode-extension/package.json`, release-surface check, Marketplace/Open VSX identity validation    |
+| `version_semver`                         | Met                                              | VS Code extension version `1.9.0` follows SemVer-style extension release numbering.                      |
+| `version_tags`                           | Met after verifying release tags                 | GitHub release tag `vscode-extension-v1.9.0`; release-please workflow                                    |
+| `release_notes_vulns`                    | Met if release notes call out security fixes     | `docs/release.md`, changelog docs, release-please workflow                                               |
+| `report_url`                             | Met                                              | GitHub Issues and `SUPPORT.md`                                                                           |
+| `report_tracker`                         | Met                                              | GitHub Issues templates and governance board                                                             |
+| `report_responses`                       | Met                                              | `SUPPORT.md` handling table                                                                              |
+| `enhancement_responses`                  | Met                                              | `SUPPORT.md`, governance board priority model                                                            |
+| `report_archive`                         | Met                                              | GitHub Issues and releases provide public historical records.                                            |
+| `vulnerability_report_process`           | Met                                              | `SECURITY.md`, `docs/security.md`                                                                        |
+| `vulnerability_report_private`           | Met                                              | GitHub Security Advisories link in `SECURITY.md`                                                         |
+| `vulnerability_report_response`          | Met                                              | `SECURITY.md` response targets                                                                           |
+| `build`                                  | Met                                              | root and extension package scripts, devcontainer docs                                                    |
+| `build_common_tools`                     | Met                                              | Node, pnpm, TypeScript, webpack, VSIX tooling                                                            |
+| `build_floss_tools`                      | Met                                              | FLOSS build/test toolchain documented in package scripts                                                 |
+| `test`                                   | Met                                              | extension unit/security/accessibility/integration/package validation tests                               |
+| `test_invocation`                        | Met                                              | README local validation and `CONTRIBUTING.md` commands                                                   |
+| `test_most`                              | Met                                              | `corepack pnpm --filter kicadstudiokit run check` covers the product surface                             |
+| `test_policy`                            | Met                                              | `CONTRIBUTING.md` regression coverage section, `docs/testing-strategy.md`                                |
+| `tests_are_added`                        | Met                                              | CONTRIBUTING regression policy                                                                           |
+| `tests_documented_added`                 | Met                                              | CONTRIBUTING regression evidence requirements                                                            |
+| `warnings`                               | Met                                              | ESLint, TypeScript, package validation, security tests                                                   |
+| `warnings_fixed`                         | Met                                              | CI gates fail on lint/type/package/security issues                                                       |
+| `warnings_strict`                        | Met                                              | strict TypeScript and package checks in extension check                                                  |
+| `static_analysis`                        | Met                                              | CodeQL workflow, ESLint, TypeScript                                                                      |
+| `static_analysis_common_vulnerabilities` | Met                                              | CodeQL plus security regression tests                                                                    |
+| `static_analysis_fixed`                  | Met                                              | required CI/security gates block known issues                                                            |
+| `static_analysis_often`                  | Met                                              | CodeQL runs on push, pull request, schedule, and manual dispatch                                         |
+| `test_continuous_integration`            | Met                                              | GitHub Actions CI, CodeQL, Security, docs workflows                                                      |
+| `no_leaked_credentials`                  | Met                                              | Gitleaks workflow and secret-related tests                                                               |
+| `english`                                | Met                                              | README, docs, issue templates, and release docs are in English.                                          |
+
+## Security and Silver-level fields
+
+| Field                            | Suggested value                                     | Evidence / note                                                                                                                                                                |
+| -------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `governance`                     | Met                                                 | `GOVERNANCE.md`, governance board model                                                                                                                                        |
+| `code_of_conduct`                | Met                                                 | `CODE_OF_CONDUCT.md`                                                                                                                                                           |
+| `roles_responsibilities`         | Met                                                 | `GOVERNANCE.md` roles table                                                                                                                                                    |
+| `access_continuity`              | Met                                                 | `GOVERNANCE.md` access continuity section                                                                                                                                      |
+| `bus_factor`                     | Met                                                 | `GOVERNANCE.md`, release/security runbooks                                                                                                                                     |
+| `documentation_roadmap`          | Met                                                 | `ROADMAP.md`, governance board, GA readiness docs                                                                                                                              |
+| `documentation_architecture`     | Met                                                 | `docs/architecture/`, ADRs                                                                                                                                                     |
+| `documentation_security`         | Met                                                 | `SECURITY.md`, `docs/security.md`, threat model                                                                                                                                |
+| `documentation_quick_start`      | Met                                                 | README local validation, getting-started/install docs                                                                                                                          |
+| `documentation_current`          | Met                                                 | docs-site generated/links checks                                                                                                                                               |
+| `accessibility_best_practices`   | Met                                                 | a11y tests and accessibility docs                                                                                                                                              |
+| `internationalization`           | Met                                                 | NLS files and NLS parity check                                                                                                                                                 |
+| `maintenance_or_update`          | Met                                                 | Renovate config, dependency lifecycle docs, security workflow                                                                                                                  |
+| `vulnerability_report_credit`    | Met                                                 | `SECURITY.md` coordinated disclosure and credit wording                                                                                                                        |
+| `vulnerability_response_process` | Met                                                 | `SECURITY.md`, release/security docs                                                                                                                                           |
+| `coding_standards`               | Met                                                 | ESLint, Prettier, TypeScript, contribution docs                                                                                                                                |
+| `coding_standards_enforced`      | Met                                                 | CI and local `check` scripts                                                                                                                                                   |
+| `build_reproducible`             | Partial / explain                                   | Lockfile installs, pinned devcontainer base and uv image digest; VSIX metadata comparison exists, but fully reproducible byte-for-byte release should be verified per release. |
+| `dependency_monitoring`          | Met                                                 | Renovate config, security workflow, lockfile supply-chain checks                                                                                                               |
+| `automated_integration_testing`  | Met                                                 | extension integration and real-pair tests where available                                                                                                                      |
+| `test_statement_coverage80`      | Review coverage report before marking               | Current aggregate statement coverage is above 80% in the extension check output.                                                                                               |
+| `signed_releases`                | Met after release verification                      | publish workflow uses GitHub artifact attestations, SBOM, checksums, and provenance; re-check after next release.                                                              |
+| `require_2FA`                    | Met only if organization/account policy enforces it | Confirm GitHub organization/user security settings before marking.                                                                                                             |
+| `secure_2FA`                     | Met only after confirming account policy            | Do not mark without checking GitHub settings.                                                                                                                                  |
+| `code_review_standards`          | Met after ruleset active                            | branch ruleset + CODEOWNERS + PR template                                                                                                                                      |
+| `two_person_review`              | Partial unless a second reviewer is required        | Current versioned ruleset requires one approval; do not overclaim.                                                                                                             |
+
+## Crypto fields
+
+KiCad Studio Kit should not claim custom cryptography. For fields about cryptographic algorithms, key lengths, PFS, password storage, random number generation, credential agility, and algorithm agility, use the form's Not Applicable option if available and explain that the extension relies on platform/Node/VS Code/GitHub/TLS mechanisms rather than implementing cryptographic primitives directly.
+
+## Fields that should remain cautious
+
+| Field                                                  | Why cautious                                                                                                                                |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dynamic_analysis` and related unsafe-input fields     | There are integration, security, accessibility, and webview tests, but not a dedicated dynamic application security testing tool.           |
+| `test_statement_coverage90` / `test_branch_coverage80` | Check the latest coverage report before claiming Gold-level coverage.                                                                       |
+| `contributors_unassociated`                            | Current public history may not show enough independent contributors.                                                                        |
+| `copyright_per_file` / `license_per_file`              | Do not mark unless every required source file carries the expected notice or the project policy explicitly allows repository-level notices. |
+| `security_review` / `assurance_case`                   | Mark only after a documented review or assurance case exists.                                                                               |

--- a/package.json
+++ b/package.json
@@ -76,7 +76,10 @@
     "docs:preview": "vitepress preview docs",
     "check:docs-site": "pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check"
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:best-practices && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check",
+    "check:best-practices": "node scripts/check-best-practices-evidence.mjs && node --test scripts/check-best-practices-evidence.test.mjs scripts/report-best-practices-status.test.mjs",
+    "best-practices:status": "node scripts/report-best-practices-status.mjs",
+    "best-practices:status:write": "node scripts/report-best-practices-status.mjs --write"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",

--- a/scripts/check-best-practices-evidence.mjs
+++ b/scripts/check-best-practices-evidence.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function requireIncludes(file, contents, phrase) {
+  if (!contents.includes(phrase)) {
+    fail(`${file}: missing required Best Practices evidence phrase: ${phrase}`);
+  }
+}
+
+function validateCoveragePolicy(root) {
+  const configPath = path.join(
+    root,
+    "apps",
+    "vscode-extension",
+    "jest.config.js",
+  );
+  const configText = fs.readFileSync(configPath, "utf8");
+  const globalMatch = /global:\s*\{([\s\S]*?)\n\s*\}/u.exec(configText);
+  if (!globalMatch || !globalMatch[1]) {
+    fail(
+      "apps/vscode-extension/jest.config.js must define coverageThreshold.global for Best Practices evidence",
+    );
+  }
+
+  const globalBlock = globalMatch[1];
+  const statementsMatch = /statements:\s*(\d+)/u.exec(globalBlock);
+  const linesMatch = /lines:\s*(\d+)/u.exec(globalBlock);
+  const functionsMatch = /functions:\s*(\d+)/u.exec(globalBlock);
+
+  if (!statementsMatch || !statementsMatch[1]) {
+    fail("coverageThreshold.global.statements must be defined");
+  }
+  if (!linesMatch || !linesMatch[1]) {
+    fail("coverageThreshold.global.lines must be defined");
+  }
+  if (!functionsMatch || !functionsMatch[1]) {
+    fail("coverageThreshold.global.functions must be defined");
+  }
+
+  const globalThreshold = {
+    statements: Number.parseInt(statementsMatch[1], 10),
+    lines: Number.parseInt(linesMatch[1], 10),
+    functions: Number.parseInt(functionsMatch[1], 10),
+  };
+
+  assert.ok(
+    globalThreshold.statements >= 80,
+    "apps/vscode-extension/jest.config.js must enforce at least 80% global statement coverage for Best Practices evidence",
+  );
+  assert.ok(
+    globalThreshold.lines >= 80,
+    "apps/vscode-extension/jest.config.js must enforce at least 80% global line coverage for Best Practices evidence",
+  );
+  assert.ok(
+    globalThreshold.functions >= 80,
+    "apps/vscode-extension/jest.config.js must enforce at least 80% global function coverage for Best Practices evidence",
+  );
+  return globalThreshold;
+}
+
+export function validateBestPracticesEvidence(root = repoRoot) {
+  const readFromRoot = (relativePath) =>
+    fs.readFileSync(path.join(root, relativePath), "utf8");
+  const readme = readFromRoot("README.md");
+  const evidence = readFromRoot("docs/best-practices-evidence.md");
+  const docsConfig = readFromRoot("docs/.vitepress/config.mts");
+  const questionnaire = readFromRoot("docs/best-practices-questionnaire.md");
+  const governance = readFromRoot("GOVERNANCE.md");
+  const roadmap = readFromRoot("ROADMAP.md");
+  const support = readFromRoot("SUPPORT.md");
+  const security = readFromRoot("SECURITY.md");
+  const statusReporter = readFromRoot(
+    "scripts/report-best-practices-status.mjs",
+  );
+  const dockerfile = readFromRoot(".devcontainer/Dockerfile");
+  const devDoctor = readFromRoot("scripts/dev-doctor.mjs");
+  const ruleset = JSON.parse(readFromRoot(".github/rulesets/main.json"));
+  const coverageThreshold = validateCoveragePolicy(root);
+
+  requireIncludes(
+    "README.md",
+    readme,
+    "https://www.bestpractices.dev/projects/13405/badge",
+  );
+  requireIncludes("README.md", readme, "docs/best-practices-evidence.md");
+  requireIncludes("README.md", readme, "Governance: [GOVERNANCE.md]");
+  requireIncludes(
+    "docs/.vitepress/config.mts",
+    docsConfig,
+    "Best Practices Evidence",
+  );
+  requireIncludes(
+    "docs/.vitepress/config.mts",
+    docsConfig,
+    "Best Practices Questionnaire",
+  );
+
+  for (const phrase of [
+    "Best Practices project",
+    "`13405`",
+    "Scorecard remediation mapping",
+    "CII-Best-Practices",
+    "Branch-Protection",
+    "Pinned-Dependencies",
+    "Signed-Releases",
+    "A strict main-branch ruleset with stable required checks is versioned in the repo.",
+  ]) {
+    requireIncludes("docs/best-practices-evidence.md", evidence, phrase);
+  }
+
+  for (const phrase of [
+    "Roles and responsibilities",
+    "Access continuity",
+    "Bus-factor policy",
+  ]) {
+    requireIncludes("GOVERNANCE.md", governance, phrase);
+  }
+  for (const phrase of ["Current priorities", "Milestones", "Update policy"]) {
+    requireIncludes("ROADMAP.md", roadmap, phrase);
+  }
+  for (const phrase of ["Expected handling", "Active vulnerability"]) {
+    requireIncludes("SUPPORT.md", support, phrase);
+  }
+  for (const phrase of [
+    "Private vulnerability handling",
+    "7 calendar days",
+    "Reporter credit is supported",
+  ]) {
+    requireIncludes("SECURITY.md", security, phrase);
+  }
+  for (const phrase of [
+    "Best Practices Questionnaire Fill Guide",
+    "best-practices:status",
+    "High-impact Passing fields",
+    "Security and Silver-level fields",
+    "Fields that should remain cautious",
+  ]) {
+    requireIncludes(
+      "docs/best-practices-questionnaire.md",
+      questionnaire,
+      phrase,
+    );
+  }
+
+  for (const phrase of [
+    "BEST_PRACTICES_PROJECT_ID = 13405",
+    "Highest-impact unanswered fields",
+    "Caution fields",
+  ]) {
+    requireIncludes(
+      "scripts/report-best-practices-status.mjs",
+      statusReporter,
+      phrase,
+    );
+  }
+
+  requireIncludes(
+    ".devcontainer/Dockerfile",
+    dockerfile,
+    "FROM ghcr.io/astral-sh/uv@sha256:",
+  );
+  for (const phrase of [
+    "BEST_PRACTICES_PROJECT_ID = 13405",
+    "Highest-impact unanswered fields",
+    "Caution fields",
+  ]) {
+    requireIncludes(
+      "scripts/report-best-practices-status.mjs",
+      statusReporter,
+      phrase,
+    );
+  }
+
+  requireIncludes(
+    ".devcontainer/Dockerfile",
+    dockerfile,
+    "COPY --from=uv-bin /uv /uvx /usr/local/bin/",
+  );
+  if (/pip\s+install[^\n]+uv==/u.test(dockerfile)) {
+    fail(
+      ".devcontainer/Dockerfile: uv must be installed from a digest-pinned official image, not hashless pip install",
+    );
+  }
+
+  requireIncludes("scripts/dev-doctor.mjs", devDoctor, "playwright-chromium");
+
+  const requiredStatusRule = (ruleset.rules ?? []).find(
+    (entry) => entry.type === "required_status_checks",
+  );
+  const contexts =
+    requiredStatusRule?.parameters?.required_status_checks?.map(
+      (entry) => entry.context,
+    ) ?? [];
+  assert.deepEqual(contexts, [
+    "required",
+    "analyze (javascript-typescript)",
+    "analyze (python)",
+    "security",
+    "scan",
+  ]);
+
+  return {
+    projectId: 13405,
+    requiredStatusChecks: contexts,
+    coverageThreshold,
+  };
+}
+
+function main() {
+  const result = validateBestPracticesEvidence();
+  console.log(
+    `Best Practices evidence is complete for project ${result.projectId} (${result.requiredStatusChecks.length} required branch checks).`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-best-practices-evidence.test.mjs
+++ b/scripts/check-best-practices-evidence.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateBestPracticesEvidence } from "./check-best-practices-evidence.mjs";
+
+test("Best Practices evidence has the repository-controlled scorecard hardening anchors", () => {
+  const result = validateBestPracticesEvidence();
+  assert.equal(result.projectId, 13405);
+  assert.deepEqual(result.requiredStatusChecks, [
+    "required",
+    "analyze (javascript-typescript)",
+    "analyze (python)",
+    "security",
+    "scan",
+  ]);
+  assert.ok(result.coverageThreshold.statements >= 80);
+  assert.ok(result.coverageThreshold.lines >= 80);
+  assert.ok(result.coverageThreshold.functions >= 80);
+});

--- a/scripts/check-branch-protection-gates.test.mjs
+++ b/scripts/check-branch-protection-gates.test.mjs
@@ -13,13 +13,13 @@ test("#414 the ruleset declares required status checks", () => {
     checks.length > 0,
     "ruleset must require at least one status check",
   );
-  // Core quality gates must be present.
-  assert.ok(checks.includes("metadata"));
+  // Core quality gates must be present. The CI workflow exposes one stable
+  // aggregate `required` check because path-scoped matrix jobs may be skipped.
+  assert.ok(checks.includes("required"));
   assert.ok(checks.includes("security"));
-  assert.ok(
-    checks.some((context) => context.startsWith("vscode-extension")),
-    "the extension build/test gate must be required",
-  );
+  assert.ok(checks.includes("scan"));
+  assert.ok(checks.includes("analyze (javascript-typescript)"));
+  assert.ok(checks.includes("analyze (python)"));
 });
 
 test("#414 the policy doc lists required status checks", () => {

--- a/scripts/check-devcontainer.mjs
+++ b/scripts/check-devcontainer.mjs
@@ -156,9 +156,11 @@ export function validateDevcontainerRepository(repoRoot = DEFAULT_REPO_ROOT) {
   requireExecutable(errors, repoRoot, ".devcontainer/postCreateCommand.sh");
 
   for (const phrase of [
+    "FROM ghcr.io/astral-sh/uv@sha256:ff07b86af50d4d9391d9daf4ff89ce427bc544f9aae87057e69a1cc0aa369946 AS uv-bin",
     "FROM mcr.microsoft.com/devcontainers/python:3.13-bookworm@sha256:",
     "ARG ACTIONLINT_VERSION=1.7.12",
     "ARG UV_VERSION=0.11.21",
+    "COPY --from=uv-bin /uv /uvx /usr/local/bin/",
     "shellcheck",
     "apt-cache show kicad",
     "actionlint_${ACTIONLINT_VERSION}_${actionlint_arch}.tar.gz",

--- a/scripts/dev-doctor.mjs
+++ b/scripts/dev-doctor.mjs
@@ -385,14 +385,56 @@ function extensionDependenciesCheck(repoRoot) {
   });
 }
 
-function mcpVersionDetail(result) {
+function pathHasFiles(directory) {
   try {
-    const payload = JSON.parse(result.stdout);
-    const version = payload.package?.version;
-    return version ? `kicad-mcp-pro ${version}` : firstLine(result.stdout);
+    return existsSync(directory) && readdirSync(directory).length > 0;
   } catch {
-    return firstLine(result.stdout || result.stderr || result.error || "");
+    return false;
   }
+}
+
+function playwrightChromiumCheck(commandOptions) {
+  const result = run(
+    "corepack",
+    [
+      "pnpm",
+      "--dir",
+      "apps/vscode-extension",
+      "exec",
+      "playwright",
+      "install",
+      "--dry-run",
+      "chromium",
+    ],
+    commandOptions,
+  );
+
+  const installLocations = String(result.stdout ?? "")
+    .split(/\r?\n/u)
+    .map((line) => line.match(/Install location:\s+(.+)$/u)?.[1]?.trim())
+    .filter(Boolean);
+  const chromiumLocations = installLocations.filter((location) =>
+    /chromium/i.test(path.basename(location)),
+  );
+  const installed = chromiumLocations.some(pathHasFiles);
+
+  return makeCheck({
+    id: "playwright-chromium",
+    label: "Playwright Chromium browser cache",
+    category: "workspace",
+    required: true,
+    ok: result.ok && installed,
+    detail:
+      result.ok && chromiumLocations.length > 0
+        ? chromiumLocations
+            .map(
+              (location) =>
+                `${location}: ${pathHasFiles(location) ? "present" : "missing"}`,
+            )
+            .join("; ")
+        : firstLine(result.stdout || result.stderr || result.error || ""),
+    hint: "Run `corepack pnpm --dir apps/vscode-extension exec playwright install chromium` before a11y/webview tests.",
+  });
 }
 
 function mcpDoctorDetail(result) {
@@ -621,6 +663,7 @@ export async function createDoctorReport(
   );
 
   checks.push(extensionDependenciesCheck(repoRoot));
+  checks.push(playwrightChromiumCheck(commandOptions));
 
   checks.push(
     commandCheck(

--- a/scripts/dev-doctor.test.mjs
+++ b/scripts/dev-doctor.test.mjs
@@ -64,6 +64,16 @@ test("dev-doctor reports the full CI-safe monorepo environment contract", async 
     mkdirSync(path.join(repoRoot, "apps/vscode-extension/node_modules/.bin"), {
       recursive: true,
     });
+    mkdirSync(path.join(repoRoot, "playwright-cache/chromium-1228"), {
+      recursive: true,
+    });
+    writeFileSync(
+      path.join(
+        repoRoot,
+        "playwright-cache/chromium-1228/INSTALLATION_COMPLETE",
+      ),
+      "ok\n",
+    );
     mkdirSync(path.join(repoRoot, "packages/kicad-fixtures"), {
       recursive: true,
     });
@@ -121,6 +131,19 @@ test("dev-doctor reports the full CI-safe monorepo environment contract", async 
         const joined = [command, ...args].join(" ");
         if (joined === "corepack pnpm --version") {
           return { ok: true, status: 0, stdout: "11.3.0", stderr: "" };
+        }
+        if (
+          joined ===
+          "corepack pnpm --dir apps/vscode-extension exec playwright install --dry-run chromium"
+        ) {
+          return {
+            ok: true,
+            status: 0,
+            stdout: `Chrome for Testing 149.0.7827.55 (playwright chromium v1228)
+  Install location:    ${path.join(repoRoot, "playwright-cache/chromium-1228")}
+`,
+            stderr: "",
+          };
         }
         if (joined === "python3 --version") {
           return { ok: true, status: 0, stdout: "Python 3.13.8", stderr: "" };
@@ -199,6 +222,7 @@ test("dev-doctor reports the full CI-safe monorepo environment contract", async 
         "uv",
         "kicad-cli",
         "vscode-extension-deps",
+        "playwright-chromium",
         "cloudflared",
         "ports",
         "workspace-scripts",

--- a/scripts/report-best-practices-status.mjs
+++ b/scripts/report-best-practices-status.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const BEST_PRACTICES_PROJECT_ID = 13405;
+export const BEST_PRACTICES_PROJECT_URL = `https://www.bestpractices.dev/projects/${BEST_PRACTICES_PROJECT_ID}`;
+export const BEST_PRACTICES_JSON_URL = `${BEST_PRACTICES_PROJECT_URL}.json`;
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const PRIORITY_FIELDS = new Set([
+  "homepage_url",
+  "description_good",
+  "interact",
+  "contribution_requirements",
+  "documentation_interface",
+  "version_unique",
+  "version_semver",
+  "version_tags",
+  "release_notes_vulns",
+  "report_url",
+  "report_tracker",
+  "report_responses",
+  "enhancement_responses",
+  "vulnerability_report_process",
+  "vulnerability_report_private",
+  "vulnerability_report_response",
+  "build",
+  "build_common_tools",
+  "build_floss_tools",
+  "test",
+  "test_invocation",
+  "test_most",
+  "test_policy",
+  "tests_are_added",
+  "tests_documented_added",
+  "warnings",
+  "warnings_fixed",
+  "warnings_strict",
+  "static_analysis",
+  "static_analysis_common_vulnerabilities",
+  "static_analysis_fixed",
+  "static_analysis_often",
+  "test_continuous_integration",
+  "no_leaked_credentials",
+  "english",
+  "governance",
+  "code_of_conduct",
+  "roles_responsibilities",
+  "access_continuity",
+  "bus_factor",
+  "documentation_roadmap",
+  "documentation_architecture",
+  "documentation_security",
+  "documentation_quick_start",
+  "documentation_current",
+  "accessibility_best_practices",
+  "internationalization",
+  "maintenance_or_update",
+  "vulnerability_report_credit",
+  "vulnerability_response_process",
+  "coding_standards",
+  "coding_standards_enforced",
+  "dependency_monitoring",
+  "automated_integration_testing",
+  "test_statement_coverage80",
+  "signed_releases",
+]);
+
+const CAUTION_FIELDS = new Set([
+  "dynamic_analysis",
+  "dynamic_analysis_unsafe",
+  "dynamic_analysis_enable_assertions",
+  "dynamic_analysis_fixed",
+  "test_statement_coverage90",
+  "test_branch_coverage80",
+  "contributors_unassociated",
+  "copyright_per_file",
+  "license_per_file",
+  "security_review",
+  "assurance_case",
+  "require_2FA",
+  "secure_2FA",
+  "two_person_review",
+]);
+
+export function summarizeStatuses(project) {
+  const summary = new Map();
+  const fields = [];
+
+  for (const [key, status] of Object.entries(project)) {
+    if (!key.endsWith("_status")) {
+      continue;
+    }
+    const field = key.slice(0, -"_status".length);
+    summary.set(status, (summary.get(status) ?? 0) + 1);
+    fields.push({
+      field,
+      status,
+      priority: PRIORITY_FIELDS.has(field),
+      caution: CAUTION_FIELDS.has(field),
+      justification: project[`${field}_justification`] ?? null,
+    });
+  }
+
+  fields.sort((left, right) => {
+    const leftRank = left.status === "Unmet" ? 0 : left.status === "?" ? 1 : 2;
+    const rightRank =
+      right.status === "Unmet" ? 0 : right.status === "?" ? 1 : 2;
+    if (leftRank !== rightRank) return leftRank - rightRank;
+    if (left.priority !== right.priority) return left.priority ? -1 : 1;
+    if (left.caution !== right.caution) return left.caution ? 1 : -1;
+    return left.field.localeCompare(right.field);
+  });
+
+  return {
+    summary: Object.fromEntries([...summary.entries()].sort()),
+    fields,
+    unmet: fields.filter((entry) => entry.status === "Unmet"),
+    unknown: fields.filter((entry) => entry.status === "?"),
+    priorityUnknown: fields.filter(
+      (entry) => entry.status === "?" && entry.priority,
+    ),
+    cautionUnknown: fields.filter(
+      (entry) => entry.status === "?" && entry.caution,
+    ),
+  };
+}
+
+function escapeMarkdownText(value) {
+  return String(value)
+    .replaceAll("\\", "\\\\")
+    .replaceAll("`", "\\`")
+    .replaceAll("[", "\\[")
+    .replaceAll("]", "\\]")
+    .replaceAll("|", "\\|")
+    .replaceAll("\n", " ");
+}
+
+function formatFieldList(entries, limit = 80) {
+  if (entries.length === 0) {
+    return "- None";
+  }
+  return entries
+    .slice(0, limit)
+    .map((entry) => {
+      const flags = [
+        entry.priority ? "priority" : null,
+        entry.caution ? "caution" : null,
+      ].filter(Boolean);
+      const suffix = flags.length > 0 ? ` _(${flags.join(", ")})_` : "";
+      return `- \`${escapeMarkdownText(entry.field)}\` — ${escapeMarkdownText(entry.status)}${suffix}`;
+    })
+    .join("\n");
+}
+
+export function renderMarkdown(project, now = new Date()) {
+  const status = summarizeStatuses(project);
+  const updated = project.updated_at ?? "unknown";
+  const badge =
+    project.badge_percentage_0 ?? project.badge_percentage ?? "unknown";
+  const silver = project.badge_percentage_1 ?? "unknown";
+  const gold = project.badge_percentage_2 ?? "unknown";
+
+  return `# Best Practices Status Report
+
+Project: [${escapeMarkdownText(project.name ?? "kicad-studio-kit")}](${BEST_PRACTICES_PROJECT_URL})  
+Generated: ${escapeMarkdownText(now.toISOString())}  
+Remote updated: ${escapeMarkdownText(updated)}
+
+## Percentages
+
+| Tier | Percentage |
+| --- | ---: |
+| Passing | ${escapeMarkdownText(badge)} |
+| Silver | ${escapeMarkdownText(silver)} |
+| Gold | ${escapeMarkdownText(gold)} |
+
+## Status counts
+
+${Object.entries(status.summary)
+  .map(
+    ([key, value]) =>
+      `- ${escapeMarkdownText(key)}: ${escapeMarkdownText(value)}`,
+  )
+  .join("\n")}
+
+## Unmet fields
+
+${formatFieldList(status.unmet)}
+
+## Highest-impact unanswered fields
+
+These are the unanswered fields that the repository evidence guide already prioritizes.
+Use \`docs/best-practices-questionnaire.md\` to fill them without overclaiming.
+
+${formatFieldList(status.priorityUnknown, 120)}
+
+## Caution fields
+
+Do not mark these as Met unless the linked evidence is genuinely present.
+
+${formatFieldList(status.cautionUnknown, 80)}
+`;
+}
+
+async function readProjectJson(options) {
+  if (options.input) {
+    return JSON.parse(await fs.readFile(options.input, "utf8"));
+  }
+
+  const response = await fetch(BEST_PRACTICES_JSON_URL, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "kicad-studio-kit-best-practices-status/1.0",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${BEST_PRACTICES_JSON_URL}: ${response.status} ${response.statusText}`,
+    );
+  }
+  return await response.json();
+}
+
+function parseArgs(argv) {
+  const options = {
+    input: null,
+    output: path.join(repoRoot, "docs", "best-practices-status.md"),
+    write: false,
+  };
+
+  const nextArg = (index, flag) => {
+    const value = argv[index + 1];
+    if (!value || value === "--" || value.startsWith("--")) {
+      throw new Error(`${flag} requires a value`);
+    }
+    return value;
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "--input") {
+      options.input = nextArg(index, arg);
+      index += 1;
+    } else if (arg === "--output") {
+      options.output = nextArg(index, arg);
+      index += 1;
+    } else if (arg === "--write") {
+      options.write = true;
+    } else if (arg === "--stdout") {
+      options.output = null;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const project = await readProjectJson(options);
+  const markdown = renderMarkdown(project);
+
+  if (options.output) {
+    if (!options.write) {
+      console.log(markdown);
+      console.log(
+        `\nDry run only. Add --write to update ${path.relative(repoRoot, options.output)}.`,
+      );
+      return { project, markdown, wrote: false };
+    }
+    await fs.writeFile(options.output, markdown);
+    console.log(`Wrote ${path.relative(repoRoot, options.output)}`);
+    return { project, markdown, wrote: true };
+  }
+
+  console.log(markdown);
+  return { project, markdown, wrote: false };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/report-best-practices-status.test.mjs
+++ b/scripts/report-best-practices-status.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  main,
+  renderMarkdown,
+  summarizeStatuses,
+} from "./report-best-practices-status.mjs";
+
+const fixture = {
+  name: "kicad-studio-kit",
+  updated_at: "2026-06-30T00:00:00.000Z",
+  badge_percentage_0: 19,
+  badge_percentage_1: 0,
+  badge_percentage_2: 4,
+  build_status: "?",
+  build_justification: null,
+  achieve_passing_status: "Unmet",
+  achieve_silver_status: "Unmet",
+  contribution_status: "Met",
+  dynamic_analysis_status: "?",
+};
+
+test("summarizeStatuses groups remote Best Practices statuses", () => {
+  const result = summarizeStatuses(fixture);
+  assert.equal(result.summary["?"], 2);
+  assert.equal(result.summary.Met, 1);
+  assert.equal(result.summary.Unmet, 2);
+  assert.deepEqual(
+    result.unmet.map((entry) => entry.field),
+    ["achieve_passing", "achieve_silver"],
+  );
+  assert.ok(result.priorityUnknown.some((entry) => entry.field === "build"));
+  assert.ok(
+    result.cautionUnknown.some((entry) => entry.field === "dynamic_analysis"),
+  );
+});
+
+test("renderMarkdown creates a maintainer-facing status report", () => {
+  const output = renderMarkdown(fixture, new Date("2026-06-30T01:02:03.000Z"));
+  assert.match(output, /Best Practices Status Report/);
+  assert.match(output, /Passing \| 19/);
+  assert.match(output, /`achieve_passing` — Unmet/);
+  assert.match(output, /`build` — \?/);
+  assert.match(output, /`dynamic_analysis` — \?/);
+});
+
+test("status reporter rejects missing --input value", async () => {
+  await assert.rejects(() => main(["--input"]), /--input requires a value/);
+});
+
+test("status reporter rejects missing --output value", async () => {
+  await assert.rejects(
+    () => main(["--output", "--write"]),
+    /--output requires a value/,
+  );
+});
+
+test("renderMarkdown escapes remote markdown-sensitive values", () => {
+  const output = renderMarkdown(
+    {
+      ...fixture,
+      name: "bad|name`[x]",
+      updated_at: "line\nfeed",
+      unsafe_field_status: "bad|status`",
+    },
+    new Date("2026-06-30T01:02:03.000Z"),
+  );
+  assert.match(output, /bad\\\|name\\`\\\[x\\\]/);
+  assert.match(output, /line feed/);
+  assert.match(output, /bad\\\|status\\`/);
+});


### PR DESCRIPTION
## Summary

Hardens KiCad Studio Kit repository health, OpenSSF Scorecard evidence, and OpenSSF Best Practices readiness.

This PR adds repository-controlled evidence and drift checks for:

- OpenSSF Best Practices project `13405`
- Scorecard Branch-Protection remediation
- Scorecard Pinned-Dependencies remediation for the devcontainer `uv` install
- Best Practices governance, roadmap, support, vulnerability handling, and questionnaire evidence
- Best Practices status reporting from the public project JSON
- Coverage evidence for the `test_statement_coverage80` Best Practices field
- Local environment doctor coverage for Playwright Chromium browser cache

## Key changes

- Add `docs/best-practices-evidence.md` as the canonical evidence register.
- Add `docs/best-practices-questionnaire.md` with field-by-field form guidance.
- Add `GOVERNANCE.md`, `ROADMAP.md`, and `SUPPORT.md`.
- Expand `SECURITY.md` with private vulnerability response targets and reporter-credit wording.
- Add README links and Best Practices badge.
- Add VitePress sidebar entries for Best Practices evidence/questionnaire docs.
- Add `check:best-practices` local gate and tests.
- Add `best-practices:status` and `best-practices:status:write` scripts to report live bestpractices.dev state.
- Change devcontainer `uv` install from hashless pip install to a digest-pinned official `ghcr.io/astral-sh/uv` image stage.
- Change the versioned branch ruleset to stable required contexts: `required`, `analyze (javascript-typescript)`, `analyze (python)`, `security`, `scan`.
- Extend `dev-doctor` to detect missing Playwright Chromium browser cache before a11y/webview tests fail.
- Make Best Practices gate validate that extension coverage thresholds stay above the 80% statement/line/function claim.

## Validation

Passed locally:

```bash
corepack pnpm run check:best-practices
corepack pnpm run check:branch-protection
corepack pnpm run check:devcontainer
corepack pnpm run check:docs-site
corepack pnpm run check:forbidden-refs
corepack pnpm --filter kicadstudiokit run check
```

Extension check summary:

- 104 unit test suites passed
- 845 unit tests passed
- 12 security tests passed
- 76 accessibility tests passed
- Production webpack build passed
- VSIX package passed
- VSIX metadata validation passed
- Statement coverage: 85.52%

## Follow-up after merge

Apply the versioned repository ruleset from `main` with a repository admin token:

```bash
python3 - <<'PY'
import json
from pathlib import Path

payload = json.loads(Path('.github/rulesets/main.json').read_text())
payload['source_type'] = 'Repository'
payload['source'] = 'oaslananka/kicad-studio-kit'
Path('/tmp/kicad-main-ruleset.json').write_text(json.dumps(payload))
PY

gh api \
  --method POST \
  repos/oaslananka/kicad-studio-kit/rulesets \
  --input /tmp/kicad-main-ruleset.json
```

Verify:

```bash
gh api repos/oaslananka/kicad-studio-kit/rulesets --jq 'length'
corepack pnpm run best-practices:status
```

Then fill the OpenSSF Best Practices form using `docs/best-practices-questionnaire.md`.
