### PR TITLE
ci(repo): upgrade zizmor to 1.28.0

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -14,7 +14,7 @@ sections that follow give the detail for each lane.
 | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | Code scanning (CodeQL, JS/TS + Python) | `CodeQL` workflow on pull requests, pushes, and weekly                                                                            | High-severity code-scanning alerts block merge                                                   |
 | Repository-specific SAST               | Semgrep 1.170.0 custom rules in the required `Security` workflow                                                                  | Shell-string execution, dynamic evaluation, and sensitive-value logging findings fail `security` |
-| Workflow security                      | actionlint 1.7.12 and zizmor 1.27.0 in the required `Security` workflow                                                           | Syntax/shell errors and high-confidence medium-or-higher Actions findings fail `security`        |
+| Workflow security                      | actionlint 1.7.12 and zizmor 1.28.0 in the required `Security` workflow                                                           | Syntax/shell errors and high-confidence medium-or-higher Actions findings fail `security`        |
 | Development-container configuration    | Trivy v0.72.0 configuration-only scan in the required `Security` workflow on pull requests, pushes, weekly, and manual runs       | HIGH/CRITICAL misconfigurations fail `security`; SARIF is published under `trivy-devcontainer`   |
 | Secret scanning                        | `Gitleaks` workflow on every pull request plus the local security gate; GitHub secret scanning with push protection stays enabled | A new secret-scanning alert blocks release until triaged                                         |
 | Dependency review                      | `Security` workflow `dependency-review` job on pull requests                                                                      | New `high`+ dependency additions block the pull request                                          |
