### PR TITLE
fix(repo): enforce validation workspace integrity

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,11 @@
 #!/usr/bin/env sh
-pnpm run check
+set -eu
+
+# Prefer the pinned rootless validation host when it is already bootstrapped.
+# Contributor machines without that profile retain the normal Corepack path.
+if command -v bash >/dev/null 2>&1 && \
+  bash scripts/run-validation-host.sh true >/dev/null 2>&1; then
+  exec bash scripts/run-validation-host.sh corepack pnpm run check
+fi
+
+exec corepack pnpm run check

--- a/docs/superpowers/plans/2026-07-22-issue-525-workspace-integrity.md
+++ b/docs/superpowers/plans/2026-07-22-issue-525-workspace-integrity.md
@@ -1,0 +1,399 @@
+# Workspace Integrity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic, non-mutating Git workspace health check and complete the canonical validation-host recovery tracked by #525.
+
+**Architecture:** A focused Node.js CLI will collect Git state through an injectable command runner, evaluate general and canonical workspace invariants, and emit human or JSON reports. Validation-host package scripts and contract tests will wire the check without requiring PR branches to be on `main`. The public runbook will describe safe recovery while operational backups remain private on the host.
+
+**Tech Stack:** Node.js 24 standard library, Git CLI, `node:test`, pnpm 11, Markdown.
+
+## Global Constraints
+
+- The checker must never fetch, reset, prune, delete, or edit Git configuration.
+- Default mode must work in ordinary branches and linked worktrees.
+- `--canonical` must require a normal checkout on `main` with `HEAD == origin/main`.
+- Public documentation must not include credentials, private host inventory, or machine-specific absolute paths.
+- Tests must be written and observed failing before implementation.
+- A normal push must run repository hooks without `HUSKY=0`.
+- Bot and agent findings must be reviewed before merge.
+
+---
+
+### Task 1: Define workspace integrity behavior with failing tests
+
+**Files:**
+
+- Create: `scripts/check-workspace-integrity.test.mjs`
+- Create: `scripts/check-workspace-integrity.mjs`
+
+**Interfaces:**
+
+- Produces: `parseWorktreePorcelain(text: string): Array<object>`
+- Produces: `evaluateWorkspaceState(state: object, options?: { canonical?: boolean }): object`
+- Produces: `inspectWorkspace(repoRoot: string, options?: object): object`
+- Produces: `formatWorkspaceReport(report: object): string`
+
+- [ ] **Step 1: Create a test file that imports the planned interfaces and asserts the invalid bare/worktree combination is rejected**
+
+```js
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  evaluateWorkspaceState,
+  parseWorktreePorcelain,
+} from "./check-workspace-integrity.mjs";
+
+test("rejects a bare repository with an explicit worktree (#525)", () => {
+  const report = evaluateWorkspaceState({
+    insideWorkTree: false,
+    bare: true,
+    coreWorktree: "/tmp/other-worktree",
+    topLevel: "",
+    gitDir: "/repo/.git",
+    commonDir: "/repo/.git",
+    branch: "main",
+    head: "abc",
+    originMain: "abc",
+    statusOk: false,
+    statusStderr: "core.bare and core.worktree do not make sense",
+    worktrees: [],
+  });
+  assert.equal(report.ok, false);
+  assert.match(report.errors.join("\n"), /core\.bare.*core\.worktree/u);
+});
+```
+
+- [ ] **Step 2: Add tests for canonical linked-worktree rejection, stale default branch state, and prunable entries**
+
+```js
+test("canonical mode rejects linked worktrees and stale main", () => {
+  const report = evaluateWorkspaceState(
+    {
+      insideWorkTree: true,
+      bare: false,
+      coreWorktree: "",
+      topLevel: "/repo/worktree",
+      gitDir: "/repo/.git/worktrees/task",
+      commonDir: "/repo/.git",
+      branch: "feature/task",
+      head: "old",
+      originMain: "new",
+      statusOk: true,
+      statusStderr: "",
+      worktrees: [],
+    },
+    { canonical: true },
+  );
+  assert.equal(report.ok, false);
+  assert.match(report.errors.join("\n"), /linked worktree/u);
+  assert.match(report.errors.join("\n"), /branch must be main/u);
+  assert.match(report.errors.join("\n"), /does not match origin\/main/u);
+});
+
+test("parses and rejects prunable worktree records", () => {
+  const worktrees = parseWorktreePorcelain(
+    "worktree /repo\nHEAD abc\nbranch refs/heads/main\n\nworktree /gone\nHEAD def\nprunable gitdir file points to non-existent location\n",
+  );
+  const report = evaluateWorkspaceState({
+    insideWorkTree: true,
+    bare: false,
+    coreWorktree: "",
+    topLevel: "/repo",
+    gitDir: "/repo/.git",
+    commonDir: "/repo/.git",
+    branch: "main",
+    head: "abc",
+    originMain: "abc",
+    statusOk: true,
+    statusStderr: "",
+    worktrees,
+  });
+  assert.equal(report.ok, false);
+  assert.match(report.errors.join("\n"), /prunable worktree/u);
+});
+```
+
+- [ ] **Step 3: Run the tests and verify RED**
+
+Run:
+
+```bash
+bash scripts/run-validation-host.sh node --test scripts/check-workspace-integrity.test.mjs
+```
+
+Expected: FAIL because the module or exported functions do not exist.
+
+- [ ] **Step 4: Commit the failing tests**
+
+```bash
+git add scripts/check-workspace-integrity.test.mjs
+git commit -m "test(repo): define workspace integrity invariants"
+```
+
+---
+
+### Task 2: Implement the non-mutating workspace checker
+
+**Files:**
+
+- Create: `scripts/check-workspace-integrity.mjs`
+- Test: `scripts/check-workspace-integrity.test.mjs`
+
+**Interfaces:**
+
+- Consumes the interfaces defined by Task 1.
+- Produces CLI flags `--canonical` and `--json`.
+
+- [ ] **Step 1: Implement porcelain parsing and invariant evaluation**
+
+```js
+export function parseWorktreePorcelain(text) {
+  return String(text)
+    .trim()
+    .split(/\n\s*\n/u)
+    .filter(Boolean)
+    .map((record) => {
+      const parsed = {};
+      for (const line of record.split(/\r?\n/u)) {
+        const [key, ...rest] = line.split(" ");
+        parsed[key] = rest.join(" ");
+      }
+      return parsed;
+    });
+}
+
+export function evaluateWorkspaceState(state, options = {}) {
+  const errors = [];
+  if (state.bare && state.coreWorktree) {
+    errors.push("core.bare and core.worktree must not be configured together");
+  }
+  if (!state.insideWorkTree || state.bare || !state.statusOk) {
+    errors.push("repository root is not a usable working tree");
+  }
+  for (const worktree of state.worktrees) {
+    if (worktree.prunable)
+      errors.push(`prunable worktree: ${worktree.worktree}`);
+  }
+  if (options.canonical) {
+    if (state.gitDir !== state.commonDir)
+      errors.push("canonical checkout must not be a linked worktree");
+    if (state.coreWorktree)
+      errors.push("canonical checkout must not configure core.worktree");
+    if (state.branch !== "main") errors.push("canonical branch must be main");
+    if (!state.originMain || state.head !== state.originMain)
+      errors.push("HEAD does not match origin/main");
+  }
+  return {
+    ok: errors.length === 0,
+    canonical: Boolean(options.canonical),
+    errors,
+    state,
+  };
+}
+```
+
+- [ ] **Step 2: Implement Git collection through `spawnSync` and an injectable runner**
+
+The collector must run `git rev-parse`, `git config`, `git status`, `git branch`, and `git worktree list --porcelain`; status code `1` from `git config --get core.worktree` means unset and is not an error.
+
+- [ ] **Step 3: Implement human and JSON CLI output**
+
+Human success output must include `Workspace integrity: pass`; failure output must list each invariant and set exit code `1`.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+```bash
+bash scripts/run-validation-host.sh node --test scripts/check-workspace-integrity.test.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add a temporary-repository integration test**
+
+Create a temporary Git repository, configure user identity, create `main`, commit one file, create `refs/remotes/origin/main`, and assert `inspectWorkspace(temp, { canonical: true })` passes.
+
+- [ ] **Step 6: Run all workspace checker tests**
+
+```bash
+bash scripts/run-validation-host.sh node --test scripts/check-workspace-integrity.test.mjs
+```
+
+Expected: PASS with no warnings.
+
+- [ ] **Step 7: Commit implementation**
+
+```bash
+git add scripts/check-workspace-integrity.mjs scripts/check-workspace-integrity.test.mjs
+git commit -m "feat(repo): add workspace integrity doctor"
+```
+
+---
+
+### Task 3: Wire the checker into validation-host contracts
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `scripts/check-validation-host.mjs`
+- Modify: `scripts/check-validation-host.test.mjs`
+
+**Interfaces:**
+
+- Produces package script `validation-host:workspace`.
+- Changes `validation-host:doctor` to run workspace integrity first.
+
+- [ ] **Step 1: Add failing contract assertions**
+
+Assert these exact scripts:
+
+```json
+{
+  "validation-host:workspace": "bash scripts/run-validation-host.sh node scripts/check-workspace-integrity.mjs --canonical",
+  "validation-host:doctor": "corepack pnpm run validation-host:workspace && bash scripts/run-validation-host.sh node scripts/dev-doctor.mjs --ci --strict"
+}
+```
+
+Also assert the checker and its test file exist and that `check:validation-host` runs `node --test scripts/check-workspace-integrity.test.mjs`.
+
+- [ ] **Step 2: Run the contract test and verify RED**
+
+```bash
+bash scripts/run-validation-host.sh node --test scripts/check-validation-host.test.mjs
+```
+
+Expected: FAIL because the package scripts and contract requirements are not wired.
+
+- [ ] **Step 3: Update package scripts and validation-host contract implementation**
+
+Set:
+
+```json
+{
+  "validation-host:workspace": "bash scripts/run-validation-host.sh node scripts/check-workspace-integrity.mjs --canonical",
+  "validation-host:doctor": "corepack pnpm run validation-host:workspace && bash scripts/run-validation-host.sh node scripts/dev-doctor.mjs --ci --strict",
+  "check:validation-host": "node scripts/check-validation-host.mjs && node --test scripts/check-validation-host.test.mjs scripts/check-workspace-integrity.test.mjs"
+}
+```
+
+- [ ] **Step 4: Run focused contract and checker tests**
+
+```bash
+bash scripts/run-validation-host.sh corepack pnpm run check:validation-host
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit integration**
+
+```bash
+git add package.json scripts/check-validation-host.mjs scripts/check-validation-host.test.mjs
+git commit -m "ci(repo): gate validation host workspace integrity"
+```
+
+---
+
+### Task 4: Document canonical topology, recovery, and rollback
+
+**Files:**
+
+- Modify: `docs/validation-host.md`
+- Modify: `scripts/check-validation-host.mjs`
+- Test: `scripts/check-validation-host.test.mjs`
+
+- [ ] **Step 1: Add a failing documentation-contract assertion**
+
+Require these public phrases in `docs/validation-host.md`:
+
+- `validation-host:workspace`
+- `git worktree list --porcelain`
+- `core.bare`
+- `core.worktree`
+- `private backup`
+- `fast-forward`
+- `rollback`
+
+- [ ] **Step 2: Run the contract test and verify RED**
+
+```bash
+bash scripts/run-validation-host.sh node --test scripts/check-validation-host.test.mjs
+```
+
+Expected: FAIL because the runbook is incomplete.
+
+- [ ] **Step 3: Add the documented topology and non-destructive procedure**
+
+Document that the supported canonical topology is a normal non-bare checkout on `main`, while task work occurs in linked worktrees. Require private backups, clean-status checks, PR association before removal, `git worktree prune` only after inventory, fast-forward synchronization, the workspace checker, full validation, and rollback from the private config backup.
+
+- [ ] **Step 4: Run documentation and validation-host checks**
+
+```bash
+bash scripts/run-validation-host.sh corepack pnpm run check:validation-host
+bash scripts/run-validation-host.sh corepack pnpm run check:docs-site
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit documentation**
+
+```bash
+git add docs/validation-host.md scripts/check-validation-host.mjs scripts/check-validation-host.test.mjs
+git commit -m "docs(repo): add validation workspace recovery runbook"
+```
+
+---
+
+### Task 5: Verify host recovery and repository-wide behavior
+
+**Files:**
+
+- No public source changes expected.
+
+- [ ] **Step 1: Verify the repaired canonical host**
+
+```bash
+git status --short --branch
+git rev-parse HEAD refs/remotes/origin/main
+git worktree list --porcelain
+corepack pnpm run validation-host:workspace
+```
+
+Expected: clean `main`, equal revisions, only expected worktrees, workspace integrity pass.
+
+- [ ] **Step 2: Run formatting and focused tests**
+
+```bash
+bash scripts/run-validation-host.sh corepack pnpm exec prettier --check scripts/check-workspace-integrity.mjs scripts/check-workspace-integrity.test.mjs scripts/check-validation-host.mjs scripts/check-validation-host.test.mjs docs/validation-host.md docs/superpowers/specs/2026-07-22-issue-525-workspace-integrity-design.md docs/superpowers/plans/2026-07-22-issue-525-workspace-integrity.md
+bash scripts/run-validation-host.sh corepack pnpm run check:validation-host
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the complete pinned validation-host check**
+
+```bash
+bash scripts/run-validation-host.sh corepack pnpm run check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Verify hook environment selection and push normally**
+
+The pre-push hook must prefer `scripts/run-validation-host.sh` when the pinned
+host is bootstrapped and fall back to `corepack pnpm run check` elsewhere.
+Neither path may use `HUSKY=0`.
+
+```bash
+git push --set-upstream origin fix/525-workspace-integrity
+```
+
+Expected: the pinned environment is selected on the validation host and the
+push succeeds through the complete Husky check without bypasses.
+
+- [ ] **Step 5: Open a pull request referencing #525**
+
+The PR body must summarize the operational recovery separately from public source changes, list validation evidence, state that no credentials or host-specific paths were committed, and include `Closes #525`.
+
+- [ ] **Step 6: Inspect all bot and agent comments before merge**
+
+Review checks, issue comments, PR reviews, and inline comments. A quota or unavailable-review message is not review evidence; perform a manual compensating review when needed.

