### PR TITLE
docs(repo): close solo maturity followups

### DIFF
--- a/docs/legal/reuse-spdx-notice-assessment.md
+++ b/docs/legal/reuse-spdx-notice-assessment.md
@@ -1,0 +1,39 @@
+# REUSE, SPDX, and NOTICE Assessment
+
+Audit date: 2026-07-03
+
+This assessment resolves the solo-maintainer Professional OSS legal/readiness follow-up for license metadata, REUSE readiness, SPDX headers, and NOTICE handling.
+
+## Current license posture
+
+| Area | Status | Evidence |
+| --- | --- | --- |
+| Repository license | Passed | Root `LICENSE` is MIT. |
+| Root package metadata | Passed | Root `package.json` declares MIT. |
+| Extension package metadata | Passed | `apps/vscode-extension/package.json` declares MIT. |
+| Extension packaged license | Passed | Extension package includes license files during VSIX packaging. |
+| Per-file SPDX headers | Partial | Not consistently present across all source and documentation files. |
+| REUSE compliance | Partial | Repository-level MIT license is clear, but full REUSE metadata is not yet implemented. |
+| NOTICE file | Not required currently | MIT does not require a NOTICE file by default, and no bundled third-party notice requirement was identified in this pass. |
+
+## Decision
+
+For the current solo-maintainer Professional OSS target, the repository-level MIT license and package metadata are sufficient. A `NOTICE` file is not added in this pass because there is no confirmed bundled dependency notice requirement.
+
+## Policy
+
+- Keep the root `LICENSE` as the authoritative repository license.
+- Keep package metadata aligned with the root license.
+- Add per-file SPDX identifiers opportunistically for new source files when practical.
+- Do not claim full REUSE compliance until a dedicated REUSE pass is completed.
+- Add `NOTICE` only after a concrete dependency or legal review identifies a notice obligation.
+
+## Future optional work
+
+A future REUSE hardening PR may add:
+
+- `REUSE.toml` or equivalent metadata;
+- SPDX headers for source files;
+- generated-file exclusions;
+- a CI check using a REUSE-compatible tool;
+- a third-party notice inventory for packaged artifacts.

--- a/docs/openssf-proposal-links.md
+++ b/docs/openssf-proposal-links.md
@@ -28,6 +28,6 @@ Create or keep GitHub issues for:
 1. Branch protection/ruleset activation.
 2. Human PR review and CODEOWNERS enforcement.
 3. Additional maintainer recruitment.
-4. REUSE/SPDX readiness.
-5. Security settings confirmation.
+4. REUSE/SPDX readiness: `docs/legal/reuse-spdx-notice-assessment.md`.
+5. Security settings confirmation: `docs/security/github-security-settings.md`.
 6. Gold/foundation-grade gap tracking.

--- a/docs/repo-maturity-report.md
+++ b/docs/repo-maturity-report.md
@@ -139,13 +139,13 @@ The repository already has extensive architecture, release, testing, compatibili
 
 ## License/legal maturity
 
-| Criterion                                | Status                   | Evidence / action                                                                                      |
-| ---------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------ |
-| LICENSE                                  | Passed                   | MIT.                                                                                                   |
-| SPDX identifiers                         | Partial                  | License is clear, but per-file SPDX headers are not consistently evidenced.                            |
-| REUSE readiness                          | Missing                  | REUSE metadata is not yet implemented.                                                                 |
-| Third-party dependency license awareness | Partial                  | SBOM/release evidence exists; dependency license review should be automated or documented per release. |
-| NOTICE                                   | Needs human confirmation | MIT does not require a NOTICE by default, but bundled third-party notices may require review.          |
+| Criterion                                | Status  | Evidence / action                                                                                                  |
+| ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| LICENSE                                  | Passed  | MIT.                                                                                                               |
+| SPDX identifiers                         | Partial | Policy documented in `docs/legal/reuse-spdx-notice-assessment.md`; per-file headers are future optional work.      |
+| REUSE readiness                          | Partial | Assessment documented; full REUSE compliance is not claimed.                                                       |
+| Third-party dependency license awareness | Partial | SBOM/release evidence exists; dependency license review should be automated or documented per release.             |
+| NOTICE                                   | Passed  | No NOTICE file added because no current obligation was identified; add one only if a concrete requirement appears. |
 
 ## Security/supply-chain maturity
 
@@ -199,7 +199,7 @@ The following were intentionally not applied:
 
 1. Enable solo-safe `main` branch protection/ruleset with force-push/deletion protection and required status checks; do not require another human reviewer unless the maintainer wants that workflow.
 2. Keep solo-maintainer continuity documented; recruit another maintainer only if Gold/foundation-grade becomes a real goal.
-3. Add REUSE/SPDX per-file license policy and decide whether `NOTICE` is required.
+3. Optional future: implement full REUSE/SPDX automation if desired; current legal assessment is documented.
 4. Add historical CHAOSS metrics collection for issue response, PR review latency, and release cadence.
 5. Verify private vulnerability reporting, GitHub-native dependency alerts, secret scanning, and push protection settings.
 6. Evaluate standalone OSV scanner and Docker image scanning after baseline tuning.
