### PR TITLE
test(kicad-studio): enforce blocking mutation baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,43 @@ jobs:
       - name: Verify extension package and no VS Code Web target
         run: corepack pnpm --filter kicadstudiokit run package:validate
 
+  mutation:
+    needs: ci-lanes
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && needs.ci-lanes.outputs.vscode_extension == 'true' }}
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - run: corepack enable
+      - run: corepack prepare pnpm@11.6.0 --activate
+      - run: corepack pnpm install --frozen-lockfile
+      - run: corepack pnpm --filter kicadstudiokit run check:mutation-policy
+      - name: Run blocking mutation baseline
+        run: corepack pnpm --filter kicadstudiokit run test:mutation
+      - name: Validate and render mutation summary
+        if: ${{ always() && hashFiles('apps/vscode-extension/reports/mutation/mutation.json') != '' }}
+        run: corepack pnpm --filter kicadstudiokit run mutation:summary
+      - name: Publish mutation summary
+        if: ${{ always() && hashFiles('apps/vscode-extension/reports/mutation/summary.md') != '' }}
+        shell: bash
+        run: cat apps/vscode-extension/reports/mutation/summary.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload mutation evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: mutation-report
+          path: apps/vscode-extension/reports/mutation
+          if-no-files-found: error
+          retention-days: 30
+
   shared-packages:
     needs: ci-lanes
     if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && needs.ci-lanes.outputs.shared_packages == 'true' }}
@@ -412,6 +449,7 @@ jobs:
       - forbidden-refs
       - shared-packages
       - vscode-extension
+      - mutation
       - performance-budgets
       - real-pair-compatibility
     runs-on: ubuntu-24.04
@@ -427,6 +465,7 @@ jobs:
             echo "| forbidden-refs | ${{ needs.forbidden-refs.result }} |"
             echo "| shared-packages | ${{ needs.shared-packages.result }} |"
             echo "| vscode-extension | ${{ needs.vscode-extension.result }} |"
+            echo "| mutation | ${{ needs.mutation.result }} |"
             echo "| performance-budgets | ${{ needs.performance-budgets.result }} |"
             echo "| real-pair-compatibility | ${{ needs.real-pair-compatibility.result }} |"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -439,6 +478,7 @@ jobs:
           needs.forbidden-refs.result == 'failure' || needs.forbidden-refs.result == 'cancelled' ||
           needs.shared-packages.result == 'failure' || needs.shared-packages.result == 'cancelled' ||
           needs.vscode-extension.result == 'failure' || needs.vscode-extension.result == 'cancelled' ||
+          needs.mutation.result == 'failure' || needs.mutation.result == 'cancelled' ||
           needs.performance-budgets.result == 'failure' || needs.performance-budgets.result == 'cancelled' ||
           needs.real-pair-compatibility.result == 'failure' || needs.real-pair-compatibility.result == 'cancelled'
         shell: bash

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   mutation:
     if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    timeout-minutes: 10
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -32,14 +33,21 @@ jobs:
       - run: corepack enable
       - run: corepack prepare pnpm@11.6.0 --activate
       - run: corepack pnpm install --frozen-lockfile
-      - name: Run Stryker mutation testing
+      - run: corepack pnpm --filter kicadstudiokit run check:mutation-policy
+      - name: Run blocking mutation baseline
         run: corepack pnpm --filter kicadstudiokit run test:mutation
-        continue-on-error: true
-      - name: Upload mutation report
+      - name: Validate and render mutation summary
+        if: ${{ always() && hashFiles('apps/vscode-extension/reports/mutation/mutation.json') != '' }}
+        run: corepack pnpm --filter kicadstudiokit run mutation:summary
+      - name: Publish mutation summary
+        if: ${{ always() && hashFiles('apps/vscode-extension/reports/mutation/summary.md') != '' }}
+        shell: bash
+        run: cat apps/vscode-extension/reports/mutation/summary.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload mutation evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: mutation-report
           path: apps/vscode-extension/reports/mutation
-          if-no-files-found: ignore
+          if-no-files-found: error
           retention-days: 30

--- a/apps/vscode-extension/.vscodeignore
+++ b/apps/vscode-extension/.vscodeignore
@@ -48,5 +48,6 @@ eslint.config.cjs
 jest.config.js
 renovate.json
 stryker.config.json
+mutation-baseline.json
 coverage-scope.json
 jest.coverage-ratchet.config.js

--- a/apps/vscode-extension/docs/testing.md
+++ b/apps/vscode-extension/docs/testing.md
@@ -44,6 +44,13 @@ pnpm run coverage:inventory
 
 # Block newly uncovered behavior in critical excluded modules
 pnpm run test:coverage:ratchet