--- a/docs/superpowers/specs/2026-07-22-issue-525-workspace-integrity-design.md
+++ b/docs/superpowers/specs/2026-07-22-issue-525-workspace-integrity-design.md
@@ -1,0 +1,78 @@
+# Issue 525 Workspace Integrity Design
+
+## Problem
+
+A repository validation host can appear available while its canonical checkout is not a valid working tree. The observed failure combined `core.bare=true` with an explicit `core.worktree`, left the local default branch behind `origin/main`, and accumulated obsolete linked worktrees. Commands then resolved against an ambiguous checkout and emitted configuration warnings.
+
+## Goals
+
+- Detect invalid or ambiguous Git workspace state before expensive validation runs.
+- Keep ordinary contributor branches and CI checkouts supported.
+- Provide a stricter canonical-host mode that verifies the default branch and remote revision.
+- Document a non-destructive recovery procedure that preserves active work and keeps host-specific details private.
+- Keep the check dependency-free, fast, and testable with the Node.js standard library.
+
+## Non-goals
+
+- Automatically mutate Git configuration or delete worktrees.
+- Require every contributor checkout to be on `main`.
+- Replace GitHub branch protection, repository bootstrap, or full validation.
+- Publish host paths, credentials, or machine inventory.
+
+## Considered approaches
+
+### Extend the existing developer doctor
+
+This would keep all diagnostics in one report, but the developer doctor already covers runtimes, tools, ports, fixtures, and package contracts. Adding canonical Git topology would make it responsible for host repair semantics and complicate its mocked command matrix.
+
+### Add shell-only checks to the validation runner
+
+A shell implementation would be short, but portable parsing and unit testing would be weaker, especially for Windows contributors and `git worktree list --porcelain` output.
+
+### Add a focused Node.js workspace-integrity checker
+
+This keeps Git topology logic isolated, supports deterministic unit tests through an injected command runner, and can be invoked independently or before the validation-host doctor. This is the selected approach.
+
+## Architecture
+
+Create `scripts/check-workspace-integrity.mjs` with two layers:
+
+1. Pure parsing and evaluation functions convert Git command results into a structured report.
+2. A CLI adapter runs Git commands from a selected repository root and renders human or JSON output.
+
+Default mode validates that the current directory is a usable non-bare working tree and that no worktree entry is marked prunable. `--canonical` adds these requirements:
+
+- the checkout is not a linked worktree;
+- local `core.worktree` is unset;
+- the current branch is `main`;
+- the working tree has no staged or unstaged changes;
+- `HEAD` equals `refs/remotes/origin/main`;
+- `git status` succeeds without configuration warnings.
+
+The checker never fetches, resets, prunes, or edits configuration. Operators must synchronize and repair explicitly using the documented runbook.
+
+## Integration
+
+- Add `validation-host:workspace` to the root package scripts.
+- Run the canonical workspace check before `validation-host:doctor`.
+- Extend the validation-host contract checker so CI proves the script, tests, package entrypoint, recovery documentation, and hook integration remain present.
+- Make the Husky pre-push hook prefer the pinned validation host when it is bootstrapped, with a Corepack fallback for ordinary contributor environments.
+- Keep the repository-wide `check` safe for PR branches by running only unit/contract tests there, not the canonical runtime mode.
+
+## Error handling
+
+Every failed Git command becomes an actionable report item. Missing `core.worktree` is treated as the expected state rather than an error. Human output must describe the failed invariant without printing credentials or remote URLs. JSON output is available for operations tooling.
+
+## Testing
+
+- Unit-test invalid `core.bare`/`core.worktree` combinations.
+- Unit-test canonical linked-worktree rejection.
+- Unit-test stale `HEAD` versus `origin/main`.
+- Unit-test prunable worktree detection.
+- Integration-test a temporary normal Git repository.
+- Re-run validation-host contract tests and the complete pinned repository check.
+- Verify a normal push executes Husky hooks without `HUSKY=0`.
+
+## Operational recovery
+
+Before changing configuration, operators must inventory every linked worktree, confirm clean status, associate branches with merged or active pull requests, and save a private backup of `.git/config` plus `git worktree list --porcelain`. Recovery then removes only confirmed obsolete worktrees, restores a normal canonical checkout, fast-forwards `main`, and runs the new checker before full validation.

