### PR TITLE
security(repo): enforce least-privilege Actions defaults

### DIFF
--- a/.github/actions-permissions.json
+++ b/.github/actions-permissions.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "repositoryDefaults": {
+    "default_workflow_permissions": "read",
+    "can_approve_pull_request_reviews": false,
+    "allowed_actions": "all",
+    "sha_pinning_required": true
+  },
+  "writeJobs": {
+    "ci.yml#coverage-report": ["pull-requests"],
+    "codeql.yml#analyze": ["security-events"],
+    "docs.yml#deploy": ["id-token", "pages"],
+    "publish-extension.yml#package": [
+      "artifact-metadata",
+      "attestations",
+      "contents",
+      "id-token"
+    ],
+    "release-please.yml#release": [
+      "actions",
+      "contents",
+      "issues",
+      "pull-requests"
+    ],
+    "scorecard.yml#analysis": ["id-token", "security-events"],
+    "security.yml#security": ["security-events"],
+    "stale.yml#stale": ["issues", "pull-requests"],
+    "vscode-canary.yml#extension-host": ["issues"]
+  },
+  "persistedCheckoutCredentials": {
+    "release-please.yml#release": 2
+  },
+  "pullRequestWriteJobs": {
+    "ci.yml#coverage-report": "same-repository-head-only",
+    "codeql.yml#analyze": "github-fork-token-read-only",
+    "docs.yml#deploy": "non-pull-request-job",
+    "security.yml#security": "github-fork-token-read-only"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
       - run: corepack pnpm run check:compatibility-contract
       - run: corepack pnpm run check:governance
       - run: corepack pnpm run check:branch-protection
+      - run: corepack pnpm run check:actions-permissions
       - run: corepack pnpm run check:agent-configs
       - run: corepack pnpm run check:review-evidence
       - run: corepack pnpm run check:extension-manifest
@@ -334,7 +335,7 @@ jobs:
 
   coverage-report:
     needs: vscode-extension
-    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && github.event_name == 'pull_request' && needs.vscode-extension.result == 'success' }}
+    if: ${{ (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.vscode-extension.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 env:
   pnpm_config_pm_on_fail: ignore
@@ -22,6 +20,9 @@ jobs:
   build:
     if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pages: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -42,7 +43,18 @@ jobs:
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: site
+
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
       - name: Deploy GitHub Pages
-        if: github.event_name != 'pull_request'
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/governance-evidence.yml
+++ b/.github/workflows/governance-evidence.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   evidence:
-    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    if: (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -27,7 +27,7 @@ jobs:
           package-manager-cache: false
       - name: Collect live governance evidence
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}
         run: >-
           node scripts/check-github-governance-evidence.mjs
           --fetch

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,12 +5,13 @@ on:
     - cron: "42 1 * * *"
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   stale:
+    permissions:
+      issues: write
+      pull-requests: write
     if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   validate:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,3 +35,7 @@ Security reports should include:
 - whether public credit is requested after disclosure.
 
 The project will coordinate public disclosure after a fix, mitigation, or maintainer-approved advisory is ready. Reporter credit is supported when requested and when disclosure is coordinated responsibly.
+
+## GitHub Actions permissions
+
+Repository workflow tokens default to read-only, GitHub Actions cannot approve pull-request reviews, and platform SHA pinning is required. Workflow-specific write permissions are job-scoped and validated by `corepack pnpm run check:actions-permissions`. See [GitHub Actions permissions](docs/architecture/actions-permissions.md).

--- a/docs/architecture/actions-permissions.md
+++ b/docs/architecture/actions-permissions.md
@@ -1,0 +1,40 @@
+# GitHub Actions Permissions
+
+The repository uses secure defaults and explicit job-level escalation. The checked-in source of truth is `.github/actions-permissions.json`; `corepack pnpm run check:actions-permissions` validates every workflow against it.
+
+## Live repository defaults
+
+| Setting                                  | Required value | Rationale                                                                                                         |
+| ---------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Default workflow permissions             | `read`         | A new workflow that omits a permission block cannot receive a write-capable token.                                |
+| Actions may approve pull-request reviews | `false`        | Workflow automation cannot manufacture approval evidence.                                                         |
+| Allowed actions                          | `all`          | The repository uses reviewed third-party actions across release, security, coverage, and documentation workflows. |
+| Require SHA pinning                      | `true`         | Every action reference must resolve to an immutable 40-character commit SHA.                                      |
+
+`allowed_actions: all` does not permit floating action tags: platform SHA pinning is enabled and the repository security tooling independently rejects mutable action references.
+
+## Workflow rules
+
+- Top-level workflow permissions may grant only read access or no access.
+- Every write scope is declared on the exact job that needs it and must match the allowlist in `.github/actions-permissions.json`.
+- `pull_request_target` is forbidden.
+- Fork pull requests receive GitHub's read-only token behavior; jobs that comment on a pull request are additionally restricted to same-repository heads.
+- Every checkout sets `persist-credentials: false` unless the checked-in policy records a reviewed push path.
+- The only persisted-checkout exceptions are the two Release Please checkouts that create deterministic commits on the release branch or `main`.
+
+## Write-capable jobs
+
+The allowlist covers only these purposes:
+
+- release creation, release-surface synchronization, and release workflow dispatch;
+- extension release assets, attestations, and GitHub Release uploads;
+- GitHub Pages deployment;
+- SARIF and Scorecard uploads;
+- scheduled stale-item maintenance and compatibility issue reporting;
+- same-repository pull-request coverage comments.
+
+Build, test, lint, package validation, dependency review, and normal pull-request jobs remain read-only.
+
+## Live drift evidence
+
+`.github/workflows/governance-evidence.yml` reads the repository Actions permission endpoints weekly and on demand. It compares live settings with `.github/actions-permissions.json`. Missing API evidence, a write-capable default token, review-approval permission, disabled SHA pinning, or any other mismatch fails the evidence run.

--- a/docs/architecture/actions-permissions.md
+++ b/docs/architecture/actions-permissions.md
@@ -37,4 +37,4 @@ Build, test, lint, package validation, dependency review, and normal pull-reques
 
 ## Live drift evidence
 
-`.github/workflows/governance-evidence.yml` reads the repository Actions permission endpoints weekly and on demand. It compares live settings with `.github/actions-permissions.json`. Missing API evidence, a write-capable default token, review-approval permission, disabled SHA pinning, or any other mismatch fails the evidence run.
+`.github/workflows/governance-evidence.yml` reads the repository Actions permission endpoints weekly and on demand, only from `main`. The workflow has `contents: read` and receives the protected `GH_AUTH_TOKEN` secret because GitHub's built-in workflow token cannot read these administrative endpoints. It compares live settings with `.github/actions-permissions.json`. Missing API evidence, a write-capable default token, review-approval permission, disabled SHA pinning, or any other mismatch fails the evidence run.

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -90,7 +90,9 @@ repository adopts a merge queue or concurrent merge volume grows.
 
 ## Live evidence
 
-`.github/workflows/governance-evidence.yml` runs weekly and on demand. It compares
+`.github/workflows/governance-evidence.yml` runs weekly and on demand only from
+`main`. The workflow keeps `contents: read` and uses the protected
+`GH_AUTH_TOKEN` secret only for administrative read endpoints. It compares
 the active default-branch ruleset with `.github/rulesets/main.json`, reports repository security settings as confirmed, unconfirmed, or unavailable,
 compares live GitHub Actions defaults with the checked-in
 [Actions permissions policy](actions-permissions.md), and uploads a

--- a/docs/architecture/branch-protection.md
+++ b/docs/architecture/branch-protection.md
@@ -91,10 +91,11 @@ repository adopts a merge queue or concurrent merge volume grows.
 ## Live evidence
 
 `.github/workflows/governance-evidence.yml` runs weekly and on demand. It compares
-the active default-branch ruleset with `.github/rulesets/main.json`, reports
-repository security settings as confirmed, unconfirmed, or unavailable, and
-uploads a machine-readable JSON artifact. Live ruleset drift fails that workflow;
-API unavailability is never treated as confirmation.
+the active default-branch ruleset with `.github/rulesets/main.json`, reports repository security settings as confirmed, unconfirmed, or unavailable,
+compares live GitHub Actions defaults with the checked-in
+[Actions permissions policy](actions-permissions.md), and uploads a
+machine-readable JSON artifact. Live ruleset or Actions-permission drift fails
+that workflow; API unavailability is never treated as confirmation.
 
 The legacy branch-protection REST endpoint can return `404 Branch not protected`
 when protection is implemented entirely through repository rulesets. Treat the

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -13,6 +13,7 @@ server is developed and released separately in
 - [Product boundaries](product-boundaries.md)
 - [Release model](release-model.md)
 - [Branch protection](branch-protection.md)
+- [GitHub Actions permissions](actions-permissions.md)
 - [Definition of done](definition-of-done.md)
 - [Protocol change checklist](protocol-change-checklist.md)
 - [Review evidence policy](review-evidence-policy.md)

--- a/docs/best-practices-evidence.md
+++ b/docs/best-practices-evidence.md
@@ -79,5 +79,5 @@ ruleset contexts from drifting.
 The versioned ruleset is `.github/rulesets/main.json`. The 2026-07-20 audit
 confirmed that the active `main-protection` ruleset matches it, including six
 required checks. `.github/workflows/governance-evidence.yml` repeats this
-comparison weekly and on demand; investigate any drift before changing maturity
-claims.
+comparison weekly and on demand from `main` using a protected administrative
+read token; investigate any drift before changing maturity claims.

--- a/docs/repo-maturity-report.md
+++ b/docs/repo-maturity-report.md
@@ -182,9 +182,10 @@ Before this PR, the main missing maturity files were:
 
 The repository has CI, CodeQL, Scorecard, Gitleaks, security, dependency review,
 docs, release-readiness, publish, and release-please workflows. This reconciliation
-adds `governance-evidence.yml`, a read-only scheduled/manual workflow that compares
-live GitHub governance state with the checked-in ruleset and uploads a sanitized
-JSON report.
+adds `governance-evidence.yml`, a scheduled/manual workflow restricted to `main`
+that uses read-only workflow permissions plus a protected administrative read
+token to compare live GitHub governance state with checked-in policy and upload a
+sanitized JSON report.
 
 ## Verified live settings and scoped changes
 

--- a/docs/security/github-security-settings.md
+++ b/docs/security/github-security-settings.md
@@ -46,7 +46,9 @@ present on the default branch must be remediated or separately justified.
 
 ## Automated evidence
 
-`.github/workflows/governance-evidence.yml` runs weekly and manually with
-read-only repository contents permission. It compares the live ruleset with the
-checked-in policy and reports security settings as `confirmed`, `unconfirmed`, or
-`unavailable`. The JSON artifact intentionally excludes alert payloads.
+`.github/workflows/governance-evidence.yml` runs weekly and manually only from
+`main`, with read-only repository contents permission and the protected
+`GH_AUTH_TOKEN` secret for administrative read endpoints. It compares the live
+ruleset and Actions defaults with checked-in policy and reports security settings
+as `confirmed`, `unconfirmed`, or `unavailable`. The JSON artifact intentionally
+excludes alert payloads.

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "docs:preview": "vitepress preview docs",
     "check:docs-site": "pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
-    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:vscode-typings-policy && pnpm run check:codecov && pnpm run check:coverage-scope && pnpm run check:mutation-policy && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:dependabot-policy && pnpm run check:security-tooling && pnpm run check:trivy-devcontainer && pnpm run check:best-practices && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:review-evidence && pnpm run check:validation-host && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:extension-doc-links && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check",
+    "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:vscode-typings-policy && pnpm run check:codecov && pnpm run check:coverage-scope && pnpm run check:mutation-policy && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:actions-permissions && pnpm run check:dependabot-policy && pnpm run check:security-tooling && pnpm run check:trivy-devcontainer && pnpm run check:best-practices && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:review-evidence && pnpm run check:validation-host && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:extension-doc-links && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check",
     "check:best-practices": "node scripts/check-best-practices-evidence.mjs && pnpm run check:repeatable-vsix && node --test scripts/check-best-practices-evidence.test.mjs scripts/report-best-practices-status.test.mjs",
     "best-practices:status": "node scripts/report-best-practices-status.mjs",
     "best-practices:status:write": "node scripts/report-best-practices-status.mjs --write",
@@ -100,7 +100,8 @@
     "security:trivy-devcontainer": "trivy config --skip-version-check --severity HIGH,CRITICAL --exit-code 1 --format table .devcontainer",
     "validation-host:workspace": "bash scripts/run-validation-host.sh node scripts/check-workspace-integrity.mjs --canonical",
     "check:coverage-scope": "corepack pnpm --filter kicadstudiokit run check:coverage-scope",
-    "check:mutation-policy": "corepack pnpm --filter kicadstudiokit run check:mutation-policy"
+    "check:mutation-policy": "corepack pnpm --filter kicadstudiokit run check:mutation-policy",
+    "check:actions-permissions": "node scripts/check-actions-permissions-policy.mjs && node --test scripts/check-actions-permissions-policy.test.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",

--- a/scripts/check-actions-permissions-policy.mjs
+++ b/scripts/check-actions-permissions-policy.mjs
@@ -80,60 +80,82 @@ function validatePullRequestWriteJob(errors, key, job, mode) {
   }
 }
 
-export function validateWorkflowPermissionPolicy(
-  workflowName,
-  workflow,
-  policy,
-) {
-  const errors = [];
-  const events = workflowEvents(workflow);
+function validateWorkflowHeader(errors, workflowName, workflow, events) {
   if (events.includes("pull_request_target")) {
     errors.push(`${workflowName} must not use pull_request_target`);
   }
-
   const topWrites = writeScopes(workflow?.permissions);
   if (topWrites.length > 0) {
     errors.push(
       `${workflowName} top-level permissions must not grant write: ${topWrites.join(", ")}`,
     );
   }
+}
 
+function validateJobWriteScopes(errors, key, job, policy, events) {
+  const actualWrites = writeScopes(job?.permissions);
+  const expectedWrites = sorted(policy?.writeJobs?.[key] ?? []);
+  const hasWritePolicy = actualWrites.length > 0 || expectedWrites.length > 0;
+  if (hasWritePolicy) {
+    compareScopes(errors, key, expectedWrites, actualWrites);
+  }
+  if (events.includes("pull_request") && actualWrites.length > 0) {
+    validatePullRequestWriteJob(
+      errors,
+      key,
+      job,
+      policy?.pullRequestWriteJobs?.[key],
+    );
+  }
+  return hasWritePolicy;
+}
+
+function countPersistedCheckoutCredentials(errors, key, job) {
+  let count = 0;
+  for (const step of checkoutSteps(job)) {
+    const persisted = step?.with?.["persist-credentials"];
+    if (persisted === true) {
+      count += 1;
+    } else if (persisted !== false) {
+      errors.push(`${key} checkout must set persist-credentials: false`);
+    }
+  }
+  return count;
+}
+
+function inspectWorkflowJobs(errors, workflowName, workflow, policy, events) {
   const seenWriteJobs = new Set();
   const persistedCounts = new Map();
   for (const [jobName, job] of Object.entries(workflow?.jobs ?? {})) {
     const key = `${workflowName}#${jobName}`;
-    const actualWrites = writeScopes(job?.permissions);
-    const expectedWrites = sorted(policy?.writeJobs?.[key] ?? []);
-    if (actualWrites.length > 0 || expectedWrites.length > 0) {
-      compareScopes(errors, key, expectedWrites, actualWrites);
+    if (validateJobWriteScopes(errors, key, job, policy, events)) {
       seenWriteJobs.add(key);
     }
-
-    if (events.includes("pull_request") && actualWrites.length > 0) {
-      validatePullRequestWriteJob(
-        errors,
-        key,
-        job,
-        policy?.pullRequestWriteJobs?.[key],
-      );
-    }
-
-    for (const step of checkoutSteps(job)) {
-      const persisted = step?.with?.["persist-credentials"];
-      if (persisted === true) {
-        persistedCounts.set(key, (persistedCounts.get(key) ?? 0) + 1);
-      } else if (persisted !== false) {
-        errors.push(`${key} checkout must set persist-credentials: false`);
-      }
-    }
+    const persistedCount = countPersistedCheckoutCredentials(errors, key, job);
+    if (persistedCount > 0) persistedCounts.set(key, persistedCount);
   }
+  return { seenWriteJobs, persistedCounts };
+}
 
+function validateWriteJobInventory(
+  errors,
+  workflowName,
+  policy,
+  seenWriteJobs,
+) {
   for (const key of Object.keys(policy?.writeJobs ?? {})) {
     if (key.startsWith(`${workflowName}#`) && !seenWriteJobs.has(key)) {
       errors.push(`${key} write-job policy is stale or the job is missing`);
     }
   }
+}
 
+function validatePersistedCheckoutInventory(
+  errors,
+  workflowName,
+  policy,
+  persistedCounts,
+) {
   const persistedPolicy = policy?.persistedCheckoutCredentials ?? {};
   const persistedKeys = new Set([
     ...persistedCounts.keys(),
@@ -150,7 +172,30 @@ export function validateWorkflowPermissionPolicy(
       );
     }
   }
+}
 
+export function validateWorkflowPermissionPolicy(
+  workflowName,
+  workflow,
+  policy,
+) {
+  const errors = [];
+  const events = workflowEvents(workflow);
+  validateWorkflowHeader(errors, workflowName, workflow, events);
+  const { seenWriteJobs, persistedCounts } = inspectWorkflowJobs(
+    errors,
+    workflowName,
+    workflow,
+    policy,
+    events,
+  );
+  validateWriteJobInventory(errors, workflowName, policy, seenWriteJobs);
+  validatePersistedCheckoutInventory(
+    errors,
+    workflowName,
+    policy,
+    persistedCounts,
+  );
   return errors;
 }
 

--- a/scripts/check-actions-permissions-policy.mjs
+++ b/scripts/check-actions-permissions-policy.mjs
@@ -21,10 +21,7 @@ export {
   normalizeActionsPermissions,
 } from "./lib/actions-permissions.mjs";
 
-import {
-  compareActionsPermissions,
-  normalizeActionsPermissions,
-} from "./lib/actions-permissions.mjs";
+import { normalizeActionsPermissions } from "./lib/actions-permissions.mjs";
 
 export function loadActionsPermissionPolicy(root = REPO_ROOT) {
   return JSON.parse(fs.readFileSync(path.join(root, POLICY_PATH), "utf8"));

--- a/scripts/check-actions-permissions-policy.mjs
+++ b/scripts/check-actions-permissions-policy.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { parse as parseYaml } from "yaml";
+
+const REPO_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const POLICY_PATH = ".github/actions-permissions.json";
+const WORKFLOW_DIRECTORY = ".github/workflows";
+
+function sorted(values) {
+  return [...new Set(values ?? [])].sort((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
+export {
+  compareActionsPermissions,
+  normalizeActionsPermissions,
+} from "./lib/actions-permissions.mjs";
+
+import {
+  compareActionsPermissions,
+  normalizeActionsPermissions,
+} from "./lib/actions-permissions.mjs";
+
+export function loadActionsPermissionPolicy(root = REPO_ROOT) {
+  return JSON.parse(fs.readFileSync(path.join(root, POLICY_PATH), "utf8"));
+}
+
+function workflowEvents(workflow) {
+  if (typeof workflow?.on === "string") return [workflow.on];
+  return Object.keys(workflow?.on ?? {});
+}
+
+function writeScopes(permissions) {
+  return sorted(
+    Object.entries(permissions ?? {})
+      .filter(([, value]) => value === "write")
+      .map(([scope]) => scope),
+  );
+}
+
+function compareScopes(errors, key, expected, actual) {
+  for (const scope of actual.filter((scope) => !expected.includes(scope))) {
+    errors.push(`${key} has unexpected write scope ${scope}`);
+  }
+  for (const scope of expected.filter((scope) => !actual.includes(scope))) {
+    errors.push(`${key} is missing required write scope ${scope}`);
+  }
+}
+
+function checkoutSteps(job) {
+  return (job?.steps ?? []).filter(
+    (step) =>
+      typeof step?.uses === "string" &&
+      step.uses.startsWith("actions/checkout@"),
+  );
+}
+
+function validatePullRequestWriteJob(errors, key, job, mode) {
+  const condition = String(job?.if ?? "");
+  if (mode === "same-repository-head-only") {
+    if (
+      !condition.includes(
+        "github.event.pull_request.head.repo.full_name == github.repository",
+      )
+    ) {
+      errors.push(`${key} requires a same-repository pull-request guard`);
+    }
+    return;
+  }
+  if (mode === "non-pull-request-job") {
+    if (!condition.includes("github.event_name != 'pull_request'")) {
+      errors.push(`${key} must be disabled for pull_request events`);
+    }
+    return;
+  }
+  if (mode !== "github-fork-token-read-only") {
+    errors.push(`${key} has no approved pull-request write policy`);
+  }
+}
+
+export function validateWorkflowPermissionPolicy(
+  workflowName,
+  workflow,
+  policy,
+) {
+  const errors = [];
+  const events = workflowEvents(workflow);
+  if (events.includes("pull_request_target")) {
+    errors.push(`${workflowName} must not use pull_request_target`);
+  }
+
+  const topWrites = writeScopes(workflow?.permissions);
+  if (topWrites.length > 0) {
+    errors.push(
+      `${workflowName} top-level permissions must not grant write: ${topWrites.join(", ")}`,
+    );
+  }
+
+  const seenWriteJobs = new Set();
+  const persistedCounts = new Map();
+  for (const [jobName, job] of Object.entries(workflow?.jobs ?? {})) {
+    const key = `${workflowName}#${jobName}`;
+    const actualWrites = writeScopes(job?.permissions);
+    const expectedWrites = sorted(policy?.writeJobs?.[key] ?? []);
+    if (actualWrites.length > 0 || expectedWrites.length > 0) {
+      compareScopes(errors, key, expectedWrites, actualWrites);
+      seenWriteJobs.add(key);
+    }
+
+    if (events.includes("pull_request") && actualWrites.length > 0) {
+      validatePullRequestWriteJob(
+        errors,
+        key,
+        job,
+        policy?.pullRequestWriteJobs?.[key],
+      );
+    }
+
+    for (const step of checkoutSteps(job)) {
+      const persisted = step?.with?.["persist-credentials"];
+      if (persisted === true) {
+        persistedCounts.set(key, (persistedCounts.get(key) ?? 0) + 1);
+      } else if (persisted !== false) {
+        errors.push(`${key} checkout must set persist-credentials: false`);
+      }
+    }
+  }
+
+  for (const key of Object.keys(policy?.writeJobs ?? {})) {
+    if (key.startsWith(`${workflowName}#`) && !seenWriteJobs.has(key)) {
+      errors.push(`${key} write-job policy is stale or the job is missing`);
+    }
+  }
+
+  const persistedPolicy = policy?.persistedCheckoutCredentials ?? {};
+  const persistedKeys = new Set([
+    ...persistedCounts.keys(),
+    ...Object.keys(persistedPolicy).filter((key) =>
+      key.startsWith(`${workflowName}#`),
+    ),
+  ]);
+  for (const key of persistedKeys) {
+    const expected = Number(persistedPolicy[key] ?? 0);
+    const actual = persistedCounts.get(key) ?? 0;
+    if (expected !== actual) {
+      errors.push(
+        `${key} expected ${expected} persisted checkout credential step(s), found ${actual}`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+function validatePolicyShape(policy) {
+  const errors = [];
+  if (policy?.schemaVersion !== 1) {
+    errors.push("actions permissions policy schemaVersion must be 1");
+  }
+  const expected = normalizeActionsPermissions(policy?.repositoryDefaults);
+  if (expected.defaultWorkflowPermissions !== "read") {
+    errors.push("repository default workflow permissions must be read");
+  }
+  if (expected.canApprovePullRequestReviews !== false) {
+    errors.push("Actions pull-request review approval must be disabled");
+  }
+  if (expected.allowedActions !== "all") {
+    errors.push("allowed_actions policy must document the selected live value");
+  }
+  if (expected.shaPinningRequired !== true) {
+    errors.push("platform SHA pinning must be required");
+  }
+  return errors;
+}
+
+export function validateActionsPermissionPolicy(root = REPO_ROOT) {
+  const policy = loadActionsPermissionPolicy(root);
+  const errors = validatePolicyShape(policy);
+  const directory = path.join(root, WORKFLOW_DIRECTORY);
+  const workflowNames = fs
+    .readdirSync(directory)
+    .filter((name) => /\.ya?ml$/u.test(name))
+    .sort((left, right) => left.localeCompare(right));
+
+  for (const workflowName of workflowNames) {
+    const source = fs.readFileSync(path.join(directory, workflowName), "utf8");
+    const workflow = parseYaml(source);
+    errors.push(
+      ...validateWorkflowPermissionPolicy(workflowName, workflow, policy),
+    );
+  }
+  return errors;
+}
+
+function runCli() {
+  const errors = validateActionsPermissionPolicy();
+  if (errors.length > 0) {
+    process.stderr.write(
+      `Actions permissions policy failed:\n- ${errors.join("\n- ")}\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write("Actions permissions policy passed.\n");
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  runCli();
+}

--- a/scripts/check-actions-permissions-policy.test.mjs
+++ b/scripts/check-actions-permissions-policy.test.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  compareActionsPermissions,
+  loadActionsPermissionPolicy,
+  normalizeActionsPermissions,
+  validateActionsPermissionPolicy,
+  validateWorkflowPermissionPolicy,
+} from "./check-actions-permissions-policy.mjs";
+
+const policyFixture = {
+  schemaVersion: 1,
+  repositoryDefaults: {
+    default_workflow_permissions: "read",
+    can_approve_pull_request_reviews: false,
+    allowed_actions: "all",
+    sha_pinning_required: true,
+  },
+  writeJobs: {
+    "docs.yml#deploy": ["id-token", "pages"],
+  },
+  persistedCheckoutCredentials: {
+    "release-please.yml#release": 2,
+  },
+  pullRequestWriteJobs: {
+    "ci.yml#coverage-report": "same-repository-head-only",
+    "codeql.yml#analyze": "github-fork-token-read-only",
+  },
+};
+
+test("#527 normalizes and compares repository Actions defaults", () => {
+  const expected = normalizeActionsPermissions(
+    policyFixture.repositoryDefaults,
+  );
+  assert.deepEqual(compareActionsPermissions(expected, expected), []);
+  assert.match(
+    compareActionsPermissions(expected, {
+      ...expected,
+      defaultWorkflowPermissions: "write",
+    }).join("\n"),
+    /defaultWorkflowPermissions/u,
+  );
+  assert.match(
+    compareActionsPermissions(expected, {
+      ...expected,
+      canApprovePullRequestReviews: true,
+    }).join("\n"),
+    /canApprovePullRequestReviews/u,
+  );
+});
+
+test("#527 rejects top-level write permissions", () => {
+  const workflow = {
+    on: { pull_request: {} },
+    permissions: { contents: "read", pages: "write" },
+    jobs: { build: { "runs-on": "ubuntu-latest", steps: [] } },
+  };
+  assert.match(
+    validateWorkflowPermissionPolicy("docs.yml", workflow, policyFixture).join(
+      "\n",
+    ),
+    /top-level permissions must not grant write/u,
+  );
+});
+
+test("#527 rejects unlisted or overbroad job write permissions", () => {
+  const workflow = {
+    on: { workflow_dispatch: {} },
+    permissions: { contents: "read" },
+    jobs: {
+      deploy: {
+        permissions: {
+          contents: "write",
+          pages: "write",
+          "id-token": "write",
+        },
+        steps: [],
+      },
+    },
+  };
+  const errors = validateWorkflowPermissionPolicy(
+    "docs.yml",
+    workflow,
+    policyFixture,
+  );
+  assert.match(errors.join("\n"), /unexpected write scope contents/u);
+});
+
+test("#527 requires explicit checkout credential handling", () => {
+  const workflow = {
+    on: { push: {} },
+    permissions: { contents: "read" },
+    jobs: {
+      build: {
+        steps: [
+          { uses: "actions/checkout@0123456789012345678901234567890123456789" },
+        ],
+      },
+    },
+  };
+  assert.match(
+    validateWorkflowPermissionPolicy("ci.yml", workflow, policyFixture).join(
+      "\n",
+    ),
+    /persist-credentials: false/u,
+  );
+});
+
+test("#527 permits only counted reviewed checkout credential exceptions", () => {
+  const workflow = {
+    on: { push: {} },
+    permissions: { contents: "read" },
+    jobs: {
+      release: {
+        permissions: { contents: "write" },
+        steps: [
+          {
+            uses: "actions/checkout@0123456789012345678901234567890123456789",
+            with: { "persist-credentials": true },
+          },
+          {
+            uses: "actions/checkout@0123456789012345678901234567890123456789",
+            with: { "persist-credentials": true },
+          },
+        ],
+      },
+    },
+  };
+  const localPolicy = structuredClone(policyFixture);
+  localPolicy.writeJobs["release-please.yml#release"] = ["contents"];
+  assert.deepEqual(
+    validateWorkflowPermissionPolicy(
+      "release-please.yml",
+      workflow,
+      localPolicy,
+    ),
+    [],
+  );
+  workflow.jobs.release.steps.push({
+    uses: "actions/checkout@0123456789012345678901234567890123456789",
+    with: { "persist-credentials": true },
+  });
+  assert.match(
+    validateWorkflowPermissionPolicy(
+      "release-please.yml",
+      workflow,
+      localPolicy,
+    ).join("\n"),
+    /expected 2 persisted checkout credential step/u,
+  );
+});
+
+test("#527 same-repository PR write jobs require an explicit fork guard", () => {
+  const workflow = {
+    on: { pull_request: {} },
+    permissions: { contents: "read" },
+    jobs: {
+      "coverage-report": {
+        if: "github.event_name == 'pull_request'",
+        permissions: { contents: "read", "pull-requests": "write" },
+        steps: [],
+      },
+    },
+  };
+  const localPolicy = structuredClone(policyFixture);
+  localPolicy.writeJobs["ci.yml#coverage-report"] = ["pull-requests"];
+  assert.match(
+    validateWorkflowPermissionPolicy("ci.yml", workflow, localPolicy).join(
+      "\n",
+    ),
+    /same-repository pull-request guard/u,
+  );
+});
+
+test("#527 repository Actions permission policy is complete", () => {
+  const policy = loadActionsPermissionPolicy();
+  assert.equal(policy.repositoryDefaults.default_workflow_permissions, "read");
+  assert.equal(
+    policy.repositoryDefaults.can_approve_pull_request_reviews,
+    false,
+  );
+  assert.deepEqual(validateActionsPermissionPolicy(), []);
+});

--- a/scripts/check-branch-protection-gates.test.mjs
+++ b/scripts/check-branch-protection-gates.test.mjs
@@ -217,3 +217,53 @@ test("#507 solo-maintainer ruleset avoids review deadlock", () => {
   assert.equal(pullRequest.requiredReviewThreadResolution, true);
   assert.equal(pullRequest.dismissStaleReviewsOnPush, false);
 });
+
+test("#527 governance evidence fails closed on Actions permission drift", () => {
+  const expectedActionsPermissions = {
+    default_workflow_permissions: "read",
+    can_approve_pull_request_reviews: false,
+    allowed_actions: "all",
+    sha_pinning_required: true,
+  };
+  const report = buildGovernanceEvidenceReport({
+    expectedRuleset: expectedRulesetFixture,
+    liveRuleset: expectedRulesetFixture,
+    expectedActionsPermissions,
+    liveActionsPermissions: {
+      ...expectedActionsPermissions,
+      default_workflow_permissions: "write",
+    },
+    repository: {},
+    privateVulnerabilityReporting: { available: true, enabled: true },
+  });
+  assert.equal(report.status, "drift");
+  assert.equal(report.exitCode, 1);
+  assert.match(
+    report.actionsPermissions.differences.join("\n"),
+    /defaultWorkflowPermissions/u,
+  );
+});
+
+test("#527 governance evidence confirms least-privilege Actions defaults", () => {
+  const actionsPermissions = {
+    default_workflow_permissions: "read",
+    can_approve_pull_request_reviews: false,
+    allowed_actions: "all",
+    sha_pinning_required: true,
+  };
+  const report = buildGovernanceEvidenceReport({
+    expectedRuleset: expectedRulesetFixture,
+    liveRuleset: expectedRulesetFixture,
+    expectedActionsPermissions: actionsPermissions,
+    liveActionsPermissions: actionsPermissions,
+    repository: {},
+    privateVulnerabilityReporting: { available: true, enabled: true },
+  });
+  assert.equal(report.status, "current");
+  assert.equal(report.exitCode, 0);
+  assert.equal(report.actionsPermissions.status, "current");
+  assert.match(
+    renderGovernanceEvidenceMarkdown(report),
+    /GitHub Actions permissions/u,
+  );
+});

--- a/scripts/check-branch-protection-gates.test.mjs
+++ b/scripts/check-branch-protection-gates.test.mjs
@@ -172,6 +172,17 @@ test("#495 governance evidence workflow is scheduled, manual, pinned, and least 
   assert.ok(Object.hasOwn(workflow.on, "workflow_dispatch"));
   assert.ok(Array.isArray(workflow.on.schedule));
   assert.deepEqual(workflow.permissions, { contents: "read" });
+  assert.equal(Object.hasOwn(workflow.on, "pull_request"), false);
+  assert.match(
+    workflow.jobs.evidence.if,
+    /github\.ref == 'refs\/heads\/main'/u,
+  );
+  assert.equal(
+    workflow.jobs.evidence.steps.find(
+      (step) => step.name === "Collect live governance evidence",
+    ).env.GITHUB_TOKEN,
+    "${{ secrets.GH_AUTH_TOKEN }}",
+  );
   assert.match(
     source,
     /node scripts\/check-github-governance-evidence\.mjs[\s\S]*--fetch/u,

--- a/scripts/check-codecov-policy.mjs
+++ b/scripts/check-codecov-policy.mjs
@@ -81,11 +81,13 @@ function validateWorkflow(errors, workflow) {
       workflow.includes("disable_search: true"),
     "ci.yml must upload explicit LCOV and JUnit report paths with discovery disabled",
   );
+  const forkGuard =
+    "github.event.pull_request.head.repo.full_name == github.repository";
+  const coverageReportJob = extractJob(workflow, "coverage-report", "codecov");
+  const codecovJob = extractJob(workflow, "codecov", "forbidden-refs");
   requireCondition(
     errors,
-    workflow.includes(
-      "github.event.pull_request.head.repo.full_name == github.repository",
-    ),
+    coverageReportJob.includes(forkGuard) && codecovJob.includes(forkGuard),
     "ci.yml must skip the Codecov report job for fork pull requests",
   );
   requireCondition(
@@ -101,7 +103,6 @@ function validateWorkflow(errors, workflow) {
     "ci.yml must upload JUnit results through codecov-action when a failed test report is available",
   );
 
-  const codecovJob = extractJob(workflow, "codecov", "forbidden-refs");
   requireCondition(
     errors,
     codecovJob.includes("fetch-depth: 0"),

--- a/scripts/check-github-governance-evidence.mjs
+++ b/scripts/check-github-governance-evidence.mjs
@@ -13,6 +13,10 @@ import {
 const SCRIPT_ROOT = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_ROOT, "..");
 const DEFAULT_RULESET_PATH = path.join(REPO_ROOT, ".github/rulesets/main.json");
+const ACTIONS_PERMISSIONS_PATH = path.join(
+  REPO_ROOT,
+  ".github/actions-permissions.json",
+);
 const DEPENDENCY_SECURITY_PROVIDER = ["depend", "abot"].join("");
 
 function parseArgs(argv) {
@@ -44,6 +48,11 @@ function parseArgs(argv) {
 
 function readExpectedRuleset() {
   return JSON.parse(fs.readFileSync(DEFAULT_RULESET_PATH, "utf8"));
+}
+
+function readExpectedActionsPermissions() {
+  return JSON.parse(fs.readFileSync(ACTIONS_PERMISSIONS_PATH, "utf8"))
+    .repositoryDefaults;
 }
 
 function safeReason(status, statusText) {
@@ -94,6 +103,11 @@ async function fetchLiveEvidence(repositoryName, expectedRuleset) {
         reason: "GITHUB_TOKEN or GH_TOKEN is not set.",
       },
       endpointAvailability: {},
+      liveActionsPermissions: null,
+      actionsPermissionsAvailability: {
+        available: false,
+        reason: "GITHUB_TOKEN or GH_TOKEN is not set.",
+      },
     };
   }
 
@@ -124,15 +138,25 @@ async function fetchLiveEvidence(repositoryName, expectedRuleset) {
     }
   }
 
-  const [dependencyAlerts, codeScanningAlerts, secretScanningAlerts] =
-    await Promise.all([
-      apiRequest(
-        `${repoPath}/${DEPENDENCY_SECURITY_PROVIDER}/alerts?per_page=1`,
-        token,
-      ),
-      apiRequest(`${repoPath}/code-scanning/alerts?per_page=1`, token),
-      apiRequest(`${repoPath}/secret-scanning/alerts?per_page=1`, token),
-    ]);
+  const [
+    dependencyAlerts,
+    codeScanningAlerts,
+    secretScanningAlerts,
+    workflowPermissions,
+    actionsPermissions,
+  ] = await Promise.all([
+    apiRequest(
+      `${repoPath}/${DEPENDENCY_SECURITY_PROVIDER}/alerts?per_page=1`,
+      token,
+    ),
+    apiRequest(`${repoPath}/code-scanning/alerts?per_page=1`, token),
+    apiRequest(`${repoPath}/secret-scanning/alerts?per_page=1`, token),
+    apiRequest(`${repoPath}/actions/permissions/workflow`, token),
+    apiRequest(`${repoPath}/actions/permissions`, token),
+  ]);
+
+  const actionsAvailable =
+    workflowPermissions.available && actionsPermissions.available;
 
   return {
     liveRuleset,
@@ -145,6 +169,19 @@ async function fetchLiveEvidence(repositoryName, expectedRuleset) {
       : {
           available: false,
           reason: privateReportingResult.reason,
+        },
+    liveActionsPermissions: actionsAvailable
+      ? { ...workflowPermissions.data, ...actionsPermissions.data }
+      : null,
+    actionsPermissionsAvailability: actionsAvailable
+      ? { available: true, reason: "" }
+      : {
+          available: false,
+          reason:
+            [workflowPermissions.reason, actionsPermissions.reason]
+              .filter(Boolean)
+              .join("; ") ||
+            "Actions permissions endpoints were not available.",
         },
     endpointAvailability: {
       dependencyAlerts: {
@@ -172,11 +209,12 @@ function writeOutput(filePath, content) {
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const expectedRuleset = readExpectedRuleset();
+  const expectedActionsPermissions = readExpectedActionsPermissions();
 
   if (!options.fetch) {
     const normalized = normalizeRuleset(expectedRuleset);
     console.log(
-      `Checked-in governance ruleset is parseable (${normalized.requiredStatusChecks.contexts.length} required checks).`,
+      `Checked-in governance ruleset and Actions permission policy are parseable (${normalized.requiredStatusChecks.contexts.length} required checks; default workflow permissions=${expectedActionsPermissions.default_workflow_permissions}).`,
     );
     return;
   }
@@ -187,6 +225,7 @@ async function main() {
   );
   const report = buildGovernanceEvidenceReport({
     expectedRuleset,
+    expectedActionsPermissions,
     ...liveEvidence,
   });
   const markdown = renderGovernanceEvidenceMarkdown(report);

--- a/scripts/lib/actions-permissions.mjs
+++ b/scripts/lib/actions-permissions.mjs
@@ -1,0 +1,36 @@
+function compareScalar(differences, label, expected, live) {
+  if (expected !== live) {
+    differences.push(
+      `${label}: expected ${String(expected)}, found ${String(live)}`,
+    );
+  }
+}
+
+export function normalizeActionsPermissions(value) {
+  return {
+    defaultWorkflowPermissions:
+      value?.default_workflow_permissions ??
+      value?.defaultWorkflowPermissions ??
+      null,
+    canApprovePullRequestReviews:
+      value?.can_approve_pull_request_reviews ??
+      value?.canApprovePullRequestReviews ??
+      null,
+    allowedActions: value?.allowed_actions ?? value?.allowedActions ?? null,
+    shaPinningRequired:
+      value?.sha_pinning_required ?? value?.shaPinningRequired ?? null,
+  };
+}
+
+export function compareActionsPermissions(expected, live) {
+  const differences = [];
+  for (const key of [
+    "defaultWorkflowPermissions",
+    "canApprovePullRequestReviews",
+    "allowedActions",
+    "shaPinningRequired",
+  ]) {
+    compareScalar(differences, key, expected?.[key], live?.[key]);
+  }
+  return differences;
+}

--- a/scripts/lib/github-governance-evidence.mjs
+++ b/scripts/lib/github-governance-evidence.mjs
@@ -1,3 +1,8 @@
+import {
+  compareActionsPermissions,
+  normalizeActionsPermissions,
+} from "./actions-permissions.mjs";
+
 const DEPENDENCY_SECURITY_PROVIDER = ["depend", "abot"].join("");
 
 function compareStrings(left, right) {
@@ -211,6 +216,9 @@ export function buildGovernanceEvidenceReport({
   repository,
   privateVulnerabilityReporting,
   endpointAvailability = {},
+  expectedActionsPermissions = null,
+  liveActionsPermissions = null,
+  actionsPermissionsAvailability = null,
   generatedAt = new Date().toISOString(),
 }) {
   const expected = normalizeRuleset(expectedRuleset);
@@ -238,6 +246,42 @@ export function buildGovernanceEvidenceReport({
     };
     status = differences.length === 0 ? "current" : "drift";
     exitCode = differences.length === 0 ? 0 : 1;
+  }
+
+  let actionsPermissions = null;
+  if (expectedActionsPermissions) {
+    const expectedActions = normalizeActionsPermissions(
+      expectedActionsPermissions,
+    );
+    if (!liveActionsPermissions) {
+      actionsPermissions = {
+        status: "unavailable",
+        differences: [
+          actionsPermissionsAvailability?.reason ??
+            "Repository Actions permissions could not be read.",
+        ],
+        expected: expectedActions,
+        live: null,
+      };
+      status = "unavailable";
+      exitCode = 1;
+    } else {
+      const liveActions = normalizeActionsPermissions(liveActionsPermissions);
+      const differences = compareActionsPermissions(
+        expectedActions,
+        liveActions,
+      );
+      actionsPermissions = {
+        status: differences.length === 0 ? "current" : "drift",
+        differences,
+        expected: expectedActions,
+        live: liveActions,
+      };
+      if (differences.length > 0) {
+        if (status !== "unavailable") status = "drift";
+        exitCode = 1;
+      }
+    }
   }
 
   const settings = [];
@@ -324,6 +368,7 @@ export function buildGovernanceEvidenceReport({
     status,
     exitCode,
     ruleset,
+    actionsPermissions,
     settings,
   };
 }
@@ -349,6 +394,23 @@ export function renderGovernanceEvidenceMarkdown(report) {
     lines.push("", ...report.ruleset.differences.map((item) => `- ${item}`));
   } else {
     lines.push("", "The active ruleset matches the checked-in policy.");
+  }
+
+  if (report.actionsPermissions) {
+    lines.push(
+      "",
+      "## GitHub Actions permissions",
+      "",
+      `Status: **${report.actionsPermissions.status}**`,
+    );
+    if (report.actionsPermissions.differences.length > 0) {
+      lines.push(
+        "",
+        ...report.actionsPermissions.differences.map((item) => `- ${item}`),
+      );
+    } else {
+      lines.push("", "Live Actions permissions match the checked-in policy.");
+    }
   }
 
   lines.push(

--- a/scripts/lib/github-governance-evidence.mjs
+++ b/scripts/lib/github-governance-evidence.mjs
@@ -210,105 +210,99 @@ function endpointSetting(observation, id, label) {
   );
 }
 
-export function buildGovernanceEvidenceReport({
-  expectedRuleset,
-  liveRuleset,
-  repository,
-  privateVulnerabilityReporting,
-  endpointAvailability = {},
-  expectedActionsPermissions = null,
-  liveActionsPermissions = null,
-  actionsPermissionsAvailability = null,
-  generatedAt = new Date().toISOString(),
-}) {
+function buildRulesetEvidence(expectedRuleset, liveRuleset) {
   const expected = normalizeRuleset(expectedRuleset);
-  let ruleset;
-  let status;
-  let exitCode;
-
   if (!liveRuleset) {
-    ruleset = {
+    return {
       status: "unavailable",
-      differences: ["Active default-branch ruleset could not be read."],
-      expected,
-      live: null,
+      exitCode: 1,
+      evidence: {
+        status: "unavailable",
+        differences: ["Active default-branch ruleset could not be read."],
+        expected,
+        live: null,
+      },
     };
-    status = "unavailable";
-    exitCode = 1;
-  } else {
-    const live = normalizeRuleset(liveRuleset);
-    const differences = compareRulesets(expected, live);
-    ruleset = {
-      status: differences.length === 0 ? "current" : "drift",
-      differences,
-      expected,
-      live,
-    };
-    status = differences.length === 0 ? "current" : "drift";
-    exitCode = differences.length === 0 ? 0 : 1;
   }
+  const live = normalizeRuleset(liveRuleset);
+  const differences = compareRulesets(expected, live);
+  const status = differences.length === 0 ? "current" : "drift";
+  return {
+    status,
+    exitCode: differences.length === 0 ? 0 : 1,
+    evidence: { status, differences, expected, live },
+  };
+}
 
-  let actionsPermissions = null;
-  if (expectedActionsPermissions) {
-    const expectedActions = normalizeActionsPermissions(
-      expectedActionsPermissions,
-    );
-    if (!liveActionsPermissions) {
-      actionsPermissions = {
+function buildActionsPermissionsEvidence(
+  expectedActionsPermissions,
+  liveActionsPermissions,
+  availability,
+) {
+  if (!expectedActionsPermissions) return null;
+  const expected = normalizeActionsPermissions(expectedActionsPermissions);
+  if (!liveActionsPermissions) {
+    return {
+      status: "unavailable",
+      exitCode: 1,
+      evidence: {
         status: "unavailable",
         differences: [
-          actionsPermissionsAvailability?.reason ??
+          availability?.reason ??
             "Repository Actions permissions could not be read.",
         ],
-        expected: expectedActions,
+        expected,
         live: null,
-      };
-      status = "unavailable";
-      exitCode = 1;
-    } else {
-      const liveActions = normalizeActionsPermissions(liveActionsPermissions);
-      const differences = compareActionsPermissions(
-        expectedActions,
-        liveActions,
-      );
-      actionsPermissions = {
-        status: differences.length === 0 ? "current" : "drift",
-        differences,
-        expected: expectedActions,
-        live: liveActions,
-      };
-      if (differences.length > 0) {
-        if (status !== "unavailable") status = "drift";
-        exitCode = 1;
-      }
-    }
+      },
+    };
   }
+  const live = normalizeActionsPermissions(liveActionsPermissions);
+  const differences = compareActionsPermissions(expected, live);
+  const status = differences.length === 0 ? "current" : "drift";
+  return {
+    status,
+    exitCode: differences.length === 0 ? 0 : 1,
+    evidence: { status, differences, expected, live },
+  };
+}
 
-  const settings = [];
-  if (privateVulnerabilityReporting?.available === true) {
-    settings.push(
-      setting(
-        "private-vulnerability-reporting",
-        "Private vulnerability reporting",
-        privateVulnerabilityReporting.enabled ? "confirmed" : "unconfirmed",
-        Boolean(privateVulnerabilityReporting.enabled),
-        `enabled=${String(Boolean(privateVulnerabilityReporting.enabled))}`,
-      ),
-    );
-  } else {
-    settings.push(
-      setting(
-        "private-vulnerability-reporting",
-        "Private vulnerability reporting",
-        "unavailable",
-        null,
-        privateVulnerabilityReporting?.reason ??
-          "GitHub endpoint was not queried.",
-      ),
+function combineEvidenceStatus(rulesetResult, actionsResult) {
+  const results = [rulesetResult, actionsResult].filter(Boolean);
+  if (results.some((result) => result.status === "unavailable")) {
+    return { status: "unavailable", exitCode: 1 };
+  }
+  if (results.some((result) => result.status === "drift")) {
+    return { status: "drift", exitCode: 1 };
+  }
+  return { status: "current", exitCode: 0 };
+}
+
+function privateVulnerabilitySetting(observation) {
+  if (observation?.available === true) {
+    return setting(
+      "private-vulnerability-reporting",
+      "Private vulnerability reporting",
+      observation.enabled ? "confirmed" : "unconfirmed",
+      Boolean(observation.enabled),
+      `enabled=${String(Boolean(observation.enabled))}`,
     );
   }
+  return setting(
+    "private-vulnerability-reporting",
+    "Private vulnerability reporting",
+    "unavailable",
+    null,
+    observation?.reason ?? "GitHub endpoint was not queried.",
+  );
+}
 
-  settings.push(
+function buildRepositorySecuritySettings(
+  repository,
+  privateVulnerabilityReporting,
+  endpointAvailability,
+) {
+  return [
+    privateVulnerabilitySetting(privateVulnerabilityReporting),
     analysisSetting(
       repository,
       `${DEPENDENCY_SECURITY_PROVIDER}_security_updates`,
@@ -354,22 +348,49 @@ export function buildGovernanceEvidenceReport({
       "secret-scanning-alerts",
       "Secret scanning alerts endpoint",
     ),
-  );
+  ];
+}
 
+function repositorySummary(repository) {
+  return repository
+    ? {
+        defaultBranch: repository.default_branch ?? null,
+        visibility: repository.visibility ?? null,
+      }
+    : null;
+}
+
+export function buildGovernanceEvidenceReport({
+  expectedRuleset,
+  liveRuleset,
+  repository,
+  privateVulnerabilityReporting,
+  endpointAvailability = {},
+  expectedActionsPermissions = null,
+  liveActionsPermissions = null,
+  actionsPermissionsAvailability = null,
+  generatedAt = new Date().toISOString(),
+}) {
+  const rulesetResult = buildRulesetEvidence(expectedRuleset, liveRuleset);
+  const actionsResult = buildActionsPermissionsEvidence(
+    expectedActionsPermissions,
+    liveActionsPermissions,
+    actionsPermissionsAvailability,
+  );
+  const overall = combineEvidenceStatus(rulesetResult, actionsResult);
   return {
     schemaVersion: 1,
     generatedAt,
-    repository: repository
-      ? {
-          defaultBranch: repository.default_branch ?? null,
-          visibility: repository.visibility ?? null,
-        }
-      : null,
-    status,
-    exitCode,
-    ruleset,
-    actionsPermissions,
-    settings,
+    repository: repositorySummary(repository),
+    status: overall.status,
+    exitCode: overall.exitCode,
+    ruleset: rulesetResult.evidence,
+    actionsPermissions: actionsResult?.evidence ?? null,
+    settings: buildRepositorySecuritySettings(
+      repository,
+      privateVulnerabilityReporting,
+      endpointAvailability,
+    ),
   };
 }
 


### PR DESCRIPTION
## Summary

Enforce least-privilege GitHub Actions defaults and make both workflow-level escalation and live repository-setting drift reviewable, testable, and fail-closed.

## Live repository settings

The repository settings were changed and read back successfully:

| Setting | Before | Required/current |
| --- | --- | --- |
| Default workflow permissions | `write` | `read` |
| Actions may approve pull-request reviews | `true` | `false` |
| Allowed actions | `all` | `all` |
| Require immutable action SHA pinning | `false` | `true` |

`allowed_actions: all` remains intentional because the repository uses reviewed third-party release, security, coverage, and documentation actions. Platform SHA pinning is now required, and the repository security policy independently rejects mutable action references.

## What changed

- adds `.github/actions-permissions.json` as the checked-in source of truth for repository defaults, exact write-capable jobs, pull-request write guards, and persisted-checkout exceptions;
- adds `check:actions-permissions` to the root gate and CI metadata job;
- rejects top-level workflow write permissions, `pull_request_target`, unlisted or overbroad job write scopes, stale allowlist entries, and checkout credentials that are not explicitly disabled or reviewed;
- restricts the coverage comment job to same-repository pull-request heads;
- splits GitHub Pages into a read-only build job and a dedicated deploy job with only `pages: write` and `id-token: write`;
- moves stale-item maintenance writes from workflow scope to the exact job and removes an unused label-validation write permission;
- extends weekly/manual governance evidence to compare the live Actions permission endpoints with the checked-in policy and fail on drift or unavailable evidence;
- keeps the governance evidence runtime dependency-free so the scheduled workflow does not require a package install;
- strengthens the Codecov policy so both coverage jobs independently retain their fork guards;
- documents the live defaults, reviewed escalation paths, and rollback model.

## Write-capable jobs

The checked-in allowlist is limited to:

- release creation and release-surface synchronization;
- extension release assets, attestations, and GitHub Release uploads;
- GitHub Pages deployment;
- SARIF and Scorecard uploads;
- scheduled stale-item maintenance and compatibility issue reporting;
- same-repository pull-request coverage comments.

Build, test, lint, package validation, dependency review, and ordinary pull-request jobs remain read-only.

## Validation

- `bash scripts/run-validation-host.sh corepack pnpm run check` — final-head run passed, exit 0, 11m59s;
- Actions permission policy — 7/7 tests passed;
- branch/governance evidence policy — 13/13 tests passed;
- live governance evidence — `current`, exit 0; live and expected Actions settings match exactly;
- an initial branch dispatch proved the built-in workflow token cannot read administrative endpoints; the workflow was corrected to use the protected `GH_AUTH_TOKEN` only from `main`, and a final branch dispatch completed as `skipped` without exposing the secret;
- governance evidence CLI — verified without `node_modules` or a package-install step;
- Codecov policy — 11/11 tests passed;
- extension unit matrix — 106 suites / 868 tests / 2 snapshots passed;
- critical coverage ratchet — 10 suites / 128 tests passed;
- security tests — 12 passed;
- accessibility tests — 76 passed;
- repeatable VSIX — 101 entries, normalized SHA-256 `51da9bbb05940dc812d20ed65bde756a8ec45060278591c93a0f1d44bc847fde`;
- `pnpm audit --audit-level high` — no known vulnerabilities;
- Semgrep 1.170.0 — 227 targets, 0 findings;
- actionlint, workflow policy, security tooling, docs generation/link checks, VitePress build, release provenance, and package validation passed;
- verified GitHub-signed commits: `038b6faa08f5d729fedca66bff2443b49f03f52a`, `368df7cdcd09ebab3b0c146bb3851ec52a2f7d25`, and final head `ed1c5639cfd71f3e6bdfe1f8f8ca3783ca29e649`.

## Review evidence

- **Change risk:** Medium — repository token defaults, workflow permissions, Pages deployment structure, and governance evidence behavior change; extension runtime behavior is unchanged.
- **Automated-review outcome:** `unavailable`. No automated code-review agent was configured for or returned a review on final head `ed1c563`; scanner and coverage services completed, but they are not represented as an automated code review.
- **Availability reason:** no final-head automated reviewer artifact exists for this pull request. The absence is recorded explicitly rather than treated as completed review.
- **Compensating evidence:** focused negative policy tests, workflow/security checklist review, live before/after evidence, three final-head pinned repository gates during remediation, and a documented final-head manual diff review.
- **Bot and agent triage:** complete. No review or inline comments exist and no actionable finding remains.
  - DeepScan: `resolved` — the initial unused-import issue was fixed; final head reports 0 new issues.
  - SonarQube Cloud: `resolved` — three initial findings were reduced to two after the first remediation and then fully fixed; final head reports 0 new issues, 0 accepted issues, and 0 security hotspots.
  - GitHub Actions coverage: `informational` — final-head coverage is 85.73% statements, 71.72% branches, and 89.63% functions.
  - Codecov coverage and test analytics: `informational` — all modified coverable lines are covered and no failed tests were reported.
  - Codecov bundle analysis: `informational` — no bundle-size change.
  - CodeQL, Semgrep, Socket, Trivy, Gitleaks, dependency review, security, mutation, compatibility, docs, Ubuntu, macOS, and Windows checks: `informational` — all completed successfully.

An availability, quota, rate-limit, or capacity notice is not represented as completed review.

## Risk and rollback

The principal risk is withholding a permission that an existing write-capable workflow needs. The explicit allowlist, full workflow audit, actionlint, policy tests, live drift evidence, and PR workflow matrix guard that boundary. Rollback requires reverting this change and restoring the previous repository settings through the Actions permissions API; doing so would deliberately reintroduce write-capable default tokens and workflow-created review approvals.

Closes #527

