### PR TITLE
docs(repo): record OpenSSF silver badge status

### DIFF
--- a/docs/best-practices-evidence.md
+++ b/docs/best-practices-evidence.md
@@ -7,13 +7,15 @@ Last reviewed: 2026-06-30.
 
 ## Current badge status
 
-| Field                    | Value                                                                  |
-| ------------------------ | ---------------------------------------------------------------------- |
-| Best Practices project   | `13405`                                                                |
-| Repository URL           | `https://github.com/oaslananka/kicad-studio-kit`                       |
-| Product represented here | VS Code extension: `oaslananka.kicadstudiokit`                         |
-| Current priority         | Reach Passing, then Silver                                             |
-| Main blockers            | Unanswered project fields, GitHub ruleset not active, Scorecard alerts |
+Silver badge achieved on 2026-06-30. The live badge is embedded in the README and resolves through the OpenSSF Best Practices project page.
+
+| Field                    | Value                                            |
+| ------------------------ | ------------------------------------------------ |
+| Best Practices project   | `13405`                                          |
+| Repository URL           | `https://github.com/oaslananka/kicad-studio-kit` |
+| Product represented here | VS Code extension: `oaslananka.kicadstudiokit`   |
+| Current badge status     | Passing and Silver achieved                      |
+| Next priority            | Gold gap analysis without overclaiming           |
 
 ## Evidence matrix
 
@@ -30,13 +32,13 @@ Last reviewed: 2026-06-30.
 | Dynamic analysis      | Runtime security, webview, and accessibility suites exercise the extension before release. | `apps/vscode-extension/package.json` `test:dynamic-analysis`, `apps/vscode-extension/test/security/`, `apps/vscode-extension/test/webview/`, `apps/vscode-extension/test/a11y/` | Keep runtime assertion suites in the dynamic-analysis gate.                  |
 | Coverage policy       | Extension unit coverage enforces at least 80% global statements, lines, and functions.     | `apps/vscode-extension/jest.config.js` `coverageThreshold.global.statements >= 80`, checked by `corepack pnpm run check:best-practices`                                         | Keep thresholds above the Best Practices 80% statement coverage claim.       |
 | Repeatable VSIX       | Two independent VSIX package runs must produce identical normalized payload content.       | `scripts/check-repeatable-vsix.mjs`, `apps/vscode-extension/scripts/validate-vsix-metadata.js`, `corepack pnpm run check:repeatable-vsix`                                       | Keep normalized content digest stable across packaging runs.                 |
-| CI                    | Pull requests and default-branch changes are validated by GitHub Actions.                  | `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, `.github/workflows/security.yml`, `.github/workflows/vsix-build.yml`, `.github/workflows/docs.yml`                  | Activate the repository ruleset so CI gates are enforced.                    |
+| CI                    | Pull requests and default-branch changes are validated by GitHub Actions.                  | `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, `.github/workflows/security.yml`, `.github/workflows/vsix-build.yml`, `.github/workflows/docs.yml`                  | Keep active repository ruleset and CI gates enforced.                        |
 | Static analysis       | CodeQL, ESLint, TypeScript, actionlint, and package validation are part of the gates.      | `.github/workflows/codeql.yml`, `.github/workflows/security.yml`, `eslint.config.cjs`, `scripts/check-ci-lanes.mjs`, `apps/vscode-extension/scripts/validate-package.js`        | Resolve the Scorecard SAST alert by confirming all sampled commits run SAST. |
 | Dependency management | Dependency updates and supply-chain checks are automated.                                  | `renovate.json`, `scripts/check-pnpm-supply-chain.mjs`, `pnpm-lock.yaml`                                                                                                        | Keep lockfile-only installs enforced.                                        |
 | Local secret hygiene  | Repository scanning and tests cover secret leakage risks.                                  | `.github/workflows/gitleaks.yml`, `apps/vscode-extension/test/security/`, `scripts/check-pnpm-supply-chain.mjs`                                                                 | Keep GitHub alert count at zero.                                             |
 | Release notes         | Releases are generated and documented.                                                     | `.github/workflows/release-please.yml`, `docs/changelog/`, `docs/release.md`, `apps/vscode-extension/CHANGELOG.md`                                                              | Call out security fixes explicitly.                                          |
 | Provenance            | Release evidence includes checksums, SBOM, and attestation steps.                          | `.github/workflows/publish-extension.yml`, `apps/vscode-extension/scripts/create-release-assets.js`, `scripts/check-release-provenance.mjs`, `docs/release.md`                  | Re-check Scorecard Signed-Releases after the next attested release.          |
