### PR TITLE
fix(kicad-studio): polish marketplace readme layout

### DIFF
--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -2,69 +2,74 @@
 
 # KiCad Studio
 
+**A focused VS Code workspace for professional KiCad review, validation, manufacturing handoff, and AI-assisted MCP workflows.**
+
 [![Open VSX](https://img.shields.io/open-vsx/v/oaslananka/kicadstudiokit?label=Open%20VSX)](https://open-vsx.org/extension/oaslananka/kicadstudiokit)
+[![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-install-blue)](https://marketplace.visualstudio.com/items?itemName=oaslananka.kicadstudiokit)
+[![License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/oaslananka/kicad-studio-kit/blob/main/LICENSE)
 
-KiCad Studio turns VS Code into a focused KiCad workspace for project navigation, schematic and PCB inspection, DRC/ERC review, manufacturing handoff, and AI-assisted MCP workflows.
-
-Canonical repository: https://github.com/oaslananka/kicad-studio-kit/tree/main/apps/vscode-extension
+KiCad Studio turns VS Code into a KiCad-aware engineering cockpit: project navigation, schematic and PCB inspection, DRC/ERC review, repeatable release outputs, and MCP readiness for AI-assisted workflows.
 
 - Extension ID: `oaslananka.kicadstudiokit`
 - Version: `1.9.1`
-- Supported MCP: `kicad-mcp-pro >=3.5.2 <4.0.0`
 - Supported KiCad projects: KiCad 8.x, 9.x, and 10.x project, schematic, PCB, DRC, and jobset files
+- Supported MCP server: `kicad-mcp-pro >=3.5.2 <4.0.0`
+- Canonical repository: https://github.com/oaslananka/kicad-studio-kit/tree/main/apps/vscode-extension
 
 ## Quick Start
 
 1. Install **KiCad Studio** from the Visual Studio Marketplace or Open VSX.
-2. Open a folder that contains a `.kicad_pro`, `.kicad_sch`, or `.kicad_pcb` file.
-3. Run **KiCad: Detect kicad-cli** from the Command Palette if KiCad is not already on `PATH`.
-4. Open a schematic or PCB file to use the built-in KiCad Studio viewer.
-5. Run **KiCad: Run DRC** or **KiCad: Run ERC** to populate Problems, status, and validation views.
+2. Open a folder containing a `.kicad_pro`, `.kicad_sch`, or `.kicad_pcb` file.
+3. Run **KiCad: Detect kicad-cli** if KiCad is not already available on `PATH`.
+4. Open a schematic or PCB file to inspect the design inside VS Code.
+5. Run **KiCad: Run DRC** or **KiCad: Run ERC** to populate Problems and validation views.
 6. Optional: start `kicad-mcp-pro` and connect your AI client with the generated `.vscode/mcp.json` schema.
-
-```powershell
-corepack enable
-corepack pnpm run dev:doctor
-corepack pnpm install --frozen-lockfile
-corepack pnpm --filter kicadstudiokit run build
-corepack pnpm --filter kicadstudiokit run package
-```
-
-## Feature Matrix
-
-| Workflow                  | KiCad Studio                                                                                         | Notes                                                                     |
-| ------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Project tree              | Native VS Code sidebar for KiCad projects, boards, schematics, jobsets, rules, and generated outputs | Designed for mixed hardware/software workspaces                           |
-| Schematic and PCB viewing | Custom editors with KiCad-aware controls and CLI fallback paths                                      | Keeps source files in VS Code while preserving KiCad as the authority     |
-| DRC/ERC review            | Problems integration, freshness state, quality gates, and focused validation views                   | Helps separate fresh failures from stale report files                     |
-| BOM, netlist, and exports | Repeatable commands for manufacturing handoff and release review                                     | Pairs with KiCad jobsets and project-specific presets                     |
-| MCP tools dashboard       | `kicad-mcp-pro` discovery, version gating, tool status, and AI workflow readiness                    | MCP-dependent commands disable themselves when the server is incompatible |
-| Localization              | English listing copy with extension string infrastructure                                            | Active                                                                    |
-
-## Screenshots
-
-![KiCad Studio project tree](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/project-tree.png)
-
-![KiCad Studio schematic viewer](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/schematic-viewer.png)
-
-![KiCad Studio PCB viewer](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/pcb-viewer.png)
-
-![KiCad Studio DRC results](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/drc-results.png)
-
-![KiCad Studio MCP tools dashboard](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/mcp-tools-dashboard.png)
 
 ## Core Workflow
 
 ![Open a project, inspect the PCB, and run DRC](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/marketplace/core-workflow.gif)
 
+## Feature Matrix
+
+| Workflow                 | KiCad Studio                                                                                         | Engineering value                                                              |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Project navigation       | Native VS Code sidebar for KiCad projects, boards, schematics, jobsets, rules, and generated outputs | Keeps hardware and software workspace context together                         |
+| Schematic and PCB review | Custom editors with KiCad-aware controls and CLI fallback paths                                      | Inspect design files without losing KiCad as the source of truth               |
+| DRC/ERC validation       | Problems integration, freshness state, quality gates, and focused validation views                   | Separates fresh failures from stale reports                                    |
+| Manufacturing handoff    | Repeatable BOM, netlist, plot, drill, and jobset-driven export commands                              | Turns review output into reproducible release artifacts                        |
+| MCP readiness            | `kicad-mcp-pro` discovery, version gating, tool status, and workspace context                        | Keeps AI-assisted commands safe when the MCP server is missing or incompatible |
+| Localization             | Marketplace copy plus extension string infrastructure                                                | Prepared for maintained user-facing locales                                    |
+
+## Screenshots
+
+### Project Tree
+
+![KiCad Studio project tree](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/project-tree.png)
+
+### Schematic Viewer
+
+![KiCad Studio schematic viewer](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/schematic-viewer.png)
+
+### PCB Viewer
+
+![KiCad Studio PCB viewer](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/pcb-viewer.png)
+
+### DRC Results
+
+![KiCad Studio DRC results](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/drc-results.png)
+
+### MCP Tools Dashboard
+
+![KiCad Studio MCP tools dashboard](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/screenshots/mcp-tools-dashboard.png)
+
 ## KiCad CLI-Only Comparison
 
-| Workflow             | KiCad CLI-only                                                     | KiCad Studio                                                                  |
-| -------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| Open project context | Requires remembering paths, commands, and output locations         | Sidebar discovers KiCad project structure inside the active VS Code workspace |
-| Inspect design state | Exports or external KiCad windows are needed for most review loops | Schematic and PCB custom editors keep review context next to source changes   |
-| Run DRC/ERC          | Terminal output and report files must be correlated manually       | Problems, validation views, and quality gates show actionable diagnostics     |
-| Share AI context     | Scripts must manually expose project files and tool capabilities   | MCP dashboard gates compatible `kicad-mcp-pro` tools and workspace context    |
+| Workflow             | KiCad CLI-only                                                     | KiCad Studio                                                               |
+| -------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Open project context | Requires remembering paths, commands, and output locations         | Discovers KiCad project structure inside the active VS Code workspace      |
+| Inspect design state | Exports or external KiCad windows are needed for most review loops | Keeps schematic and PCB review next to source changes                      |
+| Run DRC/ERC          | Terminal output and report files must be correlated manually       | Problems, validation views, and quality gates show actionable diagnostics  |
+| Share AI context     | Scripts must manually expose project files and tool capabilities   | MCP dashboard gates compatible `kicad-mcp-pro` tools and workspace context |
 
 ## MCP Compatibility
 
@@ -81,6 +86,7 @@ Release notes for Marketplace and Open VSX users live in [CHANGELOG.md](CHANGELO
 ## Local Development
 
 ```powershell
+corepack enable
 corepack pnpm run dev:doctor -- --ci
 corepack pnpm install --frozen-lockfile
 corepack pnpm --filter kicadstudiokit run marketplace:check

--- a/docs/architecture/repo-structure.md
+++ b/docs/architecture/repo-structure.md
@@ -3,9 +3,9 @@
 KiCad Studio Kit is one GitHub repository with one local release surface and
 cross-repo compatibility coverage for the external MCP server:
 
-| Workspace                                                                       | Product role                                        | Public surface                                         |
-| ------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------ |
-| `apps/vscode-extension`                                                         | KiCad Studio VS Code and Open VSX extension         | `oaslananka.kicadstudiokit`                            |
+| Workspace                                                                        | Product role                                        | Public surface                                         |
+| -------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------ |
+| `apps/vscode-extension`                                                          | KiCad Studio VS Code and Open VSX extension         | `oaslananka.kicadstudiokit`                            |
 | (external — see [oaslananka/kicad-mcp](https://github.com/oaslananka/kicad-mcp)) | KiCad MCP Pro Python server and MCP Registry source | `kicad-mcp-pro` / `io.github.oaslananka/kicad-mcp-pro` |
 
 | `packages/test-harness` | Private shared test utilities | Not published |
@@ -18,6 +18,21 @@ The folder names intentionally preserve the package roots used by the current pu
   tests and CI gates. It is never a production dependency or release surface.
 
 Do not introduce additional canonical repositories, mirrors, or alternate release roots. Cross-product work should flow through compatibility metadata, MCP manifests, shared fixtures, and contract tests rather than direct source imports.
+
+## README ownership
+
+This repository intentionally keeps two top-level user-facing README surfaces:
+
+| File                              | Audience                                                            | Why it exists                                                                                                                      |
+| --------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `README.md`                       | GitHub repository visitors, contributors, auditors, and maintainers | Explains repository scope after the MCP split, validation commands, governance, architecture, security, and contribution flow.     |
+| `apps/vscode-extension/README.md` | Visual Studio Marketplace, Open VSX, and extension users            | Ships inside the VSIX and must stay product-focused: screenshots, install flow, feature summary, compatibility, and release notes. |
+
+Do not collapse these files into one document. The Marketplace renderer reads the
+extension README from the packaged VSIX, while GitHub renders the root README as
+the repository landing page. Shared facts such as the extension version and
+Marketplace image paths are guarded by `release:surface` and `marketplace:check`
+so the two surfaces can stay intentionally different without drifting.
 
 ## Root ownership
 


### PR DESCRIPTION
Polish the extension README for Marketplace/Open VSX rendering and document why the repository intentionally keeps a root README plus a packaged extension README. Validation passed: marketplace:check, check:release-surface, check:forbidden-refs, check:docs-site, package:validate.