@@ -114,7 +114,7 @@ changes, run the local scanner gate as well:
 The MCP server security checks now run in the [KiCad MCP Pro](https://oaslananka.github.io/kicad-mcp-pro/) repository.
 
 That gate requires `pre-commit` 4.6.0, `gitleaks`, native actionlint 1.7.12,
-zizmor 1.27.0, and Semgrep 1.170.0. Run it with
+zizmor 1.28.0, and Semgrep 1.170.0. Run it with
 `task security:local` from `apps/vscode-extension`, or run the focused root
 commands `pnpm run security:workflows`, `pnpm run test:semgrep-rules`,
 `pnpm run security:semgrep`, and `pnpm run security:trivy-devcontainer`. The

--- a/docs/superpowers/plans/2026-07-21-security-tooling-gates.md
+++ b/docs/superpowers/plans/2026-07-21-security-tooling-gates.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Keep CodeQL as the broad SAST authority and GitHub push protection plus Gitleaks as the secret-scanning authority. Add a single root policy contract that pins tool versions and validates workflow/config wiring; run native actionlint, high-confidence zizmor, and narrow local Semgrep rules inside the existing required `security` job. Keep expensive scans out of the Git pre-commit hook while exposing explicit local commands.
 
-**Tech Stack:** Node.js 24 policy tests, GitHub Actions, actionlint 1.7.12, zizmor 1.27.0, Semgrep 1.170.0, pre-commit 4.6.0 with pre-commit-hooks v6.0.0.
+**Tech Stack:** Node.js 24 policy tests, GitHub Actions, actionlint 1.7.12, zizmor 1.28.0, Semgrep 1.170.0, pre-commit 4.6.0 with pre-commit-hooks v6.0.0.
 
 ## Global Constraints
 
@@ -50,7 +50,7 @@ Pin these command forms exactly:
 ```json
 {
   "check:security-tooling": "node scripts/check-security-tooling.mjs && node --test scripts/check-security-tooling.test.mjs",
-  "security:workflows": "actionlint -config-file .github/actionlint.yaml && uvx --from zizmor==1.27.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .",
+  "security:workflows": "actionlint -config-file .github/actionlint.yaml && uvx --from zizmor==1.28.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .",
   "security:semgrep": "uvx --from semgrep==1.170.0 semgrep scan --config .semgrep/semgrep.yml --error --metrics=off apps/vscode-extension/src apps/vscode-extension/scripts packages scripts",
   "test:semgrep-rules": "uvx --from semgrep==1.170.0 semgrep --metrics=off --test --config .semgrep/semgrep.yml .semgrep/semgrep.ts"
 }
@@ -109,7 +109,7 @@ Run:
 
 ```bash
 actionlint -config-file .github/actionlint.yaml
-uvx --from zizmor==1.27.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .
+uvx --from zizmor==1.28.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .
 ```
 
 Expected: both commands exit 0.
@@ -211,7 +211,7 @@ Run:
 ```bash
 uvx --from pre-commit==4.6.0 pre-commit run --all-files
 actionlint -config-file .github/actionlint.yaml
-uvx --from zizmor==1.27.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .
+uvx --from zizmor==1.28.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .
 uvx --from semgrep==1.170.0 semgrep --metrics=off --test --config .semgrep/semgrep.yml .semgrep/semgrep.ts
 uvx --from semgrep==1.170.0 semgrep scan --config .semgrep/semgrep.yml --error --metrics=off apps/vscode-extension/src apps/vscode-extension/scripts packages scripts
 corepack pnpm run check:security-tooling

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "validation-host:package": "bash scripts/run-validation-host.sh corepack pnpm run package:kicad-studio",
     "check:validation-host": "node scripts/check-validation-host.mjs && node --test scripts/check-validation-host.test.mjs scripts/check-workspace-integrity.test.mjs",
     "check:security-tooling": "node scripts/check-security-tooling.mjs && node --test scripts/check-security-tooling.test.mjs",
-    "security:workflows": "actionlint -config-file .github/actionlint.yaml && uvx --from zizmor==1.27.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .",
+    "security:workflows": "actionlint -config-file .github/actionlint.yaml && uvx --from zizmor==1.28.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .",
     "security:semgrep": "uvx --from semgrep==1.170.0 semgrep scan --config .semgrep/semgrep.yml --error --metrics=off apps/vscode-extension/src apps/vscode-extension/scripts packages scripts",
     "test:semgrep-rules": "uvx --from semgrep==1.170.0 semgrep --metrics=off --test --config .semgrep/semgrep.yml .semgrep/semgrep.ts",
     "check:dependabot-policy": "node scripts/check-dependabot-policy.mjs && node --test scripts/check-dependabot-policy.test.mjs",

--- a/renovate.json
+++ b/renovate.json
@@ -178,6 +178,16 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "aquasecurity/trivy",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^package\\.json$/"],
+      "matchStrings": [
+        "uvx --from zizmor==(?<currentValue>\\d+\\.\\d+\\.\\d+) zizmor"
+      ],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "zizmor",
+      "versioningTemplate": "pep440"
     }
   ]
 }