-| Branch protection     | A strict main-branch ruleset with stable required checks is versioned in the repo.         | `.github/rulesets/main.json`, `docs/architecture/branch-protection.md`, `scripts/check-branch-protection-gates.mjs`                                                             | Apply the ruleset through GitHub settings/API.                               |
+| Branch protection     | A strict main-branch ruleset with stable required checks is versioned in the repo.         | `.github/rulesets/main.json`, `docs/architecture/branch-protection.md`, `scripts/check-branch-protection-gates.mjs`                                                             | Ruleset is active; keep required contexts stable.                            |
 | Review process        | CODEOWNERS and PR templates exist, but recent history lacks approved reviews.              | `.github/CODEOWNERS`, `.github/pull_request_template.md`, `docs/architecture/branch-protection.md`                                                                              | Require PR review for all future human changes.                              |
 | Documentation         | User, extension, integration, release, security, and architecture docs are maintained.     | `docs/`, `docs/.vitepress/config.mts`, `scripts/check-docs-site.mjs`                                                                                                            | Keep links validated by `corepack pnpm run check:docs-site`.                 |
 | Accessibility         | Webview accessibility tests are present and run under the extension check.                 | `apps/vscode-extension/test/a11y/`, `docs/accessibility.md`, `scripts/dev-doctor.mjs`                                                                                           | Keep Playwright browser cache covered by `dev-doctor`.                       |
@@ -65,7 +67,7 @@ ruleset contexts from drifting.
 | ------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | Branch-Protection   | `.github/rulesets/main.json`, `docs/architecture/branch-protection.md`                        | Apply the ruleset in GitHub and re-run Scorecard.                                                 |
 | Code-Review         | `.github/CODEOWNERS`, PR template, branch policy doc                                          | Use reviewed PRs for all future human changes.                                                    |
-| CII-Best-Practices  | This page plus existing policy docs                                                           | Fill the Best Practices project fields and keep the badge in README.                              |
+| CII-Best-Practices  | This page plus existing policy docs                                                           | Silver achieved on 2026-06-30; keep the badge in README and maintain evidence URLs.               |
 | Signed-Releases     | `publish-extension.yml`, `create-release-assets.js`, release docs                             | Confirm that the next release exposes attestations in a detectable way.                           |
 | SAST                | CodeQL workflow and security workflow                                                         | Confirm CodeQL runs on every default-branch/PR path Scorecard samples.                            |
 | Pinned-Dependencies | Devcontainer pins the base image, the official uv image digest, and downloaded tool checksums | Re-run Scorecard/code scanning after the next default-branch scan to clear stale line references. |

--- a/docs/best-practices-questionnaire.md
+++ b/docs/best-practices-questionnaire.md
@@ -13,6 +13,10 @@ corepack pnpm run best-practices:status:write
 
 The first command prints a dry-run report. The second writes `docs/best-practices-status.md` for maintainer review.
 
+## Badge milestone
+
+Passing and Silver were achieved on 2026-06-30. Future edits should focus on preserving evidence URLs for achieved criteria and preparing Gold only when the repository has real supporting evidence.
+
 ## High-impact Passing fields
 
 | Field                                    | Suggested value                                  | Evidence                                                                                                 |