--- a/docs/validation-host.md
+++ b/docs/validation-host.md
@@ -47,11 +47,22 @@ The bootstrap ends with the strict CI-safe developer doctor. Optional remote
 
 ## Validation commands
 
+Validate the canonical Git checkout before running toolchain diagnostics:
+
 ```bash
+corepack pnpm run validation-host:workspace
 corepack pnpm run validation-host:doctor
 corepack pnpm run validation-host:check
 corepack pnpm run validation-host:package
 ```
+
+`validation-host:workspace` is a read-only check. It does not fetch, reset,
+prune, remove worktrees, or edit Git configuration. The doctor runs this check
+first so an invalid checkout cannot produce misleading release evidence.
+
+The pre-push hook automatically selects this pinned environment when the
+validation host is bootstrapped. Other contributor environments fall back to
+`corepack pnpm run check`; the hook never disables or bypasses validation.
 
 Run another command inside the same pinned/rootless environment:
 
@@ -78,7 +89,67 @@ in [testing strategy](testing-strategy.md) and the
 [KiCad support matrix](support-matrix.md). VPS-2 remains authoritative for the
 repository, browser, extension package, and release-recovery checks listed above.
 
-## Recovery
+## Canonical workspace topology
+
+The supported validation-host topology is a normal, non-bare canonical checkout
+on `main`. Issue and pull-request work belongs in linked worktrees created from
+that checkout. In the canonical checkout, `core.bare` must be `false`,
+`core.worktree` must be unset, the working tree must be clean, and `HEAD` must
+match the fetched `origin/main` revision. Linked worktrees are valid development environments,
+but they are not canonical release-recovery checkouts.
+
+Use the porcelain inventory when reviewing workspace state:
+
+```bash
+git status --short --branch
+git worktree list --porcelain
+corepack pnpm run validation-host:workspace
+```
+
+A worktree entry marked `prunable` is a failed invariant. Do not prune it until
+its directory, branch, uncommitted state, and associated pull request have been
+reviewed.
+
+## Workspace recovery and rollback
+
+Workspace repair is deliberately manual because deleting the wrong linked
+worktree can discard uncommitted work. Stop repository automation before making
+changes, then use this non-destructive sequence:
+
+1. Save a **private backup** of `.git/config` and the output of
+   `git worktree list --porcelain` outside the repository. Never commit this
+   backup because it can contain local paths or remote configuration.
+2. For every linked worktree, run `git status --porcelain`, record its branch
+   and revision, and confirm whether its pull request is active, merged, or
+   abandoned. Preserve any active or dirty worktree.
+3. Restore the canonical checkout configuration without rewriting history:
+
+   ```bash
+   git config --file .git/config core.bare false
+   git config --file .git/config --unset-all core.worktree || true
+   ```
+
+4. Remove only clean worktrees whose changes are confirmed merged or otherwise
+   preserved. Then run `git worktree prune --verbose`. Do not delete local branch
+   references as part of worktree cleanup.
+5. Synchronize the default branch with a fast-forward only update:
+
+   ```bash
+   git fetch --prune origin
+   git switch main
+   git merge --ff-only origin/main
+   ```
+
+6. Run `corepack pnpm run validation-host:workspace`, followed by
+   `corepack pnpm run validation-host:doctor` and
+   `corepack pnpm run validation-host:check`.
+
+For rollback, stop automation, restore the private `.git/config` backup, and
+recreate any removed linked worktree from its preserved branch or revision. A
+rollback must not force-push, rewrite public history, or restore an invalid
+`core.bare`/`core.worktree` combination as the final state.
+
+## Runtime cache recovery
 
 1. Remove `$HOME/.cache/kicad-studio-kit` only when rebuilding the extracted
    Ubuntu layer is desired.

