### PR TITLE
test(kicad-studio): close accessibility test resources deterministically

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2526,7 +2526,7 @@
     "test:unit": "jest --runInBand",
     "test:unit:coverage": "jest --runInBand --coverage",
     "test:security": "jest --config jest.config.js --runInBand --coverage=false --testMatch \"<rootDir>/test/security/**/*.test.ts\"",
-    "test:a11y": "jest --config jest.config.js --runInBand --coverage=false --testMatch \"<rootDir>/test/a11y/**/*.test.ts\"",
+    "test:a11y": "node --test scripts/run-a11y-tests.test.mjs && node scripts/run-a11y-tests.cjs",
     "test:perf": "jest --config jest.config.js --runInBand --coverage=false --testMatch \"<rootDir>/test/performance/**/*.test.ts\"",
     "test:integration": "pnpm run build && pnpm run compile-tests && node ./out/test/runTest.js",
     "test:integration:real": "pnpm run compile-tests && node ./out/test/integration/realServer/quickstart.flow.test.js && node ./out/test/integration/realServer/qualityGate.flow.test.js && node ./out/test/integration/realServer/contextBridge.flow.test.js && node ./out/test/integration/realServer/compatibility.flow.test.js",

--- a/apps/vscode-extension/scripts/run-a11y-tests.cjs
+++ b/apps/vscode-extension/scripts/run-a11y-tests.cjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+const path = require('node:path');
+const process = require('node:process');
+const { spawnSync } = require('node:child_process');
+
+const OPEN_HANDLE_DIAGNOSTIC =
+  /Jest has detected the following \d+ open handles? potentially keeping Jest from exiting:/u;
+const DELAYED_EXIT_DIAGNOSTIC =
+  /Jest did not exit one second after the test run has completed\./u;
+
+function evaluateA11yTestResult(result) {
+  const stdout = String(result.stdout ?? '');
+  const stderr = String(result.stderr ?? '');
+  const output = `${stdout}\n${stderr}`;
+
+  if (result.error) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message: `Unable to start the accessibility suite: ${result.error.message ?? String(result.error)}`
+    };
+  }
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    return { ok: false, exitCode: result.status, message: '' };
+  }
+
+  if (result.signal) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message: `Accessibility suite terminated by signal ${result.signal}`
+    };
+  }
+
+  if (OPEN_HANDLE_DIAGNOSTIC.test(output)) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message:
+        'Accessibility suite passed assertions but emitted open handle diagnostics.'
+    };
+  }
+
+  if (DELAYED_EXIT_DIAGNOSTIC.test(output)) {
+    return {
+      ok: false,
+      exitCode: 1,
+      message: 'Accessibility suite did not exit naturally after teardown.'
+    };
+  }
+
+  return { ok: true, exitCode: 0, message: '' };
+}
+
+function runAccessibilityTests() {
+  const scriptRoot = path.dirname(require.resolve('./run-a11y-tests.cjs'));
+  const extensionRoot = path.resolve(scriptRoot, '..');
+  const jestBin = require.resolve('jest/bin/jest', {
+    paths: [extensionRoot]
+  });
+  const result = spawnSync(
+    process.execPath,
+    [
+      jestBin,
+      '--config',
+      'jest.config.js',
+      '--runInBand',
+      '--detectOpenHandles',
+      '--coverage=false',
+      '--testMatch',
+      '<rootDir>/test/a11y/**/*.test.ts'
+    ],
+    {
+      cwd: extensionRoot,
+      encoding: 'utf8',
+      env: process.env,
+      maxBuffer: 16 * 1024 * 1024,
+      shell: false
+    }
+  );
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  const evaluation = evaluateA11yTestResult(result);
+  if (evaluation.message) {
+    process.stderr.write(`\n[a11y-resource-guard] ${evaluation.message}\n`);
+  }
+  process.exitCode = evaluation.exitCode;
+}
+
+module.exports = {
+  evaluateA11yTestResult,
+  runAccessibilityTests
+};
+
+if (require.main === module) {
+  runAccessibilityTests();
+}