@@ -57,34 +61,34 @@ The first command prints a dry-run report. The second writes `docs/best-practice
 
 ## Security and Silver-level fields
 
-| Field                            | Suggested value                                     | Evidence / note                                                                                                                                                                |
-| -------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `governance`                     | Met                                                 | `GOVERNANCE.md`, governance board model                                                                                                                                        |
-| `code_of_conduct`                | Met                                                 | `CODE_OF_CONDUCT.md`                                                                                                                                                           |
-| `roles_responsibilities`         | Met                                                 | `GOVERNANCE.md` roles table                                                                                                                                                    |
-| `access_continuity`              | Met                                                 | `GOVERNANCE.md` access continuity section                                                                                                                                      |
-| `bus_factor`                     | Met                                                 | `GOVERNANCE.md`, release/security runbooks                                                                                                                                     |
-| `documentation_roadmap`          | Met                                                 | `ROADMAP.md`, governance board, GA readiness docs                                                                                                                              |
-| `documentation_architecture`     | Met                                                 | `docs/architecture/`, ADRs                                                                                                                                                     |
-| `documentation_security`         | Met                                                 | `SECURITY.md`, `docs/security.md`, threat model                                                                                                                                |
-| `documentation_quick_start`      | Met                                                 | README local validation, getting-started/install docs                                                                                                                          |
-| `documentation_current`          | Met                                                 | docs-site generated/links checks                                                                                                                                               |
-| `accessibility_best_practices`   | Met                                                 | a11y tests and accessibility docs                                                                                                                                              |
-| `internationalization`           | Met                                                 | NLS files and NLS parity check                                                                                                                                                 |
-| `maintenance_or_update`          | Met                                                 | Renovate config, dependency lifecycle docs, security workflow                                                                                                                  |
-| `vulnerability_report_credit`    | Met                                                 | `SECURITY.md` coordinated disclosure and credit wording                                                                                                                        |
-| `vulnerability_response_process` | Met                                                 | `SECURITY.md`, release/security docs                                                                                                                                           |
-| `coding_standards`               | Met                                                 | ESLint, Prettier, TypeScript, contribution docs                                                                                                                                |
-| `coding_standards_enforced`      | Met                                                 | CI and local `check` scripts                                                                                                                                                   |
-| `build_reproducible`             | Partial / explain                                   | Lockfile installs, pinned devcontainer base and uv image digest; VSIX metadata comparison exists, but fully reproducible byte-for-byte release should be verified per release. |
-| `dependency_monitoring`          | Met                                                 | Renovate config, security workflow, lockfile supply-chain checks                                                                                                               |
-| `automated_integration_testing`  | Met                                                 | extension integration and real-pair tests where available                                                                                                                      |
-| `test_statement_coverage80`      | Review coverage report before marking               | Current aggregate statement coverage is above 80% in the extension check output.                                                                                               |
-| `signed_releases`                | Met after release verification                      | publish workflow uses GitHub artifact attestations, SBOM, checksums, and provenance; re-check after next release.                                                              |
-| `require_2FA`                    | Met only if organization/account policy enforces it | Confirm GitHub organization/user security settings before marking.                                                                                                             |
-| `secure_2FA`                     | Met only after confirming account policy            | Do not mark without checking GitHub settings.                                                                                                                                  |
-| `code_review_standards`          | Met after ruleset active                            | branch ruleset + CODEOWNERS + PR template                                                                                                                                      |
-| `two_person_review`              | Partial unless a second reviewer is required        | Current versioned ruleset requires one approval; do not overclaim.                                                                                                             |
+| Field                            | Suggested value                                     | Evidence / note                                                                                                                     |
+| -------------------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `governance`                     | Met                                                 | `GOVERNANCE.md`, governance board model                                                                                             |
+| `code_of_conduct`                | Met                                                 | `CODE_OF_CONDUCT.md`                                                                                                                |
+| `roles_responsibilities`         | Met                                                 | `GOVERNANCE.md` roles table                                                                                                         |
+| `access_continuity`              | Met                                                 | `GOVERNANCE.md` access continuity section                                                                                           |
+| `bus_factor`                     | Met                                                 | `GOVERNANCE.md`, release/security runbooks                                                                                          |
+| `documentation_roadmap`          | Met                                                 | `ROADMAP.md`, governance board, GA readiness docs                                                                                   |
+| `documentation_architecture`     | Met                                                 | `docs/architecture/`, ADRs                                                                                                          |
+| `documentation_security`         | Met                                                 | `SECURITY.md`, `docs/security.md`, threat model                                                                                     |
+| `documentation_quick_start`      | Met                                                 | README local validation, getting-started/install docs                                                                               |
+| `documentation_current`          | Met                                                 | docs-site generated/links checks                                                                                                    |
+| `accessibility_best_practices`   | Met                                                 | a11y tests and accessibility docs                                                                                                   |
+| `internationalization`           | Met                                                 | NLS files and NLS parity check                                                                                                      |
+| `maintenance_or_update`          | Met                                                 | Renovate config, dependency lifecycle docs, security workflow                                                                       |
+| `vulnerability_report_credit`    | Met                                                 | `SECURITY.md` coordinated disclosure and credit wording                                                                             |
+| `vulnerability_response_process` | Met                                                 | `SECURITY.md`, release/security docs                                                                                                |
+| `coding_standards`               | Met                                                 | ESLint, Prettier, TypeScript, contribution docs                                                                                     |
+| `coding_standards_enforced`      | Met                                                 | CI and local `check` scripts                                                                                                        |
+| `build_repeatable`               | Met                                                 | `corepack pnpm run check:repeatable-vsix` packages the VSIX twice and compares normalized payload content.                          |
+| `dependency_monitoring`          | Met                                                 | Renovate config, security workflow, lockfile supply-chain checks                                                                    |
+| `automated_integration_testing`  | Met                                                 | extension integration and real-pair tests where available                                                                           |
+| `test_statement_coverage80`      | Met                                                 | `apps/vscode-extension/jest.config.js` enforces global statement coverage above 80%, and CI coverage is above the Silver threshold. |
+| `signed_releases`                | Met after release verification                      | publish workflow uses GitHub artifact attestations, SBOM, checksums, and provenance; re-check after next release.                   |
+| `require_2FA`                    | Met only if organization/account policy enforces it | Confirm GitHub organization/user security settings before marking.                                                                  |
+| `secure_2FA`                     | Met only after confirming account policy            | Do not mark without checking GitHub settings.                                                                                       |
+| `code_review_standards`          | Met after ruleset active                            | branch ruleset + CODEOWNERS + PR template                                                                                           |
+| `two_person_review`              | Partial unless a second reviewer is required        | Current versioned ruleset requires one approval; do not overclaim.                                                                  |
 
 ## Crypto fields
 
@@ -98,4 +102,5 @@ KiCad Studio Kit should not claim custom cryptography. For fields about cryptogr
 | `test_statement_coverage90` / `test_branch_coverage80` | Check the latest coverage report before claiming Gold-level coverage.                                                                       |
 | `contributors_unassociated`                            | Current public history may not show enough independent contributors.                                                                        |
 | `copyright_per_file` / `license_per_file`              | Do not mark unless every required source file carries the expected notice or the project policy explicitly allows repository-level notices. |
-| `security_review` / `assurance_case`                   | Mark only after a documented review or assurance case exists.                                                                               |
+| `security_review`                                      | Mark only after a documented independent or structured review exists.                                                                       |
+| `assurance_case`                                       | Silver evidence exists in `SECURITY.md`, `docs/security.md`, threat-model docs, and `docs/best-practices-evidence.md`; keep URLs explicit.  |

--- a/docs/best-practices-status.md
+++ b/docs/best-practices-status.md
@@ -1,0 +1,49 @@
+# Best Practices Status Report
+
+Project: [KiCad Studio Kit](https://www.bestpractices.dev/projects/13405)
+Generated: 2026-06-30T14:35:52.138Z
+Remote updated: 2026-06-30T14:32:47.462Z
+
+## Percentages
+
+| Tier    | Percentage |
+| ------- | ---------: |
+| Passing |        100 |
+| Silver  |        100 |
+| Gold    |         26 |
+
+## Status counts
+
+- 0: 1
+- ?: 79
+- Met: 93
+- N/A: 20
+- Unmet: 3
+
+## Unmet fields
+
+- `dco` — Unmet
+- `version_tags_signed` — Unmet
+- `dynamic_analysis` — Unmet _(caution)_
+
+## Highest-impact unanswered fields
+
+These are the unanswered fields that the repository evidence guide already prioritizes.
+Use `docs/best-practices-questionnaire.md` to fill them without overclaiming.
+
+- `homepage_url` — ? _(priority)_
+- `report_url` — ? _(priority)_
+
+## Caution fields
+
+Do not mark these as Met unless the linked evidence is genuinely present.
+
+- `contributors_unassociated` — ? _(caution)_
+- `copyright_per_file` — ? _(caution)_
+- `license_per_file` — ? _(caution)_
+- `require_2FA` — ? _(caution)_
+- `secure_2FA` — ? _(caution)_
+- `security_review` — ? _(caution)_
+- `test_branch_coverage80` — ? _(caution)_
+- `test_statement_coverage90` — ? _(caution)_
+- `two_person_review` — ? _(caution)_

--- a/scripts/report-best-practices-status.mjs
+++ b/scripts/report-best-practices-status.mjs
@@ -169,8 +169,8 @@ export function renderMarkdown(project, now = new Date()) {
 
   return `# Best Practices Status Report
 
-Project: [${escapeMarkdownText(project.name ?? "kicad-studio-kit")}](${BEST_PRACTICES_PROJECT_URL})  
-Generated: ${escapeMarkdownText(now.toISOString())}  
+Project: [${escapeMarkdownText(project.name ?? "kicad-studio-kit")}](${BEST_PRACTICES_PROJECT_URL})
+Generated: ${escapeMarkdownText(now.toISOString())}
 Remote updated: ${escapeMarkdownText(updated)}
 
 ## Percentages


### PR DESCRIPTION
## Summary

Records the OpenSSF Best Practices Silver badge milestone in the repository evidence docs.

## Changes

- Update `docs/best-practices-evidence.md` to state that Passing and Silver are achieved.
- Add the latest `docs/best-practices-status.md` snapshot from the live Best Practices project API.
- Update the questionnaire guide so future edits focus on preserving evidence URLs and preparing Gold only when backed by real evidence.
- Remove trailing-whitespace output from the status reporter so generated status docs pass markdown lint.

## Validation

```bash
corepack pnpm run check:best-practices
corepack pnpm run check:docs-site
corepack pnpm run check:forbidden-refs
```