--- a/package.json
+++ b/package.json
@@ -86,17 +86,18 @@
     "check:mcp-split-docs": "node scripts/check-mcp-split-docs.mjs && node --test scripts/check-mcp-split-docs.test.mjs",
     "check:vscode-typings-policy": "node scripts/check-vscode-typings-policy.mjs && node --test scripts/check-vscode-typings-policy.test.mjs",
     "validation-host:bootstrap": "bash scripts/bootstrap-validation-host.sh",
-    "validation-host:doctor": "bash scripts/run-validation-host.sh node scripts/dev-doctor.mjs --ci --strict",
+    "validation-host:doctor": "corepack pnpm run validation-host:workspace && bash scripts/run-validation-host.sh node scripts/dev-doctor.mjs --ci --strict",
     "validation-host:check": "bash scripts/run-validation-host.sh corepack pnpm run check",
     "validation-host:package": "bash scripts/run-validation-host.sh corepack pnpm run package:kicad-studio",
-    "check:validation-host": "node scripts/check-validation-host.mjs && node --test scripts/check-validation-host.test.mjs",
+    "check:validation-host": "node scripts/check-validation-host.mjs && node --test scripts/check-validation-host.test.mjs scripts/check-workspace-integrity.test.mjs",
     "check:security-tooling": "node scripts/check-security-tooling.mjs && node --test scripts/check-security-tooling.test.mjs",
     "security:workflows": "actionlint -config-file .github/actionlint.yaml && uvx --from zizmor==1.27.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .",
     "security:semgrep": "uvx --from semgrep==1.170.0 semgrep scan --config .semgrep/semgrep.yml --error --metrics=off apps/vscode-extension/src apps/vscode-extension/scripts packages scripts",
     "test:semgrep-rules": "uvx --from semgrep==1.170.0 semgrep --metrics=off --test --config .semgrep/semgrep.yml .semgrep/semgrep.ts",
     "check:dependabot-policy": "node scripts/check-dependabot-policy.mjs && node --test scripts/check-dependabot-policy.test.mjs",
     "check:trivy-devcontainer": "node scripts/check-trivy-devcontainer.mjs && node --test scripts/check-trivy-devcontainer.test.mjs",
-    "security:trivy-devcontainer": "trivy config --skip-version-check --severity HIGH,CRITICAL --exit-code 1 --format table .devcontainer"
+    "security:trivy-devcontainer": "trivy config --skip-version-check --severity HIGH,CRITICAL --exit-code 1 --format table .devcontainer",
+    "validation-host:workspace": "bash scripts/run-validation-host.sh node scripts/check-workspace-integrity.mjs --canonical"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",

