### PR TITLE
ci(repo): enforce runtime policy drift

### DIFF
--- a/.github/workflows/runtime-policy-drift.yml
+++ b/.github/workflows/runtime-policy-drift.yml
@@ -1,0 +1,46 @@
+name: Runtime Policy Drift
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-policy-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - run: corepack enable
+      - run: corepack prepare pnpm@11.6.0 --activate
+      - run: corepack pnpm install --frozen-lockfile
+      - name: Validate deterministic runtime policy metadata
+        run: node scripts/check-runtime-policy.mjs
+      - name: Evaluate authoritative runtime sources
+        run: >-
+          node scripts/check-runtime-policy.mjs
+          --fetch
+          --json runtime-policy-report.json
+          --summary "$GITHUB_STEP_SUMMARY"
+      - name: Upload runtime policy report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: runtime-policy-report
+          path: runtime-policy-report.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -492,6 +492,11 @@ runtimePolicy:
     vscodeInsiders: "https://update.code.visualstudio.com/api/update/linux-x64/insider/latest"
     pythonReleases: "https://peps.python.org/api/python-releases.json"
     kicadDownloads: "https://www.kicad.org/download/linux/"
+  enforcement:
+    vscode: "report"
+    python: "report"
+    kicad: "report"
+    sourceUnavailable: "report"
   vscode:
     maxMinimumMinorLag: 1
     loweringRequiresChangelog: "apps/vscode-extension/CHANGELOG.md"

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -486,7 +486,7 @@ python:
     - "3.14"
 
 runtimePolicy:
-  reviewed: "2026-05-26"
+  reviewed: "2026-07-20"
   sources:
     vscodeStable: "https://update.code.visualstudio.com/api/releases/stable"
     vscodeInsiders: "https://update.code.visualstudio.com/api/update/linux-x64/insider/latest"

--- a/docs/compatibility/runtime-policy.md
+++ b/docs/compatibility/runtime-policy.md
@@ -1,0 +1,70 @@
+# Runtime Policy Enforcement
+
+`compatibility.yaml` is the source of truth for runtime support boundaries and
+for the policy used to detect drift. The checks deliberately separate local,
+deterministic validation from network freshness reporting.
+
+## Deterministic pull-request gate
+
+The root command remains:
+
+```bash
+corepack pnpm run check:compatibility-contract
+```
+
+It invokes the runtime-policy validator without network access and fails when:
+
+- `runtimePolicy.reviewed` or authoritative source URLs are malformed;
+- an enforcement value is not `report` or `error`;
+- lag/window values are not valid non-negative integers;
+- `vscode.enginesRange` differs from the extension manifest;
+- the Python support window does not match `supportedMinorWindow`, begin at
+  `python.range`, or remain contiguous;
+- KiCad primary/latest-verified version syntax is invalid.
+
+These errors are always blocking because they describe an internally
+inconsistent repository contract.
+
+## Scheduled and manual freshness gate
+
+`.github/workflows/runtime-policy-drift.yml` runs weekly and through
+`workflow_dispatch`. It executes:
+
+```bash
+node scripts/check-runtime-policy.mjs \
+  --fetch \
+  --json runtime-policy-report.json \
+  --summary "$GITHUB_STEP_SUMMARY"
+```
+
+The workflow reads the HTTPS sources declared under `runtimePolicy.sources`,
+validates each response before use, writes a human-readable job summary, and
+uploads the complete JSON report. It never edits compatibility metadata.
+
+A source timeout, HTTP failure, or malformed response is reported as `unknown`.
+It is never treated as `current`.
+
+## Enforcement values
+
+Each runtime and unavailable-source result has one explicit enforcement value:
+
+- `report`: show drift or `unknown` evidence while keeping the workflow
+  non-blocking;
+- `error`: return a failing exit code and promote that condition to a blocking
+  policy gate.
+
+Changing `report` to `error` is therefore an explicit policy decision in
+`compatibility.yaml`, not hidden checker behavior.
+
+## Runtime decisions
+
+- **VS Code:** compare `vscode.minimum` with the newest stable minor and report
+  drift beyond `maxMinimumMinorLag`.
+- **Python:** compare `python.supported` with the newest bugfix-status releases
+  selected by `supportedMinorWindow`.
+- **KiCad:** compare the primary major with the newest stable major using
+  `primaryMajorLag`. Patch freshness is reported separately; a newer patch does
+  not automatically change the support claim.
+
+Freshness evidence informs compatibility issues and canaries. Maintainers update
+support claims only after the relevant product tests pass.

--- a/docs/superpowers/plans/2026-07-20-issue-494-runtime-policy-enforcement.md
+++ b/docs/superpowers/plans/2026-07-20-issue-494-runtime-policy-enforcement.md
@@ -1,6 +1,6 @@
 # Runtime Policy Enforcement Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Enforce local runtime policy deterministically and add scheduled upstream freshness evidence for VS Code, Python, and KiCad.
 
@@ -30,11 +30,11 @@
 
 - Produces: `validateRuntimePolicyMetadata`, source parsers, `evaluateRuntimePolicy`, and `renderRuntimePolicyMarkdown`.
 
-- [ ] Write failing tests for valid metadata, malformed metadata, VS Code lag, Python window, KiCad major/patch drift, malformed source data, and `unknown` source state.
-- [ ] Run `node --test scripts/check-runtime-policy.test.mjs` and verify failure because the module does not exist.
-- [ ] Implement the minimal pure policy functions and explicit `runtimePolicy.enforcement` metadata.
-- [ ] Run the focused tests and verify they pass.
-- [ ] Commit the pure policy layer.
+- [x] Write failing tests for valid metadata, malformed metadata, VS Code lag, Python window, KiCad major/patch drift, malformed source data, and `unknown` source state.
+- [x] Run `node --test scripts/check-runtime-policy.test.mjs` and verify failure because the module does not exist.
+- [x] Implement the minimal pure policy functions and explicit `runtimePolicy.enforcement` metadata.
+- [x] Run the focused tests and verify they pass.
+- [x] Commit the pure policy layer.
 
 ### Task 2: Repository CLI and deterministic compatibility integration
 
@@ -49,11 +49,11 @@
 - Consumes: `validateRuntimePolicyMetadata`, source parsers, evaluator, renderer.
 - Produces: `node scripts/check-runtime-policy.mjs [--fetch] [--json path] [--summary path]`.
 
-- [ ] Add failing tests proving `validateCompatibilityContract` rejects malformed runtime policy and accepts the repository policy.
-- [ ] Run the compatibility tests and verify the new malformed-policy case fails.
-- [ ] Implement the CLI and integrate deterministic metadata validation into `check:compatibility-contract`.
-- [ ] Run focused runtime-policy and compatibility tests.
-- [ ] Commit the integration.
+- [x] Add failing tests proving `validateCompatibilityContract` rejects malformed runtime policy and accepts the repository policy.
+- [x] Run the compatibility tests and verify the new malformed-policy case fails.
+- [x] Implement the CLI and integrate deterministic metadata validation into `check:compatibility-contract`.
+- [x] Run focused runtime-policy and compatibility tests.
+- [x] Commit the integration.
 
 ### Task 3: Scheduled evidence workflow and documentation
 
@@ -61,19 +61,18 @@
 
 - Create: `.github/workflows/runtime-policy-drift.yml`
 - Create: `docs/compatibility/runtime-policy.md`
-- Modify: `scripts/check-ci-lanes.mjs`
-- Modify: `scripts/check-ci-lanes.test.mjs`
+- Verify: `scripts/check-ci-lanes.mjs` and `scripts/check-ci-lanes.test.mjs` already route workflow/script changes through full CI
 - Modify: `scripts/check-compatibility-contract.mjs`
 
 **Interfaces:**
 
 - Workflow executes `node scripts/check-runtime-policy.mjs --fetch --json runtime-policy-report.json --summary "$GITHUB_STEP_SUMMARY"`.
 
-- [ ] Add failing CI-lane/workflow contract tests for the new script and workflow.
-- [ ] Run the focused tests and verify failure before workflow/documentation wiring exists.
-- [ ] Add the SHA-pinned scheduled/manual workflow, documentation, required-file contract, and CI-lane triggers.
-- [ ] Run policy, compatibility, CI-lane, docs-generated, Markdown, link, and action lint checks.
-- [ ] Commit the workflow and docs.
+- [x] Add failing CI-lane/workflow contract tests for the new script and workflow.
+- [x] Run the focused tests and verify failure before workflow/documentation wiring exists.
+- [x] Add the SHA-pinned scheduled/manual workflow, documentation, and required-file contract; verify existing generic workflow/script classification already triggers full CI without a classifier change.
+- [x] Run policy, compatibility, CI-lane, docs-generated, Markdown, link, and action lint checks.
+- [x] Commit the workflow and docs.
 
 ### Task 4: Full verification and PR
 
@@ -81,8 +80,18 @@
 
 - Update plan checkboxes with actual evidence.
 
