### PR TITLE
fix(kicad-studio): use hosted readme images

### DIFF
--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -1,4 +1,4 @@
-![KiCad Studio marketplace hero](assets/marketplace/hero.png)
+![KiCad Studio marketplace hero](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/marketplace/hero.png)
 
 # KiCad Studio
 
@@ -9,7 +9,7 @@ KiCad Studio turns VS Code into a focused KiCad workspace for project navigation
 Canonical repository: https://github.com/oaslananka/kicad-studio-kit/tree/main/apps/vscode-extension
 
 - Extension ID: `oaslananka.kicadstudiokit`
-- Version: `1.8.0`
+- Version: `1.9.0`
 - Supported MCP: `kicad-mcp-pro >=3.5.2 <4.0.0`
 - Supported KiCad projects: KiCad 8.x, 9.x, and 10.x project, schematic, PCB, DRC, and jobset files
 
@@ -43,19 +43,19 @@ corepack pnpm --filter kicadstudiokit run package
 
 ## Screenshots
 
-![KiCad Studio project tree](assets/screenshots/project-tree.png)
+![KiCad Studio project tree](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/project-tree.png)
 
-![KiCad Studio schematic viewer](assets/screenshots/schematic-viewer.png)
+![KiCad Studio schematic viewer](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/schematic-viewer.png)
 
-![KiCad Studio PCB viewer](assets/screenshots/pcb-viewer.png)
+![KiCad Studio PCB viewer](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/pcb-viewer.png)
 
-![KiCad Studio DRC results](assets/screenshots/drc-results.png)
+![KiCad Studio DRC results](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/drc-results.png)
 
-![KiCad Studio MCP tools dashboard](assets/screenshots/mcp-tools-dashboard.png)
+![KiCad Studio MCP tools dashboard](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/mcp-tools-dashboard.png)
 
 ## Core Workflow
 
-![Open a project, inspect the PCB, and run DRC](assets/marketplace/core-workflow.gif)
+![Open a project, inspect the PCB, and run DRC](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/marketplace/core-workflow.gif)
 
 ## KiCad CLI-Only Comparison
 
@@ -68,7 +68,7 @@ corepack pnpm --filter kicadstudiokit run package
 
 ## MCP Compatibility
 
-KiCad Studio 1.8.0 supports `kicad-mcp-pro >=3.5.2 <4.0.0` and was tested against `3.9.2`. If a connected server reports a version outside the required range, MCP-dependent commands are disabled while KiCad-only features continue to work.
+KiCad Studio 1.9.0 supports `kicad-mcp-pro >=3.5.2 <4.0.0` and was tested against `3.9.2`. If a connected server reports a version outside the required range, MCP-dependent commands are disabled while KiCad-only features continue to work.
 
 ## Marketplace Listing Copy
 

--- a/apps/vscode-extension/scripts/check-marketplace-assets.js
+++ b/apps/vscode-extension/scripts/check-marketplace-assets.js
@@ -8,6 +8,7 @@ const root = path.resolve(__dirname, '..');
 const maxScreenshotBytes = 2 * 1024 * 1024;
 const maxGifBytes = 5 * 1024 * 1024;
 const maxGifSeconds = 30;
+const marketplaceImageHost = 'https://raw.githubusercontent.com/';
 
 const requiredSvgAssets = [
   'assets/marketplace/gallery-banner-background.svg',
@@ -129,20 +130,34 @@ function assertPng(relativePath, expectedWidth, expectedHeight, maxBytes) {
   }
 }
 
-function assertReadmeImageReferences(readme) {
+function assertReadmeImageReferences(readme, packageJson) {
   const imagePattern = /!\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/gu;
+  const baseImagesUrl = packageJson.baseImagesUrl.replace(/\/$/u, '');
+  let marketplaceAssetCount = 0;
   for (const match of readme.matchAll(imagePattern)) {
     const target = match[1];
-    if (
-      !target ||
-      target.startsWith('http://') ||
-      target.startsWith('https://') ||
-      target.startsWith('data:') ||
-      target.startsWith('#')
-    ) {
+    if (!target) {
+      fail('README.md contains an empty image target');
+    }
+    if (target.startsWith('https://img.shields.io/')) {
       continue;
     }
-    assertFile(target);
+    if (!target.startsWith(`${baseImagesUrl}/`)) {
+      fail(
+        `README.md marketplace asset images must use absolute baseImagesUrl links; found ${target}`
+      );
+    }
+    if (!target.startsWith(marketplaceImageHost)) {
+      fail(`README.md image must use raw.githubusercontent.com: ${target}`);
+    }
+    const relativeAsset = target.slice(`${baseImagesUrl}/`.length);
+    assertFile(relativeAsset);
+    marketplaceAssetCount += 1;
+  }
+  if (marketplaceAssetCount < requiredScreenshots.length + 2) {
+    fail(
+      `README.md must include hero, workflow GIF, and ${requiredScreenshots.length} screenshot images`
+    );
   }
 }
 
@@ -207,8 +222,12 @@ function assertMarketplaceMarkdown() {
   const firstLines = readme.split('\n').slice(0, 5).join('\n');
   const expectedVersion = packageJson.version;
 
-  if (!firstLines.includes('assets/marketplace/hero.png')) {
-    fail('README.md must place the hero image at the top');
+  if (
+    !firstLines.includes(
+      `${packageJson.baseImagesUrl}/assets/marketplace/hero.png`
+    )
+  ) {
+    fail('README.md must place the absolute hero image at the top');
   }
 
   // Version text in README must match package.json
@@ -247,7 +266,7 @@ function assertMarketplaceMarkdown() {
       'README.md uses Markdown/HTML that Marketplace renderers commonly strip'
     );
   }
-  assertReadmeImageReferences(readme);
+  assertReadmeImageReferences(readme, packageJson);
 }
 
 assertPackageMetadata();


### PR DESCRIPTION
Fix extension README image links so listing renderers can load the hero, screenshots, and workflow GIF. Local checks passed: marketplace:check, package, package:validate, forbidden-refs.