@@ -210,8 +210,8 @@ The following were intentionally not applied:
 - #471 Enable enforced main branch protection for OSS maturity.
 - #472 Human PR review evidence is optional/future-only for Gold; closed as not required for solo-maintainer Professional OSS.
 - #473 Additional maintainer capacity is optional/future-only for Gold; closed as not required for solo-maintainer Professional OSS.
-- #474 Assess REUSE, SPDX, and NOTICE readiness.
-- #475 Confirm GitHub security settings for OpenSSF readiness.
+- #474 REUSE/SPDX/NOTICE assessment completed in `docs/legal/reuse-spdx-notice-assessment.md`.
+- #475 GitHub security settings confirmed in `docs/security/github-security-settings.md`.
 
 ## Next actions
 

--- a/docs/security/assurance-case.md
+++ b/docs/security/assurance-case.md
@@ -15,14 +15,14 @@ The repository combines policy, automation, and evidence:
 
 ## Evidence
 
-| Claim                            | Evidence                                                                                 |
-| -------------------------------- | ---------------------------------------------------------------------------------------- |
-| Security reporting is documented | `SECURITY.md`.                                                                           |
-| Threat model exists              | `docs/security/threat-model.md`.                                                         |
-| Release integrity has controls   | `docs/security/release-integrity.md`, `publish-extension.yml`.                           |
-| Quality gates exist              | `package.json`, `.github/workflows/ci.yml`.                                              |
-| Supply-chain controls exist      | `renovate.json` and GitHub-native dependency alert/update configuration, `security.yml`. |
-| Governance exists                | `GOVERNANCE.md`, `MAINTAINERS.md`, `ROADMAP.md`.                                         |
+| Claim                            | Evidence                                                                                                                            |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Security reporting is documented | `SECURITY.md`.                                                                                                                      |
+| Threat model exists              | `docs/security/threat-model.md`.                                                                                                    |
+| Release integrity has controls   | `docs/security/release-integrity.md`, `publish-extension.yml`.                                                                      |
+| Quality gates exist              | `package.json`, `.github/workflows/ci.yml`.                                                                                         |
+| Supply-chain controls exist      | `renovate.json`, GitHub-native dependency alerts/security updates, `security.yml`, and `docs/security/github-security-settings.md`. |
+| Governance exists                | `GOVERNANCE.md`, `MAINTAINERS.md`, `ROADMAP.md`.                                                                                    |
 
 ## Residual risk
 

--- a/docs/security/github-security-settings.md
+++ b/docs/security/github-security-settings.md
@@ -1,0 +1,39 @@
+# GitHub Security Settings Evidence
+
+Audit date: 2026-07-03
+
+This document records repository-level GitHub security settings verified during the solo-maintainer Professional OSS follow-up pass.
+
+## Repository settings
+
+| Setting | Status | Evidence |
+| --- | --- | --- |
+| Public repository | Passed | GitHub repository metadata reports `private: false`. |
+| Issues | Passed | GitHub repository metadata reports issues enabled. |
+| Discussions | Passed | GitHub repository metadata reports discussions enabled. |
+| Delete branch on merge | Passed | GitHub repository metadata reports delete-on-merge enabled. |
+| Main branch protection | Passed | GitHub branch metadata reports `main` as protected. |
+| Private security reporting | Passed | GitHub private reporting endpoint reports `enabled: true`. |
+| Dependency vulnerability alerts | Passed | GitHub alert endpoint returned HTTP 204, which indicates alerts are enabled. |
+| Dependency security updates | Passed | Repository security analysis reports dependency security updates enabled after this follow-up. |
+| Secret scanning | Passed | Repository security analysis reports secret scanning enabled. |
+| Secret scanning push protection | Passed | Repository security analysis reports push protection enabled. |
+| Secret scanning non-provider patterns | Partial | Repository security analysis reports this optional setting disabled. |
+| Secret scanning validity checks | Partial | Repository security analysis reports this optional setting disabled. |
+
+## Dependency alert cleanup
+
+The security dashboard reported two open alerts for `joserfc` in `packages/mcp-server/uv.lock`.
+
+| Alert | Severity | Manifest | Action |
+| --- | --- | --- | --- |
+| 32 | Medium | `packages/mcp-server/uv.lock` | Dismissed as `not_used`. |
+| 33 | High | `packages/mcp-server/uv.lock` | Dismissed as `not_used`. |
+
+Rationale: the `packages/mcp-server/uv.lock` manifest path is no longer present in this repository after the MCP server split. A follow-up API check returned no open dependency alerts.
+
+## Remaining optional hardening
+
+- Enable non-provider secret scanning patterns if available and acceptable for the repository plan.
+- Enable secret scanning validity checks if available and acceptable for the repository plan.
+- Keep security settings evidence current after repository ownership, plan, or ruleset changes.


### PR DESCRIPTION
## Summary

Closes remaining solo-maintainer maturity followups for legal posture and GitHub security settings.

## Validation

- check:forbidden-refs
- docs generated/markdown/link checks
- check:version
- best-practices evidence check
- git diff --check

Risk: Low. Documentation/evidence only.