-- [ ] Run `check:compatibility-contract`, focused tests, docs checks, workflow lint, supply-chain checks, and `git diff --check`.
-- [ ] Run the broad root gate; record only pre-existing VPS environment blockers under issue #490.
+- [x] Run `check:compatibility-contract`, focused tests, docs checks, workflow lint, supply-chain checks, and `git diff --check`.
+- [x] Run the broad root gate; record only pre-existing VPS environment blockers under issue #490.
 - [ ] Verify DCO sign-offs, clean worktree, branch divergence, and no overlap with active PR files where avoidable.
 - [ ] Push the branch, open a draft PR closing #494, apply labels/milestone, and monitor all bot/agent reviews and CI checks.
 - [ ] Fix every actionable review or CI finding, then mark the PR ready only after terminal green checks.
+
+## Verification Evidence
+
+- Red tests were observed for the missing runtime-policy module, missing compatibility integration, missing workflow/docs, mixed VS Code feed entries, invalid calendar dates, and major-line JSON handling.
+- Focused result: 16 runtime-policy/compatibility/workflow tests pass.
+- Live evidence on 2026-07-20: VS Code `1.129.1` reports a 28-minor drift from `1.101.0`; Python `3.13`/`3.14` is current; KiCad primary major is current while verified `10.0.3` is behind stable `10.0.4`. All are `report`, so the evidence command exits successfully without changing support claims.
+- Workflow lint: actionlint `1.7.12` passes for `.github/workflows/runtime-policy-drift.yml`.
+- Repository gates passed through repeatable VSIX packaging (101 entries; normalized SHA-256 `1e2cd4590c1ab58e3c6d6ac2078625c55c380b3ff94cc0f3cd0fe36e703b892d`).
+- Broad root gate reaches the pre-existing issue #490 environment boundary: Python `3.12.3` instead of `>=3.13` and missing `uv`; actionlint/Xvfb/KiCad CLI remain warned host tools. No issue #494 policy, test, documentation, workflow, package, or reproducibility failure occurred before that boundary.
+- Branch was `0` commits behind and `4` commits ahead of `origin/main` before the evidence-only plan update.

--- a/docs/superpowers/plans/2026-07-20-issue-494-runtime-policy-enforcement.md
+++ b/docs/superpowers/plans/2026-07-20-issue-494-runtime-policy-enforcement.md
@@ -1,0 +1,88 @@
+# Runtime Policy Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce local runtime policy deterministically and add scheduled upstream freshness evidence for VS Code, Python, and KiCad.
+
+**Architecture:** Pure policy parsing/evaluation lives in `scripts/lib/runtime-policy.mjs`. The existing compatibility gate consumes metadata validation; a separate CLI and workflow own network freshness checks and evidence output.
+
+**Tech Stack:** Node.js 24 ESM, `yaml`, Node test runner, GitHub Actions.
+
+## Global Constraints
+
+- Pull-request validation must not require network access.
+- Source failure must report `unknown`, never silently `current`.
+- Upstream drift is blocking only when `runtimePolicy.enforcement` explicitly says `error`.
+- The checker must not mutate compatibility metadata.
+- Keep work limited to issue #494.
+
+---
+
+### Task 1: Pure metadata and release-source policy
+
+**Files:**
+
+- Create: `scripts/lib/runtime-policy.mjs`
+- Create: `scripts/check-runtime-policy.test.mjs`
+- Modify: `compatibility.yaml`
+
+**Interfaces:**
+
+- Produces: `validateRuntimePolicyMetadata`, source parsers, `evaluateRuntimePolicy`, and `renderRuntimePolicyMarkdown`.
+
+- [ ] Write failing tests for valid metadata, malformed metadata, VS Code lag, Python window, KiCad major/patch drift, malformed source data, and `unknown` source state.
+- [ ] Run `node --test scripts/check-runtime-policy.test.mjs` and verify failure because the module does not exist.
+- [ ] Implement the minimal pure policy functions and explicit `runtimePolicy.enforcement` metadata.
+- [ ] Run the focused tests and verify they pass.
+- [ ] Commit the pure policy layer.
+
+### Task 2: Repository CLI and deterministic compatibility integration
+
+**Files:**
+
+- Create: `scripts/check-runtime-policy.mjs`
+- Modify: `scripts/check-compatibility-contract.mjs`
+- Modify: `scripts/check-compatibility-contract.test.mjs`
+
+**Interfaces:**
+
+- Consumes: `validateRuntimePolicyMetadata`, source parsers, evaluator, renderer.
+- Produces: `node scripts/check-runtime-policy.mjs [--fetch] [--json path] [--summary path]`.
+
+- [ ] Add failing tests proving `validateCompatibilityContract` rejects malformed runtime policy and accepts the repository policy.
+- [ ] Run the compatibility tests and verify the new malformed-policy case fails.
+- [ ] Implement the CLI and integrate deterministic metadata validation into `check:compatibility-contract`.
+- [ ] Run focused runtime-policy and compatibility tests.
+- [ ] Commit the integration.
+
+### Task 3: Scheduled evidence workflow and documentation
+
+**Files:**
+
+- Create: `.github/workflows/runtime-policy-drift.yml`
+- Create: `docs/compatibility/runtime-policy.md`
+- Modify: `scripts/check-ci-lanes.mjs`
+- Modify: `scripts/check-ci-lanes.test.mjs`
+- Modify: `scripts/check-compatibility-contract.mjs`
+
+**Interfaces:**
+
+- Workflow executes `node scripts/check-runtime-policy.mjs --fetch --json runtime-policy-report.json --summary "$GITHUB_STEP_SUMMARY"`.
+
+- [ ] Add failing CI-lane/workflow contract tests for the new script and workflow.
+- [ ] Run the focused tests and verify failure before workflow/documentation wiring exists.
+- [ ] Add the SHA-pinned scheduled/manual workflow, documentation, required-file contract, and CI-lane triggers.
+- [ ] Run policy, compatibility, CI-lane, docs-generated, Markdown, link, and action lint checks.
+- [ ] Commit the workflow and docs.
+
+### Task 4: Full verification and PR
+
+**Files:**
+
+- Update plan checkboxes with actual evidence.
+
+- [ ] Run `check:compatibility-contract`, focused tests, docs checks, workflow lint, supply-chain checks, and `git diff --check`.
+- [ ] Run the broad root gate; record only pre-existing VPS environment blockers under issue #490.
+- [ ] Verify DCO sign-offs, clean worktree, branch divergence, and no overlap with active PR files where avoidable.
+- [ ] Push the branch, open a draft PR closing #494, apply labels/milestone, and monitor all bot/agent reviews and CI checks.
+- [ ] Fix every actionable review or CI finding, then mark the PR ready only after terminal green checks.

--- a/docs/superpowers/specs/2026-07-20-issue-494-runtime-policy-enforcement-design.md
+++ b/docs/superpowers/specs/2026-07-20-issue-494-runtime-policy-enforcement-design.md
@@ -1,0 +1,48 @@
+# Issue 494 Runtime Policy Enforcement Design
+
+## Goal
+
+Make `compatibility.yaml.runtimePolicy` enforceable without making pull-request validation depend on network access.
+
+## Decision
+
+Use two layers:
+
+1. **Deterministic metadata validation** runs inside the existing root `check:compatibility-contract` command. It validates the policy schema and local relationships between VS Code, Python, and KiCad compatibility metadata.
+2. **Upstream freshness evaluation** runs only in a new scheduled/manual workflow. It fetches authoritative sources, validates their shapes, emits JSON and Markdown evidence, and reports `current`, `drift`, or `unknown` per runtime.
+
+## Policy model
+
+`runtimePolicy.enforcement` declares `report` or `error` for each upstream runtime and for unavailable/malformed sources. `report` keeps the workflow green while surfacing drift. `error` promotes that finding to a blocking failure without changing checker code.
+
+Internal metadata errors always fail. Network failures never become implicit success: they produce `unknown` and follow `sourceUnavailable` enforcement.
+
+## Pure interfaces
+
+`scripts/lib/runtime-policy.mjs` owns pure validation and evaluation:
+
+- `validateRuntimePolicyMetadata({ compatibility, extensionPackage }) -> string[]`
+- `parseVsCodeStableRelease(payload) -> string`
+- `parsePythonBugfixWindow(payload) -> string[]`
+- `parseKiCadStableRelease(html) -> string`
+- `evaluateRuntimePolicy({ compatibility, upstream }) -> RuntimePolicyReport`
+- `renderRuntimePolicyMarkdown(report) -> string`
+
+`scripts/check-runtime-policy.mjs` owns repository I/O, fetch timeouts, report files, CLI arguments, and exit status.
+
+## Runtime rules
+
+- VS Code: compare `vscode.minimum` minor to the latest stable minor. Drift exists when lag exceeds `maxMinimumMinorLag`.
+- Python: compare `python.supported` to the highest `supportedMinorWindow` releases whose status is `bugfix`.
+- KiCad: compare the major from `kicad.primary` to the latest stable major. Drift exists when lag exceeds `primaryMajorLag`. Patch freshness is reported separately by comparing `kicad.latestVerified` with the fetched stable release; patch drift does not change the primary-major decision.
+
+## Workflow
+
+`.github/workflows/runtime-policy-drift.yml` runs weekly and manually with read-only contents permission. It installs the pinned Node/pnpm toolchain, executes the checker with `--fetch`, appends Markdown to `$GITHUB_STEP_SUMMARY`, and uploads the JSON report. No issue-writing permission is required.
+
+## Non-goals
+
+- Automatically editing compatibility claims.
+- Installing KiCad or running CLI canaries.
+- Moving server-owned Python policy into this repository.
+- Making transient upstream outages silently pass as current.