--- a/scripts/check-security-tooling.mjs
+++ b/scripts/check-security-tooling.mjs
@@ -182,7 +182,7 @@ function validateRenovate(renovate) {
       manager?.depNameTemplate === "zizmor" &&
       manager?.versioningTemplate === "pep440" &&
       Array.isArray(manager.managerFilePatterns) &&
-      manager.managerFilePatterns.includes("/^package\\.json$/") &&
+      manager.managerFilePatterns.includes(String.raw`/^package\.json$/`) &&
       Array.isArray(manager.matchStrings) &&
       manager.matchStrings.some(
         (pattern) =>

--- a/scripts/check-security-tooling.mjs
+++ b/scripts/check-security-tooling.mjs
@@ -13,7 +13,7 @@ const EXPECTED_SCRIPTS = {
   "check:security-tooling":
     "node scripts/check-security-tooling.mjs && node --test scripts/check-security-tooling.test.mjs",
   "security:workflows":
-    "actionlint -config-file .github/actionlint.yaml && uvx --from zizmor==1.27.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .",
+    "actionlint -config-file .github/actionlint.yaml && uvx --from zizmor==1.28.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .",
   "security:semgrep":
     "uvx --from semgrep==1.170.0 semgrep scan --config .semgrep/semgrep.yml --error --metrics=off apps/vscode-extension/src apps/vscode-extension/scripts packages scripts",
   "test:semgrep-rules":
@@ -74,7 +74,7 @@ function validatePackageScripts(packageJson) {
     scripts["security:workflows"] !== EXPECTED_SCRIPTS["security:workflows"]
   ) {
     errors.push(
-      "package.json must pin actionlint plus zizmor 1.27.0 in the deterministic workflow-security command",
+      "package.json must pin actionlint plus zizmor 1.28.0 in the deterministic workflow-security command",
     );
   }
   if (scripts["security:semgrep"] !== EXPECTED_SCRIPTS["security:semgrep"]) {
@@ -170,6 +170,49 @@ function validateZizmor(zizmor) {
   return errors;
 }
 
+function validateRenovate(renovate) {
+  const errors = [];
+  const customManagers = Array.isArray(renovate.customManagers)
+    ? renovate.customManagers
+    : [];
+  const hasZizmorManager = customManagers.some((manager) => {
+    return (
+      manager?.customType === "regex" &&
+      manager?.datasourceTemplate === "pypi" &&
+      manager?.depNameTemplate === "zizmor" &&
+      manager?.versioningTemplate === "pep440" &&
+      Array.isArray(manager.managerFilePatterns) &&
+      manager.managerFilePatterns.includes("/^package\\.json$/") &&
+      Array.isArray(manager.matchStrings) &&
+      manager.matchStrings.some(
+        (pattern) =>
+          pattern.includes("zizmor==") && pattern.includes("currentValue"),
+      )
+    );
+  });
+  if (
+    !Array.isArray(renovate.enabledManagers) ||
+    !renovate.enabledManagers.includes("custom.regex") ||
+    !hasZizmorManager
+  ) {
+    errors.push(
+      "Renovate must own the exact zizmor PyPI pin through a custom regex manager",
+    );
+  }
+  return errors;
+}
+
+function validateSecurityDocs(securityDocs) {
+  const errors = [];
+  if (!securityDocs.includes("zizmor 1.28.0")) {
+    errors.push("docs/security.md must document the pinned zizmor 1.28.0 gate");
+  }
+  if (securityDocs.includes("zizmor 1.27.0")) {
+    errors.push("docs/security.md must not reference yanked zizmor 1.27.0");
+  }
+  return errors;
+}
+
 function validateSemgrep(semgrep, semgrepIgnore) {
   const errors = [];
   for (const rule of REQUIRED_SEMGREP_RULES) {
@@ -233,6 +276,8 @@ export function validateSecurityTooling(root = REPO_ROOT) {
     ),
     ...validatePrecommit(readText(root, ".pre-commit-config.yaml")),
     ...validateZizmor(readText(root, ".github/zizmor.yml")),
+    ...validateRenovate(readJson(root, "renovate.json")),
+    ...validateSecurityDocs(readText(root, "docs/security.md")),
     ...validateSemgrep(
       readText(root, ".semgrep/semgrep.yml"),
       readText(root, ".semgrepignore"),

--- a/scripts/check-security-tooling.test.mjs
+++ b/scripts/check-security-tooling.test.mjs
@@ -23,6 +23,8 @@ const RELEVANT_FILES = [
   ".semgrep/semgrep.yml",
   ".semgrep/semgrep.ts",
   "package.json",
+  "renovate.json",
+  "docs/security.md",
 ];
 
 function createFixture() {
@@ -54,11 +56,43 @@ test("#508 repository security-tooling policy is complete", () => {
 test("#508 exact scanner versions cannot drift", () => {
   const root = createFixture();
   try {
-    replaceInFixture(root, "package.json", "zizmor==1.27.0", "zizmor==latest");
+    replaceInFixture(root, "package.json", "zizmor==1.28.0", "zizmor==latest");
     replaceInFixture(root, "package.json", "semgrep==1.170.0", "semgrep");
     const errors = validateSecurityTooling(root);
-    assert.ok(errors.some((error) => error.includes("zizmor 1.27.0")));
+    assert.ok(errors.some((error) => error.includes("zizmor 1.28.0")));
     assert.ok(errors.some((error) => error.includes("Semgrep 1.170.0")));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("#524 Renovate owns the exact zizmor pin", () => {
+  const root = createFixture();
+  try {
+    const renovatePath = path.join(root, "renovate.json");
+    const renovate = JSON.parse(readFileSync(renovatePath, "utf8"));
+    renovate.customManagers = (renovate.customManagers ?? []).filter(
+      (manager) => !JSON.stringify(manager).includes("zizmor"),
+    );
+    writeFileSync(renovatePath, `${JSON.stringify(renovate, null, 2)}\n`);
+    const errors = validateSecurityTooling(root);
+    assert.ok(errors.some((error) => error.includes("Renovate")));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("#524 security documentation rejects the yanked zizmor release", () => {
+  const root = createFixture();
+  try {
+    replaceInFixture(
+      root,
+      "docs/security.md",
+      "zizmor 1.28.0",
+      "zizmor 1.27.0",
+    );
+    const errors = validateSecurityTooling(root);
+    assert.ok(errors.some((error) => error.includes("yanked zizmor 1.27.0")));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- replace the yanked `zizmor==1.27.0` workflow scanner pin with patched `zizmor==1.28.0`;
- preserve the existing offline, strict-collection, high-confidence medium-or-higher workflow security gate;
- add policy tests that reject scanner-version drift, stale security documentation, and missing Renovate ownership;
- add a Renovate regex manager for the explicit PyPI pin in `package.json`;
- update active security documentation and maintenance commands without changing scanner ownership boundaries.

## Security context

`zizmor 1.27.0` was yanked because `GHSA-f42p-wjw5-97qh` can expose available GitHub credentials through debug logging. The advisory identifies `1.28.0` as the patched version. This pull request changes only repository security tooling and documentation; extension runtime behavior and release artifacts are unchanged.

## Validation

- full pinned validation host: `bash scripts/run-validation-host.sh corepack pnpm run check`
- workflow security gate: `bash scripts/run-validation-host.sh corepack pnpm run security:workflows`
- zizmor result: `v1.28.0`, all repository workflows audited, no reportable findings (`3` reviewed ignores, `63` suppressed policy findings)
- security tooling policy: 10/10 tests passed
- Renovate regex extraction: `zizmor` / PyPI / PEP 440 / current value `1.28.0`
- extension unit tests: 106 suites / 862 tests passed
- extension security tests: 12 passed
- accessibility tests: 76 passed; the existing post-run open-handle warning remains tracked by #529
- documentation generation, linting, links, and VitePress build passed; the existing chunk-size warning remains tracked by #531
- repeatable VSIX validation passed: 101 entries, normalized SHA-256 `c3b5ba63298c16387264eb981884272ed510c4c9e0eb2e986a6e14739bed4135`
- required-signature compliance: both commits are verified GitHub-signed; current head is `8c79e9c`
- signed-head CI: all required jobs and Linux/macOS/Windows extension matrices passed
- Sonar follow-up: rule S7780 was resolved with `String.raw`; final quality gate reports 0 new issues and 0 security hotspots

## Risk and rollback

Risk is limited to workflow scanner compatibility. Rollback is a one-line pin reversal plus removal of the associated policy expectations, but returning to the yanked vulnerable version is not recommended. If `1.28.0` introduces an operational regression, the security job must remain fail-closed while a safe upstream version is selected.

All bot outputs, PR comments, reviews, and inline threads were inspected. No automated agent review was available, so a documented manual compensating review was completed. No blocking finding remains.

Closes #524