### PR TITLE
feat(repo): add rootless validation host

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ Python/MCP server checks run from the
 For a reproducible VS Code Dev Containers or GitHub Codespaces environment, use
 the checked-in [devcontainer configuration](docs/devcontainer.md). The container
 sets up Node, pnpm, Python, uv, Playwright, shellcheck, actionlint, GitHub CLI,
-and best-effort KiCad CLI support for root checks and MCP tests.
+and best-effort KiCad CLI support for root checks and MCP tests. For a
+least-privilege VPS without a container daemon, use the checked-in
+[rootless validation-host profile](docs/validation-host.md).
 
 ## Install
 
@@ -135,6 +137,7 @@ for the command catalog.
 - [Release model](docs/architecture/release-model.md)
 - [Testing strategy](docs/testing-strategy.md)
 - [Dev container](docs/devcontainer.md)
+- [Rootless validation host](docs/validation-host.md)
 - [KiCad fixture corpus](docs/kicad-fixture-corpus.md)
 - [Integration model](docs/integration/kicad-studio-mcp.md)
 - [Agent onboarding](docs/agents/index.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -110,3 +110,12 @@ Use the [dev container](devcontainer.md) for reproducible VS Code Dev Containers
 or GitHub Codespaces setup. Inside the container,
 `corepack pnpm run dev-doctor -- --require-devcontainer` confirms the
 devcontainer marker and required tools.
+
+For a least-privilege Linux validation or release-recovery host without a
+container daemon, use the [rootless validation-host runbook](validation-host.md):
+
+```bash
+corepack pnpm run validation-host:bootstrap
+corepack pnpm run validation-host:doctor
+corepack pnpm run validation-host:check
+```

--- a/docs/superpowers/plans/2026-07-20-issue-490-vps-validation-host.md
+++ b/docs/superpowers/plans/2026-07-20-issue-490-vps-validation-host.md
@@ -22,11 +22,11 @@
 
 - Create: `scripts/check-validation-host.test.mjs`
 
-- [ ] Test exact mise pins and package-script wiring.
-- [ ] Test that bootstrap and runner are executable and contain rootless/least-privilege safeguards.
-- [ ] Test the runner's print-environment mode under a temporary HOME.
-- [ ] Test that documentation records the KiCad canary boundary.
-- [ ] Run the tests and verify RED before implementation.
+- [x] Test exact mise pins and package-script wiring.
+- [x] Test that bootstrap and runner are executable and contain rootless/least-privilege safeguards.
+- [x] Test the runner's print-environment mode under a temporary HOME.
+- [x] Test that documentation records the KiCad canary boundary.
+- [x] Run the tests and verify RED before implementation.
 
 ### Task 2: Implement the pinned and rootless environment
 
@@ -37,12 +37,12 @@
 - Create: `scripts/bootstrap-validation-host.sh`
 - Create: `scripts/run-validation-host.sh`
 
-- [ ] Pin Node 24.18.0, Python 3.13.14, uv 0.11.21, actionlint 1.7.12, and ShellCheck 0.9.0.
-- [ ] Force mise data/config/cache/state under `$HOME` and neutralize leaked global config paths.
-- [ ] Install tools, enable pnpm in the pinned Node prefix, install frozen dependencies, and install Chromium.
-- [ ] Derive Playwright dependencies, add Xvfb/xauth, resolve apt candidates, and atomically build a cached apt root.
-- [ ] Export PATH/library/font/XKB/Playwright variables only through the wrapper.
-- [ ] Prove repeat runs are no-op/cache reuse where inputs are unchanged.
+- [x] Pin Node 24.18.0, Python 3.13.14, uv 0.11.21, actionlint 1.7.12, and ShellCheck 0.9.0.
+- [x] Force mise data/config/cache/state under `$HOME` and neutralize leaked global config paths.
+- [x] Install tools, enable pnpm in the pinned Node prefix, install frozen dependencies, and install Chromium.
+- [x] Derive Playwright dependencies, add Xvfb/xauth, resolve apt candidates, and atomically build a cached apt root.
+- [x] Export PATH/library/font/XKB/Playwright variables only through the wrapper.
+- [x] Prove repeat runs are no-op/cache reuse where inputs are unchanged.
 
 ### Task 3: Add repository validation and documentation
 
@@ -53,16 +53,19 @@
 - Modify: `package.json`
 - Modify: `README.md`
 - Modify: `docs/contributing.md`
+- Modify: `scripts/generate-docs-site.mjs`
+- Modify: `packages/test-harness/test/paths.test.ts`
 
-- [ ] Validate exact pins, scripts, docs, package wiring, and canary ownership.
-- [ ] Add bootstrap, doctor, check, package, and static-check scripts.
-- [ ] Link the runbook from contributor entry points.
-- [ ] Run static tests and verify GREEN.
+- [x] Validate exact pins, scripts, docs, package wiring, and canary ownership.
+- [x] Add bootstrap, doctor, check, package, and static-check scripts.
+- [x] Link the runbook from contributor entry points.
+- [x] Run static tests and verify GREEN.
+- [x] Make repository-root validation work from canonical clones and Git worktrees.
 
 ### Task 4: Verify on VPS-2 and deliver
 
-- [ ] Bootstrap twice and verify idempotence.
-- [ ] Run strict doctor and confirm only documented optional/canary warnings remain.
-- [ ] Run real a11y under rootless Chromium libraries.
-- [ ] Run the full root check and extension package validation.
+- [x] Bootstrap twice and verify idempotence.
+- [x] Run strict doctor and confirm only documented optional/canary warnings remain.
+- [x] Run real a11y under rootless Chromium libraries.
+- [x] Run the full root check and extension package validation.
 - [ ] Review the diff, commit with DCO sign-off, push, open a PR closing #490, and watch all required checks to terminal state.

--- a/docs/superpowers/plans/2026-07-20-issue-490-vps-validation-host.md
+++ b/docs/superpowers/plans/2026-07-20-issue-490-vps-validation-host.md
@@ -1,0 +1,68 @@
+# Issue 490 VPS Validation Host Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans or superpowers:subagent-driven-development task-by-task.
+
+**Goal:** Provide an idempotent rootless bootstrap and execution wrapper that makes VPS-2 reproduce repository, browser, packaging, and release-recovery checks.
+
+**Architecture:** Pin user tools in `mise.toml`; install/cache them with a Bash bootstrap; derive and extract Playwright/Xvfb Ubuntu packages into a user cache; activate the environment through one wrapper; validate the contract with deterministic Node tests.
+
+**Tech Stack:** Bash, mise, Corepack/pnpm 11, Playwright, apt/dpkg, Node 24 test runner.
+
+## Constraints
+
+- Work only on #490.
+- Do not use or require sudo, Docker daemon access, or repository secrets.
+- Do not lower Node/Python/KiCad support requirements.
+- Do not install Ubuntu's unsupported KiCad 7 package.
+- Keep downloaded tools and packages outside the repository.
+
+### Task 1: Capture the validation-host contract
+
+**Files:**
+
+- Create: `scripts/check-validation-host.test.mjs`
+
+- [ ] Test exact mise pins and package-script wiring.
+- [ ] Test that bootstrap and runner are executable and contain rootless/least-privilege safeguards.
+- [ ] Test the runner's print-environment mode under a temporary HOME.
+- [ ] Test that documentation records the KiCad canary boundary.
+- [ ] Run the tests and verify RED before implementation.
+
+### Task 2: Implement the pinned and rootless environment
+
+**Files:**
+
+- Create: `mise.toml`
+- Create: `scripts/lib/validation-host-env.sh`
+- Create: `scripts/bootstrap-validation-host.sh`
+- Create: `scripts/run-validation-host.sh`
+
+- [ ] Pin Node 24.18.0, Python 3.13.14, uv 0.11.21, actionlint 1.7.12, and ShellCheck 0.9.0.
+- [ ] Force mise data/config/cache/state under `$HOME` and neutralize leaked global config paths.
+- [ ] Install tools, enable pnpm in the pinned Node prefix, install frozen dependencies, and install Chromium.
+- [ ] Derive Playwright dependencies, add Xvfb/xauth, resolve apt candidates, and atomically build a cached apt root.
+- [ ] Export PATH/library/font/XKB/Playwright variables only through the wrapper.
+- [ ] Prove repeat runs are no-op/cache reuse where inputs are unchanged.
+
+### Task 3: Add repository validation and documentation
+
+**Files:**
+
+- Create: `scripts/check-validation-host.mjs`
+- Create: `docs/validation-host.md`
+- Modify: `package.json`
+- Modify: `README.md`
+- Modify: `docs/contributing.md`
+
+- [ ] Validate exact pins, scripts, docs, package wiring, and canary ownership.
+- [ ] Add bootstrap, doctor, check, package, and static-check scripts.
+- [ ] Link the runbook from contributor entry points.
+- [ ] Run static tests and verify GREEN.
+
+### Task 4: Verify on VPS-2 and deliver
+
+- [ ] Bootstrap twice and verify idempotence.
+- [ ] Run strict doctor and confirm only documented optional/canary warnings remain.
+- [ ] Run real a11y under rootless Chromium libraries.
+- [ ] Run the full root check and extension package validation.
+- [ ] Review the diff, commit with DCO sign-off, push, open a PR closing #490, and watch all required checks to terminal state.

--- a/docs/superpowers/specs/2026-07-20-issue-490-vps-validation-host-design.md
+++ b/docs/superpowers/specs/2026-07-20-issue-490-vps-validation-host-design.md
@@ -1,0 +1,38 @@
+# Issue 490 VPS Validation Host Design
+
+## Goal
+
+Make VPS-2 a reproducible, least-privilege validation and release-recovery host without weakening repository runtime requirements or requiring root access.
+
+## Architecture
+
+The checked-in contract has three layers:
+
+1. `mise.toml` pins the user-space toolchain: Node, Python, uv, actionlint, and ShellCheck.
+2. `scripts/bootstrap-validation-host.sh` installs the pinned tools, enables Corepack pnpm, performs the frozen-lockfile install, installs Playwright Chromium, and builds a rootless Ubuntu runtime under the user's cache.
+3. `scripts/run-validation-host.sh` activates the pinned mise tools and rootless runtime before executing doctor, check, package, or an arbitrary validation command.
+
+The rootless runtime is not a chroot and does not modify `/usr`. It derives the required Chromium/Xvfb package names from Playwright's own `install-deps --dry-run chromium` output, adds `xauth`, downloads packages through the host's signed apt metadata, and extracts the `.deb` payloads into `$HOME/.cache/kicad-studio-kit`. `PATH`, `LD_LIBRARY_PATH`, XKB, font, and Playwright cache variables expose that layer only to wrapped commands.
+
+## Idempotence and trust
+
+All mise state is forced under the executing account's real `$HOME`; this prevents the current service environment from leaking the read-only `/home/opsrunner` configuration into the `exec-agent` account. The repository config contains only safe plain `[tools]` entries, but bootstrap still records trust explicitly. Repeated runs reuse pinned mise installations, pnpm's store, Playwright's browser cache, downloaded `.deb` files, and an apt-root manifest hash.
+
+The rootless apt layer is rebuilt atomically when the Ubuntu release, architecture, Playwright dependency package list, or apt candidate versions change. Repository files never contain credentials or host-specific absolute paths.
+
+## KiCad CLI boundary
+
+Ubuntu 24.04's configured repository offers KiCad 7.0.11, below this repository's supported 8–10 range. Bootstrap must not install or pretend to validate against that unsupported version. VPS-2 covers repository, extension, browser, packaging, and release-recovery gates; supported KiCad CLI/GUI compatibility remains isolated to the existing scheduled/manual canary lanes and is reported as a non-blocking doctor warning in CI mode.
+
+## Validation contract
+
+The implementation is complete when these commands pass from a fresh user cache:
+
+```bash
+bash scripts/bootstrap-validation-host.sh
+corepack pnpm run validation-host:doctor
+corepack pnpm run validation-host:check
+corepack pnpm run validation-host:package
+```
+
+Static repository checks must verify exact tool pins, executable scripts, rootless package behavior, documentation, package-script wiring, and the canary boundary.

--- a/docs/validation-host.md
+++ b/docs/validation-host.md
@@ -1,0 +1,91 @@
+# Rootless Validation Host
+
+VPS-2 can reproduce repository, extension, browser, packaging, and emergency
+release checks without administrator access. The checked-in validation-host
+contract complements the [dev container](devcontainer.md): use the container
+when a daemon is available, and use this rootless profile for the least-privilege
+`exec-agent` service account.
+
+## Host prerequisites
+
+The host must provide Ubuntu 24.04, Git, `mise` 2026.7.7 or newer, and the
+standard `apt-get`, `apt-cache`, `dpkg`, `dpkg-deb`, and `dpkg-architecture`
+commands. The service account needs a writable `$HOME` and read access to the
+host's signed apt metadata. It does not need sudo, Docker, or repository
+credentials. The bootstrap manages every project runtime below that `$HOME`; it
+does not install `mise` itself.
+
+## What the bootstrap installs
+
+`mise.toml` pins Node 24.18.0, Python 3.13.14, uv 0.11.21, actionlint 1.7.12,
+and ShellCheck 0.9.0. Bootstrap forces mise state below the executing account's
+`$HOME`, enables pnpm through Corepack, installs the frozen workspace lockfile,
+and installs Playwright Chromium.
+
+On Ubuntu 24.04, Chromium and Xvfb system packages are downloaded through the
+host's signed apt metadata and extracted below
+`$HOME/.cache/kicad-studio-kit`. Nothing is written to `/usr`, no daemon is
+required, and repeated runs reuse a manifest-keyed cache. The cache can be
+removed safely; the next bootstrap reconstructs it.
+
+## Bootstrap
+
+From the repository root:
+
+```bash
+bash scripts/bootstrap-validation-host.sh
+```
+
+Preview the actions without changing caches:
+
+```bash
+bash scripts/bootstrap-validation-host.sh --dry-run
+```
+
+The bootstrap ends with the strict CI-safe developer doctor. Optional remote
+`tunnel` tooling is not installed.
+
+## Validation commands
+
+```bash
+corepack pnpm run validation-host:doctor
+corepack pnpm run validation-host:check
+corepack pnpm run validation-host:package
+```
+
+Run another command inside the same pinned/rootless environment:
+
+```bash
+bash scripts/run-validation-host.sh corepack pnpm --filter kicadstudiokit run test:a11y
+```
+
+Inspect the isolated paths:
+
+```bash
+bash scripts/run-validation-host.sh --print-environment
+```
+
+## KiCad CLI canary boundary
+
+The configured Ubuntu 24.04 repository offers KiCad 7.0.11, while this repository
+supports KiCad CLI 8.x, 9.x, and 10.x. VPS-2 therefore must not install that
+unsupported package or claim real KiCad compatibility evidence. Strict CI-mode
+doctor reports `kicad-cli` as a warning on this host.
+
+Real KiCad CLI, GUI IPC, and file-format canaries remain owned by KiCad MCP Pro,
+using the shared fixture corpus and the scheduled/manual canary process described
+in [testing strategy](testing-strategy.md) and the
+[KiCad support matrix](support-matrix.md). VPS-2 remains authoritative for the
+repository, browser, extension package, and release-recovery checks listed above.
+
+## Recovery
+
+1. Remove `$HOME/.cache/kicad-studio-kit` only when rebuilding the extracted
+   Ubuntu layer is desired.
+2. Remove `$HOME/.cache/ms-playwright` only when refreshing browser artifacts.
+3. Re-run `bash scripts/bootstrap-validation-host.sh`.
+4. Run `corepack pnpm run validation-host:doctor` and
+   `corepack pnpm run validation-host:check` before relying on the host for
+   release recovery.
+
+The scripts never read or create marketplace, GitHub, or release credentials.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,8 @@
+min_version = "2026.7.7"
+
+[tools]
+node = "24.18.0"
+python = "3.13.14"
+uv = "0.11.21"
+actionlint = "1.7.12"
+shellcheck = "0.9.0"

--- a/package.json
+++ b/package.json
@@ -78,13 +78,18 @@
     "docs:preview": "vitepress preview docs",
     "check:docs-site": "pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:vscode-typings-policy && pnpm run check:codecov && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:best-practices && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:extension-doc-links && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check",
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:vscode-typings-policy && pnpm run check:codecov && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:best-practices && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:validation-host && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:extension-doc-links && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check",
     "check:best-practices": "node scripts/check-best-practices-evidence.mjs && pnpm run check:repeatable-vsix && node --test scripts/check-best-practices-evidence.test.mjs scripts/report-best-practices-status.test.mjs",
     "best-practices:status": "node scripts/report-best-practices-status.mjs",
     "best-practices:status:write": "node scripts/report-best-practices-status.mjs --write",
     "check:repeatable-vsix": "node scripts/check-repeatable-vsix.mjs",
     "check:mcp-split-docs": "node scripts/check-mcp-split-docs.mjs && node --test scripts/check-mcp-split-docs.test.mjs",
-    "check:vscode-typings-policy": "node scripts/check-vscode-typings-policy.mjs && node --test scripts/check-vscode-typings-policy.test.mjs"
+    "check:vscode-typings-policy": "node scripts/check-vscode-typings-policy.mjs && node --test scripts/check-vscode-typings-policy.test.mjs",
+    "validation-host:bootstrap": "bash scripts/bootstrap-validation-host.sh",
+    "validation-host:doctor": "bash scripts/run-validation-host.sh node scripts/dev-doctor.mjs --ci --strict",
+    "validation-host:check": "bash scripts/run-validation-host.sh corepack pnpm run check",
+    "validation-host:package": "bash scripts/run-validation-host.sh corepack pnpm run package:kicad-studio",
+    "check:validation-host": "node scripts/check-validation-host.mjs && node --test scripts/check-validation-host.test.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",

--- a/packages/test-harness/test/paths.test.ts
+++ b/packages/test-harness/test/paths.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
@@ -14,7 +15,7 @@ import {
 
 test("resolves repository and KiCad fixture paths", () => {
   const repoRoot = findRepoRoot();
-  assert.equal(path.basename(repoRoot), "kicad-studio-kit");
+  assert.equal(fs.existsSync(path.join(repoRoot, "pnpm-workspace.yaml")), true);
   assert.equal(
     normalizePathForSnapshot(kicadFixtureRoot(repoRoot), repoRoot),
     "packages/kicad-fixtures/fixtures",

--- a/scripts/bootstrap-validation-host.sh
+++ b/scripts/bootstrap-validation-host.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck source=scripts/lib/validation-host-env.sh
+source "${repo_root}/scripts/lib/validation-host-env.sh"
+validation_host_configure_base
+cd "${repo_root}"
+
+dry_run=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  dry_run=1
+  shift
+fi
+if [[ "$#" -ne 0 ]]; then
+  echo "Usage: scripts/bootstrap-validation-host.sh [--dry-run]" >&2
+  exit 2
+fi
+
+if [[ "${dry_run}" -eq 1 ]]; then
+  validation_host_print_environment
+  cat <<'VALIDATION_PLAN'
+- mise trust and install pinned tools from mise.toml
+- enable Corepack pnpm in the pinned Node prefix
+- install workspace dependencies with the frozen lockfile
+- install Playwright Chromium
+- derive Playwright Linux packages with playwright install-deps --dry-run chromium
+- download signed Ubuntu packages with apt-get download and extract them without root
+- run strict dev-doctor in the activated validation environment
+VALIDATION_PLAN
+  exit 0
+fi
+
+for command in mise apt-get apt-cache dpkg dpkg-deb dpkg-architecture git sha256sum; do
+  if ! command -v "${command}" >/dev/null 2>&1; then
+    echo "Required bootstrap command is missing: ${command}" >&2
+    exit 1
+  fi
+done
+
+mkdir -p \
+  "${MISE_DATA_DIR}" \
+  "${MISE_CACHE_DIR}" \
+  "${MISE_CONFIG_DIR}" \
+  "${MISE_STATE_DIR}" \
+  "${KICAD_STUDIO_VALIDATION_CACHE_ROOT}/apt-root" \
+  "${KICAD_STUDIO_VALIDATION_CACHE_ROOT}/debs" \
+  "${PLAYWRIGHT_BROWSERS_PATH}"
+
+mise trust --yes "${repo_root}/mise.toml"
+mise install
+mise exec -- corepack enable pnpm
+mise exec -- corepack pnpm install --frozen-lockfile
+mise exec -- corepack pnpm --dir apps/vscode-extension exec playwright install chromium
+
+set +e
+playwright_dependency_output="$(
+  mise exec -- corepack pnpm --dir apps/vscode-extension exec \
+    playwright install-deps --dry-run chromium 2>&1
+)"
+playwright_dependency_status=$?
+set -e
+if [[ "${playwright_dependency_status}" -ne 0 ]] \
+  && ! grep -q '^Missing system dependencies' <<< "${playwright_dependency_output}"; then
+  printf '%s\n' "${playwright_dependency_output}" >&2
+  echo "Playwright dependency discovery failed." >&2
+  exit "${playwright_dependency_status}"
+fi
+
+packages=(xauth x11-xkb-utils libxfont2 xserver-common xvfb)
+while IFS= read -r package; do
+  [[ -n "${package}" ]] && packages+=("${package}")
+done < <(
+  printf '%s\n' "${playwright_dependency_output}" \
+    | sed -n '/^Missing system dependencies/,$p' \
+    | tail -n +2 \
+    | sed -E 's/^[[:space:]]+//' \
+    | grep -E '^[a-z0-9][a-z0-9.+-]*(:[a-z0-9]+)?$' || true
+)
+mapfile -t packages < <(printf '%s\n' "${packages[@]}" | sort -u)
+
+if [[ "${#packages[@]}" -eq 0 ]]; then
+  echo "Playwright dependency discovery returned no packages." >&2
+  exit 1
+fi
+
+manifest_lines=(
+  "schema=1"
+  "codename=$(validation_host_os_codename)"
+  "architecture=$(validation_host_architecture)"
+)
+for package in "${packages[@]}"; do
+  candidate="$(apt-cache policy "${package}" | awk '/Candidate:/ && !found { print $2; found = 1 }')"
+  if [[ -z "${candidate}" || "${candidate}" == "(none)" ]]; then
+    echo "No apt candidate is available for ${package}." >&2
+    exit 1
+  fi
+  manifest_lines+=("${package}=${candidate}")
+done
+manifest="$(printf '%s\n' "${manifest_lines[@]}")"
+manifest_hash="$(printf '%s' "${manifest}" | sha256sum | awk '{ print $1 }')"
+manifest_path="${KICAD_STUDIO_VALIDATION_APT_ROOT}/.validation-host-manifest"
+
+if [[ -f "${manifest_path}" ]] \
+  && grep -qx "hash=${manifest_hash}" "${manifest_path}" \
+  && [[ -x "${KICAD_STUDIO_VALIDATION_APT_ROOT}/usr/bin/xvfb-run" ]]; then
+  echo "Rootless Ubuntu runtime is current: ${manifest_hash}"
+else
+  apt_parent="$(dirname "${KICAD_STUDIO_VALIDATION_APT_ROOT}")"
+  deb_parent="$(dirname "${KICAD_STUDIO_VALIDATION_DEB_ROOT}")"
+  apt_staging="$(mktemp -d "${apt_parent}/.validation-host-apt.XXXXXX")"
+  deb_staging="$(mktemp -d "${deb_parent}/.validation-host-debs.XXXXXX")"
+  cleanup() {
+    rm -rf "${apt_staging}" "${deb_staging}"
+  }
+  trap cleanup EXIT
+
+  (
+    cd "${deb_staging}"
+    apt-get download "${packages[@]}"
+  )
+  for archive in "${deb_staging}"/*.deb; do
+    dpkg-deb -x "${archive}" "${apt_staging}"
+  done
+
+  case "${KICAD_STUDIO_VALIDATION_APT_ROOT}" in
+    "${KICAD_STUDIO_VALIDATION_CACHE_ROOT}"/apt-root/*) ;;
+    *)
+      echo "Refusing to replace apt root outside the validation cache." >&2
+      exit 1
+      ;;
+  esac
+  case "${KICAD_STUDIO_VALIDATION_DEB_ROOT}" in
+    "${KICAD_STUDIO_VALIDATION_CACHE_ROOT}"/debs/*) ;;
+    *)
+      echo "Refusing to replace package cache outside the validation cache." >&2
+      exit 1
+      ;;
+  esac
+
+  rm -rf "${KICAD_STUDIO_VALIDATION_APT_ROOT}" "${KICAD_STUDIO_VALIDATION_DEB_ROOT}"
+  mv "${apt_staging}" "${KICAD_STUDIO_VALIDATION_APT_ROOT}"
+  mv "${deb_staging}" "${KICAD_STUDIO_VALIDATION_DEB_ROOT}"
+  trap - EXIT
+
+  mkdir -p "${KICAD_STUDIO_VALIDATION_APT_ROOT}/.fontconfig" \
+    "${KICAD_STUDIO_VALIDATION_CACHE_ROOT}/fontconfig-cache"
+  cat > "${KICAD_STUDIO_VALIDATION_APT_ROOT}/.fontconfig/fonts.conf" <<FONTCONFIG
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <dir>/usr/share/fonts</dir>
+  <dir>${KICAD_STUDIO_VALIDATION_APT_ROOT}/usr/share/fonts</dir>
+  <cachedir>${KICAD_STUDIO_VALIDATION_CACHE_ROOT}/fontconfig-cache</cachedir>
+</fontconfig>
+FONTCONFIG
+  {
+    printf 'hash=%s\n' "${manifest_hash}"
+    printf '%s\n' "${manifest}"
+  } > "${manifest_path}"
+  echo "Built rootless Ubuntu runtime: ${manifest_hash}"
+fi
+
+validation_host_activate_rootless_runtime
+xvfb-run --help >/dev/null
+browser="$(
+  find "${PLAYWRIGHT_BROWSERS_PATH}" -type f -name chrome-headless-shell -perm -u+x -print -quit
+)"
+if [[ -z "${browser}" ]]; then
+  echo "Playwright Chromium executable is missing." >&2
+  exit 1
+fi
+if ldd "${browser}" | grep -q 'not found'; then
+  ldd "${browser}" | grep 'not found' >&2
+  echo "Rootless Chromium runtime still has missing shared libraries." >&2
+  exit 1
+fi
+"${browser}" --no-sandbox --headless --disable-gpu --dump-dom about:blank >/dev/null
+mise exec -- node scripts/dev-doctor.mjs --ci --strict
+
+echo "Validation host bootstrap completed."
+echo "Next: corepack pnpm run validation-host:check"

--- a/scripts/check-validation-host.mjs
+++ b/scripts/check-validation-host.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptRoot = path.dirname(fileURLToPath(import.meta.url));
+const defaultRepoRoot = path.resolve(scriptRoot, "..");
+
+function requireIncludes(errors, label, text, expected) {
+  if (!text.includes(expected)) {
+    errors.push(`${label} must include ${JSON.stringify(expected)}`);
+  }
+}
+
+function executableErrors(repoRoot, relativePath) {
+  const filePath = path.join(repoRoot, relativePath);
+  if (!existsSync(filePath)) return [`${relativePath} must exist`];
+  if (process.platform !== "win32" && (statSync(filePath).mode & 0o111) === 0) {
+    return [`${relativePath} must be executable`];
+  }
+  return [];
+}
+
+export function validateValidationHostContract(contract) {
+  const errors = [];
+  const expectedPins = [
+    'node = "24.18.0"',
+    'python = "3.13.14"',
+    'uv = "0.11.21"',
+    'actionlint = "1.7.12"',
+    'shellcheck = "0.9.0"',
+  ];
+  for (const pin of expectedPins) {
+    requireIncludes(errors, "mise.toml", contract.miseText, pin);
+  }
+
+  for (const phrase of [
+    'MISE_DATA_DIR="${HOME}/.local/share/mise"',
+    'MISE_CONFIG_FILE="${MISE_CONFIG_DIR}/config.toml"',
+    "KICAD_STUDIO_VALIDATION_CACHE_ROOT",
+    "KICAD_STUDIO_VALIDATION_APT_ROOT",
+    "LD_LIBRARY_PATH",
+    "XKB_CONFIG_ROOT",
+  ]) {
+    requireIncludes(
+      errors,
+      "validation-host environment",
+      contract.commonText,
+      phrase,
+    );
+  }
+
+  for (const phrase of [
+    "mise trust --yes",
+    "mise install",
+    "corepack enable pnpm",
+    "pnpm install --frozen-lockfile",
+    "playwright install chromium",
+    "playwright install-deps --dry-run chromium",
+    'apt-get download "${packages[@]}"',
+    'dpkg-deb -x "${archive}"',
+    ".validation-host-manifest",
+    "node scripts/dev-doctor.mjs --ci --strict",
+  ]) {
+    requireIncludes(errors, "bootstrap script", contract.bootstrapText, phrase);
+  }
+  if (/\bsudo\b/u.test(contract.bootstrapText)) {
+    errors.push("bootstrap script must not invoke sudo");
+  }
+  if (
+    !contract.bootstrapText.includes(
+      "playwright install-deps --dry-run chromium",
+    )
+  ) {
+    errors.push("bootstrap script must retain Playwright dependency discovery");
+  }
+
+  for (const phrase of [
+    "--print-environment",
+    "validation_host_activate_rootless_runtime",
+    "exec mise exec --",
+  ]) {
+    requireIncludes(errors, "runner script", contract.runnerText, phrase);
+  }
+
+  for (const phrase of [
+    "Ubuntu 24.04",
+    "KiCad 7.0.11",
+    "KiCad MCP Pro",
+    "validation-host:doctor",
+    "validation-host:check",
+    "validation-host:package",
+    "$HOME/.cache/kicad-studio-kit",
+  ]) {
+    requireIncludes(
+      errors,
+      "docs/validation-host.md",
+      contract.docsText,
+      phrase,
+    );
+  }
+  requireIncludes(
+    errors,
+    "README.md",
+    contract.readmeText,
+    "docs/validation-host.md",
+  );
+  requireIncludes(
+    errors,
+    "docs/contributing.md",
+    contract.contributingText,
+    "validation-host:bootstrap",
+  );
+
+  const scripts = contract.packageJson?.scripts ?? {};
+  const expectedScripts = {
+    "validation-host:bootstrap": "bash scripts/bootstrap-validation-host.sh",
+    "validation-host:doctor":
+      "bash scripts/run-validation-host.sh node scripts/dev-doctor.mjs --ci --strict",
+    "validation-host:check":
+      "bash scripts/run-validation-host.sh corepack pnpm run check",
+    "validation-host:package":
+      "bash scripts/run-validation-host.sh corepack pnpm run package:kicad-studio",
+    "check:validation-host":
+      "node scripts/check-validation-host.mjs && node --test scripts/check-validation-host.test.mjs",
+  };
+  for (const [name, expected] of Object.entries(expectedScripts)) {
+    if (scripts[name] !== expected) {
+      errors.push(`package.json scripts.${name} must be ${expected}`);
+    }
+  }
+  if (!scripts.check?.includes("pnpm run check:validation-host")) {
+    errors.push("package.json check must run check:validation-host");
+  }
+
+  return errors;
+}
+
+export function validateValidationHostRepository(repoRoot = defaultRepoRoot) {
+  const read = (relativePath) =>
+    readFileSync(path.join(repoRoot, relativePath), "utf8");
+  const errors = validateValidationHostContract({
+    miseText: read("mise.toml"),
+    commonText: read("scripts/lib/validation-host-env.sh"),
+    bootstrapText: read("scripts/bootstrap-validation-host.sh"),
+    runnerText: read("scripts/run-validation-host.sh"),
+    docsText: read("docs/validation-host.md"),
+    readmeText: read("README.md"),
+    contributingText: read("docs/contributing.md"),
+    packageJson: JSON.parse(read("package.json")),
+  });
+  errors.push(
+    ...executableErrors(repoRoot, "scripts/bootstrap-validation-host.sh"),
+  );
+  errors.push(...executableErrors(repoRoot, "scripts/run-validation-host.sh"));
+  return errors;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const errors = validateValidationHostRepository();
+  if (errors.length > 0) {
+    console.error("Validation-host contract failed:");
+    for (const error of errors) console.error(`- ${error}`);
+    process.exitCode = 1;
+  } else {
+    console.log("Validation-host contract passed.");
+  }
+}

--- a/scripts/check-validation-host.mjs
+++ b/scripts/check-validation-host.mjs
@@ -152,8 +152,8 @@ export function validateValidationHostRepository(repoRoot = defaultRepoRoot) {
   });
   errors.push(
     ...executableErrors(repoRoot, "scripts/bootstrap-validation-host.sh"),
+    ...executableErrors(repoRoot, "scripts/run-validation-host.sh"),
   );
-  errors.push(...executableErrors(repoRoot, "scripts/run-validation-host.sh"));
   return errors;
 }
 

--- a/scripts/check-validation-host.test.mjs
+++ b/scripts/check-validation-host.test.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  validateValidationHostContract,
+  validateValidationHostRepository,
+} from "./check-validation-host.mjs";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+function repositoryContract() {
+  return {
+    miseText: readFileSync(path.join(repoRoot, "mise.toml"), "utf8"),
+    commonText: readFileSync(
+      path.join(repoRoot, "scripts/lib/validation-host-env.sh"),
+      "utf8",
+    ),
+    bootstrapText: readFileSync(
+      path.join(repoRoot, "scripts/bootstrap-validation-host.sh"),
+      "utf8",
+    ),
+    runnerText: readFileSync(
+      path.join(repoRoot, "scripts/run-validation-host.sh"),
+      "utf8",
+    ),
+    docsText: readFileSync(
+      path.join(repoRoot, "docs/validation-host.md"),
+      "utf8",
+    ),
+    readmeText: readFileSync(path.join(repoRoot, "README.md"), "utf8"),
+    contributingText: readFileSync(
+      path.join(repoRoot, "docs/contributing.md"),
+      "utf8",
+    ),
+    packageJson: JSON.parse(
+      readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+    ),
+  };
+}
+
+test("validation-host repository contract is complete (#490)", () => {
+  assert.deepEqual(validateValidationHostRepository(repoRoot), []);
+});
+
+test("stale or weakened tool pins are rejected (#490)", () => {
+  const contract = repositoryContract();
+  contract.miseText = contract.miseText.replace(
+    'python = "3.13.14"',
+    'python = "3.12.3"',
+  );
+
+  assert.match(
+    validateValidationHostContract(contract).join("\n"),
+    /mise\.toml must include.*3\.13\.14/u,
+  );
+});
+
+test("bootstrap accepts Playwright's missing-dependency discovery status (#490)", () => {
+  const bootstrapText = repositoryContract().bootstrapText;
+
+  assert.match(bootstrapText, /playwright_dependency_status=\$\?/u);
+  assert.match(bootstrapText, /Missing system dependencies/u);
+});
+
+test("bootstrap must remain rootless and derive Playwright packages (#490)", () => {
+  const contract = repositoryContract();
+  contract.bootstrapText = contract.bootstrapText
+    .replaceAll("playwright install-deps --dry-run chromium", "true")
+    .replace('apt-get download "${packages[@]}"', "sudo apt-get install xvfb");
+
+  const errors = validateValidationHostContract(contract).join("\n");
+  assert.match(errors, /Playwright dependency discovery/u);
+  assert.match(errors, /apt-get download/u);
+  assert.match(errors, /must not invoke sudo/u);
+});
+
+test("root package exposes bootstrap, doctor, check, and package entrypoints (#490)", () => {
+  const scripts = repositoryContract().packageJson.scripts;
+
+  assert.equal(
+    scripts["validation-host:bootstrap"],
+    "bash scripts/bootstrap-validation-host.sh",
+  );
+  assert.equal(
+    scripts["validation-host:doctor"],
+    "bash scripts/run-validation-host.sh node scripts/dev-doctor.mjs --ci --strict",
+  );
+  assert.equal(
+    scripts["validation-host:check"],
+    "bash scripts/run-validation-host.sh corepack pnpm run check",
+  );
+  assert.equal(
+    scripts["validation-host:package"],
+    "bash scripts/run-validation-host.sh corepack pnpm run package:kicad-studio",
+  );
+  assert.equal(
+    scripts["check:validation-host"],
+    "node scripts/check-validation-host.mjs && node --test scripts/check-validation-host.test.mjs",
+  );
+  assert.match(scripts.check, /pnpm run check:validation-host/u);
+});
+
+test("runner isolates mise and runtime paths under the executing HOME (#490)", (t) => {
+  const home = mkdtempSync(path.join(os.tmpdir(), "kicad-validation-home-"));
+  t.after(() => rmSync(home, { recursive: true, force: true }));
+
+  const result = spawnSync(
+    "bash",
+    [
+      path.join(repoRoot, "scripts/run-validation-host.sh"),
+      "--print-environment",
+    ],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        HOME: home,
+        MISE_CONFIG_FILE: "/home/opsrunner/leaked.toml",
+        KICAD_STUDIO_MISE_DATA_DIR: "/tmp/leaked-mise",
+        KICAD_STUDIO_VALIDATION_CACHE_ROOT: "/tmp/leaked-validation",
+        PLAYWRIGHT_BROWSERS_PATH: "/tmp/leaked-playwright",
+      },
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    new RegExp(`MISE_DATA_DIR=${home}/\\.local/share/mise`, "u"),
+  );
+  assert.match(
+    result.stdout,
+    new RegExp(`MISE_CONFIG_FILE=${home}/\\.config/mise/config\\.toml`, "u"),
+  );
+  assert.match(
+    result.stdout,
+    new RegExp(
+      `KICAD_STUDIO_VALIDATION_CACHE_ROOT=${home}/\\.cache/kicad-studio-kit`,
+      "u",
+    ),
+  );
+  assert.match(
+    result.stdout,
+    new RegExp(`PLAYWRIGHT_BROWSERS_PATH=${home}/\\.cache/ms-playwright`, "u"),
+  );
+  assert.doesNotMatch(result.stdout, /\/home\/opsrunner|\/tmp\/leaked/u);
+});

--- a/scripts/generate-docs-site.mjs
+++ b/scripts/generate-docs-site.mjs
@@ -93,7 +93,9 @@ function productVersions() {
   return {
     root: root.version,
     extension: extension.version,
-    mcpServer: compatibility.products["kicad-studio"]?.compatibleMcpPro?.testedAgainst ?? "unknown",
+    mcpServer:
+      compatibility.products["kicad-studio"]?.compatibleMcpPro?.testedAgainst ??
+      "unknown",
   };
 }
 
@@ -482,6 +484,15 @@ Use the [dev container](devcontainer.md) for reproducible VS Code Dev Containers
 or GitHub Codespaces setup. Inside the container,
 \`corepack pnpm run dev-doctor -- --require-devcontainer\` confirms the
 devcontainer marker and required tools.
+
+For a least-privilege Linux validation or release-recovery host without a
+container daemon, use the [rootless validation-host runbook](validation-host.md):
+
+\`\`\`bash
+corepack pnpm run validation-host:bootstrap
+corepack pnpm run validation-host:doctor
+corepack pnpm run validation-host:check
+\`\`\`
 `;
 }
 

--- a/scripts/lib/validation-host-env.sh
+++ b/scripts/lib/validation-host-env.sh
@@ -2,14 +2,17 @@
 
 validation_host_os_codename() {
   awk -F= '$1 == "VERSION_CODENAME" { gsub(/"/, "", $2); print $2; exit }' /etc/os-release
+  return "$?"
 }
 
 validation_host_architecture() {
   dpkg --print-architecture
+  return "$?"
 }
 
 validation_host_multiarch() {
   dpkg-architecture -qDEB_HOST_MULTIARCH
+  return "$?"
 }
 
 validation_host_configure_base() {
@@ -35,6 +38,7 @@ validation_host_configure_base() {
 
   export KICAD_STUDIO_VALIDATION_APT_ROOT="${KICAD_STUDIO_VALIDATION_CACHE_ROOT}/apt-root/${codename}-${architecture}"
   export KICAD_STUDIO_VALIDATION_DEB_ROOT="${KICAD_STUDIO_VALIDATION_CACHE_ROOT}/debs/${codename}-${architecture}"
+  return 0
 }
 
 validation_host_activate_rootless_runtime() {
@@ -46,6 +50,7 @@ validation_host_activate_rootless_runtime() {
   export FONTCONFIG_PATH="${KICAD_STUDIO_VALIDATION_APT_ROOT}/.fontconfig"
   export FONTCONFIG_FILE="${KICAD_STUDIO_VALIDATION_APT_ROOT}/.fontconfig/fonts.conf"
   export XKB_CONFIG_ROOT="${KICAD_STUDIO_VALIDATION_APT_ROOT}/usr/share/X11/xkb"
+  return 0
 }
 
 validation_host_print_environment() {
@@ -58,4 +63,5 @@ validation_host_print_environment() {
   printf 'KICAD_STUDIO_VALIDATION_APT_ROOT=%s\n' "${KICAD_STUDIO_VALIDATION_APT_ROOT}"
   printf 'KICAD_STUDIO_VALIDATION_DEB_ROOT=%s\n' "${KICAD_STUDIO_VALIDATION_DEB_ROOT}"
   printf 'PLAYWRIGHT_BROWSERS_PATH=%s\n' "${PLAYWRIGHT_BROWSERS_PATH}"
+  return 0
 }

--- a/scripts/lib/validation-host-env.sh
+++ b/scripts/lib/validation-host-env.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+validation_host_os_codename() {
+  awk -F= '$1 == "VERSION_CODENAME" { gsub(/"/, "", $2); print $2; exit }' /etc/os-release
+}
+
+validation_host_architecture() {
+  dpkg --print-architecture
+}
+
+validation_host_multiarch() {
+  dpkg-architecture -qDEB_HOST_MULTIARCH
+}
+
+validation_host_configure_base() {
+  : "${HOME:?HOME must be set for the validation host}"
+
+  export MISE_DATA_DIR="${HOME}/.local/share/mise"
+  export MISE_CACHE_DIR="${HOME}/.cache/mise"
+  export MISE_CONFIG_DIR="${HOME}/.config/mise"
+  export MISE_CONFIG_FILE="${MISE_CONFIG_DIR}/config.toml"
+  export MISE_STATE_DIR="${HOME}/.local/state/mise"
+  export KICAD_STUDIO_VALIDATION_CACHE_ROOT="${HOME}/.cache/kicad-studio-kit"
+  export PLAYWRIGHT_BROWSERS_PATH="${HOME}/.cache/ms-playwright"
+  export UV_LINK_MODE="${UV_LINK_MODE:-copy}"
+  export UV_PYTHON="${UV_PYTHON:-3.13}"
+
+  local codename architecture
+  codename="$(validation_host_os_codename)"
+  architecture="$(validation_host_architecture)"
+  if [[ -z "${codename}" || -z "${architecture}" ]]; then
+    echo "Unable to determine Ubuntu codename or Debian architecture." >&2
+    return 1
+  fi
+
+  export KICAD_STUDIO_VALIDATION_APT_ROOT="${KICAD_STUDIO_VALIDATION_CACHE_ROOT}/apt-root/${codename}-${architecture}"
+  export KICAD_STUDIO_VALIDATION_DEB_ROOT="${KICAD_STUDIO_VALIDATION_CACHE_ROOT}/debs/${codename}-${architecture}"
+}
+
+validation_host_activate_rootless_runtime() {
+  local multiarch
+  multiarch="$(validation_host_multiarch)"
+
+  export PATH="${KICAD_STUDIO_VALIDATION_APT_ROOT}/usr/bin:${PATH}"
+  export LD_LIBRARY_PATH="${KICAD_STUDIO_VALIDATION_APT_ROOT}/usr/lib/${multiarch}:${KICAD_STUDIO_VALIDATION_APT_ROOT}/lib/${multiarch}:${LD_LIBRARY_PATH:-}"
+  export FONTCONFIG_PATH="${KICAD_STUDIO_VALIDATION_APT_ROOT}/.fontconfig"
+  export FONTCONFIG_FILE="${KICAD_STUDIO_VALIDATION_APT_ROOT}/.fontconfig/fonts.conf"
+  export XKB_CONFIG_ROOT="${KICAD_STUDIO_VALIDATION_APT_ROOT}/usr/share/X11/xkb"
+}
+
+validation_host_print_environment() {
+  printf 'MISE_DATA_DIR=%s\n' "${MISE_DATA_DIR}"
+  printf 'MISE_CACHE_DIR=%s\n' "${MISE_CACHE_DIR}"
+  printf 'MISE_CONFIG_DIR=%s\n' "${MISE_CONFIG_DIR}"
+  printf 'MISE_CONFIG_FILE=%s\n' "${MISE_CONFIG_FILE}"
+  printf 'MISE_STATE_DIR=%s\n' "${MISE_STATE_DIR}"
+  printf 'KICAD_STUDIO_VALIDATION_CACHE_ROOT=%s\n' "${KICAD_STUDIO_VALIDATION_CACHE_ROOT}"
+  printf 'KICAD_STUDIO_VALIDATION_APT_ROOT=%s\n' "${KICAD_STUDIO_VALIDATION_APT_ROOT}"
+  printf 'KICAD_STUDIO_VALIDATION_DEB_ROOT=%s\n' "${KICAD_STUDIO_VALIDATION_DEB_ROOT}"
+  printf 'PLAYWRIGHT_BROWSERS_PATH=%s\n' "${PLAYWRIGHT_BROWSERS_PATH}"
+}

--- a/scripts/run-validation-host.sh
+++ b/scripts/run-validation-host.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck source=scripts/lib/validation-host-env.sh
+source "${repo_root}/scripts/lib/validation-host-env.sh"
+validation_host_configure_base
+
+if [[ "${1:-}" == "--print-environment" ]]; then
+  validation_host_print_environment
+  exit 0
+fi
+
+if [[ "$#" -eq 0 ]]; then
+  echo "Usage: scripts/run-validation-host.sh COMMAND [ARG ...]" >&2
+  exit 2
+fi
+
+if [[ ! -f "${KICAD_STUDIO_VALIDATION_APT_ROOT}/.validation-host-manifest" ]]; then
+  echo "Validation host is not bootstrapped. Run: bash scripts/bootstrap-validation-host.sh" >&2
+  exit 1
+fi
+
+validation_host_activate_rootless_runtime
+cd "${repo_root}"
+exec mise exec -- "$@"


### PR DESCRIPTION
## Summary

- add a pinned, rootless VPS validation profile backed by `mise.toml`
- bootstrap Playwright Chromium and Xvfb dependencies into a manifest-keyed user cache without sudo or Docker
- document the KiCad CLI canary ownership boundary and recovery procedure
- make repository-root test-harness validation work in canonical clones and Git worktrees
- add a repository contract that prevents tool-pin, script, permission, and documentation drift

## Validation

- bootstrap completed twice; the second run reused rootless runtime cache `b90165eb4eaef144925b6e782f3f4c76fdd49f295b36c2d4e9f958860400694b`
- strict dev doctor: `Status: ok`; only documented KiCad CLI and optional tunnel warnings remain
- accessibility: 76/76 passed
- full root validation: passed, including 106 extension unit suites / 862 tests and 12/12 security tests
- extension package validation: 101-file, 1.74 MB VSIX
- repeatable VSIX normalized SHA-256: `6bb8e3f24f4e5d55c91ab467c3a4343cbe1ce16743e418055fd4dd570037be44`
- ShellCheck, generated docs, Markdown, links, release surfaces, and DCO checks passed

Closes #490.