--- a/scripts/check-compatibility-contract.mjs
+++ b/scripts/check-compatibility-contract.mjs
@@ -18,6 +18,7 @@ const DOCS_FILES = [
   "docs/publishing.md",
   "docs/protocol-schemas.md",
   "docs/support-matrix.md",
+  "docs/compatibility/runtime-policy.md",
 ];
 
 const REQUIRED_FILES = [
@@ -31,6 +32,14 @@ const REQUIRED_FILES = [
     label: "Release coordination runbook",
   },
   { path: "docs/EMERGENCY-RELEASE-FLOW.md", label: "Emergency release flow" },
+  {
+    path: ".github/workflows/runtime-policy-drift.yml",
+    label: "Runtime policy drift workflow",
+  },
+  {
+    path: "docs/compatibility/runtime-policy.md",
+    label: "Runtime policy documentation",
+  },
 ];
 
 function readFile(filePath) {

--- a/scripts/check-compatibility-contract.mjs
+++ b/scripts/check-compatibility-contract.mjs
@@ -6,6 +6,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 
+import { validateRuntimePolicyMetadata } from "./lib/runtime-policy.mjs";
+
 const SCRIPT_ROOT = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_ROOT, "..");
 
@@ -293,6 +295,24 @@ function checkLocalProtocolSchemasAbsent(errors) {
   }
 }
 
