### PR TITLE
chore: auto-assign incoming issues and PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,25 @@
+name: Auto assign incoming issues and PRs
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    if: github.actor != 'oaslananka'
+
+    steps:
+      - name: Assign to oaslananka
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          gh api --method POST "/repos/$REPO/issues/$NUMBER/assignees" -f assignees[]=oaslananka


### PR DESCRIPTION
Adds repository automation to:

- auto-assign newly opened issues to @oaslananka
- auto-assign newly opened/reopened/ready PRs to @oaslananka
- request @oaslananka as CODEOWNER reviewer for all files

The workflow does not checkout or execute pull request code.