+
+# Validate the mutation scope and documented survivor policy
+pnpm run check:mutation-policy
+
+# Run the blocking mutation baseline and render its summary
+pnpm run test:mutation
+pnpm run mutation:summary
 ```
 
 ## CI Behavior
@@ -64,7 +71,7 @@ pnpm run test:coverage:ratchet
   `coverage/coverage-scope.md`, and enforces the critical-module coverage
   ratchet separately. The ratchet freezes the maximum current uncovered count
   observed across the pinned validation host and GitHub Ubuntu runner.
-- Mutation score is tracked weekly; see Actions tab.
+- The 96.3% mutation baseline is required on extension changes and is also rerun weekly. CI publishes JSON, HTML, and Markdown evidence; undocumented survivors, scope shrinkage, timeouts, no-coverage mutants, or module-score regressions fail closed.
 
 ## VS Code Extension Test Constraints
 

--- a/apps/vscode-extension/mutation-baseline.json
+++ b/apps/vscode-extension/mutation-baseline.json
@@ -1,0 +1,289 @@
+{
+  "schemaVersion": 1,
+  "description": "Blocking mutation-testing baseline for deterministic security, compatibility, trust, and assistant-tool boundary logic.",
+  "minimumScore": 96.3,
+  "scope": {
+    "mutate": [
+      "src/mcp/protocol/mcp2025ProtocolAdapter.ts",
+      "src/mcp/protocol/protocolAdapter.ts",
+      "src/mcp/protocol/protocolAdapterRegistry.ts",
+      "src/mcp/compat.ts",
+      "src/lm/toolCapabilityModes.ts",
+      "src/utils/workspaceTrust.ts",
+      "src/mcp/toolCallParser.ts"
+    ],
+    "testFiles": [
+      "test/unit/mcpProtocolAdapter.test.ts",
+      "test/unit/mcpCompat.test.ts",
+      "test/unit/toolCapabilityModes.test.ts",
+      "test/unit/workspaceTrust.test.ts",
+      "test/unit/toolCallParser.test.ts"
+    ],
+    "minimumMutants": 166,
+    "measuredTests": 27,
+    "measuredDurationSeconds": 93,
+    "ciBudgetMinutes": 10
+  },
+  "measured": {
+    "score": 96.3855,
+    "mutants": 166,
+    "killed": 160,
+    "timeout": 0,
+    "survived": 6,
+    "noCoverage": 0,
+    "errors": 0
+  },
+  "files": {
+    "src/lm/toolCapabilityModes.ts": {
+      "minimumScore": 80,
+      "minimumMutants": 20,
+      "measured": {
+        "score": 80.0,
+        "mutants": 20,
+        "killed": 16,
+        "timeout": 0,
+        "survived": 4,
+        "noCoverage": 0,
+        "errors": 0
+      }
+    },
+    "src/mcp/compat.ts": {
+      "minimumScore": 95,
+      "minimumMutants": 40,
+      "measured": {
+        "score": 95.0,
+        "mutants": 40,
+        "killed": 38,
+        "timeout": 0,
+        "survived": 2,
+        "noCoverage": 0,
+        "errors": 0
+      }
+    },
+    "src/mcp/protocol/mcp2025ProtocolAdapter.ts": {
+      "minimumScore": 100,
+      "minimumMutants": 28,
+      "measured": {
+        "score": 100.0,
+        "mutants": 28,
+        "killed": 28,
+        "timeout": 0,
+        "survived": 0,
+        "noCoverage": 0,
+        "errors": 0
+      }
+    },
+    "src/mcp/protocol/protocolAdapter.ts": {
+      "minimumScore": 100,
+      "minimumMutants": 4,
+      "measured": {
+        "score": 100.0,
+        "mutants": 4,
+        "killed": 4,
+        "timeout": 0,
+        "survived": 0,
+        "noCoverage": 0,
+        "errors": 0
+      }
+    },
+    "src/mcp/protocol/protocolAdapterRegistry.ts": {
+      "minimumScore": 100,
+      "minimumMutants": 10,
+      "measured": {
+        "score": 100.0,
+        "mutants": 10,
+        "killed": 10,
+        "timeout": 0,
+        "survived": 0,
+        "noCoverage": 0,
+        "errors": 0
+      }
+    },
+    "src/mcp/toolCallParser.ts": {
+      "minimumScore": 100,
+      "minimumMutants": 45,
+      "measured": {
+        "score": 100.0,
+        "mutants": 45,
+        "killed": 45,
+        "timeout": 0,
+        "survived": 0,
+        "noCoverage": 0,
+        "errors": 0
+      }
+    },
+    "src/utils/workspaceTrust.ts": {
+      "minimumScore": 100,
+      "minimumMutants": 19,
+      "measured": {
+        "score": 100.0,
+        "mutants": 19,
+        "killed": 19,
+        "timeout": 0,
+        "survived": 0,
+        "noCoverage": 0,
+        "errors": 0
+      }
+    }
+  },
+  "allowedSurvivors": [
+    {
+      "file": "src/lm/toolCapabilityModes.ts",
+      "id": "0",
+      "mutatorName": "ObjectLiteral",
+      "replacement": "{}",
+      "static": true,
+      "location": {
+        "end": {
+          "column": 2,
+          "line": 16
+        },
+        "start": {
+          "column": 66,
+          "line": 9
+        }
+      },
+      "classification": "static-initialization",
+      "reason": "Stryker marks this mutant static and reports no per-test coverage because Jest evaluates the exported constant during module initialization. Exact object and string values are asserted by test/unit/toolCapabilityModes.test.ts.",
+      "evidence": ["test/unit/toolCapabilityModes.test.ts"]
+    },
+    {
+      "file": "src/lm/toolCapabilityModes.ts",
+      "id": "1",
+      "mutatorName": "StringLiteral",
+      "replacement": "\"\"",
+      "static": true,
+      "location": {
+        "end": {
+          "column": 101,
+          "line": 11
+        },
+        "start": {
+          "column": 5,
+          "line": 11
+        }
+      },
+      "classification": "static-initialization",
+      "reason": "Stryker marks this mutant static and reports no per-test coverage because Jest evaluates the exported constant during module initialization. Exact object and string values are asserted by test/unit/toolCapabilityModes.test.ts.",
+      "evidence": ["test/unit/toolCapabilityModes.test.ts"]
+    },
+    {
+      "file": "src/lm/toolCapabilityModes.ts",
+      "id": "2",
+      "mutatorName": "StringLiteral",
+      "replacement": "\"\"",
+      "static": true,
+      "location": {
+        "end": {
+          "column": 125,
+          "line": 13
+        },
+        "start": {
+          "column": 5,
+          "line": 13
+        }
+      },
+      "classification": "static-initialization",
+      "reason": "Stryker marks this mutant static and reports no per-test coverage because Jest evaluates the exported constant during module initialization. Exact object and string values are asserted by test/unit/toolCapabilityModes.test.ts.",
+      "evidence": ["test/unit/toolCapabilityModes.test.ts"]
+    },
+    {
+      "file": "src/lm/toolCapabilityModes.ts",
+      "id": "3",
+      "mutatorName": "StringLiteral",
+      "replacement": "\"\"",
+      "static": true,
+      "location": {
+        "end": {
+          "column": 161,
+          "line": 15
+        },
+        "start": {
+          "column": 5,
+          "line": 15
+        }
+      },
+      "classification": "static-initialization",
+      "reason": "Stryker marks this mutant static and reports no per-test coverage because Jest evaluates the exported constant during module initialization. Exact object and string values are asserted by test/unit/toolCapabilityModes.test.ts.",
+      "evidence": ["test/unit/toolCapabilityModes.test.ts"]
+    },
+    {
+      "file": "src/mcp/compat.ts",
+      "id": "23",
+      "mutatorName": "ConditionalExpression",
+      "replacement": "false",
+      "static": false,
+      "location": {
+        "end": {
+          "column": 15,
+          "line": 11
+        },
+        "start": {
+          "column": 7,
+          "line": 11
+        }
+      },
+      "classification": "equivalent",
+      "reason": "Removing the explicit undefined guard is behaviorally equivalent because semver.coerce(undefined) returns null; normalization and user-facing descriptions are asserted by test/unit/mcpCompat.test.ts.",
+      "evidence": ["test/unit/mcpCompat.test.ts"]
+    },
+    {
+      "file": "src/mcp/compat.ts",
+      "id": "24",
+      "mutatorName": "BlockStatement",
+      "replacement": "{}",
+      "static": false,
+      "location": {
+        "end": {
+          "column": 4,
+          "line": 13
+        },
+        "start": {
+          "column": 17,
+          "line": 11
+        }
+      },
+      "classification": "equivalent",
+      "reason": "Removing the explicit undefined guard is behaviorally equivalent because semver.coerce(undefined) returns null; normalization and user-facing descriptions are asserted by test/unit/mcpCompat.test.ts.",
+      "evidence": ["test/unit/mcpCompat.test.ts"]
+    }
+  ],
+  "deferredExpensiveScope": {
+    "experiment": {
+      "mutateFiles": 11,
+      "testFiles": 9,
+      "tests": 55,
+      "mutants": 782,
+      "dryRunSeconds": 101,
+      "timeoutMinutes": 30,
+      "resultsEmittedBeforeTimeout": 310,
+      "outcome": "The combined scope exceeded the CI budget and projected roughly two hours, so large deterministic modules are split into future reviewed shards rather than silently excluded."
+    },
+    "files": [
+      {
+        "path": "src/cli/exportPresets.ts",
+        "owner": "CLI/export shard",
+        "reason": "Deferred from the first blocking shard after the 782-mutant combined experiment exceeded 30 minutes.",
+        "evidence": ["test/unit/exportPresets.test.ts"]
+      },
+      {
+        "path": "src/language/sExpressionParser.ts",
+        "owner": "Parser shard",
+        "reason": "Large parser surface dominated the combined mutation budget and requires a dedicated shard.",
+        "evidence": ["test/unit/sExpressionParser.test.ts"]
+      },
+      {
+        "path": "src/language/diagnosticsAggregator.ts",
+        "owner": "Diagnostics/state shard",
+        "reason": "Deferred to an isolated diagnostics shard so mutation runtime remains reviewable.",
+        "evidence": ["test/unit/diagnosticsAggregator.test.ts"]
+      },
+      {
+        "path": "src/utils/pathUtils.ts",
+        "owner": "Path normalization shard",
+        "reason": "Deferred to an isolated path-normalization shard after the combined experiment exceeded the CI budget.",
+        "evidence": ["test/unit/pathUtils.test.ts"]
+      }
+    ]
+  }
+}

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2510,17 +2510,17 @@
     "build": "pnpm run prepare:media && webpack --mode production",
     "build:prod": "pnpm run build",
     "watch": "webpack --mode development --watch",
-    "format": "prettier --ignore-unknown --no-error-on-unmatched-pattern --write package.json package.nls.json README.md SECURITY.md docs/**/*.md scripts/**/*.{cjs,js,mjs} .vscode/*.json tsconfig*.json playwright*.config.ts .prettierrc .prettierignore eslint.config.cjs jest.config.js webpack.config.js stryker.config.json Taskfile.yml .editorconfig .vscodeignore language-configuration.json schemas/**/*.json snippets/**/*.{json,code-snippets} syntaxes/**/*.json test/webview/**/*.ts test/visual/**/*.ts",
-    "format:check": "prettier --ignore-unknown --no-error-on-unmatched-pattern --check package.json package.nls.json README.md SECURITY.md docs/**/*.md scripts/**/*.{cjs,js,mjs} .vscode/*.json tsconfig*.json playwright*.config.ts .prettierrc .prettierignore eslint.config.cjs jest.config.js webpack.config.js stryker.config.json Taskfile.yml .editorconfig .vscodeignore language-configuration.json schemas/**/*.json snippets/**/*.{json,code-snippets} syntaxes/**/*.json test/webview/**/*.ts test/visual/**/*.ts",
+    "format": "prettier --ignore-unknown --no-error-on-unmatched-pattern --write package.json package.nls.json README.md SECURITY.md docs/**/*.md scripts/**/*.{cjs,js,mjs} .vscode/*.json tsconfig*.json playwright*.config.ts .prettierrc .prettierignore eslint.config.cjs jest.config.js webpack.config.js stryker.config.json mutation-baseline.json Taskfile.yml .editorconfig .vscodeignore language-configuration.json schemas/**/*.json snippets/**/*.{json,code-snippets} syntaxes/**/*.json test/webview/**/*.ts test/visual/**/*.ts",
+    "format:check": "prettier --ignore-unknown --no-error-on-unmatched-pattern --check package.json package.nls.json README.md SECURITY.md docs/**/*.md scripts/**/*.{cjs,js,mjs} .vscode/*.json tsconfig*.json playwright*.config.ts .prettierrc .prettierignore eslint.config.cjs jest.config.js webpack.config.js stryker.config.json mutation-baseline.json Taskfile.yml .editorconfig .vscodeignore language-configuration.json schemas/**/*.json snippets/**/*.{json,code-snippets} syntaxes/**/*.json test/webview/**/*.ts test/visual/**/*.ts",
     "lint": "eslint src test scripts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "audit:ci": "pnpm audit --audit-level high",
     "check:staged": "lint-staged",
-    "check": "pnpm run check:extension-manifest && pnpm run check:nls-parity && pnpm run check:coverage-scope && pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test:unit && pnpm run test:coverage:ratchet && pnpm run test:security && pnpm run test:a11y && pnpm run build && pnpm run package && pnpm run package:validate",
+    "check": "pnpm run check:extension-manifest && pnpm run check:nls-parity && pnpm run check:coverage-scope && pnpm run check:mutation-policy && pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test:unit && pnpm run test:coverage:ratchet && pnpm run test:security && pnpm run test:a11y && pnpm run build && pnpm run package && pnpm run package:validate",
     "check:extension-manifest": "node scripts/check-package-contributions.mjs",
     "check:nls-parity": "node ../../scripts/check-nls-parity.mjs && node --test ../../scripts/check-nls-parity.test.mjs",
     "check:workspace-trust": "node scripts/check-untrusted-workspace.js",
-    "check:ci": "pnpm run audit:ci && pnpm run format:check && pnpm run docs:check && pnpm run check:coverage-scope && pnpm run workflows:lint && pnpm run lint && pnpm run typecheck && pnpm run check:workspace-trust && pnpm run test:unit:coverage && pnpm run test:coverage:ratchet && pnpm run test:security && pnpm run test:a11y && pnpm run build && pnpm run test:integration && pnpm run package && pnpm run package:validate && pnpm run release:dry-run && pnpm run check:bundle-size",
+    "check:ci": "pnpm run audit:ci && pnpm run format:check && pnpm run docs:check && pnpm run check:coverage-scope && pnpm run check:mutation-policy && pnpm run workflows:lint && pnpm run lint && pnpm run typecheck && pnpm run check:workspace-trust && pnpm run test:unit:coverage && pnpm run test:coverage:ratchet && pnpm run test:security && pnpm run test:a11y && pnpm run build && pnpm run test:integration && pnpm run package && pnpm run package:validate && pnpm run release:dry-run && pnpm run check:bundle-size",
     "compile-tests": "tsc -p tsconfig.test.json",
     "test": "pnpm run test:unit && pnpm run test:security && pnpm run test:integration",
     "test:unit": "jest --runInBand",
@@ -2552,7 +2552,9 @@
     "test:dynamic-analysis": "pnpm run test:security && pnpm run test:webview && pnpm run test:a11y",
     "check:coverage-scope": "node --test scripts/coverage-scope.test.mjs && node scripts/coverage-scope.cjs --check",
     "coverage:inventory": "node scripts/coverage-scope.cjs --write",
-    "test:coverage:ratchet": "jest --config jest.coverage-ratchet.config.js --runInBand --coverage"
+    "test:coverage:ratchet": "jest --config jest.coverage-ratchet.config.js --runInBand --coverage",
+    "check:mutation-policy": "node --test scripts/mutation-baseline.test.mjs && node scripts/mutation-baseline.cjs",
+    "mutation:summary": "node scripts/mutation-baseline.cjs --report reports/mutation/mutation.json --write-summary"
   },
   "c8": {
     "reporter": [

--- a/apps/vscode-extension/scripts/mutation-baseline.cjs
+++ b/apps/vscode-extension/scripts/mutation-baseline.cjs
@@ -1,0 +1,530 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const process = require('node:process');
+
+const REQUIRED_REPORTERS = ['clear-text', 'html', 'json', 'progress'];
+const SCORE_EPSILON = 0.0001;
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function compareStrings(left, right) {
+  return left.localeCompare(right);
+}
+
+function sortedStrings(values) {
+  return [...values].sort(compareStrings);
+}
+
+function sameStringSet(left, right) {
+  return (
+    JSON.stringify(sortedStrings(left ?? [])) ===
+    JSON.stringify(sortedStrings(right ?? []))
+  );
+}
+
+function countStatuses(mutants) {
+  const counts = {
+    mutants: mutants.length,
+    killed: 0,
+    timeout: 0,
+    survived: 0,
+    noCoverage: 0,
+    errors: 0
+  };
+  for (const mutant of mutants) {
+    switch (mutant.status) {
+      case 'Killed':
+        counts.killed += 1;
+        break;
+      case 'Timeout':
+        counts.timeout += 1;
+        break;
+      case 'Survived':
+        counts.survived += 1;
+        break;
+      case 'NoCoverage':
+        counts.noCoverage += 1;
+        break;
+      default:
+        counts.errors += 1;
+    }
+  }
+  const denominator =
+    counts.killed + counts.timeout + counts.survived + counts.noCoverage;
+  counts.score =
+    denominator === 0
+      ? 100
+      : Number(
+          ((100 * (counts.killed + counts.timeout)) / denominator).toFixed(4)
+        );
+  return counts;
+}
+
+function survivorFingerprint(file, mutant) {
+  return JSON.stringify({
+    file,
+    id: String(mutant.id),
+    mutatorName: mutant.mutatorName,
+    replacement: mutant.replacement,
+    static: Boolean(mutant.static),
+    location: mutant.location
+  });
+}
+
+function loadPolicy(extensionRoot) {
+  return {
+    config: readJson(path.join(extensionRoot, 'stryker.config.json')),
+    baseline: readJson(path.join(extensionRoot, 'mutation-baseline.json'))
+  };
+}
+
+function validateExistingPaths(extensionRoot, paths, label, errors) {
+  for (const relativePath of paths) {
+    if (!fs.existsSync(path.join(extensionRoot, relativePath))) {
+      errors.push(`${label} references missing path ${relativePath}`);
+    }
+  }
+}
+
+function pushWhenInvalid(errors, condition, message) {
+  if (!condition) {
+    errors.push(message);
+  }
+}
+
+function validateStrykerConfiguration(config, baseline, errors) {
+  pushWhenInvalid(
+    errors,
+    config.testRunner === 'jest' && config.coverageAnalysis === 'perTest',
+    'Stryker must use the Jest runner with perTest coverage analysis'
+  );
+  pushWhenInvalid(
+    errors,
+    sameStringSet(config.plugins, ['@stryker-mutator/jest-runner']),
+    'Stryker must explicitly load @stryker-mutator/jest-runner'
+  );
+  for (const reporter of REQUIRED_REPORTERS) {
+    pushWhenInvalid(
+      errors,
+      config.reporters?.includes(reporter),
+      `Stryker reporters must include ${reporter}`
+    );
+  }
+  pushWhenInvalid(
+    errors,
+    config.jsonReporter?.fileName === 'reports/mutation/mutation.json',
+    'Stryker JSON report must be reports/mutation/mutation.json'
+  );
+  pushWhenInvalid(
+    errors,
+    config.cleanTempDir === 'always',
+    'Stryker cleanTempDir must be always'
+  );
+  pushWhenInvalid(
+    errors,
+    config.concurrency === 2,
+    'Stryker concurrency must remain 2 for deterministic CI resource use'
+  );
+  pushWhenInvalid(
+    errors,
+    config.thresholds?.break === baseline.minimumScore,
+    `Stryker break threshold ${config.thresholds?.break} must equal baseline ${baseline.minimumScore}`
+  );
+  pushWhenInvalid(
+    errors,
+    sameStringSet(config.mutate, baseline.scope?.mutate),
+    'Stryker mutate scope must match mutation-baseline.json'
+  );
+  pushWhenInvalid(
+    errors,
+    sameStringSet(config.testFiles, baseline.scope?.testFiles),
+    'Stryker testFiles scope must match mutation-baseline.json'
+  );
+}
+
+function validateBaselineStructure(extensionRoot, baseline, errors) {
+  const baselineFiles = Object.keys(baseline.files ?? {});
+  const fileMutantTotal = Object.values(baseline.files ?? {}).reduce(
+    (sum, file) => sum + Number(file.minimumMutants ?? 0),
+    0
+  );
+  pushWhenInvalid(
+    errors,
+    baseline.schemaVersion === 1,
+    'mutation-baseline.json schemaVersion must be 1'
+  );
+  pushWhenInvalid(
+    errors,
+    sameStringSet(baselineFiles, baseline.scope?.mutate ?? []),
+    'mutation-baseline.json file baselines must match the mutate scope'
+  );
+  pushWhenInvalid(
+    errors,
+    fileMutantTotal === baseline.scope?.minimumMutants,
+    'mutation baseline file mutant counts must sum to scope.minimumMutants'
+  );
+  pushWhenInvalid(
+    errors,
+    baseline.measured?.mutants === baseline.scope?.minimumMutants,
+    'measured mutant count must equal scope.minimumMutants'
+  );
+  pushWhenInvalid(
+    errors,
+    baseline.measured?.score >= baseline.minimumScore,
+    'measured mutation score must satisfy minimumScore'
+  );
+  pushWhenInvalid(
+    errors,
+    Number.isInteger(baseline.scope?.ciBudgetMinutes) &&
+      baseline.scope.ciBudgetMinutes >= 1,
+    'mutation scope must declare a positive integer CI budget'
+  );
+  validateExistingPaths(
+    extensionRoot,
+    baseline.scope?.mutate ?? [],
+    'mutation scope',
+    errors
+  );
+  validateExistingPaths(
+    extensionRoot,
+    baseline.scope?.testFiles ?? [],
+    'mutation tests',
+    errors
+  );
+  return baselineFiles;
+}
+
+function validateAllowedSurvivors(
+  extensionRoot,
+  baseline,
+  baselineFiles,
+  errors
+) {
+  const fingerprints = new Set();
+  for (const survivor of baseline.allowedSurvivors ?? []) {
+    const fingerprint = survivorFingerprint(survivor.file, survivor);
+    pushWhenInvalid(
+      errors,
+      !fingerprints.has(fingerprint),
+      `duplicate allowed survivor ${survivor.file}#${survivor.id}`
+    );
+    fingerprints.add(fingerprint);
+    pushWhenInvalid(
+      errors,
+      baselineFiles.includes(survivor.file),
+      `allowed survivor is outside mutation scope: ${survivor.file}`
+    );
+    pushWhenInvalid(
+      errors,
+      ['equivalent', 'static-initialization'].includes(survivor.classification),
+      `unsupported survivor classification for ${survivor.file}#${survivor.id}`
+    );
+    pushWhenInvalid(
+      errors,
+      Boolean(survivor.reason) &&
+        Array.isArray(survivor.evidence) &&
+        survivor.evidence.length > 0,
+      `allowed survivor requires a reason and evidence: ${survivor.file}#${survivor.id}`
+    );
+    validateExistingPaths(
+      extensionRoot,
+      survivor.evidence ?? [],
+      'survivor evidence',
+      errors
+    );
+  }
+  pushWhenInvalid(
+    errors,
+    (baseline.allowedSurvivors ?? []).length === baseline.measured?.survived,
+    'allowed survivor count must equal the measured survivor count'
+  );
+}
+
+function validateDeferredScope(extensionRoot, baseline, baselineFiles, errors) {
+  for (const deferred of baseline.deferredExpensiveScope?.files ?? []) {
+    pushWhenInvalid(
+      errors,
+      !baselineFiles.includes(deferred.path),
+      `deferred mutation file is already in the blocking scope: ${deferred.path}`
+    );
+    pushWhenInvalid(
+      errors,
+      Boolean(deferred.owner) && Boolean(deferred.reason),
+      `deferred mutation file requires owner and reason: ${deferred.path}`
+    );
+    validateExistingPaths(
+      extensionRoot,
+      [deferred.path],
+      'deferred mutation scope',
+      errors
+    );
+    validateExistingPaths(
+      extensionRoot,
+      deferred.evidence ?? [],
+      'deferred mutation evidence',
+      errors
+    );
+  }
+}
+
+function validateMutationPolicy(extensionRoot) {
+  const errors = [];
+  const { config, baseline } = loadPolicy(extensionRoot);
+  validateStrykerConfiguration(config, baseline, errors);
+  const baselineFiles = validateBaselineStructure(
+    extensionRoot,
+    baseline,
+    errors
+  );
+  validateAllowedSurvivors(extensionRoot, baseline, baselineFiles, errors);
+  validateDeferredScope(extensionRoot, baseline, baselineFiles, errors);
+  return { errors, config, baseline };
+}
+
+function collectReportMutants(report) {
+  return Object.entries(report.files ?? {})
+    .sort(([left], [right]) => compareStrings(left, right))
+    .flatMap(([file, value]) =>
+      (value.mutants ?? []).map((mutant) => ({ file, mutant }))
+    );
+}
+
+function validateReportMetadata(report, config, baseline, errors) {
+  pushWhenInvalid(
+    errors,
+    report.schemaVersion === '1.0',
+    `unsupported mutation report schema ${report.schemaVersion}`
+  );
+  pushWhenInvalid(
+    errors,
+    sameStringSet(report.config?.mutate, config.mutate),
+    'mutation report mutate scope does not match stryker.config.json'
+  );
+  pushWhenInvalid(
+    errors,
+    sameStringSet(report.config?.testFiles, config.testFiles),
+    'mutation report testFiles do not match stryker.config.json'
+  );
+  pushWhenInvalid(
+    errors,
+    report.thresholds?.break === baseline.minimumScore,
+    'mutation report break threshold does not match the baseline'
+  );
+  pushWhenInvalid(
+    errors,
+    sameStringSet(Object.keys(report.files ?? {}), baseline.scope.mutate),
+    'mutation report file set does not match the blocking scope'
+  );
+}
+
+function validateOverallSummary(overall, baseline, errors) {
+  pushWhenInvalid(
+    errors,
+    overall.mutants >= baseline.scope.minimumMutants,
+    `mutation report has ${overall.mutants} mutants; baseline requires at least ${baseline.scope.minimumMutants}`
+  );
+  pushWhenInvalid(
+    errors,
+    overall.score + SCORE_EPSILON >= baseline.minimumScore,
+    `mutation score ${overall.score} is below blocking baseline ${baseline.minimumScore}`
+  );
+  pushWhenInvalid(
+    errors,
+    overall.timeout <= baseline.measured.timeout,
+    `mutation timeouts regressed from ${baseline.measured.timeout} to ${overall.timeout}`
+  );
+  pushWhenInvalid(
+    errors,
+    overall.noCoverage <= baseline.measured.noCoverage,
+    `no-coverage mutants regressed from ${baseline.measured.noCoverage} to ${overall.noCoverage}`
+  );
+  pushWhenInvalid(
+    errors,
+    overall.errors <= baseline.measured.errors,
+    `mutation errors regressed from ${baseline.measured.errors} to ${overall.errors}`
+  );
+}
+
+function buildFileSummaries(report, baseline, errors) {
+  const summaries = {};
+  for (const file of sortedStrings(Object.keys(report.files ?? {}))) {
+    const summary = countStatuses(report.files[file]?.mutants ?? []);
+    const expected = baseline.files[file];
+    summaries[file] = summary;
+    if (!expected) {
+      continue;
+    }
+    pushWhenInvalid(
+      errors,
+      summary.mutants >= expected.minimumMutants,
+      `${file} has ${summary.mutants} mutants; baseline requires at least ${expected.minimumMutants}`
+    );
+    pushWhenInvalid(
+      errors,
+      summary.score + SCORE_EPSILON >= expected.minimumScore,
+      `${file} mutation score ${summary.score} is below ${expected.minimumScore}`
+    );
+  }
+  return summaries;
+}
+
+function validateReportSurvivors(entries, baseline, errors) {
+  const actual = new Set(
+    entries
+      .filter(({ mutant }) => mutant.status === 'Survived')
+      .map(({ file, mutant }) => survivorFingerprint(file, mutant))
+  );
+  const allowed = new Set(
+    (baseline.allowedSurvivors ?? []).map((survivor) =>
+      survivorFingerprint(survivor.file, survivor)
+    )
+  );
+  for (const fingerprint of actual) {
+    const survivor = JSON.parse(fingerprint);
+    pushWhenInvalid(
+      errors,
+      allowed.has(fingerprint),
+      `undocumented surviving mutant ${survivor.file}#${survivor.id}`
+    );
+  }
+  for (const fingerprint of allowed) {
+    const survivor = JSON.parse(fingerprint);
+    pushWhenInvalid(
+      errors,
+      actual.has(fingerprint),
+      `stale allowed survivor ${survivor.file}#${survivor.id}`
+    );
+  }
+}
+
+function validateMutationReport(extensionRoot, report) {
+  const policy = validateMutationPolicy(extensionRoot);
+  const errors = [...policy.errors];
+  const { config, baseline } = policy;
+  validateReportMetadata(report, config, baseline, errors);
+  const entries = collectReportMutants(report);
+  const overall = countStatuses(entries.map(({ mutant }) => mutant));
+  validateOverallSummary(overall, baseline, errors);
+  const files = buildFileSummaries(report, baseline, errors);
+  validateReportSurvivors(entries, baseline, errors);
+  return { errors, overall, files, baseline };
+}
+
+function renderMutationSummaryMarkdown(result) {
+  const lines = [
+    '# Mutation Baseline',
+    '',
+    `- Score: **${result.overall.score.toFixed(2)}%** (minimum ${result.baseline.minimumScore}%)`,
+    `- Mutants: **${result.overall.mutants}**`,
+    `- Killed: **${result.overall.killed}**`,
+    `- Survived: **${result.overall.survived}** (${result.baseline.allowedSurvivors.length} documented)`,
+    `- Timeout / no coverage / errors: **${result.overall.timeout} / ${result.overall.noCoverage} / ${result.overall.errors}**`,
+    '',
+    '## Module ratchet',
+    '',
+    '| File | Score | Minimum | Mutants | Killed | Survived |',
+    '| --- | ---: | ---: | ---: | ---: | ---: |'
+  ];
+  for (const file of sortedStrings(Object.keys(result.files))) {
+    const summary = result.files[file];
+    const expected = result.baseline.files[file];
+    lines.push(
+      `| \`${file}\` | ${summary.score.toFixed(2)}% | ${expected.minimumScore}% | ${summary.mutants} | ${summary.killed} | ${summary.survived} |`
+    );
+  }
+  lines.push('', '## Documented survivors', '');
+  for (const survivor of result.baseline.allowedSurvivors) {
+    lines.push(
+      `- \`${survivor.file}#${survivor.id}\` — ${survivor.classification}: ${survivor.reason}`
+    );
+  }
+  lines.push('', '## Deferred expensive shards', '');
+  for (const deferred of result.baseline.deferredExpensiveScope.files) {
+    lines.push(
+      `- \`${deferred.path}\` — ${deferred.owner}: ${deferred.reason}`
+    );
+  }
+  lines.push('');
+  return `${lines.join('\n')}\n`;
+}
+
+function writeMutationSummary(extensionRoot, result) {
+  const reportDirectory = path.join(extensionRoot, 'reports', 'mutation');
+  fs.mkdirSync(reportDirectory, { recursive: true });
+  fs.writeFileSync(
+    path.join(reportDirectory, 'summary.json'),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        minimumScore: result.baseline.minimumScore,
+        overall: result.overall,
+        files: result.files,
+        documentedSurvivors: result.baseline.allowedSurvivors,
+        deferredExpensiveScope: result.baseline.deferredExpensiveScope
+      },
+      null,
+      2
+    )}\n`
+  );
+  fs.writeFileSync(
+    path.join(reportDirectory, 'summary.md'),
+    renderMutationSummaryMarkdown(result)
+  );
+}
+
+function runCli() {
+  const extensionRoot = path.resolve(
+    path.dirname(require.resolve('./mutation-baseline.cjs')),
+    '..'
+  );
+  const reportFlagIndex = process.argv.indexOf('--report');
+  if (reportFlagIndex === -1) {
+    const policy = validateMutationPolicy(extensionRoot);
+    if (policy.errors.length > 0) {
+      process.stderr.write(
+        `Mutation policy failed:\n- ${policy.errors.join('\n- ')}\n`
+      );
+      process.exitCode = 1;
+      return;
+    }
+    process.stdout.write(
+      `Mutation policy passed: ${policy.baseline.scope.mutate.length} files, ${policy.baseline.scope.minimumMutants} mutants, ${policy.baseline.minimumScore}% break threshold.\n`
+    );
+    return;
+  }
+  const reportPath = process.argv[reportFlagIndex + 1];
+  if (!reportPath) {
+    throw new Error('--report requires a path');
+  }
+  const report = readJson(path.resolve(extensionRoot, reportPath));
+  const result = validateMutationReport(extensionRoot, report);
+  if (process.argv.includes('--write-summary')) {
+    writeMutationSummary(extensionRoot, result);
+  }
+  if (result.errors.length > 0) {
+    process.stderr.write(
+      `Mutation baseline failed:\n- ${result.errors.join('\n- ')}\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(
+    `Mutation baseline passed: ${result.overall.score}% score, ${result.overall.killed}/${result.overall.mutants} killed, ${result.overall.survived} documented survivors.\n`
+  );
+}
+
+module.exports = {
+  countStatuses,
+  loadPolicy,
+  renderMutationSummaryMarkdown,
+  survivorFingerprint,
+  validateMutationPolicy,
+  validateMutationReport,
+  writeMutationSummary
+};
+
+if (require.main === module) {
+  runCli();
+}