--- a/scripts/check-validation-host.mjs
+++ b/scripts/check-validation-host.mjs
@@ -85,12 +85,60 @@ export function validateValidationHostContract(contract) {
   }
 
   for (const phrase of [
+    "scripts/run-validation-host.sh true",
+    "scripts/run-validation-host.sh corepack pnpm run check",
+    "corepack pnpm run check",
+  ]) {
+    requireIncludes(
+      errors,
+      "pre-push hook",
+      contract.prePushText ?? "",
+      phrase,
+    );
+  }
+  if ((contract.prePushText ?? "").includes("HUSKY=0")) {
+    errors.push("pre-push hook must not bypass Husky validation");
+  }
+
+  for (const phrase of [
+    "parseWorktreePorcelain",
+    "--canonical",
+    "canonical checkout must be clean",
+    "origin/main",
+  ]) {
+    requireIncludes(
+      errors,
+      "workspace integrity checker",
+      contract.workspaceCheckerText ?? "",
+      phrase,
+    );
+  }
+  for (const phrase of [
+    "prunable worktree",
+    "canonical mode accepts a synchronized normal repository",
+  ]) {
+    requireIncludes(
+      errors,
+      "workspace integrity tests",
+      contract.workspaceTestText ?? "",
+      phrase,
+    );
+  }
+
+  for (const phrase of [
     "Ubuntu 24.04",
     "KiCad 7.0.11",
     "KiCad MCP Pro",
+    "validation-host:workspace",
     "validation-host:doctor",
     "validation-host:check",
     "validation-host:package",
+    "git worktree list --porcelain",
+    "core.bare",
+    "core.worktree",
+    "private backup",
+    "fast-forward",
+    "rollback",
     "$HOME/.cache/kicad-studio-kit",
   ]) {
     requireIncludes(
@@ -116,14 +164,16 @@ export function validateValidationHostContract(contract) {
   const scripts = contract.packageJson?.scripts ?? {};
   const expectedScripts = {
     "validation-host:bootstrap": "bash scripts/bootstrap-validation-host.sh",
+    "validation-host:workspace":
+      "bash scripts/run-validation-host.sh node scripts/check-workspace-integrity.mjs --canonical",
     "validation-host:doctor":
-      "bash scripts/run-validation-host.sh node scripts/dev-doctor.mjs --ci --strict",
+      "corepack pnpm run validation-host:workspace && bash scripts/run-validation-host.sh node scripts/dev-doctor.mjs --ci --strict",
     "validation-host:check":
       "bash scripts/run-validation-host.sh corepack pnpm run check",
     "validation-host:package":
       "bash scripts/run-validation-host.sh corepack pnpm run package:kicad-studio",
     "check:validation-host":
-      "node scripts/check-validation-host.mjs && node --test scripts/check-validation-host.test.mjs",
+      "node scripts/check-validation-host.mjs && node --test scripts/check-validation-host.test.mjs scripts/check-workspace-integrity.test.mjs",
   };
   for (const [name, expected] of Object.entries(expectedScripts)) {
     if (scripts[name] !== expected) {
@@ -145,6 +195,9 @@ export function validateValidationHostRepository(repoRoot = defaultRepoRoot) {
     commonText: read("scripts/lib/validation-host-env.sh"),
     bootstrapText: read("scripts/bootstrap-validation-host.sh"),
     runnerText: read("scripts/run-validation-host.sh"),
+    workspaceCheckerText: read("scripts/check-workspace-integrity.mjs"),
+    workspaceTestText: read("scripts/check-workspace-integrity.test.mjs"),
+    prePushText: read(".husky/pre-push"),
     docsText: read("docs/validation-host.md"),
     readmeText: read("README.md"),
     contributingText: read("docs/contributing.md"),

--- a/scripts/check-validation-host.test.mjs
+++ b/scripts/check-validation-host.test.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -32,6 +32,15 @@ function repositoryContract() {
       path.join(repoRoot, "scripts/run-validation-host.sh"),
       "utf8",
     ),
+    workspaceCheckerText: readFileSync(
+      path.join(repoRoot, "scripts/check-workspace-integrity.mjs"),
+      "utf8",
+    ),
+    workspaceTestText: readFileSync(
+      path.join(repoRoot, "scripts/check-workspace-integrity.test.mjs"),
+      "utf8",
+    ),
+    prePushText: readFileSync(path.join(repoRoot, ".husky/pre-push"), "utf8"),
     docsText: readFileSync(
       path.join(repoRoot, "docs/validation-host.md"),
       "utf8",
@@ -83,7 +92,49 @@ test("bootstrap must remain rootless and derive Playwright packages (#490)", () 
   assert.match(errors, /must not invoke sudo/u);
 });
 
-test("root package exposes bootstrap, doctor, check, and package entrypoints (#490)", () => {
+test("validation-host contract requires hook-safe pre-push execution (#525)", () => {
+  const contract = repositoryContract();
+  contract.prePushText = "";
+
+  const errors = validateValidationHostContract(contract).join("\n");
+  assert.match(errors, /pre-push hook/u);
+});
+
+test("validation-host recovery docs require canonical workspace guidance (#525)", () => {
+  const contract = repositoryContract();
+  for (const phrase of [
+    "validation-host:workspace",
+    "git worktree list --porcelain",
+    "core.bare",
+    "core.worktree",
+    "private backup",
+    "fast-forward",
+    "rollback",
+  ]) {
+    contract.docsText = contract.docsText.replaceAll(phrase, "removed");
+  }
+
+  const errors = validateValidationHostContract(contract).join("\n");
+  assert.match(errors, /validation-host:workspace/u);
+  assert.match(errors, /git worktree list --porcelain/u);
+  assert.match(errors, /core\.bare/u);
+  assert.match(errors, /core\.worktree/u);
+  assert.match(errors, /private backup/u);
+  assert.match(errors, /fast-forward/u);
+  assert.match(errors, /rollback/u);
+});
+
+test("validation-host contract requires workspace integrity coverage (#525)", () => {
+  const contract = repositoryContract();
+  contract.workspaceCheckerText = "";
+  contract.workspaceTestText = "";
+
+  const errors = validateValidationHostContract(contract).join("\n");
+  assert.match(errors, /workspace integrity checker/u);
+  assert.match(errors, /workspace integrity tests/u);
+});
+
+test("root package exposes bootstrap, workspace, doctor, check, and package entrypoints (#490, #525)", () => {
   const scripts = repositoryContract().packageJson.scripts;
 
   assert.equal(
@@ -91,8 +142,12 @@ test("root package exposes bootstrap, doctor, check, and package entrypoints (#4
     "bash scripts/bootstrap-validation-host.sh",
   );
   assert.equal(
+    scripts["validation-host:workspace"],
+    "bash scripts/run-validation-host.sh node scripts/check-workspace-integrity.mjs --canonical",
+  );
+  assert.equal(
     scripts["validation-host:doctor"],
-    "bash scripts/run-validation-host.sh node scripts/dev-doctor.mjs --ci --strict",
+    "corepack pnpm run validation-host:workspace && bash scripts/run-validation-host.sh node scripts/dev-doctor.mjs --ci --strict",
   );
   assert.equal(
     scripts["validation-host:check"],
@@ -104,7 +159,17 @@ test("root package exposes bootstrap, doctor, check, and package entrypoints (#4
   );
   assert.equal(
     scripts["check:validation-host"],
-    "node scripts/check-validation-host.mjs && node --test scripts/check-validation-host.test.mjs",
+    "node scripts/check-validation-host.mjs && node --test scripts/check-validation-host.test.mjs scripts/check-workspace-integrity.test.mjs",
+  );
+  assert.equal(
+    existsSync(path.join(repoRoot, "scripts/check-workspace-integrity.mjs")),
+    true,
+  );
+  assert.equal(
+    existsSync(
+      path.join(repoRoot, "scripts/check-workspace-integrity.test.mjs"),
+    ),
+    true,
   );
   assert.match(scripts.check, /pnpm run check:validation-host/u);
 });

--- a/scripts/check-workspace-integrity.mjs
+++ b/scripts/check-workspace-integrity.mjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { accessSync, constants as fsConstants } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptRoot = path.dirname(fileURLToPath(import.meta.url));
+const defaultRepoRoot = path.resolve(scriptRoot, "..");
+const bootstrapGitLocalEnvVars = new Set([
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_GRAFT_FILE",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_PREFIX",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_SHALLOW_FILE",
+  "GIT_WORK_TREE",
+]);
+let gitLocalEnvVarNames;
+let defaultGitExecutable;
+
+function defaultGitCandidates(platform = process.platform, env = process.env) {
+  if (platform === "win32") {
+    const roots = [
+      env.ProgramW6432,
+      env.ProgramFiles,
+      env["ProgramFiles(x86)"],
+    ].filter(Boolean);
+    return roots.flatMap((root) => [
+      path.win32.join(root, "Git", "cmd", "git.exe"),
+      path.win32.join(root, "Git", "bin", "git.exe"),
+    ]);
+  }
+  if (platform === "darwin") {
+    return ["/usr/bin/git", "/opt/homebrew/bin/git", "/usr/local/bin/git"];
+  }
+  return ["/usr/bin/git", "/bin/git", "/usr/local/bin/git"];
+}
+
+function isAbsoluteForPlatform(candidate, platform) {
+  return platform === "win32"
+    ? path.win32.isAbsolute(candidate)
+    : path.posix.isAbsolute(candidate);
+}
+
+function isExecutableFile(candidate) {
+  try {
+    accessSync(candidate, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveGitExecutable(options = {}) {
+  const platform = options.platform ?? process.platform;
+  const candidates =
+    options.candidates ?? defaultGitCandidates(platform, options.env);
+  const isExecutable = options.isExecutable ?? isExecutableFile;
+  let hasRelativeCandidate = false;
+
+  for (const candidate of candidates) {
+    if (!isAbsoluteForPlatform(candidate, platform)) {
+      hasRelativeCandidate = true;
+      continue;
+    }
+    if (isExecutable(candidate)) return candidate;
+  }
+
+  if (hasRelativeCandidate) {
+    throw new Error(
+      "Git executable candidates must use an absolute Git executable path",
+    );
+  }
+  throw new Error(
+    `No executable Git binary found in approved ${platform} locations`,
+  );
+}
+
+function getDefaultGitExecutable() {
+  defaultGitExecutable ??= resolveGitExecutable();
+  return defaultGitExecutable;
+}
+
+function spawnGit(args, options) {
+  // NOSONAR: resolveGitExecutable permits only executable absolute paths from fixed locations.
+  return spawnSync(getDefaultGitExecutable(), args, options);
+}
+
+function commandResult(result) {
+  return {
+    ok: result.ok ?? result.status === 0,
+    status: result.status ?? (result.ok ? 0 : 1),
+    stdout: String(result.stdout ?? "").trim(),
+    stderr: String(result.stderr ?? "").trim(),
+    error: result.error?.message ?? result.error ?? "",
+  };
+}
+
+export function createGitSubprocessEnv(baseEnv = process.env) {
+  const env = { ...baseEnv };
+  for (const name of getGitLocalEnvVarNames()) {
+    delete env[name];
+  }
+  return env;
+}
+
+function getGitLocalEnvVarNames() {
+  if (gitLocalEnvVarNames) return gitLocalEnvVarNames;
+
+  const discoveryEnv = { ...process.env };
+  for (const name of bootstrapGitLocalEnvVars) delete discoveryEnv[name];
+  const result = spawnGit(["rev-parse", "--local-env-vars"], {
+    env: discoveryEnv,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const discovered =
+    result.status === 0
+      ? String(result.stdout)
+          .split(/\r?\n/u)
+          .map((name) => name.trim())
+          .filter(Boolean)
+      : [];
+  gitLocalEnvVarNames = new Set([...bootstrapGitLocalEnvVars, ...discovered]);
+  return gitLocalEnvVarNames;
+}
+
+function runGit(repoRoot, args, commandRunner) {
+  const env = createGitSubprocessEnv();
+  if (commandRunner) {
+    return commandResult(commandRunner("git", args, { cwd: repoRoot, env }));
+  }
+
+  return commandResult(
+    spawnGit(args, {
+      cwd: repoRoot,
+      env,
+      encoding: "utf8",
+      shell: false,
+    }),
+  );
+}
+
+function absoluteGitPath(repoRoot, value) {
+  if (!value) return "";
+  return path.resolve(repoRoot, value);
+}
+
+export function parseWorktreePorcelain(text) {
+  const trimmed = String(text).trim();
+  if (!trimmed) return [];
+
+  return trimmed
+    .split(/\r?\n\s*\r?\n/u)
+    .filter(Boolean)
+    .map((record) => {
+      const parsed = {};
+      for (const line of record.split(/\r?\n/u)) {
+        const separator = line.indexOf(" ");
+        if (separator === -1) {
+          parsed[line] = true;
+        } else {
+          parsed[line.slice(0, separator)] = line.slice(separator + 1);
+        }
+      }
+      return parsed;
+    });
+}
+
+function generalWorkspaceErrors(state) {
+  const errors = [];
+  if (state.bare && state.coreWorktree) {
+    errors.push("core.bare and core.worktree must not be configured together");
+  }
+  if (!state.insideWorkTree || state.bare || !state.statusOk) {
+    errors.push("repository root is not a usable working tree");
+  }
+  if (
+    /core\.bare.*core\.worktree|unable to set up work tree|invalid config/iu.test(
+      state.statusStderr ?? "",
+    )
+  ) {
+    errors.push("git status reported incompatible working-tree configuration");
+  }
+  return errors;
+}
+
+function worktreeInventoryErrors(worktrees = []) {
+  return worktrees
+    .filter((worktree) => worktree.prunable)
+    .map(
+      (worktree) =>
+        `prunable worktree detected: ${worktree.worktree ?? "unknown"}`,
+    );
+}
+
+function canonicalWorkspaceErrors(state) {
+  const errors = [];
+  const isLinkedWorktree =
+    !state.gitDir || !state.commonDir || state.gitDir !== state.commonDir;
+  if (isLinkedWorktree) {
+    errors.push("canonical checkout must not be a linked worktree");
+  }
+  if (state.coreWorktree) {
+    errors.push("canonical checkout must not configure core.worktree");
+  }
+  if (state.branch !== "main") {
+    errors.push("canonical branch must be main");
+  }
+  if (state.statusStdout) {
+    errors.push("canonical checkout must be clean");
+  }
+  if (!state.originMain) {
+    errors.push(
+      "origin/main is unavailable; fetch the remote before validation",
+    );
+  } else if (state.head !== state.originMain) {
+    errors.push("HEAD does not match origin/main");
+  }
+  return errors;
+}
+
+export function evaluateWorkspaceState(state, options = {}) {
+  const canonical = Boolean(options.canonical);
+  const errors = [
+    ...(state.commandErrors ?? []),
+    ...generalWorkspaceErrors(state),
+    ...worktreeInventoryErrors(state.worktrees),
+    ...(canonical ? canonicalWorkspaceErrors(state) : []),
+  ];
+
+  return {
+    schemaVersion: 1,
+    ok: errors.length === 0,
+    mode: canonical ? "canonical" : "working-tree",
+    errors: [...new Set(errors)],
+    state,
+  };
+}
+
+export function inspectWorkspace(repoRoot = defaultRepoRoot, options = {}) {
+  const commandRunner = options.commandRunner;
+  const required = (label, args) => {
+    const result = runGit(repoRoot, args, commandRunner);
+    return { label, result };
+  };
+
+  const inside = required("inside work tree", [
+    "rev-parse",
+    "--is-inside-work-tree",
+  ]);
+  const bare = required("bare repository state", [
+    "rev-parse",
+    "--is-bare-repository",
+  ]);
+  const coreWorktree = runGit(
+    repoRoot,
+    ["config", "--local", "--get", "core.worktree"],
+    commandRunner,
+  );
+  const topLevel = required("repository top level", [
+    "rev-parse",
+    "--show-toplevel",
+  ]);
+  const gitDir = required("Git directory", ["rev-parse", "--git-dir"]);
+  const commonDir = required("Git common directory", [
+    "rev-parse",
+    "--git-common-dir",
+  ]);
+  const branch = required("current branch", ["branch", "--show-current"]);
+  const head = required("HEAD revision", ["rev-parse", "HEAD"]);
+  const originMain = runGit(
+    repoRoot,
+    ["rev-parse", "--verify", "refs/remotes/origin/main"],
+    commandRunner,
+  );
+  const status = required("git status", ["status", "--porcelain=v1"]);
+  const worktrees = required("worktree inventory", [
+    "worktree",
+    "list",
+    "--porcelain",
+  ]);
+
+  const commandErrors = [
+    inside,
+    bare,
+    topLevel,
+    gitDir,
+    commonDir,
+    branch,
+    head,
+    status,
+    worktrees,
+  ]
+    .filter(({ result }) => !result.ok)
+    .map(
+      ({ label, result }) =>
+        `${label} failed: ${
+          result.stderr ||
+          result.stdout ||
+          result.error ||
+          `exit ${result.status}`
+        }`,
+    );
+
+  if (options.canonical && !originMain.ok) {
+    commandErrors.push(
+      `origin/main lookup failed: ${
+        originMain.stderr ||
+        originMain.stdout ||
+        originMain.error ||
+        `exit ${originMain.status}`
+      }`,
+    );
+  }
+
+  const state = {
+    insideWorkTree: inside.result.ok && inside.result.stdout === "true",
+    bare: bare.result.ok && bare.result.stdout === "true",
+    coreWorktree: coreWorktree.ok ? coreWorktree.stdout : "",
+    topLevel: topLevel.result.ok
+      ? absoluteGitPath(repoRoot, topLevel.result.stdout)
+      : "",
+    gitDir: gitDir.result.ok
+      ? absoluteGitPath(repoRoot, gitDir.result.stdout)
+      : "",
+    commonDir: commonDir.result.ok
+      ? absoluteGitPath(repoRoot, commonDir.result.stdout)
+      : "",
+    branch: branch.result.stdout,
+    head: head.result.stdout,
+    originMain: originMain.ok ? originMain.stdout : "",
+    statusOk: status.result.ok,
+    statusStdout: status.result.stdout,
+    statusStderr: status.result.stderr,
+    worktrees: worktrees.result.ok
+      ? parseWorktreePorcelain(worktrees.result.stdout)
+      : [],
+    commandErrors,
+  };
+
+  return evaluateWorkspaceState(state, options);
+}
+
+export function formatWorkspaceReport(report) {
+  const lines = [
+    `Workspace integrity: ${report.ok ? "pass" : "fail"}`,
+    `Mode: ${report.mode}`,
+    `Branch: ${report.state.branch || "(unavailable)"}`,
+    `HEAD: ${report.state.head || "(unavailable)"}`,
+    `Working tree: ${report.state.statusStdout ? "dirty" : "clean"}`,
+  ];
+
+  if (!report.ok) {
+    for (const error of report.errors) lines.push(`- ${error}`);
+  }
+
+  return lines.join("\n");
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const args = new Set(process.argv.slice(2));
+  const report = inspectWorkspace(defaultRepoRoot, {
+    canonical: args.has("--canonical"),
+  });
+
+  if (args.has("--json")) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatWorkspaceReport(report));
+  }
+
+  if (!report.ok) process.exitCode = 1;
+}

--- a/scripts/check-workspace-integrity.test.mjs
+++ b/scripts/check-workspace-integrity.test.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import {
+  createGitSubprocessEnv,
+  evaluateWorkspaceState,
+  formatWorkspaceReport,
+  inspectWorkspace,
+  parseWorktreePorcelain,
+  resolveGitExecutable,
+} from "./check-workspace-integrity.mjs";
+
+function healthyState(overrides = {}) {
+  return {
+    insideWorkTree: true,
+    bare: false,
+    coreWorktree: "",
+    topLevel: "/repo",
+    gitDir: "/repo/.git",
+    commonDir: "/repo/.git",
+    branch: "main",
+    head: "abc",
+    originMain: "abc",
+    statusOk: true,
+    statusStdout: "",
+    statusStderr: "",
+    worktrees: [],
+    ...overrides,
+  };
+}
+
+function runGit(cwd, args) {
+  const result = spawnSync("git", args, {
+    cwd,
+    env: createGitSubprocessEnv(),
+    encoding: "utf8",
+    shell: false,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+test("resolves Git from fixed absolute executable locations (#525)", () => {
+  const executable = resolveGitExecutable({
+    platform: "linux",
+    candidates: ["/untrusted/git", "/usr/bin/git"],
+    isExecutable: (candidate) => candidate === "/usr/bin/git",
+  });
+
+  assert.equal(executable, "/usr/bin/git");
+});
+
+test("rejects relative Git executable candidates (#525)", () => {
+  assert.throws(
+    () =>
+      resolveGitExecutable({
+        platform: "linux",
+        candidates: ["git"],
+        isExecutable: () => true,
+      }),
+    /absolute Git executable/u,
+  );
+});
+
+test("rejects a bare repository with an explicit worktree (#525)", () => {
+  const report = evaluateWorkspaceState(
+    healthyState({
+      insideWorkTree: false,
+      bare: true,
+      coreWorktree: "/tmp/other-worktree",
+      statusOk: false,
+      statusStderr: "core.bare and core.worktree do not make sense",
+    }),
+  );
+
+  assert.equal(report.ok, false);
+  assert.match(report.errors.join("\n"), /core\.bare.*core\.worktree/u);
+  assert.match(report.errors.join("\n"), /usable working tree/u);
+});
+
+test("canonical mode rejects linked worktrees and stale main (#525)", () => {
+  const report = evaluateWorkspaceState(
+    healthyState({
+      topLevel: "/repo/worktree",
+      gitDir: "/repo/.git/worktrees/task",
+      commonDir: "/repo/.git",
+      branch: "feature/task",
+      head: "old",
+      originMain: "new",
+    }),
+    { canonical: true },
+  );
+
+  assert.equal(report.ok, false);
+  assert.match(report.errors.join("\n"), /linked worktree/u);
+  assert.match(report.errors.join("\n"), /branch must be main/u);
+  assert.match(report.errors.join("\n"), /does not match origin\/main/u);
+});
+
+test("canonical mode rejects an uncommitted working tree (#525)", () => {
+  const report = evaluateWorkspaceState(
+    healthyState({ statusStdout: " M docs/validation-host.md" }),
+    { canonical: true },
+  );
+
+  assert.equal(report.ok, false);
+  assert.match(report.errors.join("\n"), /canonical checkout must be clean/u);
+});
+
+test("parses and rejects prunable worktree records (#525)", () => {
+  const worktrees = parseWorktreePorcelain(
+    [
+      "worktree /repo",
+      "HEAD abc",
+      "branch refs/heads/main",
+      "",
+      "worktree /gone",
+      "HEAD def",
+      "prunable gitdir file points to non-existent location",
+      "",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(worktrees, [
+    {
+      worktree: "/repo",
+      HEAD: "abc",
+      branch: "refs/heads/main",
+    },
+    {
+      worktree: "/gone",
+      HEAD: "def",
+      prunable: "gitdir file points to non-existent location",
+    },
+  ]);
+
+  const report = evaluateWorkspaceState(healthyState({ worktrees }));
+  assert.equal(report.ok, false);
+  assert.match(report.errors.join("\n"), /prunable worktree.*\/gone/u);
+});
+
+function restoreEnv(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+test("synthetic repositories ignore hook-local Git environment (#525)", () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), "workspace-hook-env-"));
+  const previous = {
+    GIT_DIR: process.env.GIT_DIR,
+    GIT_WORK_TREE: process.env.GIT_WORK_TREE,
+  };
+  try {
+    runGit(repoRoot, ["init", "--initial-branch=main"]);
+    runGit(repoRoot, ["config", "user.name", "Workspace Test"]);
+    runGit(repoRoot, ["config", "user.email", "workspace@example.invalid"]);
+    writeFileSync(path.join(repoRoot, "README.md"), "workspace test\n");
+    runGit(repoRoot, ["add", "README.md"]);
+    runGit(repoRoot, ["commit", "-m", "test: initialize repository"]);
+    const head = runGit(repoRoot, ["rev-parse", "HEAD"]);
+    runGit(repoRoot, ["update-ref", "refs/remotes/origin/main", head]);
+
+    process.env.GIT_DIR = path.join(process.cwd(), ".git");
+    process.env.GIT_WORK_TREE = process.cwd();
+
+    const report = inspectWorkspace(repoRoot, { canonical: true });
+    assert.equal(report.ok, true, formatWorkspaceReport(report));
+    assert.equal(report.state.topLevel, repoRoot);
+  } finally {
+    restoreEnv("GIT_DIR", previous.GIT_DIR);
+    restoreEnv("GIT_WORK_TREE", previous.GIT_WORK_TREE);
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("canonical mode accepts a synchronized normal repository (#525)", () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), "workspace-integrity-"));
+  try {
+    runGit(repoRoot, ["init", "--initial-branch=main"]);
+    runGit(repoRoot, ["config", "user.name", "Workspace Test"]);
+    runGit(repoRoot, ["config", "user.email", "workspace@example.invalid"]);
+    writeFileSync(path.join(repoRoot, "README.md"), "workspace test\n");
+    runGit(repoRoot, ["add", "README.md"]);
+    runGit(repoRoot, ["commit", "-m", "test: initialize repository"]);
+    const head = runGit(repoRoot, ["rev-parse", "HEAD"]);
+    runGit(repoRoot, ["update-ref", "refs/remotes/origin/main", head]);
+
+    const report = inspectWorkspace(repoRoot, { canonical: true });
+
+    assert.equal(report.ok, true, formatWorkspaceReport(report));
+    assert.equal(report.state.branch, "main");
+    assert.equal(report.state.head, report.state.originMain);
+    assert.match(formatWorkspaceReport(report), /Workspace integrity: pass/u);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- add a read-only Git workspace integrity checker with normal working-tree and strict canonical-host modes;
- reject incompatible `core.bare`/`core.worktree` configuration, linked canonical checkouts, dirty or stale `main`, and prunable worktree records;
- isolate every checker and synthetic-test Git subprocess from hook-local Git environment variables;
- resolve Git only from fixed absolute executable locations and cover the policy with regression tests;
- gate the validation-host contract on the checker, regression tests, recovery documentation, and pre-push integration;
- make the Husky pre-push hook prefer the pinned rootless validation host when available, with a Corepack fallback for ordinary contributor environments;
- document safe inventory, recovery, fast-forward synchronization, and rollback procedures.

## Operational recovery

The canonical validation checkout was repaired non-destructively before implementation:

- repository configuration and worktree inventory were backed up privately outside the repository;
- every linked worktree was checked for uncommitted state and associated with its active or merged pull request before cleanup;
- only clean, obsolete worktrees were removed;
- the canonical checkout was restored as a normal non-bare `main` worktree and synchronized with `origin/main` using fast-forward-only history;
- no credentials, private backup data, or host-specific absolute paths are included in this pull request.

## Validation

- `bash scripts/run-validation-host.sh corepack pnpm run check`
- `bash scripts/run-validation-host.sh corepack pnpm run check:validation-host`
- `shellcheck .husky/pre-push`
- canonical workspace inspection: pass with clean `main` and `HEAD == origin/main`
- normal `git push --set-upstream origin fix/525-workspace-integrity`: passed through the complete Husky pre-push hook without `HUSKY=0`
- required-signature compliance: branch history was consolidated into one GitHub-signed commit using the official `createCommitOnBranch` API; current head `c664cc7` is verified
- signed-head GitHub Actions: CI, CodeQL, Security, Gitleaks, Dependency Review, Docs, and cross-repository compatibility passed
- extension unit tests: 106 suites / 862 tests passed
- security tests: 12 passed
- accessibility tests: 76 passed; the existing post-run open-handle warning remains tracked by #529
- documentation generation, linting, link checks, and VitePress build passed; the existing chunk-size warning remains tracked by #531
- repeatable VSIX validation passed: 101 entries, normalized SHA-256 `c3b5ba63298c16387264eb981884272ed510c4c9e0eb2e986a6e14739bed4135`
- Sonar quality gate: OK, 0 open PR issues, and 0 security hotspots; a cancelled decoration caused by the branch reset/automatic close-reopen sequence was investigated and is not a required ruleset context

## Risk and rollback

Risk is limited to repository validation and developer operations; extension runtime behavior is unchanged. The checker is non-mutating. If hook environment selection causes an unexpected contributor regression, the hook change can be reverted independently while retaining the checker and recovery documentation. Operational rollback uses the private configuration backup and preserved branch revisions without rewriting public history.

All bot outputs were reviewed before merge. No automated agent review was available, so a documented manual compensating review was completed.

Closes #525