--- a/apps/vscode-extension/scripts/run-a11y-tests.test.mjs
+++ b/apps/vscode-extension/scripts/run-a11y-tests.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const { evaluateA11yTestResult } = require('./run-a11y-tests.cjs');
+
+test('accepts a clean successful accessibility run (#529)', () => {
+  assert.deepEqual(
+    evaluateA11yTestResult({
+      status: 0,
+      stdout: 'Tests: 76 passed, 76 total\n',
+      stderr: ''
+    }),
+    { ok: true, exitCode: 0, message: '' }
+  );
+});
+
+test('fails when Jest reports open handles despite passing assertions (#529)', () => {
+  const result = evaluateA11yTestResult({
+    status: 0,
+    stdout: '',
+    stderr:
+      'Jest has detected the following 2 open handles potentially keeping Jest from exiting:\n'
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.exitCode, 1);
+  assert.match(result.message, /open handle diagnostics/u);
+});
+
+test('fails when Jest reports a delayed natural exit (#529)', () => {
+  const result = evaluateA11yTestResult({
+    status: 0,
+    stdout: '',
+    stderr: 'Jest did not exit one second after the test run has completed.\n'
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.exitCode, 1);
+  assert.match(result.message, /did not exit naturally/u);
+});
+
+test('preserves an existing Jest failure status (#529)', () => {
+  assert.deepEqual(
+    evaluateA11yTestResult({
+      status: 2,
+      stdout: '',
+      stderr: 'FAIL test/a11y/accessibilityConformance.test.ts\n'
+    }),
+    { ok: false, exitCode: 2, message: '' }
+  );
+});

--- a/apps/vscode-extension/test/a11y/accessibilityConformance.test.ts
+++ b/apps/vscode-extension/test/a11y/accessibilityConformance.test.ts
@@ -72,8 +72,11 @@ describe('WCAG 2.1 AA webview conformance gate', () => {
   });
 
   afterAll(async () => {
-    await page?.close();
-    await browser?.close();
+    try {
+      await page?.close();
+    } finally {
+      await browser?.close();
+    }
   });
 
   it.each(themeSurfaceCases())(
@@ -1030,20 +1033,34 @@ async function collectMcpToolsTreeIssues(): Promise<string[]> {
     prompts: ['manufacturing-review'],
     diagnostics: ['Live KiCad PCB context is unavailable.']
   };
-  const provider = new McpToolsProvider({
-    getState: () => ({
-      kind: 'Connected',
-      available: true,
-      connected: true,
-      install: { found: true, command: 'uvx', source: 'uvx', version: '1.0.0' },
-      server: {
-        version: '1.0.0',
-        compat: 'ok',
-        capturedAt: '2026-05-24T00:00:00.000Z',
-        capabilities
-      }
-    })
-  } as never);
+  const provider = new McpToolsProvider(
+    {
+      getState: () => ({
+        kind: 'Connected',
+        available: true,
+        connected: true,
+        install: {
+          found: true,
+          command: 'uvx',
+          source: 'uvx',
+          version: '1.0.0'
+        },
+        server: {
+          version: '1.0.0',
+          compat: 'ok',
+          capturedAt: '2026-05-24T00:00:00.000Z',
+          capabilities
+        }
+      })
+    } as never,
+    {
+      installed: false,
+      healthy: false,
+      message:
+        'External BoardReadyOps probes are disabled in accessibility fixtures.',
+      tools: []
+    }
+  );
   return collectTreeProviderIssues('MCP Tools', provider);
 }
 


### PR DESCRIPTION
## Summary

- isolate accessibility fixtures from the real `boardreadyops doctor` subprocess;
- close Playwright page and browser resources through failure-safe teardown;
- add an accessibility test runner that enables Jest open-handle detection;
- fail the accessibility lane when Jest reports leaked handles or delayed natural shutdown;
- add regression tests for the resource guard.

## Root cause

The accessibility suite instantiated `McpToolsProvider` without a BoardReadyOps status override. Its constructor launched a real `npx boardreadyops doctor --format json` subprocess while the accessibility assertions were running. Jest subsequently reported `PROCESSWRAP`, `Timeout`, and `PIPEWRAP` handles even though all assertions passed.

The accessibility fixture now supplies deterministic BoardReadyOps state and does not start external CLI probes. The browser teardown also closes the browser in a `finally` path if page cleanup fails.

## Validation

- focused Jest run with `--detectOpenHandles`: 76/76 passed with no open-handle diagnostics;
- two consecutive `test:a11y` runs: 76/76 passed and exited naturally;
- resource guard tests: 4/4 passed;
- full pinned validation host: `bash scripts/run-validation-host.sh corepack pnpm run check`;
- extension unit tests: 106 suites / 862 tests passed;
- security tests: 12 passed;
- accessibility tests: 76 passed;
- format, lint, typecheck, docs, package validation, and repeatable VSIX checks passed;
- verified GitHub-signed head commit: `0d28376676770985167732d2586d78e2338ca9e8`.

## Risk and rollback

Risk is limited to test infrastructure. Runtime extension behavior is unchanged. Rollback consists of restoring the previous accessibility command and fixture construction, but that would reintroduce nondeterministic external process execution and remove the leak regression guard.

All bot and agent findings will be reviewed before merge. An unavailable or quota-exhausted automated review will be treated as no review and replaced with documented manual review evidence.

Closes #529