--- a/apps/vscode-extension/scripts/mutation-baseline.test.mjs
+++ b/apps/vscode-extension/scripts/mutation-baseline.test.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const {
+  renderMutationSummaryMarkdown,
+  validateMutationPolicy,
+  validateMutationReport
+} = require('./mutation-baseline.cjs');
+
+const extensionRoot = path.resolve(import.meta.dirname, '..');
+const config = require('../stryker.config.json');
+const baseline = require('../mutation-baseline.json');
+
+function location(line) {
+  return {
+    start: { line, column: 0 },
+    end: { line, column: 1 }
+  };
+}
+
+function reportFixture() {
+  const files = {};
+  for (const [file, expected] of Object.entries(baseline.files)) {
+    const allowed = baseline.allowedSurvivors.filter(
+      (item) => item.file === file
+    );
+    const mutants = allowed.map((item) => ({
+      id: item.id,
+      mutatorName: item.mutatorName,
+      replacement: item.replacement,
+      static: item.static,
+      location: item.location,
+      status: 'Survived'
+    }));
+    for (
+      let index = mutants.length;
+      index < expected.minimumMutants;
+      index += 1
+    ) {
+      mutants.push({
+        id: `killed-${index}`,
+        mutatorName: 'BooleanLiteral',
+        replacement: 'false',
+        static: false,
+        location: location(index + 100),
+        status: 'Killed'
+      });
+    }
+    files[file] = { language: 'typescript', mutants, source: '' };
+  }
+  return {
+    schemaVersion: '1.0',
+    thresholds: config.thresholds,
+    config,
+    files,
+    testFiles: {}
+  };
+}
+
+test('current mutation policy is complete and blocking (#496)', () => {
+  const result = validateMutationPolicy(extensionRoot);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.config.thresholds.break, 96.3);
+  assert.equal(result.baseline.scope.mutate.length, 7);
+  assert.equal(result.baseline.scope.minimumMutants, 166);
+  assert.equal(result.baseline.allowedSurvivors.length, 6);
+});
+
+test('baseline report passes with documented survivors and module scores (#496)', () => {
+  const result = validateMutationReport(extensionRoot, reportFixture());
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.overall.score, 96.3855);
+  assert.equal(result.overall.survived, 6);
+  assert.equal(result.overall.noCoverage, 0);
+  assert.match(
+    renderMutationSummaryMarkdown(result),
+    /Deferred expensive shards/u
+  );
+});
+
+test('an undocumented survivor fails even when the overall score remains high (#496)', () => {
+  const report = reportFixture();
+  const mutant =
+    report.files['src/mcp/protocol/mcp2025ProtocolAdapter.ts'].mutants[0];
+  mutant.status = 'Survived';
+
+  const result = validateMutationReport(extensionRoot, report);
+  assert.ok(
+    result.errors.some((error) =>
+      error.includes('undocumented surviving mutant')
+    )
+  );
+  assert.ok(result.errors.some((error) => error.includes('mutation score')));
+});
+
+test('scope shrinkage and no-coverage regressions fail closed (#496)', () => {
+  const report = reportFixture();
+  report.files['src/mcp/toolCallParser.ts'].mutants.pop();
+  report.files['src/utils/workspaceTrust.ts'].mutants[0].status = 'NoCoverage';
+
+  const result = validateMutationReport(extensionRoot, report);
+  assert.ok(
+    result.errors.some((error) => error.includes('baseline requires at least'))
+  );
+  assert.ok(
+    result.errors.some((error) =>
+      error.includes('no-coverage mutants regressed')
+    )
+  );
+});

