### PR TITLE
fix(repo): improve marketplace status surfaces and docs deploy retry

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,15 +56,37 @@ jobs:
             "${ACTIONS_ID_TOKEN_REQUEST_URL}")"
           oidc_token="$(jq -r '.value' <<< "${oidc_response}")"
 
-          deployment_response="$(gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2026-03-10" \
-            "/repos/${GITHUB_REPOSITORY}/pages/deployments" \
-            -F artifact_id="${ARTIFACT_ID}" \
-            -F environment="github-pages" \
-            -F pages_build_version="${GITHUB_SHA}" \
-            -F oidc_token="${oidc_token}")"
+          deployment_response=""
+          deadline=$((SECONDS + 600))
+          while (( SECONDS < deadline )); do
+            set +e
+            deployment_response="$(gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2026-03-10" \
+              "/repos/${GITHUB_REPOSITORY}/pages/deployments" \
+              -F artifact_id="${ARTIFACT_ID}" \
+              -F environment="github-pages" \
+              -F pages_build_version="${GITHUB_SHA}" \
+              -F oidc_token="${oidc_token}" 2>&1)"
+            deployment_exit=$?
+            set -e
+            if [[ "${deployment_exit}" -eq 0 ]]; then
+              break
+            fi
+            if grep -qi "in progress deployment" <<< "${deployment_response}"; then
+              echo "GitHub Pages already has an in-progress deployment; waiting before retrying."
+              sleep 15
+              continue
+            fi
+            echo "${deployment_response}" >&2
+            exit "${deployment_exit}"
+          done
+
+          if [[ -z "${deployment_response}" ]] || ! jq -e '.id' <<< "${deployment_response}" >/dev/null; then
+            echo "Timed out waiting to create a Pages deployment." >&2
+            exit 1
+          fi
 
           deployment_id="$(jq -r '.id' <<< "${deployment_response}")"
           status_url="$(jq -r '.status_url' <<< "${deployment_response}")"

--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -11,8 +11,12 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13405/badge)](https://www.bestpractices.dev/projects/13405)
 
 [![Open VSX](https://img.shields.io/open-vsx/v/oaslananka/kicadstudiokit?label=Open%20VSX)](https://open-vsx.org/extension/oaslananka/kicadstudiokit)
+[![Open VSX Downloads](https://img.shields.io/open-vsx/dt/oaslananka/kicadstudiokit?label=Open%20VSX%20downloads)](https://open-vsx.org/extension/oaslananka/kicadstudiokit)
 [![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-install-blue)](https://marketplace.visualstudio.com/items?itemName=oaslananka.kicadstudiokit)
+[![VS Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/oaslananka.kicadstudiokit?label=VS%20installs)](https://marketplace.visualstudio.com/items?itemName=oaslananka.kicadstudiokit)
+[![VS Marketplace Rating](https://img.shields.io/visual-studio-marketplace/r/oaslananka.kicadstudiokit?label=VS%20rating)](https://marketplace.visualstudio.com/items?itemName=oaslananka.kicadstudiokit&ssr=false#review-details)
 [![License](https://img.shields.io/badge/license-MIT-blue)](https://github.com/oaslananka/kicad-studio-kit/blob/main/LICENSE)
+[![Buy me a coffee](https://img.shields.io/badge/Buy%20me%20a%20coffee-support-FFDD00?logo=buymeacoffee&logoColor=000000&labelColor=FFDD00&color=111111)](https://www.buymeacoffee.com/oaslananka)
 
 KiCad Studio turns VS Code into a KiCad-aware engineering cockpit: project navigation, schematic and PCB inspection, DRC/ERC review, repeatable release outputs, and MCP readiness for AI-assisted workflows.
 


### PR DESCRIPTION
Adds Marketplace/Open VSX status surface improvements and fixes a real Docs workflow reliability issue.\n\nChanges:\n- Add Open VSX downloads, VS Marketplace installs, VS Marketplace rating, and Buy me a coffee support badges to the packaged extension README.\n- Make the Docs GitHub Pages deploy step retry when a previous Pages deployment is still in progress instead of failing immediately.\n\nValidation passed locally:\n- workflow YAML parse\n- marketplace:check\n- check:release-surface\n- check:forbidden-refs\n- check:docs-site\n- package:validate