### PR TITLE
ci(repo): scan development container misconfigurations

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,8 @@ concurrency:
 
 env:
   pnpm_config_pm_on_fail: ignore
+  # renovate: datasource=github-releases depName=aquasecurity/trivy
+  TRIVY_VERSION: v0.72.0
 
 jobs:
   dependency-review:
@@ -31,6 +33,9 @@ jobs:
   security:
     if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -68,6 +73,41 @@ jobs:
       - run: corepack pnpm run test:semgrep-rules
       - run: corepack pnpm run security:semgrep
       - run: corepack pnpm audit --audit-level high
+      - name: Scan development container misconfigurations
+        id: trivy-devcontainer
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: config
+          scan-ref: .devcontainer
+          format: sarif
+          output: trivy-devcontainer.sarif
+          exit-code: "1"
+          severity: HIGH,CRITICAL
+          limit-severities-for-sarif: true
+          hide-progress: true
+          skip-version-check: true
+          version: ${{ env.TRIVY_VERSION }}
+      - name: Upload development container SARIF
+        if: ${{ always() && hashFiles('trivy-devcontainer.sarif') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        with:
+          sarif_file: trivy-devcontainer.sarif
+          category: trivy-devcontainer
+      - name: Store development container SARIF
+        if: ${{ always() && hashFiles('trivy-devcontainer.sarif') != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: trivy-devcontainer-sarif
+          path: trivy-devcontainer.sarif
+          if-no-files-found: error
+          retention-days: 14
+      - name: Fail on development container misconfigurations
+        if: ${{ steps.trivy-devcontainer.outcome == 'failure' }}
+        shell: bash
+        run: |
+          echo "::error::Trivy found HIGH or CRITICAL development-container misconfigurations, or the scan failed operationally."
+          exit 1
 
   extension-security-regressions:
     if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'

--- a/apps/vscode-extension/Taskfile.yml
+++ b/apps/vscode-extension/Taskfile.yml
@@ -72,9 +72,15 @@ tasks:
     cmds:
       - task: security
 
-  security:local:
-    desc: Heavy local security checks (requires uv, gitleaks, and actionlint)
+  security:trivy-devcontainer:
+    desc: Scan development container configuration for HIGH/CRITICAL misconfigurations
     cmds:
+      - pnpm --dir ../.. run security:trivy-devcontainer
+
+  security:local:
+    desc: Heavy local security checks (requires uv, gitleaks, actionlint, and Trivy)
+    cmds:
+      - task: security:trivy-devcontainer
       - cmd: bash scripts/local-security.sh
         platforms: [linux, darwin]
       - cmd: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/local-security.ps1

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,6 +15,7 @@ sections that follow give the detail for each lane.
 | Code scanning (CodeQL, JS/TS + Python) | `CodeQL` workflow on pull requests, pushes, and weekly                                                                            | High-severity code-scanning alerts block merge                                                   |
 | Repository-specific SAST               | Semgrep 1.170.0 custom rules in the required `Security` workflow                                                                  | Shell-string execution, dynamic evaluation, and sensitive-value logging findings fail `security` |
 | Workflow security                      | actionlint 1.7.12 and zizmor 1.27.0 in the required `Security` workflow                                                           | Syntax/shell errors and high-confidence medium-or-higher Actions findings fail `security`        |
+| Development-container configuration    | Trivy v0.72.0 configuration-only scan in the required `Security` workflow on pull requests, pushes, weekly, and manual runs       | HIGH/CRITICAL misconfigurations fail `security`; SARIF is published under `trivy-devcontainer`   |
 | Secret scanning                        | `Gitleaks` workflow on every pull request plus the local security gate; GitHub secret scanning with push protection stays enabled | A new secret-scanning alert blocks release until triaged                                         |
 | Dependency review                      | `Security` workflow `dependency-review` job on pull requests                                                                      | New `high`+ dependency additions block the pull request                                          |
 | Dependency audit                       | `Security` workflow `pnpm audit --audit-level high`                                                                               | High-severity advisories fail the check                                                          |
@@ -30,6 +31,8 @@ sections that follow give the detail for each lane.
   and sensitive-value logging; broad generic SAST remains CodeQL's job.
 - **Workflow validation** uses native actionlint plus offline zizmor with
   high-confidence, medium-or-higher findings as the blocking threshold.
+- **Development-container configuration** uses Trivy v0.72.0 in configuration-only mode against `.devcontainer/`. HIGH/CRITICAL findings block the existing required `security` status after SARIF evidence is uploaded under the `trivy-devcontainer` category.
+- **Scanner ownership stays narrow**: CodeQL owns broad SAST; dependency review, pnpm audit, and Snyk own dependency risk; GitHub push protection and Gitleaks own secrets. Trivy does not run vulnerability, dependency, license, or secret scanners here.
 - **Secret scanning**: GitHub secret scanning with push protection is expected
   to remain enabled on the canonical repository. `Gitleaks` enforces the same
   gate in CI and the `apps/vscode-extension/scripts/local-security` scripts
@@ -113,8 +116,10 @@ The MCP server security checks now run in the [KiCad MCP Pro](https://oaslananka
 That gate requires `pre-commit` 4.6.0, `gitleaks`, native actionlint 1.7.12,
 zizmor 1.27.0, and Semgrep 1.170.0. Run it with
 `task security:local` from `apps/vscode-extension`, or run the focused root
-commands `pnpm run security:workflows`, `pnpm run test:semgrep-rules`, and
-`pnpm run security:semgrep`. Scanner findings must be fixed or explicitly
+commands `pnpm run security:workflows`, `pnpm run test:semgrep-rules`,
+`pnpm run security:semgrep`, and `pnpm run security:trivy-devcontainer`. The
+Trivy command is configuration-only and scans `.devcontainer/` at the same
+HIGH/CRITICAL threshold used in CI. Scanner findings must be fixed or explicitly
 triaged before release work proceeds. CodeQL remains the broad SAST authority,
 and push protection plus Gitleaks remain the secret-scanning authorities.
 

--- a/docs/superpowers/plans/2026-07-22-trivy-devcontainer-analysis.md
+++ b/docs/superpowers/plans/2026-07-22-trivy-devcontainer-analysis.md
@@ -1,0 +1,94 @@
+# Targeted Trivy Devcontainer Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fail-closed Trivy misconfiguration gate for `.devcontainer/` without duplicating dependency, vulnerability, license, or secret scanning.
+
+**Architecture:** Extend the existing required `Security / security` job so its status-check name remains stable. A SHA-pinned Trivy action runs the `config` scanner against `.devcontainer/`, writes SARIF, uploads review evidence, and defers the final failure until evidence upload has run. A dedicated repository policy validator locks scan scope, severity, versions, permissions, and non-duplication.
+
+**Tech Stack:** GitHub Actions, Trivy Action v0.36.0 with Trivy v0.72.0, CodeQL SARIF upload, Node.js policy tests, Renovate custom regex management.
+
+## Global Constraints
+
+- Scan only `.devcontainer/` with Trivy's configuration scanner.
+- Fail the existing required `security` status on HIGH or CRITICAL misconfigurations.
+- Do not enable filesystem vulnerability, dependency, license, or secret scanning.
+- Pin all GitHub Actions to immutable commit SHAs.
+- Keep Trivy v0.72.0 explicit and Renovate-managed.
+- Upload SARIF when available, including when the Trivy scan reports findings.
+- Preserve fork safety and the existing required status-check name.
+
+---
+
+### Task 1: Policy contract
+
+**Files:**
+
+- Create: `scripts/check-trivy-devcontainer.mjs`
+- Create: `scripts/check-trivy-devcontainer.test.mjs`
+- Modify: `package.json`
+
+**Interfaces:**
+
+- Produces: `validateTrivyDevcontainerPolicy(root): string[]`
+- Produces: `pnpm run check:trivy-devcontainer`
+- Produces: `pnpm run security:trivy-devcontainer`
+
+- [ ] Write failing tests for exact action SHA, embedded Trivy version, config scan type, `.devcontainer` scan reference, HIGH/CRITICAL severity, SARIF upload, deferred fail, fork guard, and absence of vulnerability/secret/license scanners.
+- [ ] Run `node --test scripts/check-trivy-devcontainer.test.mjs` and confirm the repository contract fails because the workflow and scripts do not exist.
+- [ ] Implement the minimal validator and package-script wiring.
+- [ ] Re-run the focused tests and keep failures limited to the not-yet-added workflow contract.
+- [ ] Commit the policy contract.
+
+### Task 2: Required security job integration
+
+**Files:**
+
+- Modify: `.github/workflows/security.yml`
+- Modify: `renovate.json`
+
+**Interfaces:**
+
+- Consumes: `validateTrivyDevcontainerPolicy(root)`
+- Produces: SARIF file `trivy-devcontainer.sarif`
+- Produces: code-scanning category `trivy-devcontainer`
+
+- [ ] Add a failing workflow-fixture test proving missing SARIF upload, wrong scope, wrong severity, or direct early failure is rejected.
+- [ ] Add `security-events: write` only to the existing `security` job.
+- [ ] Add SHA-pinned `aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25` with `scan-type: config`, `scan-ref: .devcontainer`, `version: v0.72.0`, `limit-severities-for-sarif: true`, `severity: HIGH,CRITICAL`, `exit-code: 1`, and `continue-on-error: true`.
+- [ ] Upload SARIF through the existing SHA-pinned CodeQL action only when a report exists and the token is allowed to write.
+- [ ] Upload the SARIF as a retained artifact, then fail the job when the Trivy step outcome is failure.
+- [ ] Add a Renovate custom regex manager for the explicit Trivy version.
+- [ ] Run policy tests, actionlint, and zizmor; fix every actionable finding.
+- [ ] Commit the workflow integration.
+
+### Task 3: Local command and documentation
+
+**Files:**
+
+- Modify: `docs/security.md`
+- Modify: `apps/vscode-extension/Taskfile.yml`
+
+**Interfaces:**
+
+- Consumes: `pnpm run security:trivy-devcontainer`
+- Produces: documented ownership boundary for Trivy versus CodeQL, pnpm audit, dependency review, Snyk, Gitleaks, and push protection.
+
+- [ ] Add policy-test assertions that the documented command and non-duplication statement cannot disappear.
+- [ ] Add the root Trivy command to `security:local` without widening its target beyond `.devcontainer/`.
+- [ ] Document the blocking threshold, SARIF category, weekly/manual execution inherited from `Security`, and scanner ownership boundaries.
+- [ ] Run docs lint/links and policy tests.
+- [ ] Commit the local and documentation surface.
+
+### Task 4: Live validation and integration
+
+**Files:**
+
+- No production files unless validation reveals a defect.
+
+- [ ] Download Trivy v0.72.0 from the official release and verify its published checksum.
+- [ ] Run `trivy config --severity HIGH,CRITICAL --exit-code 1 .devcontainer` locally and record the exact findings.
+- [ ] Run frozen install, root policy checks, actionlint, zizmor, docs checks, and the complete repository validation gate.
+- [ ] Push through the normal pre-push hook.
+- [ ] Open a PR closing #512 and inspect every GitHub Actions, CodeQL, Codecov, Sonar, Snyk, DeepScan, Socket, Aikido, Opire, and review-thread result.
+- [ ] Resolve actionable findings, merge only after terminal required checks, and verify the signed merge commit and `main` security run.

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "docs:preview": "vitepress preview docs",
     "check:docs-site": "pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:vscode-typings-policy && pnpm run check:codecov && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:dependabot-policy && pnpm run check:security-tooling && pnpm run check:best-practices && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:validation-host && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:extension-doc-links && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check",
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:vscode-typings-policy && pnpm run check:codecov && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:dependabot-policy && pnpm run check:security-tooling && pnpm run check:trivy-devcontainer && pnpm run check:best-practices && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:validation-host && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:extension-doc-links && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check",
     "check:best-practices": "node scripts/check-best-practices-evidence.mjs && pnpm run check:repeatable-vsix && node --test scripts/check-best-practices-evidence.test.mjs scripts/report-best-practices-status.test.mjs",
     "best-practices:status": "node scripts/report-best-practices-status.mjs",
     "best-practices:status:write": "node scripts/report-best-practices-status.mjs --write",
@@ -94,7 +94,9 @@
     "security:workflows": "actionlint -config-file .github/actionlint.yaml && uvx --from zizmor==1.27.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .",
     "security:semgrep": "uvx --from semgrep==1.170.0 semgrep scan --config .semgrep/semgrep.yml --error --metrics=off apps/vscode-extension/src apps/vscode-extension/scripts packages scripts",
     "test:semgrep-rules": "uvx --from semgrep==1.170.0 semgrep --metrics=off --test --config .semgrep/semgrep.yml .semgrep/semgrep.ts",
-    "check:dependabot-policy": "node scripts/check-dependabot-policy.mjs && node --test scripts/check-dependabot-policy.test.mjs"
+    "check:dependabot-policy": "node scripts/check-dependabot-policy.mjs && node --test scripts/check-dependabot-policy.test.mjs",
+    "check:trivy-devcontainer": "node scripts/check-trivy-devcontainer.mjs && node --test scripts/check-trivy-devcontainer.test.mjs",
+    "security:trivy-devcontainer": "trivy config --skip-version-check --severity HIGH,CRITICAL --exit-code 1 --format table .devcontainer"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,13 @@
   "prHourlyLimit": 2,
   "prConcurrentLimit": 5,
   "minimumReleaseAge": "3 days",
-  "enabledManagers": ["npm", "github-actions", "dockerfile", "pep621"],
+  "enabledManagers": [
+    "npm",
+    "github-actions",
+    "dockerfile",
+    "pep621",
+    "custom.regex"
+  ],
   "rangeStrategy": "pin",
   "separateMajorMinor": true,
   "separateMinorPatch": false,
@@ -161,5 +167,17 @@
     "automergeType": "pr",
     "platformAutomerge": true,
     "addLabels": ["risk:low"]
-  }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github\\/workflows\\/security\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=github-releases depName=aquasecurity/trivy\\n\\s*TRIVY_VERSION: v(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "aquasecurity/trivy",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ]
 }

--- a/scripts/check-trivy-devcontainer.mjs
+++ b/scripts/check-trivy-devcontainer.mjs
@@ -26,6 +26,12 @@ function includesAll(source, snippets) {
   return snippets.every((snippet) => source.includes(snippet));
 }
 
+function addErrorWhen(errors, condition, message) {
+  if (condition) {
+    errors.push(message);
+  }
+}
+
 export function validateTrivyDevcontainerPolicy(root = REPO_ROOT) {
   const errors = [];
   const workflow = readText(root, ".github/workflows/security.yml");
@@ -109,11 +115,20 @@ export function validateTrivyDevcontainerPolicy(root = REPO_ROOT) {
     );
   }
 
-  if (/scanners:\s*[^\n]*(?:vuln|secret|license)/iu.test(workflow)) {
-    errors.push(
-      "Trivy must not duplicate vulnerability, dependency, license, or secret scanning",
+  const duplicateScannerOwnership = workflow.split(/\r?\n/u).some((line) => {
+    const normalized = line.toLowerCase();
+    return (
+      normalized.includes("scanners:") &&
+      ["vuln", "secret", "license"].some((scanner) =>
+        normalized.includes(scanner),
+      )
     );
-  }
+  });
+  addErrorWhen(
+    errors,
+    duplicateScannerOwnership,
+    "Trivy must not duplicate vulnerability, dependency, license, or secret scanning",
+  );
 
   const localCommand = packageJson.scripts?.["security:trivy-devcontainer"];
   if (
@@ -171,7 +186,7 @@ export function validateTrivyDevcontainerPolicy(root = REPO_ROOT) {
   const customManagers = Array.isArray(renovate.customManagers)
     ? renovate.customManagers
     : [];
-  const trivyManager = customManagers.find(
+  const hasTrivyManager = customManagers.some(
     (manager) =>
       manager?.customType === "regex" &&
       JSON.stringify(manager).includes("aquasecurity/trivy") &&
@@ -180,7 +195,7 @@ export function validateTrivyDevcontainerPolicy(root = REPO_ROOT) {
   if (
     !Array.isArray(renovate.enabledManagers) ||
     !renovate.enabledManagers.includes("custom.regex") ||
-    !trivyManager
+    !hasTrivyManager
   ) {
     errors.push(
       "Renovate must own the explicit Trivy scanner version through a custom regex manager",

--- a/scripts/check-trivy-devcontainer.mjs
+++ b/scripts/check-trivy-devcontainer.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const TRIVY_ACTION_SHA = "ed142fd0673e97e23eac54620cfb913e5ce36c25";
+const CODEQL_ACTION_SHA = "8aad20d150bbac5944a9f9d289da16a4b0d87c1e";
+const UPLOAD_ARTIFACT_SHA = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
+const TRIVY_VERSION = "v0.72.0";
+
+function readText(root, relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function readJson(root, relativePath) {
+  return JSON.parse(readText(root, relativePath));
+}
+
+function includesAll(source, snippets) {
+  return snippets.every((snippet) => source.includes(snippet));
+}
+
+export function validateTrivyDevcontainerPolicy(root = REPO_ROOT) {
+  const errors = [];
+  const workflow = readText(root, ".github/workflows/security.yml");
+  const packageJson = readJson(root, "package.json");
+  const renovate = readJson(root, "renovate.json");
+  const taskfile = readText(root, "apps/vscode-extension/Taskfile.yml");
+  const securityDocs = readText(root, "docs/security.md");
+
+  if (!workflow.includes(`aquasecurity/trivy-action@${TRIVY_ACTION_SHA}`)) {
+    errors.push(
+      `security.yml must use the immutable Trivy action commit ${TRIVY_ACTION_SHA}`,
+    );
+  }
+
+  if (
+    !workflow.includes(`TRIVY_VERSION: ${TRIVY_VERSION}`) ||
+    !workflow.includes("version: ${{ env.TRIVY_VERSION }}")
+  ) {
+    errors.push(
+      `security.yml must pin and pass Trivy ${TRIVY_VERSION} explicitly`,
+    );
+  }
+
+  if (!workflow.includes("scan-type: config")) {
+    errors.push(
+      "security.yml must use Trivy's configuration scanner for the development container",
+    );
+  }
+  if (!workflow.includes("scan-ref: .devcontainer")) {
+    errors.push("security.yml must scan only .devcontainer with Trivy");
+  }
+
+  if (
+    !includesAll(workflow, [
+      "format: sarif",
+      "output: trivy-devcontainer.sarif",
+      "limit-severities-for-sarif: true",
+      `github/codeql-action/upload-sarif@${CODEQL_ACTION_SHA}`,
+      "category: trivy-devcontainer",
+      `actions/upload-artifact@${UPLOAD_ARTIFACT_SHA}`,
+      "name: trivy-devcontainer-sarif",
+    ])
+  ) {
+    errors.push(
+      "security.yml must retain Trivy SARIF generation, code-scanning upload, and artifact evidence",
+    );
+  }
+
+  if (
+    !workflow.includes("severity: HIGH,CRITICAL") ||
+    !workflow.includes('exit-code: "1"')
+  ) {
+    errors.push(
+      "security.yml must fail Trivy on HIGH,CRITICAL development-container misconfigurations",
+    );
+  }
+
+  if (
+    !workflow.includes("continue-on-error: true") ||
+    !workflow.includes("id: trivy-devcontainer")
+  ) {
+    errors.push(
+      "security.yml must defer failure until Trivy evidence has been uploaded",
+    );
+  }
+
+  if (!workflow.includes("steps.trivy-devcontainer.outcome == 'failure'")) {
+    errors.push(
+      "security.yml must fail the required security job when the Trivy scan fails",
+    );
+  }
+
+  if (
+    !workflow.includes(
+      "github.event.pull_request.head.repo.full_name == github.repository",
+    ) ||
+    !workflow.includes("security-events: write")
+  ) {
+    errors.push(
+      "security.yml must keep Trivy SARIF upload fork-safe with least-privilege code-scanning permissions",
+    );
+  }
+
+  if (/scanners:\s*[^\n]*(?:vuln|secret|license)/iu.test(workflow)) {
+    errors.push(
+      "Trivy must not duplicate vulnerability, dependency, license, or secret scanning",
+    );
+  }
+
+  const localCommand = packageJson.scripts?.["security:trivy-devcontainer"];
+  if (
+    typeof localCommand !== "string" ||
+    !includesAll(localCommand, [
+      "trivy config",
+      "--skip-version-check",
+      "--severity HIGH,CRITICAL",
+      "--exit-code 1",
+      ".devcontainer",
+    ])
+  ) {
+    errors.push(
+      "package.json must expose a local Trivy command scoped to .devcontainer",
+    );
+  }
+
+  const policyCommand = packageJson.scripts?.["check:trivy-devcontainer"];
+  const rootCheck = packageJson.scripts?.check;
+  if (
+    typeof policyCommand !== "string" ||
+    !policyCommand.includes("scripts/check-trivy-devcontainer.mjs") ||
+    !policyCommand.includes("scripts/check-trivy-devcontainer.test.mjs") ||
+    typeof rootCheck !== "string" ||
+    !rootCheck.includes("pnpm run check:trivy-devcontainer")
+  ) {
+    errors.push(
+      "package.json must wire the Trivy policy validator and tests into the root check",
+    );
+  }
+
+  if (
+    !taskfile.includes("security:trivy-devcontainer:") ||
+    !taskfile.includes("pnpm --dir ../.. run security:trivy-devcontainer") ||
+    !taskfile.includes("task: security:trivy-devcontainer")
+  ) {
+    errors.push(
+      "Taskfile security:local must include the root local Trivy command",
+    );
+  }
+
+  if (
+    !/\| Development-container configuration\s+\| Trivy v0\.72\.0/u.test(
+      securityDocs,
+    ) ||
+    !securityDocs.includes("trivy-devcontainer") ||
+    !securityDocs.includes("HIGH/CRITICAL") ||
+    !securityDocs.includes("configuration-only")
+  ) {
+    errors.push(
+      "docs/security.md must document Trivy v0.72.0, its configuration-only scope, evidence category, and HIGH/CRITICAL gate",
+    );
+  }
+
+  const customManagers = Array.isArray(renovate.customManagers)
+    ? renovate.customManagers
+    : [];
+  const trivyManager = customManagers.find(
+    (manager) =>
+      manager?.customType === "regex" &&
+      JSON.stringify(manager).includes("aquasecurity/trivy") &&
+      JSON.stringify(manager).includes("TRIVY_VERSION"),
+  );
+  if (
+    !Array.isArray(renovate.enabledManagers) ||
+    !renovate.enabledManagers.includes("custom.regex") ||
+    !trivyManager
+  ) {
+    errors.push(
+      "Renovate must own the explicit Trivy scanner version through a custom regex manager",
+    );
+  }
+
+  return errors;
+}
+
+function main() {
+  const errors = validateTrivyDevcontainerPolicy();
+  if (errors.length > 0) {
+    console.error("Targeted Trivy devcontainer policy failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+  console.log("Targeted Trivy devcontainer policy is valid.");
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-trivy-devcontainer.test.mjs
+++ b/scripts/check-trivy-devcontainer.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import {
+  cpSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { validateTrivyDevcontainerPolicy } from "./check-trivy-devcontainer.mjs";
+
+const RELEVANT_FILES = [
+  ".github/workflows/security.yml",
+  "apps/vscode-extension/Taskfile.yml",
+  "docs/security.md",
+  "package.json",
+  "renovate.json",
+];
+
+function createFixture() {
+  const root = mkdtempSync(path.join(os.tmpdir(), "kicad-trivy-policy-"));
+  for (const relativePath of RELEVANT_FILES) {
+    const target = path.join(root, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    cpSync(relativePath, target);
+  }
+  return root;
+}
+
+function replaceInFixture(root, relativePath, before, after) {
+  const filePath = path.join(root, relativePath);
+  const source = readFileSync(filePath, "utf8");
+  assert.ok(source.includes(before), `${relativePath} must contain ${before}`);
+  writeFileSync(filePath, source.replace(before, after));
+}
+
+function withFixture(run) {
+  const root = createFixture();
+  try {
+    run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("#512 targeted Trivy devcontainer policy is complete", () => {
+  assert.deepEqual(validateTrivyDevcontainerPolicy(), []);
+});
+
+test("#512 Trivy action and scanner versions remain immutable", () => {
+  withFixture((root) => {
+    replaceInFixture(
+      root,
+      ".github/workflows/security.yml",
+      "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25",
+      "aquasecurity/trivy-action@v0.36.0",
+    );
+    replaceInFixture(
+      root,
+      ".github/workflows/security.yml",
+      "TRIVY_VERSION: v0.72.0",
+      "TRIVY_VERSION: latest",
+    );
+    const errors = validateTrivyDevcontainerPolicy(root);
+    assert.ok(errors.some((error) => error.includes("immutable Trivy action")));
+    assert.ok(errors.some((error) => error.includes("Trivy v0.72.0")));
+  });
+});
+
+test("#512 scan scope cannot widen beyond devcontainer configuration", () => {
+  withFixture((root) => {
+    replaceInFixture(
+      root,
+      ".github/workflows/security.yml",
+      "scan-type: config",
+      "scan-type: fs",
+    );
+    replaceInFixture(
+      root,
+      ".github/workflows/security.yml",
+      "scan-ref: .devcontainer",
+      "scan-ref: .",
+    );
+    const errors = validateTrivyDevcontainerPolicy(root);
+    assert.ok(errors.some((error) => error.includes("configuration scanner")));
+    assert.ok(errors.some((error) => error.includes("only .devcontainer")));
+  });
+});
+
+test("#512 HIGH and CRITICAL findings fail only after evidence upload", () => {
+  withFixture((root) => {
+    replaceInFixture(
+      root,
+      ".github/workflows/security.yml",
+      "severity: HIGH,CRITICAL",
+      "severity: CRITICAL",
+    );
+    replaceInFixture(
+      root,
+      ".github/workflows/security.yml",
+      "continue-on-error: true",
+      "continue-on-error: false",
+    );
+    replaceInFixture(
+      root,
+      ".github/workflows/security.yml",
+      "steps.trivy-devcontainer.outcome == 'failure'",
+      "false",
+    );
+    const errors = validateTrivyDevcontainerPolicy(root);
+    assert.ok(errors.some((error) => error.includes("HIGH,CRITICAL")));
+    assert.ok(errors.some((error) => error.includes("defer failure")));
+    assert.ok(
+      errors.some((error) => error.includes("fail the required security job")),
+    );
+  });
+});
+
+test("#512 SARIF evidence and fork-safe upload cannot disappear", () => {
+  withFixture((root) => {
+    replaceInFixture(
+      root,
+      ".github/workflows/security.yml",
+      "format: sarif",
+      "format: table",
+    );
+    replaceInFixture(
+      root,
+      ".github/workflows/security.yml",
+      "github.event.pull_request.head.repo.full_name == github.repository",
+      "true",
+    );
+    const errors = validateTrivyDevcontainerPolicy(root);
+    assert.ok(errors.some((error) => error.includes("SARIF")));
+    assert.ok(errors.some((error) => error.includes("fork-safe")));
+  });
+});
+
+test("#512 Trivy cannot duplicate vulnerability, dependency, license, or secret scanning", () => {
+  withFixture((root) => {
+    const workflowPath = path.join(root, ".github/workflows/security.yml");
+    writeFileSync(
+      workflowPath,
+      `${readFileSync(workflowPath, "utf8")}\n# scanners: vuln,secret,license\n`,
+    );
+    const errors = validateTrivyDevcontainerPolicy(root);
+    assert.ok(errors.some((error) => error.includes("must not duplicate")));
+  });
+});
+
+test("#512 local command, documentation, root check, and Renovate ownership remain wired", () => {
+  withFixture((root) => {
+    const packagePath = path.join(root, "package.json");
+    const packageJson = JSON.parse(readFileSync(packagePath, "utf8"));
+    delete packageJson.scripts["security:trivy-devcontainer"];
+    packageJson.scripts.check = packageJson.scripts.check.replace(
+      " && pnpm run check:trivy-devcontainer",
+      "",
+    );
+    writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    replaceInFixture(root, "docs/security.md", "Trivy v0.72.0", "Trivy");
+    const renovatePath = path.join(root, "renovate.json");
+    const renovate = JSON.parse(readFileSync(renovatePath, "utf8"));
+    renovate.customManagers = [];
+    writeFileSync(renovatePath, `${JSON.stringify(renovate, null, 2)}\n`);
+    const errors = validateTrivyDevcontainerPolicy(root);
+    assert.ok(errors.some((error) => error.includes("root check")));
+    assert.ok(errors.some((error) => error.includes("local Trivy command")));
+    assert.ok(errors.some((error) => error.includes("document Trivy v0.72.0")));
+    assert.ok(errors.some((error) => error.includes("Renovate")));
+  });
+});


### PR DESCRIPTION
## Summary

- add a SHA-pinned Trivy configuration scan scoped only to `.devcontainer/`
- block the existing required `security` status on HIGH/CRITICAL misconfigurations after SARIF evidence is uploaded
- keep vulnerability, dependency, license, and secret scanning with their existing owners
- pin Trivy v0.72.0 explicitly and make the version Renovate-managed
- add repository policy tests, a focused local command, and security documentation

## Validation

- official Trivy v0.72.0 archive checksum verified
- `trivy config --skip-version-check --severity HIGH,CRITICAL --exit-code 1 .devcontainer` — 0 findings
- Trivy policy tests — 7/7
- actionlint — clean
- zizmor high-confidence medium+ gate — clean
- docs lint and links — clean
- release/version policy — clean

Closes #512