--- a/apps/vscode-extension/scripts/package-allowlist.json
+++ b/apps/vscode-extension/scripts/package-allowlist.json
@@ -96,6 +96,7 @@
     "jest.config.js",
     "stryker.config.json",
     "release-please-config.json",
-    ".release-please-manifest.json"
+    ".release-please-manifest.json",
+    "mutation-baseline.json"
   ]
 }

--- a/apps/vscode-extension/src/mcp/compat.ts
+++ b/apps/vscode-extension/src/mcp/compat.ts
@@ -7,12 +7,15 @@ export const MCP_COMPAT =
 
 export type McpCompatStatus = 'ok' | 'warn' | 'incompatible';
 
-export function normalizeMcpVersion(version: string | undefined): string {
+function coerceMcpVersion(version: string | undefined): string | undefined {
   if (!version) {
-    return '0.0.0';
+    return undefined;
   }
-  const parsed = semver.coerce(version);
-  return parsed?.version ?? '0.0.0';
+  return semver.coerce(version)?.version;
+}
+
+export function normalizeMcpVersion(version: string | undefined): string {
+  return coerceMcpVersion(version) ?? '0.0.0';
 }
 
 export function isMcpVersionSupported(version: string | undefined): boolean {
@@ -33,7 +36,7 @@ export function getMcpCompatStatus(
 }
 
 export function describeMcpCompatibility(version: string | undefined): string {
-  const normalized = normalizeMcpVersion(version);
+  const normalized = coerceMcpVersion(version);
   if (!normalized) {
     return `Unable to determine kicad-mcp-pro version. Required range: ${MCP_COMPAT.required}.`;
   }

--- a/apps/vscode-extension/src/mcp/toolCallParser.ts
+++ b/apps/vscode-extension/src/mcp/toolCallParser.ts
@@ -1,39 +1,37 @@
 import type { McpToolCall } from '../types';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export function extractMcpToolCalls(markdown: string): McpToolCall[] {
   const matches = [...markdown.matchAll(/```mcp\s*([\s\S]*?)```/gi)];
   const toolCalls: McpToolCall[] = [];
 
   for (const match of matches) {
-    const source = match[1]?.trim();
-    if (!source) {
-      continue;
-    }
+    const source = match[1]!;
     try {
       const parsed = JSON.parse(source) as unknown;
       const values = Array.isArray(parsed) ? parsed : [parsed];
       for (const value of values) {
-        if (typeof value !== 'object' || value === null) {
+        if (!isRecord(value)) {
           continue;
         }
-        const record = value as Record<string, unknown>;
-        if (typeof record['name'] !== 'string') {
+        if (typeof value['name'] !== 'string') {
           continue;
         }
+        const argumentsValue = value['arguments'];
         toolCalls.push({
-          name: record['name'],
-          arguments:
-            typeof record['arguments'] === 'object' &&
-            record['arguments'] !== null
-              ? (record['arguments'] as Record<string, unknown>)
-              : {},
-          ...(typeof record['preview'] === 'string'
-            ? { preview: record['preview'] }
+          name: value['name'],
+          arguments: isRecord(argumentsValue) ? argumentsValue : {},
+          ...(typeof value['preview'] === 'string'
+            ? { preview: value['preview'] }
             : {})
         });
       }
     } catch {
-      continue;
+      // Malformed MCP blocks are intentionally ignored so surrounding markdown
+      // remains renderable and later valid blocks can still be processed.
     }
   }
 

--- a/apps/vscode-extension/stryker.config.json
+++ b/apps/vscode-extension/stryker.config.json
@@ -1,11 +1,35 @@
 {
   "packageManager": "pnpm",
-  "reporters": ["html", "clear-text", "progress"],
+  "reporters": ["html", "json", "clear-text", "progress"],
+  "jsonReporter": {
+    "fileName": "reports/mutation/mutation.json"
+  },
   "testRunner": "jest",
   "coverageAnalysis": "perTest",
+  "concurrency": 2,
+  "timeoutMS": 10000,
+  "dryRunTimeoutMinutes": 5,
+  "mutate": [
+    "src/mcp/protocol/mcp2025ProtocolAdapter.ts",
+    "src/mcp/protocol/protocolAdapter.ts",
+    "src/mcp/protocol/protocolAdapterRegistry.ts",
+    "src/mcp/compat.ts",
+    "src/lm/toolCapabilityModes.ts",
+    "src/utils/workspaceTrust.ts",
+    "src/mcp/toolCallParser.ts"
+  ],
+  "testFiles": [
+    "test/unit/mcpProtocolAdapter.test.ts",
+    "test/unit/mcpCompat.test.ts",
+    "test/unit/toolCapabilityModes.test.ts",
+    "test/unit/workspaceTrust.test.ts",
+    "test/unit/toolCallParser.test.ts"
+  ],
   "thresholds": {
-    "high": 80,
-    "low": 60,
-    "break": 0
-  }
+    "high": 97,
+    "low": 96.3,
+    "break": 96.3
+  },
+  "plugins": ["@stryker-mutator/jest-runner"],
+  "cleanTempDir": "always"
 }

--- a/apps/vscode-extension/test/unit/mcpCompat.test.ts
+++ b/apps/vscode-extension/test/unit/mcpCompat.test.ts
@@ -1,5 +1,6 @@
 import {
   MCP_COMPAT,
+  describeMcpCompatibility,
   getMcpCompatStatus,
   isMcpVersionSupported,
   normalizeMcpVersion
@@ -26,5 +27,32 @@ describe('MCP compatibility helpers', () => {
     expect(getMcpCompatStatus(undefined)).toBe('incompatible');
     expect(isMcpVersionSupported('3.5.2')).toBe(true);
     expect(isMcpVersionSupported('4.0.0')).toBe(false);
+  });
+
+  it('describes unknown, incompatible, warning, and supported versions', () => {
+    expect(describeMcpCompatibility(undefined)).toBe(
+      `Unable to determine kicad-mcp-pro version. Required range: ${MCP_COMPAT.required}.`
+    );
+    expect(describeMcpCompatibility('not-a-version')).toBe(
+      `Unable to determine kicad-mcp-pro version. Required range: ${MCP_COMPAT.required}.`
+    );
+    expect(describeMcpCompatibility('3.5.1')).toBe(
+      `kicad-mcp-pro 3.5.1 is outside the required range ${MCP_COMPAT.required}.`
+    );
+    expect(describeMcpCompatibility('3.9.2')).toBe(
+      'kicad-mcp-pro 3.9.2 is supported.'
+    );
+
+    const mutableCompat = MCP_COMPAT as { recommended: string };
+    const originalRecommended = mutableCompat.recommended;
+    try {
+      mutableCompat.recommended = '>=3.6.0 <4.0.0';
+      expect(getMcpCompatStatus('3.5.2')).toBe('warn');
+      expect(describeMcpCompatibility('3.5.2')).toBe(
+        'kicad-mcp-pro 3.5.2 satisfies the required range but is older than >=3.6.0 <4.0.0.'
+      );
+    } finally {
+      mutableCompat.recommended = originalRecommended;
+    }
   });
 });

--- a/apps/vscode-extension/test/unit/mcpProtocolAdapter.test.ts
+++ b/apps/vscode-extension/test/unit/mcpProtocolAdapter.test.ts
@@ -39,6 +39,18 @@ describe('MCP protocol adapter boundary (#492)', () => {
     }
   });
 
+  it('formats unsupported-version diagnostics for multiple supported adapters', () => {
+    const error = new UnsupportedMcpProtocolVersionError('draft', [
+      '2025-11-25',
+      '2026-07-28'
+    ]);
+
+    expect(error.message).toBe(
+      'Unsupported MCP protocol version draft. Supported versions: 2025-11-25, 2026-07-28.'
+    );
+    expect(error.name).toBe('UnsupportedMcpProtocolVersionError');
+  });
+
   it('builds the exact 2025 initialize discovery request (#492)', () => {
     const adapter = resolveMcpProtocolAdapter('2025-11-25');
 
@@ -131,7 +143,14 @@ describe('MCP protocol adapter boundary (#492)', () => {
       capabilities: {}
     };
 
+    expect(() => adapter.validateDiscoveryResult(undefined)).not.toThrow();
     expect(() => adapter.validateDiscoveryResult(legacyResult)).not.toThrow();
+    expect(() =>
+      adapter.validateDiscoveryResult({
+        ...legacyResult,
+        protocolVersion: '2025-11-25'
+      })
+    ).not.toThrow();
     expect(() =>
       adapter.validateDiscoveryResult({
         ...legacyResult,
@@ -151,6 +170,10 @@ describe('MCP protocol adapter boundary (#492)', () => {
         receivedVersion: '2026-07-28',
         hint: expect.stringContaining('matching protocol adapter')
       });
+      expect((error as Error).name).toBe('McpProtocolVersionMismatchError');
+      expect((error as Error).message).toBe(
+        'MCP protocol version mismatch: expected 2025-11-25, received 2026-07-28.'
+      );
     }
   });
 

--- a/apps/vscode-extension/test/unit/toolCallParser.test.ts
+++ b/apps/vscode-extension/test/unit/toolCallParser.test.ts
@@ -18,11 +18,18 @@ Text before
     ]);
   });
 
-  it('parses arrays and ignores invalid entries', () => {
+  it('accepts a block without whitespace after the mcp fence', () => {
+    expect(
+      extractMcpToolCalls('```mcp{"name":"compact","arguments":{"value":1}}```')
+    ).toEqual([{ name: 'compact', arguments: { value: 1 } }]);
+  });
+
+  it('parses arrays and preserves valid entries around invalid values', () => {
     const calls = extractMcpToolCalls(`
 \`\`\`mcp
 [
   {"name":"tool_one","arguments":{"a":1}},
+  null,
   {"name":2},
   "skip me",
   {"name":"tool_two","arguments":{}}
@@ -36,8 +43,27 @@ Text before
     ]);
   });
 
-  it('returns an empty list for malformed blocks or missing blocks', () => {
+  it('normalizes invalid arguments and preview values', () => {
+    const calls = extractMcpToolCalls(`
+\`\`\`mcp
+[
+  {"name":"null_args","arguments":null,"preview":123},
+  {"name":"array_args","arguments":[1,2,3]},
+  {"name":"string_args","arguments":"invalid"}
+]
+\`\`\`
+`);
+
+    expect(calls).toEqual([
+      { name: 'null_args', arguments: {} },
+      { name: 'array_args', arguments: {} },
+      { name: 'string_args', arguments: {} }
+    ]);
+  });
+
+  it('returns an empty list for empty, malformed, or missing blocks', () => {
     expect(extractMcpToolCalls('plain markdown only')).toEqual([]);
+    expect(extractMcpToolCalls('```mcp   ```')).toEqual([]);
     expect(
       extractMcpToolCalls(`
 \`\`\`mcp

--- a/apps/vscode-extension/test/unit/toolCapabilityModes.test.ts
+++ b/apps/vscode-extension/test/unit/toolCapabilityModes.test.ts
@@ -18,6 +18,17 @@ describe('#406 assistant tool capability modes', () => {
     }
   });
 
+  it('keeps capability descriptions explicit and non-empty', () => {
+    expect(MODE_DESCRIPTIONS).toEqual({
+      'read-only':
+        'Explorer mode. Returns information about the project and never changes files or project state.',
+      review:
+        'Advisory mode. Runs checks/validations and returns findings plus proposed next steps; it does not modify design files.',
+      'release-preparation':
+        'Release-preparation mode. Changes release-relevant project state or produces artifacts. Requires workspace trust and a preview/confirmation before acting.'
+    });
+  });
+
   it('does not classify any unknown tools', () => {
     const known = new Set<string>(Object.values(TOOL_NAMES));
     for (const toolName of Object.keys(TOOL_CAPABILITY_MODES)) {

--- a/apps/vscode-extension/test/unit/workspaceTrust.test.ts
+++ b/apps/vscode-extension/test/unit/workspaceTrust.test.ts
@@ -26,6 +26,21 @@ describe('workspace trust helpers', () => {
     );
   });
 
+  it('forwards trusted command arguments and return values', async () => {
+    const handler = jest.fn(async (value: string) => `handled:${value}`);
+    registerTrustedCommand(
+      'kicadstudio.testTrustedCommand',
+      handler,
+      'Export Gerbers'
+    );
+    const registered = (commands.registerCommand as jest.Mock).mock
+      .calls[0]?.[1] as (value: string) => Promise<string>;
+
+    await expect(registered('board-a')).resolves.toBe('handled:board-a');
+    expect(handler).toHaveBeenCalledWith('board-a');
+    expect(window.showWarningMessage).not.toHaveBeenCalled();
+  });
+
   it('wraps registered command handlers behind the trust check', async () => {
     workspace.isTrusted = false;
     const handler = jest.fn();

--- a/docs/development/testing-policy.md
+++ b/docs/development/testing-policy.md
@@ -19,6 +19,10 @@ The root `check` script is the full repository gate. It can be expensive. For sm
 
 The repository has global coverage thresholds for the configured extension unit-test denominator. The percentage is not a whole-source claim. `apps/vscode-extension/coverage-scope.json` classifies every explicit exclusion and assigns either integration ownership or a targeted blocking ratchet. Validate the policy with `corepack pnpm run check:coverage-scope` and do not lower global or ratchet thresholds without maintainer approval and an issue describing the reason and recovery plan.
 
+## Mutation testing
+
+The extension mutation scope is controlled by `apps/vscode-extension/mutation-baseline.json` and validated with `corepack pnpm --filter kicadstudiokit run check:mutation-policy`. The blocking command is `corepack pnpm --filter kicadstudiokit run test:mutation`; it must complete within the documented 10-minute budget and may not use `continue-on-error`. Do not lower the 96.3% break threshold, shrink a module's mutant count, or add survivor exceptions to make unrelated work pass. New survivors require focused tests or a reviewed equivalent/static classification with evidence. Large deferred modules must be introduced as separate measured shards.
+
 ## Flaky or environment-bound tests
 
 Display-bound VS Code, Playwright, visual, and integration tests may require Xvfb on Linux. If a test is skipped because the required external server or display is unavailable, document the skip in the PR evidence.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -10,20 +10,21 @@ notes can add detail, but they should not weaken these gates.
 
 ## Gate Summary
 
-| Gate               | Trigger                                                              | Purpose                                                                                                              | Required command                                                                                |
-| ------------------ | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Fast PR gate       | Every pull request                                                   | Catch formatting, lint, type, unit, package, metadata, boundary, and compatibility regressions.                      | `corepack pnpm run check`                                                                       |
-| Bug-fix regression | Every bug-fix pull request                                           | Prove the repeatable bug fails before the fix, passes after it, and references the issue.                            | Relevant test command plus PR checklist evidence                                                |
-| Performance budget | Product, integration, and shared fixture/schema pull requests        | Report shared baseline drift and fail measured lanes that exceed the regression budget.                              | `corepack pnpm run check:performance-budgets`                                                   |
-| Product gate       | Product-scoped changes                                               | Prove the touched product still builds, tests, and packages independently.                                           | Product commands below                                                                          |
-| Accessibility gate | Extension-owned UI and webview changes                               | Prove WCAG 2.1 AA automated checks remain clean for in-scope extension surfaces.                                     | `corepack pnpm --filter kicadstudiokit run test:a11y`                                           |
-| Contract gate      | Protocol, compatibility, or cross-product changes                    | Prove extension and MCP assumptions remain aligned.                                                                  | `corepack pnpm run check:protocol-schemas` and `corepack pnpm run check:compatibility-contract` |
-| Protocol PR gate   | Protocol, compatibility, or cross-product review changes             | Keep protocol-impact PRs visible through the PR template and architecture guidance.                                  | `corepack pnpm run check:protocol-pr-template`                                                  |
-| GUI smoke policy   | Real KiCad GUI smoke workflow/test wiring changes                    | Keep live-editor IPC smoke coverage wired without adding GUI work to the PR path.                                    | `corepack pnpm run check:kicad-gui-smoke`                                                       |
-| Fixture gate       | Parser, diagnostics, command-builder, or KiCad file behavior changes | Prove deterministic KiCad corpus behavior stays stable.                                                              | `corepack pnpm run test:fixtures`                                                               |
-| VS Code canary     | Scheduled and manual workflow                                        | Check supported VS Code host lanes before runtime/API changes reach users.                                           | `.github/workflows/vscode-canary.yml`                                                           |
-| Cross-repo canary  | Push, pull request, and manual workflow                              | Verify this repository consumes published `@oaslananka/kicad-protocol-schemas` and `kicad-mcp-pro` server artifacts. | `.github/workflows/cross-repo-compatibility.yml`                                                |
-| Manual smoke       | Release candidate only                                               | Final human inspection where automation is not practical.                                                            | PR notes must name the exact manual check                                                       |
+| Gate               | Trigger                                                              | Purpose                                                                                                                 | Required command                                                                                |
+| ------------------ | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Fast PR gate       | Every pull request                                                   | Catch formatting, lint, type, unit, package, metadata, boundary, and compatibility regressions.                         | `corepack pnpm run check`                                                                       |
+| Bug-fix regression | Every bug-fix pull request                                           | Prove the repeatable bug fails before the fix, passes after it, and references the issue.                               | Relevant test command plus PR checklist evidence                                                |
+| Performance budget | Product, integration, and shared fixture/schema pull requests        | Report shared baseline drift and fail measured lanes that exceed the regression budget.                                 | `corepack pnpm run check:performance-budgets`                                                   |
+| Mutation baseline  | Extension compatibility, trust, protocol, and assistant-tool changes | Kill behavioral mutants and reject scope shrinkage, new survivors, no-coverage mutants, timeouts, or score regressions. | `corepack pnpm --filter kicadstudiokit run test:mutation`                                       |
+| Product gate       | Product-scoped changes                                               | Prove the touched product still builds, tests, and packages independently.                                              | Product commands below                                                                          |
+| Accessibility gate | Extension-owned UI and webview changes                               | Prove WCAG 2.1 AA automated checks remain clean for in-scope extension surfaces.                                        | `corepack pnpm --filter kicadstudiokit run test:a11y`                                           |
+| Contract gate      | Protocol, compatibility, or cross-product changes                    | Prove extension and MCP assumptions remain aligned.                                                                     | `corepack pnpm run check:protocol-schemas` and `corepack pnpm run check:compatibility-contract` |
+| Protocol PR gate   | Protocol, compatibility, or cross-product review changes             | Keep protocol-impact PRs visible through the PR template and architecture guidance.                                     | `corepack pnpm run check:protocol-pr-template`                                                  |
+| GUI smoke policy   | Real KiCad GUI smoke workflow/test wiring changes                    | Keep live-editor IPC smoke coverage wired without adding GUI work to the PR path.                                       | `corepack pnpm run check:kicad-gui-smoke`                                                       |
+| Fixture gate       | Parser, diagnostics, command-builder, or KiCad file behavior changes | Prove deterministic KiCad corpus behavior stays stable.                                                                 | `corepack pnpm run test:fixtures`                                                               |
+| VS Code canary     | Scheduled and manual workflow                                        | Check supported VS Code host lanes before runtime/API changes reach users.                                              | `.github/workflows/vscode-canary.yml`                                                           |
+| Cross-repo canary  | Push, pull request, and manual workflow                              | Verify this repository consumes published `@oaslananka/kicad-protocol-schemas` and `kicad-mcp-pro` server artifacts.    | `.github/workflows/cross-repo-compatibility.yml`                                                |
+| Manual smoke       | Release candidate only                                               | Final human inspection where automation is not practical.                                                               | PR notes must name the exact manual check                                                       |
 
 ## Coverage and Mutation Thresholds
 
@@ -72,11 +73,43 @@ current uncovered count observed across the pinned validation host and GitHub's
 Ubuntu runner, preventing platform-specific instrumentation variance from
 creating a false regression while still blocking any larger uncovered surface.
 
-Mutation testing is configured in `stryker.config.json` (Jest runner, `perTest`
-analysis, thresholds high 80 / low 60). It currently runs with `break: 0` so it
-never fails the build. Issue #496 owns the next mutation-baseline step and should
-reuse the same critical-module ownership map rather than adding a competing
-scope.
+### Blocking Mutation Baseline
+
+Mutation testing is configured in `apps/vscode-extension/stryker.config.json`
+with the Jest runner, `perTest` coverage analysis, explicit pnpm plugin loading,
+and two deterministic workers. `apps/vscode-extension/mutation-baseline.json`
+owns the reviewed scope, module baselines, survivor fingerprints, and CI budget.
+
+The first blocking shard covers seven compatibility, protocol, workspace-trust,
+tool-capability, and MCP tool-call parsing modules. Its accepted measurement is
+166 mutants, 160 killed, six documented survivors, zero timeout/no-coverage/error
+results, and a 96.3855% score. Stryker's `thresholds.break` is **96.3%**. The CI
+policy adds stronger ratchets: every module has a minimum score and mutant count,
+and any survivor not listed in the manifest fails even when the overall score
+would remain above the threshold. The aggregate `required` job depends on the
+mutation job, so a regression blocks merge and release readiness.
+
+Four survivors are static initialization mutants for exact capability-description
+constants. Stryker marks them `static: true` and cannot attribute them to a test
+after Jest has loaded the module; exact values remain asserted by unit tests. Two
+compatibility survivors are equivalent: removing the explicit undefined guard has
+the same result because `semver.coerce(undefined)` returns `null`. These exceptions
+are fingerprinted with reason and evidence; a new or stale exception fails policy.
+
+A broader experiment across 11 modules produced 782 mutants and emitted only 310
+results before a 30-minute timeout, with roughly two hours projected. Large parser,
+export, diagnostics, and path-normalization modules are therefore recorded as
+**deferred expensive shards** rather than silently excluded. Add them in separate
+reviewed shards without lowering the current baseline or exceeding the declared
+10-minute CI budget.
+
+Run and validate the baseline with:
+
+```bash
+corepack pnpm --filter kicadstudiokit run check:mutation-policy
+corepack pnpm --filter kicadstudiokit run test:mutation
+corepack pnpm --filter kicadstudiokit run mutation:summary
+```
 
 ### Codecov observability
 
@@ -398,22 +431,23 @@ right layer instead of relying on manual screenshots or ad-hoc verification.
 Use the narrowest command first while developing, then run the broader gate
 before pushing.
 
-| Change type                    | Narrow command                                                       | Broad command                          |
-| ------------------------------ | -------------------------------------------------------------------- | -------------------------------------- |
-| Root docs or governance        | `corepack pnpm run check:testing-strategy`                           | `corepack pnpm run check`              |
-| Performance baselines          | `corepack pnpm run check:performance-budgets`                        | CI `performance-budgets` artifact lane |
-| Extension unit behavior        | `corepack pnpm --filter kicadstudiokit run test:unit -- <test file>` | `corepack pnpm run check:kicad-studio` |
-| Extension accessibility        | `corepack pnpm --filter kicadstudiokit run test:a11y`                | `corepack pnpm run check:kicad-studio` |
-| Extension integration behavior | `corepack pnpm --filter kicadstudiokit run test:integration`         | `corepack pnpm run check:kicad-studio` |
-| Extension webview/E2E behavior | `corepack pnpm --filter kicadstudiokit run test:e2e`                 | `corepack pnpm run check:kicad-studio` |
-| Extension visual snapshots     | `corepack pnpm --filter kicadstudiokit run test:visual`              | Windows PR lane for committed goldens  |
-| MCP unit behavior              | See [KiCad MCP Pro](https://oaslananka.github.io/kicad-mcp-pro/)     | Run from the KiCad MCP Pro repository  |
-| MCP full behavior              | See [KiCad MCP Pro](https://oaslananka.github.io/kicad-mcp-pro/)     | Run from the KiCad MCP Pro repository  |
-| Protocol or compatibility      | `corepack pnpm run check:protocol-schemas`                           | `corepack pnpm run check`              |
-| Protocol PR checklist          | `corepack pnpm run check:protocol-pr-template`                       | `corepack pnpm run check`              |
-| KiCad GUI smoke wiring         | `corepack pnpm run check:kicad-gui-smoke`                            | `corepack pnpm run check`              |
-| Real KiCad GUI smoke           | See [KiCad MCP Pro](https://oaslananka.github.io/kicad-mcp-pro/)     | Run from the KiCad MCP Pro repository  |
-| Fixtures                       | `corepack pnpm run test:fixtures`                                    | `corepack pnpm run check`              |
+| Change type                    | Narrow command                                                       | Broad command                                             |
+| ------------------------------ | -------------------------------------------------------------------- | --------------------------------------------------------- |
+| Root docs or governance        | `corepack pnpm run check:testing-strategy`                           | `corepack pnpm run check`                                 |
+| Performance baselines          | `corepack pnpm run check:performance-budgets`                        | CI `performance-budgets` artifact lane                    |
+| Mutation policy/baseline       | `corepack pnpm --filter kicadstudiokit run check:mutation-policy`    | `corepack pnpm --filter kicadstudiokit run test:mutation` |
+| Extension unit behavior        | `corepack pnpm --filter kicadstudiokit run test:unit -- <test file>` | `corepack pnpm run check:kicad-studio`                    |
+| Extension accessibility        | `corepack pnpm --filter kicadstudiokit run test:a11y`                | `corepack pnpm run check:kicad-studio`                    |
+| Extension integration behavior | `corepack pnpm --filter kicadstudiokit run test:integration`         | `corepack pnpm run check:kicad-studio`                    |
+| Extension webview/E2E behavior | `corepack pnpm --filter kicadstudiokit run test:e2e`                 | `corepack pnpm run check:kicad-studio`                    |
+| Extension visual snapshots     | `corepack pnpm --filter kicadstudiokit run test:visual`              | Windows PR lane for committed goldens                     |
+| MCP unit behavior              | See [KiCad MCP Pro](https://oaslananka.github.io/kicad-mcp-pro/)     | Run from the KiCad MCP Pro repository                     |
+| MCP full behavior              | See [KiCad MCP Pro](https://oaslananka.github.io/kicad-mcp-pro/)     | Run from the KiCad MCP Pro repository                     |
+| Protocol or compatibility      | `corepack pnpm run check:protocol-schemas`                           | `corepack pnpm run check`                                 |
+| Protocol PR checklist          | `corepack pnpm run check:protocol-pr-template`                       | `corepack pnpm run check`                                 |
+| KiCad GUI smoke wiring         | `corepack pnpm run check:kicad-gui-smoke`                            | `corepack pnpm run check`                                 |
+| Real KiCad GUI smoke           | See [KiCad MCP Pro](https://oaslananka.github.io/kicad-mcp-pro/)     | Run from the KiCad MCP Pro repository                     |
+| Fixtures                       | `corepack pnpm run test:fixtures`                                    | `corepack pnpm run check`                                 |
 
 ## KiCad Fixture Corpus
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "docs:preview": "vitepress preview docs",
     "check:docs-site": "pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:vscode-typings-policy && pnpm run check:codecov && pnpm run check:coverage-scope && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:dependabot-policy && pnpm run check:security-tooling && pnpm run check:trivy-devcontainer && pnpm run check:best-practices && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:validation-host && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:extension-doc-links && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check",
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:vscode-typings-policy && pnpm run check:codecov && pnpm run check:coverage-scope && pnpm run check:mutation-policy && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:dependabot-policy && pnpm run check:security-tooling && pnpm run check:trivy-devcontainer && pnpm run check:best-practices && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:validation-host && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:extension-doc-links && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check",
     "check:best-practices": "node scripts/check-best-practices-evidence.mjs && pnpm run check:repeatable-vsix && node --test scripts/check-best-practices-evidence.test.mjs scripts/report-best-practices-status.test.mjs",
     "best-practices:status": "node scripts/report-best-practices-status.mjs",
     "best-practices:status:write": "node scripts/report-best-practices-status.mjs --write",
@@ -98,7 +98,8 @@
     "check:trivy-devcontainer": "node scripts/check-trivy-devcontainer.mjs && node --test scripts/check-trivy-devcontainer.test.mjs",
     "security:trivy-devcontainer": "trivy config --skip-version-check --severity HIGH,CRITICAL --exit-code 1 --format table .devcontainer",
     "validation-host:workspace": "bash scripts/run-validation-host.sh node scripts/check-workspace-integrity.mjs --canonical",
-    "check:coverage-scope": "corepack pnpm --filter kicadstudiokit run check:coverage-scope"
+    "check:coverage-scope": "corepack pnpm --filter kicadstudiokit run check:coverage-scope",
+    "check:mutation-policy": "corepack pnpm --filter kicadstudiokit run check:mutation-policy"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",

--- a/scripts/check-testing-strategy.mjs
+++ b/scripts/check-testing-strategy.mjs
@@ -8,6 +8,12 @@ const compatibilityPath = path.join(root, "compatibility.yaml");
 const strategyPath = path.join(root, "docs", "testing-strategy.md");
 const packagePath = path.join(root, "package.json");
 const ciWorkflowPath = path.join(root, ".github", "workflows", "ci.yml");
+const mutationWorkflowPath = path.join(
+  root,
+  ".github",
+  "workflows",
+  "mutation.yml",
+);
 const vscodeCanaryWorkflowPath = path.join(
   root,
   ".github",
@@ -26,6 +32,7 @@ const requiredSections = [
   "## Gate Summary",
   "## Coverage and Mutation Thresholds",
   "### Coverage Scope Inventory",
+  "### Blocking Mutation Baseline",
   "## Test Layers",
   "## Fast PR Gates",
   "## Bug-Fix Regression Requirement",
@@ -53,6 +60,12 @@ const requiredPhrases = [
   "corepack pnpm run check:coverage-scope",
   "corepack pnpm --filter kicadstudiokit run coverage:inventory",
   "corepack pnpm --filter kicadstudiokit run test:coverage:ratchet",
+  "corepack pnpm --filter kicadstudiokit run check:mutation-policy",
+  "corepack pnpm --filter kicadstudiokit run test:mutation",
+  "corepack pnpm --filter kicadstudiokit run mutation:summary",
+  "apps/vscode-extension/mutation-baseline.json",
+  "96.3%",
+  "deferred expensive shards",
   "The headline percentage is not whole-product coverage",
   "maximum uncovered counts",
   "corepack pnpm run check:ci-lanes",
@@ -126,6 +139,7 @@ const compatibility = parse(readText(compatibilityPath));
 const packageJson = JSON.parse(readText(packagePath));
 const extensionPackageJson = JSON.parse(readText(extensionPackagePath));
 const ciWorkflow = readText(ciWorkflowPath);
+const mutationWorkflow = readText(mutationWorkflowPath);
 const vscodeCanaryWorkflow = readText(vscodeCanaryWorkflowPath);
 const vscodeCanaryWorkflowConfig = parse(vscodeCanaryWorkflow);
 const vscodeMinimum = requireString(
@@ -176,6 +190,17 @@ if (!scripts.check?.includes("pnpm run check:coverage-scope")) {
   throw new Error("package.json check must run check:coverage-scope");
 }
 
+if (
+  scripts["check:mutation-policy"] !==
+  "corepack pnpm --filter kicadstudiokit run check:mutation-policy"
+) {
+  throw new Error("package.json must define check:mutation-policy");
+}
+
+if (!scripts.check?.includes("pnpm run check:mutation-policy")) {
+  throw new Error("package.json check must run check:mutation-policy");
+}
+
 const extensionScripts = extensionPackageJson.scripts ?? {};
 for (const [scriptName, expectedCommand] of [
   [
@@ -186,6 +211,15 @@ for (const [scriptName, expectedCommand] of [
   [
     "test:coverage:ratchet",
     "jest --config jest.coverage-ratchet.config.js --runInBand --coverage",
+  ],
+  [
+    "check:mutation-policy",
+    "node --test scripts/mutation-baseline.test.mjs && node scripts/mutation-baseline.cjs",
+  ],
+  ["test:mutation", "stryker run"],
+  [
+    "mutation:summary",
+    "node scripts/mutation-baseline.cjs --report reports/mutation/mutation.json --write-summary",
   ],
 ]) {
   if (extensionScripts[scriptName] !== expectedCommand) {
@@ -204,6 +238,10 @@ if (!extensionScripts.check?.includes("test:coverage:ratchet")) {
   throw new Error("extension check must enforce the coverage ratchet");
 }
 
+if (!extensionScripts.check?.includes("check:mutation-policy")) {
+  throw new Error("extension check must enforce the mutation policy");
+}
+
 for (const requiredCoverageWorkflowText of [
   "Enforce critical coverage ratchet",
   "corepack pnpm --filter kicadstudiokit run test:coverage:ratchet",
@@ -213,6 +251,39 @@ for (const requiredCoverageWorkflowText of [
   'cat apps/vscode-extension/coverage/coverage-scope.md >> "$GITHUB_STEP_SUMMARY"',
 ]) {
   assertIncludes(ciWorkflow, requiredCoverageWorkflowText, "ci workflow");
+}
+
+for (const requiredMutationWorkflowText of [
+  "  mutation:",
+  "timeout-minutes: 10",
+  "Run blocking mutation baseline",
+  "corepack pnpm --filter kicadstudiokit run test:mutation",
+  "corepack pnpm --filter kicadstudiokit run mutation:summary",
+  "apps/vscode-extension/reports/mutation/summary.md",
+  "needs.mutation.result",
+]) {
+  assertIncludes(ciWorkflow, requiredMutationWorkflowText, "ci workflow");
+}
+
+for (const requiredScheduledMutationText of [
+  "name: Mutation Testing",
+  "cron:",
+  "timeout-minutes: 10",
+  "Run blocking mutation baseline",
+  "corepack pnpm --filter kicadstudiokit run test:mutation",
+  "corepack pnpm --filter kicadstudiokit run mutation:summary",
+  "Upload mutation evidence",
+]) {
+  assertIncludes(
+    mutationWorkflow,
+    requiredScheduledMutationText,
+    "mutation workflow",
+  );
+}
+if (mutationWorkflow.includes("continue-on-error")) {
+  throw new Error(
+    "mutation workflow must fail closed without continue-on-error",
+  );
 }
 
 assertIncludes(


### PR DESCRIPTION
## Summary

Establish a deterministic, blocking mutation-testing baseline for critical KiCad Studio extension logic and make mutation regressions part of the required pull-request gate.

## What changed

- scopes Stryker to seven deterministic compatibility, protocol, workspace-trust, assistant-capability, and MCP tool-call parsing modules;
- records the reviewed baseline, per-module minimums, CI budget, deferred expensive shards, and exact survivor fingerprints in `mutation-baseline.json`;
- raises `thresholds.break` from `0` to **96.3%**;
- explicitly loads the pnpm-isolated Jest runner plugin and emits JSON, HTML, Markdown, and machine-readable summary evidence;
- rejects overall or per-module score regressions, scope shrinkage, new survivors, stale survivor exceptions, timeouts, no-coverage mutants, and mutation errors;
- adds a required Ubuntu mutation job to the aggregate `required` check and removes `continue-on-error` from the scheduled workflow;
- keeps mutation policy/config/report files outside the shipped VSIX;
- updates the canonical testing strategy, local commands, package boundary policy, and validation contracts.

## Baseline

| Metric | Result |
| --- | ---: |
| Mutated modules | 7 |
| Focused test files | 5 |
| Focused tests | 27 |
| Mutants | 166 |
| Killed | 160 |
| Documented survivors | 6 |
| Timeout / no coverage / errors | 0 / 0 / 0 |
| Mutation score | **96.3855%** |
| Blocking threshold | **96.3%** |
| Measured runtime | **93 seconds** |
| CI budget | **10 minutes** |

The protocol adapter boundary, tool-call parser, and workspace-trust modules measure **100%** mutation score. Four static-initialization mutants and two behaviorally equivalent semver guard mutants remain explicitly fingerprinted with test evidence.

## Behavior fixes discovered by mutation testing

- unknown or malformed MCP versions now produce the intended “unable to determine” compatibility message instead of being reported as an incompatible `0.0.0` version;
- MCP tool-call parsing now accepts only plain object records for `arguments`, rejecting arrays and other invalid shapes while continuing to ignore malformed fenced blocks safely.

## Scope and CI budget

An initial 11-module / 782-mutant experiment processed only 310 mutants before the 30-minute validation-host limit and projected roughly two hours. The four expensive deterministic modules are therefore recorded as owned future shards rather than silently excluded:

- `src/cli/exportPresets.ts`
- `src/language/sExpressionParser.ts`
- `src/language/diagnosticsAggregator.ts`
- `src/utils/pathUtils.ts`

## Validation

- `bash scripts/run-validation-host.sh corepack pnpm run check` — passed, exit 0, approximately 14m27s;
- Stryker blocking run — 166 mutants, 96.3855%, approximately 1m36s;
- mutation policy tests — 4/4 passed;
- extension unit tests — 106 suites / 868 tests / 2 snapshots passed;
- critical coverage ratchet — 10 suites / 128 tests passed;
- security tests — 12 passed;
- accessibility tests — 76 passed with deterministic process exit;
- actionlint, format, lint, typecheck, docs generation/link checks, VitePress build, release provenance, package validation, and workspace checks passed;
- repeatable VSIX — 101 entries, normalized SHA-256 `51da9bbb05940dc812d20ed65bde756a8ec45060278591c93a0f1d44bc847fde`;
- verified GitHub-signed commit: `c7b16ca2aeafb0115ade5e257cb5a94193307978`.

## Risk and rollback

The primary risk is CI cost or a stale survivor fingerprint after intentional source refactoring. The shard completes well inside the ten-minute budget, and policy tests fail closed when scope, thresholds, survivor evidence, or workflow wiring drift. Rollback would remove required mutation enforcement, but would restore the previous non-blocking `break: 0` configuration.

All bot and agent findings will be reviewed before merge. An unavailable or quota-exhausted automated review is treated as no review and replaced with documented manual review evidence.

Closes #496
