### PR TITLE
fix(kicad-studio): show trust badges in marketplace readme

### DIFF
--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -1,8 +1,14 @@
 ![KiCad Studio marketplace hero](https://raw.githubusercontent.com/oaslananka/kicad-studio-kit/main/apps/vscode-extension/assets/marketplace/hero.png)
 
-# KiCad Studio
+# KiCad Studio Kit
 
 **A focused VS Code workspace for professional KiCad review, validation, manufacturing handoff, and AI-assisted MCP workflows.**
+
+[![CI](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/codeql.yml/badge.svg)](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/codeql.yml)
+[![Security](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/security.yml/badge.svg)](https://github.com/oaslananka/kicad-studio-kit/actions/workflows/security.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/oaslananka/kicad-studio-kit/badge)](https://scorecard.dev/viewer/?uri=github.com/oaslananka/kicad-studio-kit)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13405/badge)](https://www.bestpractices.dev/projects/13405)
 
 [![Open VSX](https://img.shields.io/open-vsx/v/oaslananka/kicadstudiokit?label=Open%20VSX)](https://open-vsx.org/extension/oaslananka/kicadstudiokit)
 [![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-install-blue)](https://marketplace.visualstudio.com/items?itemName=oaslananka.kicadstudiokit)

--- a/apps/vscode-extension/scripts/check-marketplace-assets.js
+++ b/apps/vscode-extension/scripts/check-marketplace-assets.js
@@ -9,6 +9,12 @@ const maxScreenshotBytes = 2 * 1024 * 1024;
 const maxGifBytes = 5 * 1024 * 1024;
 const maxGifSeconds = 30;
 const marketplaceImageHost = 'https://raw.githubusercontent.com/';
+const trustedBadgePrefixes = [
+  'https://img.shields.io/',
+  'https://github.com/oaslananka/kicad-studio-kit/actions/workflows/',
+  'https://api.scorecard.dev/projects/github.com/oaslananka/kicad-studio-kit/badge',
+  'https://www.bestpractices.dev/projects/13405/badge'
+];
 
 const requiredSvgAssets = [
   'assets/marketplace/gallery-banner-background.svg',
@@ -139,7 +145,7 @@ function assertReadmeImageReferences(readme, packageJson) {
     if (!target) {
       fail('README.md contains an empty image target');
     }
-    if (target.startsWith('https://img.shields.io/')) {
+    if (trustedBadgePrefixes.some((prefix) => target.startsWith(prefix))) {
       continue;
     }
     if (!target.startsWith(`${baseImagesUrl}/`)) {


### PR DESCRIPTION
Add CI, CodeQL, Security, OpenSSF Scorecard, and OpenSSF Best Practices badges to the extension README used by Marketplace and Open VSX. Align the title with KiCad Studio Kit and allow trusted external badge sources in marketplace:check. Local validation passed: marketplace:check, check:release-surface, check:forbidden-refs, package, package:validate.