+function checkRuntimePolicyMetadata(errors, options = {}) {
+  if (
+    !fileExists("compatibility.yaml") ||
+    !fileExists("apps/vscode-extension/package.json")
+  ) {
+    return;
+  }
+  const compatibility =
+    options.runtimePolicyCompatibility ??
+    parseYaml(readFile("compatibility.yaml"));
+  const extensionPackage =
+    options.runtimePolicyExtensionPackage ??
+    JSON.parse(readFile("apps/vscode-extension/package.json"));
+  errors.push(
+    ...validateRuntimePolicyMetadata({ compatibility, extensionPackage }),
+  );
+}
+
 function checkDocsChangedWithContract(errors, changedFiles) {
   const contractChanged = changedFiles.some((file) =>
     COMPATIBILITY_CONTRACT_FILES.some(
@@ -323,6 +343,7 @@ export function validateCompatibilityContract(options = {}) {
   checkEmbeddedExtensionCompatibilityMatrix(errors);
   checkStudioConsumesPublishedPackage(errors);
   checkLocalProtocolSchemasAbsent(errors);
+  checkRuntimePolicyMetadata(errors, options);
   checkDocsChangedWithContract(errors, changedFiles);
 
   return errors;

--- a/scripts/check-compatibility-contract.test.mjs
+++ b/scripts/check-compatibility-contract.test.mjs
@@ -55,3 +55,16 @@ test("embedded extension compatibility matrix rejects product-version drift", ()
 test("repository compatibility contract validates current state", () => {
   assert.deepEqual(validateCompatibilityContract(), []);
 });
+
+test("#494 compatibility contract rejects malformed runtime policy metadata", () => {
+  const malformed = structuredClone(compatibility);
+  malformed.runtimePolicy.enforcement.vscode = "ignore";
+
+  assert.match(
+    validateCompatibilityContract({
+      runtimePolicyCompatibility: malformed,
+      runtimePolicyExtensionPackage: extensionPackage,
+    }).join("\n"),
+    /runtimePolicy\.enforcement\.vscode/u,
+  );
+});

--- a/scripts/check-runtime-policy-workflow.test.mjs
+++ b/scripts/check-runtime-policy-workflow.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import { parse as parseYaml } from "yaml";
+
+const workflowPath = ".github/workflows/runtime-policy-drift.yml";
+const docsPath = "docs/compatibility/runtime-policy.md";
+
+test("#494 scheduled runtime policy workflow is manual, weekly, and least privilege", () => {
+  const source = fs.readFileSync(workflowPath, "utf8");
+  const workflow = parseYaml(source);
+
+  assert.ok(Object.hasOwn(workflow.on, "workflow_dispatch"));
+  assert.equal(workflow.on.schedule.length, 1);
+  assert.equal(workflow.permissions.contents, "read");
+  assert.equal(workflow.jobs.drift["runs-on"], "ubuntu-24.04");
+  assert.match(
+    source,
+    /node scripts\/check-runtime-policy\.mjs[\s\S]*?--fetch/u,
+  );
+  assert.match(source, /--json runtime-policy-report\.json/u);
+  assert.match(source, /GITHUB_STEP_SUMMARY/u);
+  assert.match(source, /actions\/upload-artifact@[0-9a-f]{40}/u);
+  assert.doesNotMatch(source, /issues:\s*write/u);
+});
+
+test("#494 runtime policy documentation explains deterministic and network gates", () => {
+  const docs = fs.readFileSync(docsPath, "utf8");
+  assert.match(docs, /^# Runtime Policy Enforcement$/mu);
+  assert.match(docs, /check:compatibility-contract/u);
+  assert.match(docs, /scheduled and manual/iu);
+  assert.match(docs, /unknown/u);
+  assert.match(docs, /report/u);
+  assert.match(docs, /error/u);
+});

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+import {
+  evaluateRuntimePolicy,
+  parseKiCadStableRelease,
+  parsePythonBugfixWindow,
+  parseVsCodeStableRelease,
+  renderRuntimePolicyMarkdown,
+  validateRuntimePolicyMetadata,
+} from "./lib/runtime-policy.mjs";
+
+const SCRIPT_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_ROOT, "..");
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+function readCompatibility() {
+  return parseYaml(
+    fs.readFileSync(path.join(REPO_ROOT, "compatibility.yaml"), "utf8"),
+  );
+}
+
+function readExtensionPackage() {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(REPO_ROOT, "apps/vscode-extension/package.json"),
+      "utf8",
+    ),
+  );
+}
+
+function parseArgs(argv) {
+  const options = { fetch: false };
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--fetch") {
+      options.fetch = true;
+    } else if (arg === "--json") {
+      options.jsonPath = argv[++index];
+    } else if (arg === "--summary") {
+      options.summaryPath = argv[++index];
+    } else if (arg === "--timeout-ms") {
+      options.timeoutMs = Number(argv[++index]);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (
+    options.timeoutMs !== undefined &&
+    (!Number.isInteger(options.timeoutMs) || options.timeoutMs < 1)
+  ) {
+    throw new Error("--timeout-ms must be a positive integer");
+  }
+  return options;
+}
+
+async function fetchSource(url, format, timeoutMs) {
+  const response = await fetch(url, {
+    headers: {
+      accept:
+        format === "json"
+          ? "application/json"
+          : "text/html,application/xhtml+xml",
+      "user-agent": "kicad-studio-kit-runtime-policy/1",
+    },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+  }
+  return format === "json" ? response.json() : response.text();
+}
+
+async function resolveUpstream(compatibility, timeoutMs) {
+  const sources = compatibility.runtimePolicy.sources;
+  const upstream = {};
+
+  try {
+    const payload = await fetchSource(sources.vscodeStable, "json", timeoutMs);
+    upstream.vscode = {
+      status: "available",
+      version: parseVsCodeStableRelease(payload),
+    };
+  } catch (error) {
+    upstream.vscode = { status: "unknown", error: error.message };
+  }
+
+  try {
+    const payload = await fetchSource(
+      sources.pythonReleases,
+      "json",
+      timeoutMs,
+    );
+    upstream.python = {
+      status: "available",
+      versions: parsePythonBugfixWindow(payload),
+    };
+  } catch (error) {
+    upstream.python = { status: "unknown", error: error.message };
+  }
+
+  try {
+    const payload = await fetchSource(
+      sources.kicadDownloads,
+      "html",
+      timeoutMs,
+    );
+    upstream.kicad = {
+      status: "available",
+      version: parseKiCadStableRelease(payload),
+    };
+  } catch (error) {
+    upstream.kicad = { status: "unknown", error: error.message };
+  }
+
+  return upstream;
+}
+
+function writeFile(relativeOrAbsolutePath, content, append = false) {
+  const target = path.isAbsolute(relativeOrAbsolutePath)
+    ? relativeOrAbsolutePath
+    : path.join(REPO_ROOT, relativeOrAbsolutePath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  if (append) {
+    fs.appendFileSync(target, content, "utf8");
+  } else {
+    fs.writeFileSync(target, content, "utf8");
+  }
+}
+
+export async function runRuntimePolicyCheck(options = {}) {
+  const compatibility = options.compatibility ?? readCompatibility();
+  const extensionPackage = options.extensionPackage ?? readExtensionPackage();
+  const errors = validateRuntimePolicyMetadata({
+    compatibility,
+    extensionPackage,
+  });
+  if (errors.length > 0) {
+    return { errors, report: undefined, exitCode: 1 };
+  }
+  if (!options.fetch) {
+    return { errors: [], report: undefined, exitCode: 0 };
+  }
+
+  const upstream =
+    options.upstream ??
+    (await resolveUpstream(
+      compatibility,
+      options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    ));
+  const report = evaluateRuntimePolicy({ compatibility, upstream });
+  return { errors: [], report, exitCode: report.exitCode };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const result = await runRuntimePolicyCheck(options);
+  if (result.errors.length > 0) {
+    console.error("Runtime policy metadata validation failed:");
+    for (const error of result.errors) console.error(`- ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!result.report) {
+    console.log("Runtime policy metadata is internally consistent.");
+    return;
+  }
+
+  const markdown = renderRuntimePolicyMarkdown(result.report);
+  console.log(markdown);
+  if (options.jsonPath) {
+    writeFile(options.jsonPath, `${JSON.stringify(result.report, null, 2)}\n`);
+  }
+  if (options.summaryPath) {
+    writeFile(options.summaryPath, `${markdown}\n`, true);
+  }
+  process.exitCode = result.exitCode;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`Runtime policy check failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check-runtime-policy.mjs
+++ b/scripts/check-runtime-policy.mjs
@@ -183,8 +183,10 @@ async function main() {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  main().catch((error) => {
+  try {
+    await main();
+  } catch (error) {
     console.error(`Runtime policy check failed: ${error.message}`);
     process.exitCode = 1;
-  });
+  }
 }

--- a/scripts/check-runtime-policy.test.mjs
+++ b/scripts/check-runtime-policy.test.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evaluateRuntimePolicy,
+  parseKiCadStableRelease,
+  parsePythonBugfixWindow,
+  parseVsCodeStableRelease,
+  renderRuntimePolicyMarkdown,
+  validateRuntimePolicyMetadata,
+} from "./lib/runtime-policy.mjs";
+
+function makeCompatibility() {
+  return {
+    kicad: { primary: "10.0.x", latestVerified: "10.0.3" },
+    vscode: { minimum: "1.128.0", enginesRange: "^1.128.0" },
+    python: {
+      range: ">=3.13",
+      primary: "3.13",
+      supported: ["3.13", "3.14"],
+    },
+    runtimePolicy: {
+      reviewed: "2026-07-20",
+      sources: {
+        vscodeStable:
+          "https://update.code.visualstudio.com/api/releases/stable",
+        vscodeInsiders:
+          "https://update.code.visualstudio.com/api/update/linux-x64/insider/latest",
+        pythonReleases: "https://peps.python.org/api/python-releases.json",
+        kicadDownloads: "https://www.kicad.org/download/linux/",
+      },
+      enforcement: {
+        vscode: "report",
+        python: "report",
+        kicad: "report",
+        sourceUnavailable: "report",
+      },
+      vscode: {
+        maxMinimumMinorLag: 1,
+        loweringRequiresChangelog: "apps/vscode-extension/CHANGELOG.md",
+      },
+      python: { supportedMinorWindow: 2 },
+      kicad: {
+        primaryMajorLag: 0,
+        loweringRequiresChangelogs: ["apps/vscode-extension/CHANGELOG.md"],
+      },
+    },
+  };
+}
+
+const extensionPackage = { engines: { vscode: "^1.128.0" } };
+
+test("#494 validates deterministic runtime policy metadata", () => {
+  assert.deepEqual(
+    validateRuntimePolicyMetadata({
+      compatibility: makeCompatibility(),
+      extensionPackage,
+    }),
+    [],
+  );
+});
+
+test("#494 rejects malformed and internally inconsistent runtime policy metadata", () => {
+  const compatibility = makeCompatibility();
+  compatibility.runtimePolicy.reviewed = "not-a-date";
+  compatibility.runtimePolicy.enforcement.python = "ignore";
+  compatibility.runtimePolicy.vscode.maxMinimumMinorLag = -1;
+  compatibility.runtimePolicy.python.supportedMinorWindow = 3;
+  compatibility.runtimePolicy.kicad.primaryMajorLag = "zero";
+  compatibility.vscode.enginesRange = "^1.127.0";
+
+  const errors = validateRuntimePolicyMetadata({
+    compatibility,
+    extensionPackage,
+  }).join("\n");
+
+  assert.match(errors, /runtimePolicy\.reviewed/u);
+  assert.match(errors, /runtimePolicy\.enforcement\.python/u);
+  assert.match(errors, /maxMinimumMinorLag/u);
+  assert.match(errors, /supportedMinorWindow/u);
+  assert.match(errors, /primaryMajorLag/u);
+  assert.match(errors, /engines\.vscode/u);
+});
+
+test("#494 parses authoritative VS Code, Python, and KiCad source shapes", () => {
+  assert.equal(parseVsCodeStableRelease(["1.129.1", "1.129.0"]), "1.129.1");
+  assert.deepEqual(
+    parsePythonBugfixWindow({
+      metadata: {
+        3.12: { status: "security" },
+        3.13: { status: "bugfix" },
+        3.14: { status: "bugfix" },
+        3.15: { status: "prerelease" },
+      },
+    }),
+    ["3.13", "3.14"],
+  );
+  assert.equal(
+    parseKiCadStableRelease(
+      '<a href="https://downloads.kicad.org/kicad-10.0.4-x86_64.AppImage">Download</a>',
+    ),
+    "10.0.4",
+  );
+});
+
+test("#494 source parsers fail closed for malformed upstream data", () => {
+  assert.throws(() => parseVsCodeStableRelease({}), /VS Code/u);
+  assert.throws(
+    () => parsePythonBugfixWindow({ metadata: { 3.14: {} } }),
+    /Python/u,
+  );
+  assert.throws(() => parseKiCadStableRelease("no release here"), /KiCad/u);
+});
+
+test("#494 reports current runtime policy when all upstream data is within policy", () => {
+  const report = evaluateRuntimePolicy({
+    compatibility: makeCompatibility(),
+    upstream: {
+      vscode: { status: "available", version: "1.129.1" },
+      python: { status: "available", versions: ["3.13", "3.14"] },
+      kicad: { status: "available", version: "10.0.3" },
+    },
+  });
+
+  assert.equal(report.status, "current");
+  assert.deepEqual(
+    report.runtimes.map(({ runtime, status }) => ({ runtime, status })),
+    [
+      { runtime: "vscode", status: "current" },
+      { runtime: "python", status: "current" },
+      { runtime: "kicad", status: "current" },
+    ],
+  );
+  assert.equal(report.exitCode, 0);
+});
+
+test("#494 reports VS Code, Python, and KiCad drift with patch freshness evidence", () => {
+  const report = evaluateRuntimePolicy({
+    compatibility: makeCompatibility(),
+    upstream: {
+      vscode: { status: "available", version: "1.131.0" },
+      python: { status: "available", versions: ["3.14", "3.15"] },
+      kicad: { status: "available", version: "11.0.1" },
+    },
+  });
+
+  assert.equal(report.status, "drift");
+  assert.match(report.runtimes[0].message, /lag 3 exceeds 1/u);
+  assert.match(report.runtimes[1].message, /3\.14, 3\.15/u);
+  assert.match(report.runtimes[2].message, /major lag 1 exceeds 0/u);
+  assert.equal(report.runtimes[2].details.patchFreshness, "behind");
+  assert.equal(report.exitCode, 0, "report enforcement is non-blocking");
+});
+
+test("#494 promotes explicitly configured upstream drift to a failure", () => {
+  const compatibility = makeCompatibility();
+  compatibility.runtimePolicy.enforcement.vscode = "error";
+
+  const report = evaluateRuntimePolicy({
+    compatibility,
+    upstream: {
+      vscode: { status: "available", version: "1.131.0" },
+      python: { status: "available", versions: ["3.13", "3.14"] },
+      kicad: { status: "available", version: "10.0.3" },
+    },
+  });
+
+  assert.equal(report.exitCode, 1);
+  assert.equal(report.runtimes[0].enforcement, "error");
+});
+
+test("#494 reports unavailable sources as unknown instead of current", () => {
+  const report = evaluateRuntimePolicy({
+    compatibility: makeCompatibility(),
+    upstream: {
+      vscode: { status: "unknown", error: "timeout" },
+      python: { status: "available", versions: ["3.13", "3.14"] },
+      kicad: { status: "available", version: "10.0.3" },
+    },
+  });
+
+  assert.equal(report.status, "unknown");
+  assert.equal(report.runtimes[0].status, "unknown");
+  assert.match(report.runtimes[0].message, /timeout/u);
+  assert.equal(report.exitCode, 0);
+});
+
+test("#494 renders a readable workflow summary", () => {
+  const report = evaluateRuntimePolicy({
+    compatibility: makeCompatibility(),
+    upstream: {
+      vscode: { status: "available", version: "1.129.1" },
+      python: { status: "available", versions: ["3.13", "3.14"] },
+      kicad: { status: "available", version: "10.0.4" },
+    },
+  });
+
+  const markdown = renderRuntimePolicyMarkdown(report);
+  assert.match(markdown, /^# Runtime Policy Drift Report/mu);
+  assert.match(markdown, /\| VS Code \| current \| report \|/u);
+  assert.match(markdown, /KiCad stable patch 10\.0\.4/u);
+});

--- a/scripts/check-runtime-policy.test.mjs
+++ b/scripts/check-runtime-policy.test.mjs
@@ -62,7 +62,7 @@ test("#494 validates deterministic runtime policy metadata", () => {
 
 test("#494 rejects malformed and internally inconsistent runtime policy metadata", () => {
   const compatibility = makeCompatibility();
-  compatibility.runtimePolicy.reviewed = "not-a-date";
+  compatibility.runtimePolicy.reviewed = "2026-02-31";
   compatibility.runtimePolicy.enforcement.python = "ignore";
   compatibility.runtimePolicy.vscode.maxMinimumMinorLag = -1;
   compatibility.runtimePolicy.python.supportedMinorWindow = 3;
@@ -84,6 +84,10 @@ test("#494 rejects malformed and internally inconsistent runtime policy metadata
 
 test("#494 parses authoritative VS Code, Python, and KiCad source shapes", () => {
   assert.equal(parseVsCodeStableRelease(["1.129.1", "1.129.0"]), "1.129.1");
+  assert.equal(
+    parseVsCodeStableRelease(["1.129.1", "1.20.0-insider", "legacy"]),
+    "1.129.1",
+  );
   assert.deepEqual(
     parsePythonBugfixWindow({
       metadata: {
@@ -150,6 +154,22 @@ test("#494 reports VS Code, Python, and KiCad drift with patch freshness evidenc
   assert.match(report.runtimes[2].message, /major lag 1 exceeds 0/u);
   assert.equal(report.runtimes[2].details.patchFreshness, "behind");
   assert.equal(report.exitCode, 0, "report enforcement is non-blocking");
+});
+
+test("#494 reports a VS Code major-line change without non-finite JSON values", () => {
+  const report = evaluateRuntimePolicy({
+    compatibility: makeCompatibility(),
+    upstream: {
+      vscode: { status: "available", version: "2.0.0" },
+      python: { status: "available", versions: ["3.13", "3.14"] },
+      kicad: { status: "available", version: "10.0.3" },
+    },
+  });
+
+  assert.equal(report.runtimes[0].status, "drift");
+  assert.equal(report.runtimes[0].details.minorLag, null);
+  assert.match(report.runtimes[0].message, /major line/u);
+  assert.doesNotMatch(JSON.stringify(report), /null.*Infinity|Infinity/u);
 });
 
 test("#494 promotes explicitly configured upstream drift to a failure", () => {

--- a/scripts/lib/runtime-policy.mjs
+++ b/scripts/lib/runtime-policy.mjs
@@ -40,8 +40,8 @@ function compareVersions(left, right) {
   return 0;
 }
 
-function compareVersionsDescending(left, right) {
-  return compareVersions(right, left);
+function compareVersionsDescending(first, second) {
+  return compareVersions(second, first);
 }
 
 function isNonNegativeInteger(value) {

--- a/scripts/lib/runtime-policy.mjs
+++ b/scripts/lib/runtime-policy.mjs
@@ -37,7 +37,13 @@ function validDate(value) {
   if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
     return false;
   }
-  return !Number.isNaN(Date.parse(`${value}T00:00:00Z`));
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
 }
 
 function validateHttpsSource(errors, sources, key) {
@@ -197,9 +203,11 @@ export function parseVsCodeStableRelease(payload) {
   if (!Array.isArray(payload)) {
     throw new Error("VS Code stable release source must be an array");
   }
-  const versions = payload.map((value) =>
-    parseNumericVersion(value, "VS Code stable release", 3),
-  );
+  const versions = payload
+    .filter(
+      (value) => typeof value === "string" && /^\d+\.\d+\.\d+$/u.test(value),
+    )
+    .map((value) => parseNumericVersion(value, "VS Code stable release", 3));
   if (versions.length === 0) {
     throw new Error("VS Code stable release source returned no versions");
   }
@@ -259,21 +267,29 @@ function evaluateVsCode(compatibility, upstream) {
     3,
   );
   const stable = parseNumericVersion(upstream.version, "VS Code stable", 3);
-  const lag =
-    stable.major === minimum.major
-      ? stable.minor - minimum.minor
-      : Number.POSITIVE_INFINITY;
+  const majorLineChanged = stable.major !== minimum.major;
+  const lag = majorLineChanged ? null : stable.minor - minimum.minor;
   const allowed = policy.vscode.maxMinimumMinorLag;
-  const status = lag > allowed ? "drift" : "current";
+  const status = majorLineChanged || lag > allowed ? "drift" : "current";
+  let message;
+  if (status === "current") {
+    message = `VS Code minimum ${minimum.value} is within ${allowed} minor(s) of stable ${stable.value}.`;
+  } else if (majorLineChanged) {
+    message = `VS Code stable ${stable.value} is on a different major line than minimum ${minimum.value}.`;
+  } else {
+    message = `VS Code minimum ${minimum.value} lag ${lag} exceeds ${allowed} against stable ${stable.value}.`;
+  }
   return {
     runtime: "vscode",
     status,
     enforcement: policy.enforcement.vscode,
-    message:
-      status === "current"
-        ? `VS Code minimum ${minimum.value} is within ${allowed} minor(s) of stable ${stable.value}.`
-        : `VS Code minimum ${minimum.value} lag ${String(lag)} exceeds ${allowed} against stable ${stable.value}.`,
-    details: { minimum: minimum.value, stable: stable.value, minorLag: lag },
+    message,
+    details: {
+      minimum: minimum.value,
+      stable: stable.value,
+      minorLag: lag,
+      majorLineChanged,
+    },
   };
 }
 
@@ -334,7 +350,7 @@ function evaluateKiCad(compatibility, upstream) {
     enforcement: policy.enforcement.kicad,
     message:
       status === "current"
-        ? `KiCad primary ${compatibility.kicad.primary} matches stable major ${stable.major}; KiCad stable patch ${stable.value} is ${patchFreshness} versus verified ${verified.value}.`
+        ? `KiCad primary ${compatibility.kicad.primary} matches stable major ${stable.major}; verified baseline ${verified.value} is ${patchFreshness} versus KiCad stable patch ${stable.value}.`
         : `KiCad primary ${compatibility.kicad.primary} major lag ${majorLag} exceeds ${allowed} against stable ${stable.value}; verified patch is ${verified.value}.`,
     details: {
       primary: compatibility.kicad.primary,

--- a/scripts/lib/runtime-policy.mjs
+++ b/scripts/lib/runtime-policy.mjs
@@ -1,11 +1,22 @@
 const ENFORCEMENT_VALUES = new Set(["report", "error"]);
 const RUNTIMES = ["vscode", "python", "kicad"];
+const SOURCE_KEYS = [
+  "vscodeStable",
+  "vscodeInsiders",
+  "pythonReleases",
+  "kicadDownloads",
+];
+const VERSION_PATTERN = /^(\d+)\.(\d+)(?:\.(\d+))?$/u;
+const STRICT_VERSION_PATTERN = /^\d+\.\d+\.\d+$/u;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
+const KICAD_PRIMARY_PATTERN = /^(\d+)\.(\d+)\.x$/u;
+const KICAD_DOWNLOAD_VERSION_PATTERN = /\bkicad-(\d+\.\d+\.\d+)\b/giu;
 
 function parseNumericVersion(value, label, segments = 2) {
   if (typeof value !== "string") {
-    throw new Error(`${label} must be a version string`);
+    throw new TypeError(`${label} must be a version string`);
   }
-  const match = value.match(/^(\d+)\.(\d+)(?:\.(\d+))?$/u);
+  const match = VERSION_PATTERN.exec(value);
   if (!match || (segments === 3 && match[3] === undefined)) {
     throw new Error(`${label} must be a numeric ${segments}-segment version`);
   }
@@ -29,12 +40,16 @@ function compareVersions(left, right) {
   return 0;
 }
 
+function compareVersionsDescending(left, right) {
+  return compareVersions(right, left);
+}
+
 function isNonNegativeInteger(value) {
   return Number.isInteger(value) && value >= 0;
 }
 
 function validDate(value) {
-  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
+  if (typeof value !== "string" || !DATE_PATTERN.test(value)) {
     return false;
   }
   const [year, month, day] = value.split("-").map(Number);
@@ -50,7 +65,7 @@ function validateHttpsSource(errors, sources, key) {
   const value = sources?.[key];
   try {
     const url = new URL(value);
-    if (url.protocol !== "https:") throw new Error("not HTTPS");
+    if (url.protocol !== "https:") throw new TypeError("not HTTPS");
   } catch {
     errors.push(
       `compatibility.yaml runtimePolicy.sources.${key} must be a valid HTTPS URL`,
@@ -58,31 +73,15 @@ function validateHttpsSource(errors, sources, key) {
   }
 }
 
-export function validateRuntimePolicyMetadata({
-  compatibility,
-  extensionPackage,
-} = {}) {
-  const errors = [];
-  const policy = compatibility?.runtimePolicy;
-  if (!policy || typeof policy !== "object") {
-    return ["compatibility.yaml: missing runtimePolicy object"];
-  }
-
+function validatePolicyEnvelope(errors, policy) {
   if (!validDate(policy.reviewed)) {
     errors.push(
       "compatibility.yaml runtimePolicy.reviewed must be a valid YYYY-MM-DD date",
     );
   }
-
-  for (const key of [
-    "vscodeStable",
-    "vscodeInsiders",
-    "pythonReleases",
-    "kicadDownloads",
-  ]) {
+  for (const key of SOURCE_KEYS) {
     validateHttpsSource(errors, policy.sources, key);
   }
-
   for (const key of [...RUNTIMES, "sourceUnavailable"]) {
     if (!ENFORCEMENT_VALUES.has(policy.enforcement?.[key])) {
       errors.push(
@@ -90,7 +89,9 @@ export function validateRuntimePolicyMetadata({
       );
     }
   }
+}
 
+function validatePolicyThresholds(errors, policy) {
   if (!isNonNegativeInteger(policy.vscode?.maxMinimumMinorLag)) {
     errors.push(
       "compatibility.yaml runtimePolicy.vscode.maxMinimumMinorLag must be a non-negative integer",
@@ -109,12 +110,23 @@ export function validateRuntimePolicyMetadata({
       "compatibility.yaml runtimePolicy.kicad.primaryMajorLag must be a non-negative integer",
     );
   }
+}
 
+function appendVersionError(errors, value, label, segments) {
   try {
-    parseNumericVersion(compatibility?.vscode?.minimum, "vscode.minimum", 3);
+    parseNumericVersion(value, label, segments);
   } catch (error) {
     errors.push(`compatibility.yaml ${error.message}`);
   }
+}
+
+function validateVsCodeMetadata(errors, compatibility, extensionPackage) {
+  appendVersionError(
+    errors,
+    compatibility?.vscode?.minimum,
+    "vscode.minimum",
+    3,
+  );
   if (
     compatibility?.vscode?.enginesRange !== extensionPackage?.engines?.vscode
   ) {
@@ -122,103 +134,142 @@ export function validateRuntimePolicyMetadata({
       `apps/vscode-extension/package.json engines.vscode (${String(extensionPackage?.engines?.vscode)}) must match compatibility.yaml vscode.enginesRange (${String(compatibility?.vscode?.enginesRange)})`,
     );
   }
+}
 
-  const supportedPython = compatibility?.python?.supported;
+function normalizePythonSupported(errors, supportedPython) {
   if (!Array.isArray(supportedPython) || supportedPython.length === 0) {
     errors.push(
       "compatibility.yaml python.supported must be a non-empty array",
     );
-  } else {
-    const normalized = [];
-    for (const value of supportedPython) {
-      try {
-        normalized.push(parseMinorVersion(value, "python.supported entry"));
-      } catch (error) {
-        errors.push(`compatibility.yaml ${error.message}`);
-      }
-    }
-    if (
-      isNonNegativeInteger(policy.python?.supportedMinorWindow) &&
-      normalized.length !== policy.python.supportedMinorWindow
-    ) {
-      errors.push(
-        `compatibility.yaml python.supported must contain exactly runtimePolicy.python.supportedMinorWindow (${policy.python.supportedMinorWindow}) entries`,
-      );
-    }
-    if (normalized.length > 0) {
-      const expectedRange = `>=${normalized[0]}`;
-      if (compatibility.python?.range !== expectedRange) {
-        errors.push(
-          `compatibility.yaml python.range must start at the first supported minor (${expectedRange})`,
-        );
-      }
-      if (compatibility.python?.primary !== normalized[0]) {
-        errors.push(
-          `compatibility.yaml python.primary must equal the first supported minor (${normalized[0]})`,
-        );
-      }
-      for (let index = 1; index < normalized.length; index++) {
-        const previous = parseNumericVersion(
-          normalized[index - 1],
-          "python.supported",
-          2,
-        );
-        const current = parseNumericVersion(
-          normalized[index],
-          "python.supported",
-          2,
-        );
-        if (
-          current.major !== previous.major ||
-          current.minor !== previous.minor + 1
-        ) {
-          errors.push(
-            "compatibility.yaml python.supported minors must be contiguous and ascending",
-          );
-          break;
-        }
-      }
+    return [];
+  }
+  const normalized = [];
+  for (const value of supportedPython) {
+    try {
+      normalized.push(parseMinorVersion(value, "python.supported entry"));
+    } catch (error) {
+      errors.push(`compatibility.yaml ${error.message}`);
     }
   }
+  return normalized;
+}
 
-  if (!/^\d+\.\d+\.x$/u.test(compatibility?.kicad?.primary ?? "")) {
+function validatePythonWindowSize(errors, normalized, window) {
+  if (isNonNegativeInteger(window) && normalized.length !== window) {
+    errors.push(
+      `compatibility.yaml python.supported must contain exactly runtimePolicy.python.supportedMinorWindow (${window}) entries`,
+    );
+  }
+}
+
+function validatePythonRangeAndPrimary(errors, compatibility, normalized) {
+  if (normalized.length === 0) return;
+  const expectedRange = `>=${normalized[0]}`;
+  if (compatibility.python?.range !== expectedRange) {
+    errors.push(
+      `compatibility.yaml python.range must start at the first supported minor (${expectedRange})`,
+    );
+  }
+  if (compatibility.python?.primary !== normalized[0]) {
+    errors.push(
+      `compatibility.yaml python.primary must equal the first supported minor (${normalized[0]})`,
+    );
+  }
+}
+
+function pythonMinorsAreContiguous(normalized) {
+  for (let index = 1; index < normalized.length; index++) {
+    const previous = parseNumericVersion(
+      normalized[index - 1],
+      "python.supported",
+      2,
+    );
+    const current = parseNumericVersion(
+      normalized[index],
+      "python.supported",
+      2,
+    );
+    if (
+      current.major !== previous.major ||
+      current.minor !== previous.minor + 1
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function validatePythonMetadata(errors, compatibility, policy) {
+  const normalized = normalizePythonSupported(
+    errors,
+    compatibility?.python?.supported,
+  );
+  validatePythonWindowSize(
+    errors,
+    normalized,
+    policy.python?.supportedMinorWindow,
+  );
+  validatePythonRangeAndPrimary(errors, compatibility, normalized);
+  if (normalized.length > 0 && !pythonMinorsAreContiguous(normalized)) {
+    errors.push(
+      "compatibility.yaml python.supported minors must be contiguous and ascending",
+    );
+  }
+}
+
+function validateKiCadMetadata(errors, compatibility) {
+  if (!KICAD_PRIMARY_PATTERN.test(compatibility?.kicad?.primary ?? "")) {
     errors.push(
       "compatibility.yaml kicad.primary must use a major.minor.x range",
     );
   }
-  try {
-    parseNumericVersion(
-      compatibility?.kicad?.latestVerified,
-      "kicad.latestVerified",
-      3,
-    );
-  } catch (error) {
-    errors.push(`compatibility.yaml ${error.message}`);
+  appendVersionError(
+    errors,
+    compatibility?.kicad?.latestVerified,
+    "kicad.latestVerified",
+    3,
+  );
+}
+
+export function validateRuntimePolicyMetadata({
+  compatibility,
+  extensionPackage,
+} = {}) {
+  const policy = compatibility?.runtimePolicy;
+  if (!policy || typeof policy !== "object") {
+    return ["compatibility.yaml: missing runtimePolicy object"];
   }
 
+  const errors = [];
+  validatePolicyEnvelope(errors, policy);
+  validatePolicyThresholds(errors, policy);
+  validateVsCodeMetadata(errors, compatibility, extensionPackage);
+  validatePythonMetadata(errors, compatibility, policy);
+  validateKiCadMetadata(errors, compatibility);
   return errors;
 }
 
 export function parseVsCodeStableRelease(payload) {
   if (!Array.isArray(payload)) {
-    throw new Error("VS Code stable release source must be an array");
+    throw new TypeError("VS Code stable release source must be an array");
   }
   const versions = payload
     .filter(
-      (value) => typeof value === "string" && /^\d+\.\d+\.\d+$/u.test(value),
+      (value) =>
+        typeof value === "string" && STRICT_VERSION_PATTERN.test(value),
     )
     .map((value) => parseNumericVersion(value, "VS Code stable release", 3));
   if (versions.length === 0) {
     throw new Error("VS Code stable release source returned no versions");
   }
-  versions.sort((left, right) => compareVersions(right, left));
+  versions.sort(compareVersionsDescending);
   return versions[0].value;
 }
 
 export function parsePythonBugfixWindow(payload) {
   const metadata = payload?.metadata;
   if (!metadata || typeof metadata !== "object") {
-    throw new Error("Python release source must contain metadata");
+    throw new TypeError("Python release source must contain metadata");
   }
   const versions = Object.entries(metadata)
     .filter(([, value]) => value?.status === "bugfix")
@@ -233,16 +284,16 @@ export function parsePythonBugfixWindow(payload) {
 
 export function parseKiCadStableRelease(html) {
   if (typeof html !== "string") {
-    throw new Error("KiCad download source must be HTML text");
+    throw new TypeError("KiCad download source must be HTML text");
   }
-  const matches = [...html.matchAll(/\bkicad-(\d+\.\d+\.\d+)\b/giu)];
+  const matches = [...html.matchAll(KICAD_DOWNLOAD_VERSION_PATTERN)];
   if (matches.length === 0) {
     throw new Error("KiCad download source returned no stable release version");
   }
   const versions = matches.map((match) =>
     parseNumericVersion(match[1], "KiCad stable release", 3),
   );
-  versions.sort((left, right) => compareVersions(right, left));
+  versions.sort(compareVersionsDescending);
   return versions[0].value;
 }
 
@@ -328,7 +379,7 @@ function evaluateKiCad(compatibility, upstream) {
   if (upstream?.status !== "available") {
     return unknownRuntime("kicad", upstream, policy);
   }
-  const primaryMatch = compatibility.kicad.primary.match(/^(\d+)\.(\d+)\.x$/u);
+  const primaryMatch = KICAD_PRIMARY_PATTERN.exec(compatibility.kicad.primary);
   const primary = {
     major: Number(primaryMatch[1]),
     minor: Number(primaryMatch[2]),
@@ -362,14 +413,18 @@ function evaluateKiCad(compatibility, upstream) {
   };
 }
 
+function determineOverallStatus(runtimes) {
+  if (runtimes.some(({ status }) => status === "unknown")) return "unknown";
+  if (runtimes.some(({ status }) => status === "drift")) return "drift";
+  return "current";
+}
+
 export function evaluateRuntimePolicy({ compatibility, upstream } = {}) {
   const runtimes = [
     evaluateVsCode(compatibility, upstream?.vscode),
     evaluatePython(compatibility, upstream?.python),
     evaluateKiCad(compatibility, upstream?.kicad),
   ];
-  const hasUnknown = runtimes.some(({ status }) => status === "unknown");
-  const hasDrift = runtimes.some(({ status }) => status === "drift");
   const exitCode = runtimes.some(
     ({ status, enforcement }) =>
       status !== "current" && enforcement === "error",
@@ -379,7 +434,7 @@ export function evaluateRuntimePolicy({ compatibility, upstream } = {}) {
   return {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
-    status: hasUnknown ? "unknown" : hasDrift ? "drift" : "current",
+    status: determineOverallStatus(runtimes),
     exitCode,
     runtimes,
   };
@@ -390,10 +445,11 @@ function label(runtime) {
 }
 
 export function renderRuntimePolicyMarkdown(report) {
+  const escapedPipe = String.raw`\|`;
   const rows = report.runtimes
     .map(
       (item) =>
-        `| ${label(item.runtime)} | ${item.status} | ${item.enforcement} | ${item.message.replaceAll("|", "\\|")} |`,
+        `| ${label(item.runtime)} | ${item.status} | ${item.enforcement} | ${item.message.replaceAll("|", escapedPipe)} |`,
     )
     .join("\n");
   return `# Runtime Policy Drift Report

--- a/scripts/lib/runtime-policy.mjs
+++ b/scripts/lib/runtime-policy.mjs
@@ -1,0 +1,391 @@
+const ENFORCEMENT_VALUES = new Set(["report", "error"]);
+const RUNTIMES = ["vscode", "python", "kicad"];
+
+function parseNumericVersion(value, label, segments = 2) {
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a version string`);
+  }
+  const match = value.match(/^(\d+)\.(\d+)(?:\.(\d+))?$/u);
+  if (!match || (segments === 3 && match[3] === undefined)) {
+    throw new Error(`${label} must be a numeric ${segments}-segment version`);
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3] ?? 0),
+    value,
+  };
+}
+
+function parseMinorVersion(value, label) {
+  const parsed = parseNumericVersion(value, label, 2);
+  return `${parsed.major}.${parsed.minor}`;
+}
+
+function compareVersions(left, right) {
+  for (const key of ["major", "minor", "patch"]) {
+    if (left[key] !== right[key]) return left[key] - right[key];
+  }
+  return 0;
+}
+
+function isNonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function validDate(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
+    return false;
+  }
+  return !Number.isNaN(Date.parse(`${value}T00:00:00Z`));
+}
+
+function validateHttpsSource(errors, sources, key) {
+  const value = sources?.[key];
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:") throw new Error("not HTTPS");
+  } catch {
+    errors.push(
+      `compatibility.yaml runtimePolicy.sources.${key} must be a valid HTTPS URL`,
+    );
+  }
+}
+
+export function validateRuntimePolicyMetadata({
+  compatibility,
+  extensionPackage,
+} = {}) {
+  const errors = [];
+  const policy = compatibility?.runtimePolicy;
+  if (!policy || typeof policy !== "object") {
+    return ["compatibility.yaml: missing runtimePolicy object"];
+  }
+
+  if (!validDate(policy.reviewed)) {
+    errors.push(
+      "compatibility.yaml runtimePolicy.reviewed must be a valid YYYY-MM-DD date",
+    );
+  }
+
+  for (const key of [
+    "vscodeStable",
+    "vscodeInsiders",
+    "pythonReleases",
+    "kicadDownloads",
+  ]) {
+    validateHttpsSource(errors, policy.sources, key);
+  }
+
+  for (const key of [...RUNTIMES, "sourceUnavailable"]) {
+    if (!ENFORCEMENT_VALUES.has(policy.enforcement?.[key])) {
+      errors.push(
+        `compatibility.yaml runtimePolicy.enforcement.${key} must be report or error`,
+      );
+    }
+  }
+
+  if (!isNonNegativeInteger(policy.vscode?.maxMinimumMinorLag)) {
+    errors.push(
+      "compatibility.yaml runtimePolicy.vscode.maxMinimumMinorLag must be a non-negative integer",
+    );
+  }
+  if (
+    !isNonNegativeInteger(policy.python?.supportedMinorWindow) ||
+    policy.python.supportedMinorWindow < 1
+  ) {
+    errors.push(
+      "compatibility.yaml runtimePolicy.python.supportedMinorWindow must be a positive integer",
+    );
+  }
+  if (!isNonNegativeInteger(policy.kicad?.primaryMajorLag)) {
+    errors.push(
+      "compatibility.yaml runtimePolicy.kicad.primaryMajorLag must be a non-negative integer",
+    );
+  }
+
+  try {
+    parseNumericVersion(compatibility?.vscode?.minimum, "vscode.minimum", 3);
+  } catch (error) {
+    errors.push(`compatibility.yaml ${error.message}`);
+  }
+  if (
+    compatibility?.vscode?.enginesRange !== extensionPackage?.engines?.vscode
+  ) {
+    errors.push(
+      `apps/vscode-extension/package.json engines.vscode (${String(extensionPackage?.engines?.vscode)}) must match compatibility.yaml vscode.enginesRange (${String(compatibility?.vscode?.enginesRange)})`,
+    );
+  }
+
+  const supportedPython = compatibility?.python?.supported;
+  if (!Array.isArray(supportedPython) || supportedPython.length === 0) {
+    errors.push(
+      "compatibility.yaml python.supported must be a non-empty array",
+    );
+  } else {
+    const normalized = [];
+    for (const value of supportedPython) {
+      try {
+        normalized.push(parseMinorVersion(value, "python.supported entry"));
+      } catch (error) {
+        errors.push(`compatibility.yaml ${error.message}`);
+      }
+    }
+    if (
+      isNonNegativeInteger(policy.python?.supportedMinorWindow) &&
+      normalized.length !== policy.python.supportedMinorWindow
+    ) {
+      errors.push(
+        `compatibility.yaml python.supported must contain exactly runtimePolicy.python.supportedMinorWindow (${policy.python.supportedMinorWindow}) entries`,
+      );
+    }
+    if (normalized.length > 0) {
+      const expectedRange = `>=${normalized[0]}`;
+      if (compatibility.python?.range !== expectedRange) {
+        errors.push(
+          `compatibility.yaml python.range must start at the first supported minor (${expectedRange})`,
+        );
+      }
+      if (compatibility.python?.primary !== normalized[0]) {
+        errors.push(
+          `compatibility.yaml python.primary must equal the first supported minor (${normalized[0]})`,
+        );
+      }
+      for (let index = 1; index < normalized.length; index++) {
+        const previous = parseNumericVersion(
+          normalized[index - 1],
+          "python.supported",
+          2,
+        );
+        const current = parseNumericVersion(
+          normalized[index],
+          "python.supported",
+          2,
+        );
+        if (
+          current.major !== previous.major ||
+          current.minor !== previous.minor + 1
+        ) {
+          errors.push(
+            "compatibility.yaml python.supported minors must be contiguous and ascending",
+          );
+          break;
+        }
+      }
+    }
+  }
+
+  if (!/^\d+\.\d+\.x$/u.test(compatibility?.kicad?.primary ?? "")) {
+    errors.push(
+      "compatibility.yaml kicad.primary must use a major.minor.x range",
+    );
+  }
+  try {
+    parseNumericVersion(
+      compatibility?.kicad?.latestVerified,
+      "kicad.latestVerified",
+      3,
+    );
+  } catch (error) {
+    errors.push(`compatibility.yaml ${error.message}`);
+  }
+
+  return errors;
+}
+
+export function parseVsCodeStableRelease(payload) {
+  if (!Array.isArray(payload)) {
+    throw new Error("VS Code stable release source must be an array");
+  }
+  const versions = payload.map((value) =>
+    parseNumericVersion(value, "VS Code stable release", 3),
+  );
+  if (versions.length === 0) {
+    throw new Error("VS Code stable release source returned no versions");
+  }
+  versions.sort((left, right) => compareVersions(right, left));
+  return versions[0].value;
+}
+
+export function parsePythonBugfixWindow(payload) {
+  const metadata = payload?.metadata;
+  if (!metadata || typeof metadata !== "object") {
+    throw new Error("Python release source must contain metadata");
+  }
+  const versions = Object.entries(metadata)
+    .filter(([, value]) => value?.status === "bugfix")
+    .map(([version]) => parseNumericVersion(version, "Python release", 2))
+    .sort(compareVersions)
+    .map(({ major, minor }) => `${major}.${minor}`);
+  if (versions.length === 0) {
+    throw new Error("Python release source returned no bugfix releases");
+  }
+  return versions;
+}
+
+export function parseKiCadStableRelease(html) {
+  if (typeof html !== "string") {
+    throw new Error("KiCad download source must be HTML text");
+  }
+  const matches = [...html.matchAll(/\bkicad-(\d+\.\d+\.\d+)\b/giu)];
+  if (matches.length === 0) {
+    throw new Error("KiCad download source returned no stable release version");
+  }
+  const versions = matches.map((match) =>
+    parseNumericVersion(match[1], "KiCad stable release", 3),
+  );
+  versions.sort((left, right) => compareVersions(right, left));
+  return versions[0].value;
+}
+
+function unknownRuntime(runtime, upstream, policy) {
+  return {
+    runtime,
+    status: "unknown",
+    enforcement: policy.enforcement.sourceUnavailable,
+    message: `Source unavailable or malformed: ${upstream?.error ?? "unknown error"}`,
+    details: {},
+  };
+}
+
+function evaluateVsCode(compatibility, upstream) {
+  const policy = compatibility.runtimePolicy;
+  if (upstream?.status !== "available") {
+    return unknownRuntime("vscode", upstream, policy);
+  }
+  const minimum = parseNumericVersion(
+    compatibility.vscode.minimum,
+    "vscode.minimum",
+    3,
+  );
+  const stable = parseNumericVersion(upstream.version, "VS Code stable", 3);
+  const lag =
+    stable.major === minimum.major
+      ? stable.minor - minimum.minor
+      : Number.POSITIVE_INFINITY;
+  const allowed = policy.vscode.maxMinimumMinorLag;
+  const status = lag > allowed ? "drift" : "current";
+  return {
+    runtime: "vscode",
+    status,
+    enforcement: policy.enforcement.vscode,
+    message:
+      status === "current"
+        ? `VS Code minimum ${minimum.value} is within ${allowed} minor(s) of stable ${stable.value}.`
+        : `VS Code minimum ${minimum.value} lag ${String(lag)} exceeds ${allowed} against stable ${stable.value}.`,
+    details: { minimum: minimum.value, stable: stable.value, minorLag: lag },
+  };
+}
+
+function evaluatePython(compatibility, upstream) {
+  const policy = compatibility.runtimePolicy;
+  if (upstream?.status !== "available") {
+    return unknownRuntime("python", upstream, policy);
+  }
+  const window = policy.python.supportedMinorWindow;
+  const upstreamVersions = [...upstream.versions]
+    .map((version) =>
+      parseNumericVersion(version, "Python upstream version", 2),
+    )
+    .sort(compareVersions)
+    .slice(-window)
+    .map(({ major, minor }) => `${major}.${minor}`);
+  const declared = compatibility.python.supported;
+  const status =
+    JSON.stringify(declared) === JSON.stringify(upstreamVersions)
+      ? "current"
+      : "drift";
+  return {
+    runtime: "python",
+    status,
+    enforcement: policy.enforcement.python,
+    message:
+      status === "current"
+        ? `Python supported window matches bugfix releases ${upstreamVersions.join(", ")}.`
+        : `Python supported window ${declared.join(", ")} differs from bugfix releases ${upstreamVersions.join(", ")}.`,
+    details: { declared, upstream: upstreamVersions },
+  };
+}
+
+function evaluateKiCad(compatibility, upstream) {
+  const policy = compatibility.runtimePolicy;
+  if (upstream?.status !== "available") {
+    return unknownRuntime("kicad", upstream, policy);
+  }
+  const primaryMatch = compatibility.kicad.primary.match(/^(\d+)\.(\d+)\.x$/u);
+  const primary = {
+    major: Number(primaryMatch[1]),
+    minor: Number(primaryMatch[2]),
+  };
+  const stable = parseNumericVersion(upstream.version, "KiCad stable", 3);
+  const verified = parseNumericVersion(
+    compatibility.kicad.latestVerified,
+    "kicad.latestVerified",
+    3,
+  );
+  const majorLag = stable.major - primary.major;
+  const allowed = policy.kicad.primaryMajorLag;
+  const status = majorLag > allowed ? "drift" : "current";
+  const patchFreshness =
+    compareVersions(verified, stable) < 0 ? "behind" : "current";
+  return {
+    runtime: "kicad",
+    status,
+    enforcement: policy.enforcement.kicad,
+    message:
+      status === "current"
+        ? `KiCad primary ${compatibility.kicad.primary} matches stable major ${stable.major}; KiCad stable patch ${stable.value} is ${patchFreshness} versus verified ${verified.value}.`
+        : `KiCad primary ${compatibility.kicad.primary} major lag ${majorLag} exceeds ${allowed} against stable ${stable.value}; verified patch is ${verified.value}.`,
+    details: {
+      primary: compatibility.kicad.primary,
+      stable: stable.value,
+      latestVerified: verified.value,
+      majorLag,
+      patchFreshness,
+    },
+  };
+}
+
+export function evaluateRuntimePolicy({ compatibility, upstream } = {}) {
+  const runtimes = [
+    evaluateVsCode(compatibility, upstream?.vscode),
+    evaluatePython(compatibility, upstream?.python),
+    evaluateKiCad(compatibility, upstream?.kicad),
+  ];
+  const hasUnknown = runtimes.some(({ status }) => status === "unknown");
+  const hasDrift = runtimes.some(({ status }) => status === "drift");
+  const exitCode = runtimes.some(
+    ({ status, enforcement }) =>
+      status !== "current" && enforcement === "error",
+  )
+    ? 1
+    : 0;
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    status: hasUnknown ? "unknown" : hasDrift ? "drift" : "current",
+    exitCode,
+    runtimes,
+  };
+}
+
+function label(runtime) {
+  return { vscode: "VS Code", python: "Python", kicad: "KiCad" }[runtime];
+}
+
+export function renderRuntimePolicyMarkdown(report) {
+  const rows = report.runtimes
+    .map(
+      (item) =>
+        `| ${label(item.runtime)} | ${item.status} | ${item.enforcement} | ${item.message.replaceAll("|", "\\|")} |`,
+    )
+    .join("\n");
+  return `# Runtime Policy Drift Report
+
+Overall status: **${report.status}**
+
+| Runtime | Status | Enforcement | Evidence |
+| --- | --- | --- | --- |
+${rows}
+`;
+}


### PR DESCRIPTION
## Summary

- enforce `compatibility.yaml.runtimePolicy` as a deterministic, network-free part of `check:compatibility-contract`
- add pure VS Code, Python, and KiCad source parsers plus `current` / `drift` / `unknown` evaluation with explicit `report` or `error` enforcement
- add a least-privilege weekly/manual workflow that writes a job summary and uploads JSON evidence without mutating support claims
- document local and upstream enforcement behavior, including fail-closed source validation

The current live evidence is intentionally report-only:

- VS Code stable `1.129.1` versus minimum `1.101.0`: drift (28 minors)
- Python bugfix window `3.13`, `3.14`: current
- KiCad stable `10.0.4` versus verified `10.0.3`: patch freshness behind while primary major remains current

No runtime support floor or compatibility claim is changed automatically.

## Linked issue

Closes #494

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [x] type:chore
- [ ] breaking

## Test evidence

- `node --test scripts/check-runtime-policy.test.mjs scripts/check-runtime-policy-workflow.test.mjs scripts/check-compatibility-contract.test.mjs` — 16 passing
- `node scripts/check-runtime-policy.mjs --fetch --json ... --summary ...` — live report produced; report-only drift exits successfully
- `actionlint 1.7.12 .github/workflows/runtime-policy-drift.yml` — passed
- `corepack pnpm run check:compatibility-contract` — passed
- `corepack pnpm run check:forbidden-refs` — passed
- `corepack pnpm run check:version` — passed
- `corepack pnpm run check:supply-chain` — passed
- `corepack pnpm run check:ci-lanes` — 9 passing
- `corepack pnpm run check:testing-strategy` — passed
- generated docs, Markdown, link checks, and VitePress build — passed
- repeatable VSIX validation — 101 entries, normalized SHA-256 `1e2cd4590c1ab58e3c6d6ac2078625c55c380b3ff94cc0f3cd0fe36e703b892d`
- broad `corepack pnpm run check` reached only the existing #490 host boundary: Python 3.12.3 instead of >=3.13 and missing `uv`; no #494 gate failed before it

## Protocol / MCP impact

This PR changes compatibility-policy metadata, not MCP protocol behavior or product compatibility ranges.

Checklist reference: `docs/architecture/protocol-change-checklist.md`

- [ ] Not applicable; reason:
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [x] Contract tests updated
- [x] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

Backward compatibility impact: none. Existing VS Code, Python, KiCad, MCP, and product version declarations remain unchanged; only policy enforcement metadata is added.

## Repository maturity impact

- [ ] No repository maturity impact
- [x] Documentation/community health updated
- [x] CI/quality/release process updated
- [ ] Governance/security/supply-chain process updated
- [ ] Manual GitHub setting or maintainer action required and documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [x] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
- [x] Developer Certificate of Origin sign-off is present on non-trivial commits (`git commit -s`) or not applicable with rationale
- [x] Meets the [Definition of Done](../docs/architecture/definition-of-done.md) for this change type; not-applicable items are justified

Not-applicable checklist items: this is not a bug fix and has no user-visible release-note requirement; those boxes are acknowledged as not applicable rather than omitted.
