### PR TITLE
security(repo): reconcile retired dependency graph evidence

### DIFF
--- a/.github/retired-dependency-manifests.json
+++ b/.github/retired-dependency-manifests.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "repository": "oaslananka/kicad-studio-kit",
+  "manifests": [
+    {
+      "path": "packages/mcp-server/uv.lock",
+      "directory": "packages/mcp-server",
+      "removalCommit": "59c971605bc2e4451a622276a992af8d4f5a5fcc",
+      "dismissalReason": "not_used",
+      "ownerDocumentation": "https://oaslananka.github.io/kicad-mcp-pro/",
+      "allowedResidualDependencyCounts": [0, 183],
+      "residueDisposition": "github-native-python-graph-residue"
+    }
+  ]
+}

--- a/.github/workflows/governance-evidence.yml
+++ b/.github/workflows/governance-evidence.yml
@@ -34,11 +34,23 @@ jobs:
           --repo "$GITHUB_REPOSITORY"
           --json governance-evidence.json
           --summary "$GITHUB_STEP_SUMMARY"
+      - name: Collect retired dependency evidence
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}
+        run: >-
+          node scripts/check-retired-dependency-evidence.mjs
+          --fetch
+          --repo "$GITHUB_REPOSITORY"
+          --json retired-dependency-evidence.json
+          --summary "$GITHUB_STEP_SUMMARY"
       - name: Upload governance evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: governance-evidence
-          path: governance-evidence.json
+          path: |
+            governance-evidence.json
+            retired-dependency-evidence.json
           if-no-files-found: warn
           retention-days: 30

--- a/docs/dependency-lifecycle.md
+++ b/docs/dependency-lifecycle.md
@@ -8,6 +8,10 @@ Renovate is the only normal version-update PR author for this repository. It own
 
 GitHub's dependency graph and security alert service remain enabled. Dependabot is security-only for the active root npm and GitHub Actions surfaces; `.github/dependabot.yml` uses `open-pull-requests-limit: 0`, so it can customize native security-fix pull requests without becoming a second routine version-update author. Renovate remains the normal version-update authority and also consumes vulnerability alerts for immediate lowest-patched fixes. The MCP server moved to KiCad MCP Pro, so this repository must never restore the retired `/packages/mcp-server` uv target.
 
+### Retired manifest reconciliation
+
+`.github/retired-dependency-manifests.json` is the source of truth for dependency manifests that moved to another repository. `check:dependabot-policy` fails if a retired directory or manifest returns to the working tree. The weekly Governance Evidence workflow reads the live dependency graph and open-alert endpoint with the protected administrative read token. An absent graph node, an empty residue, or the frozen 183-dependency native Python graph residue is current while the manifest remains absent and open alerts remain zero. Any other dependency count, any open alert, or restoration of the retired tree fails closed.
+
 ## Update lanes
 
 | Lane              | Source                                                                                      | Default cadence                       | Approval                                                                                                                                     |

--- a/docs/security.md
+++ b/docs/security.md
@@ -39,7 +39,7 @@ sections that follow give the detail for each lane.
   enforce it locally before pushing.
 - **Dependency review** runs on every pull request and blocks high-severity
   dependency additions.
-- **Automated security updates**: Dependabot is security-only for the active root npm and GitHub Actions surfaces; both entries use `open-pull-requests-limit: 0`, while routine dependency version bumps remain delegated to Renovate. The removed MCP server has no local Dependabot ecosystem, and the retired `/packages/mcp-server` uv target must never be restored here.
+- **Automated security updates**: Dependabot is security-only for the active root npm and GitHub Actions surfaces; both entries use `open-pull-requests-limit: 0`, while routine dependency version bumps remain delegated to Renovate. The removed MCP server has no local Dependabot ecosystem. `.github/retired-dependency-manifests.json`, `check:dependabot-policy`, and weekly live evidence prevent the retired `/packages/mcp-server` uv target from returning and fail on new dependency-graph or open-alert drift.
 - **Workflow permissions** are least-privilege: every workflow declares a
   top-level `permissions:` block that defaults to `contents: read`. Jobs
   escalate only the scopes they need, for example `security-events: write` for

--- a/docs/security/github-security-settings.md
+++ b/docs/security/github-security-settings.md
@@ -1,6 +1,6 @@
 # GitHub Security Settings Evidence
 
-Audit date: 2026-07-20
+Audit date: 2026-07-23
 
 This document records point-in-time repository-level GitHub security evidence.
 Values are reported only when confirmed by the GitHub API; unavailable evidence is
@@ -25,15 +25,41 @@ not guessed.
 
 ## Dependency alert cleanup
 
-The 2026-07-20 audit found three new high-severity alerts (`#34`, `#35`, and
-`#36`) that all referenced `packages/mcp-server/uv.lock`. That manifest is absent
-from the default branch after the KiCad MCP Pro repository split, and this
-repository neither ships nor consumes the affected Python runtime.
+The Python MCP server and its `packages/mcp-server/uv.lock` manifest were removed
+from this repository by commit
+`59c971605bc2e4451a622276a992af8d4f5a5fcc` when ownership moved to
+[KiCad MCP Pro](https://oaslananka.github.io/kicad-mcp-pro/).
 
-The alerts were dismissed as `not_used` with an explicit repository-split
-rationale. Alerts `#32` and `#33` had previously been dismissed for the same
-removed manifest. A follow-up query of the open-alert endpoint returned an empty
-array.
+A 2026-07-23 API reconciliation confirmed:
+
+- the default branch contains no Python manifest or `packages/mcp-server` tree;
+- the open Dependabot alert endpoint returns an empty array;
+- all 37 dismissed alerts are associated with the retired lockfile and retain an
+  evidence-backed `not_used` disposition;
+- alerts `#59` and `#60` specifically record that the affected runtime is no
+  longer installed or shipped by this repository;
+- `corepack pnpm audit --audit-level high` reports no known vulnerabilities for
+  the active workspace.
+
+GitHub's native Python dependency graph job still exposes a manifest node for the
+removed path with 183 historical dependencies. Its blob path does not exist on
+`main`, all 37 alerts are dismissed as `not_used`, and the open-alert endpoint is
+empty. This is classified as a `frozen-residue`, not as an active repository
+runtime.
+
+A supported empty Dependency Submission API snapshot was accepted during the
+audit but did not replace the GitHub-native Python graph record. The test
+submission was immediately superseded by an empty manifest set under the same
+correlator. The repository does not depend on an undocumented destructive API or
+on a persistent user-submitted tombstone.
+
+`.github/retired-dependency-manifests.json` records the ownership boundary,
+removal commit, dismissal rationale, and the observed residual dependency counts
+`0` and `183`. The root Dependabot policy rejects restoration of the retired
+directory or lockfile. The scheduled Governance Evidence workflow fails if the
+native residue changes to any other count or if an open alert references the
+absent manifest. A future GitHub cleanup to zero dependencies or complete
+manifest removal remains an accepted improvement.
 
 This is not a blanket vulnerability waiver: any alert that references a manifest
 present on the default branch must be remediated or separately justified.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "security:workflows": "actionlint -config-file .github/actionlint.yaml && uvx --from zizmor==1.28.0 zizmor --config .github/zizmor.yml --offline --strict-collection --format plain --min-severity medium --min-confidence high .",
     "security:semgrep": "uvx --from semgrep==1.170.0 semgrep scan --config .semgrep/semgrep.yml --error --metrics=off apps/vscode-extension/src apps/vscode-extension/scripts packages scripts",
     "test:semgrep-rules": "uvx --from semgrep==1.170.0 semgrep --metrics=off --test --config .semgrep/semgrep.yml .semgrep/semgrep.ts",
-    "check:dependabot-policy": "node scripts/check-dependabot-policy.mjs && node --test scripts/check-dependabot-policy.test.mjs",
+    "check:dependabot-policy": "node scripts/check-dependabot-policy.mjs && node --test scripts/check-dependabot-policy.test.mjs scripts/check-retired-dependency-evidence.test.mjs",
     "check:trivy-devcontainer": "node scripts/check-trivy-devcontainer.mjs && node --test scripts/check-trivy-devcontainer.test.mjs",
     "security:trivy-devcontainer": "trivy config --skip-version-check --severity HIGH,CRITICAL --exit-code 1 --format table .devcontainer",
     "validation-host:workspace": "bash scripts/run-validation-host.sh node scripts/check-workspace-integrity.mjs --canonical",

--- a/scripts/check-branch-protection-gates.test.mjs
+++ b/scripts/check-branch-protection-gates.test.mjs
@@ -187,6 +187,23 @@ test("#495 governance evidence workflow is scheduled, manual, pinned, and least 
     source,
     /node scripts\/check-github-governance-evidence\.mjs[\s\S]*--fetch/u,
   );
+  const retiredDependencyStep = workflow.jobs.evidence.steps.find(
+    (step) => step.name === "Collect retired dependency evidence",
+  );
+  assert.equal(retiredDependencyStep.if, "always()");
+  assert.equal(
+    retiredDependencyStep.env.GITHUB_TOKEN,
+    "${{ secrets.GH_AUTH_TOKEN }}",
+  );
+  assert.match(
+    source,
+    /node scripts\/check-retired-dependency-evidence\.mjs[\s\S]*--fetch/u,
+  );
+  const artifactPath = workflow.jobs.evidence.steps.find(
+    (step) => step.name === "Upload governance evidence",
+  ).with.path;
+  assert.match(artifactPath, /governance-evidence\.json/u);
+  assert.match(artifactPath, /retired-dependency-evidence\.json/u);
   for (const action of source.matchAll(/uses:\s*([^\s]+)/gu)) {
     assert.match(action[1], /@[0-9a-f]{40}$/u);
   }

--- a/scripts/check-dependabot-policy.mjs
+++ b/scripts/check-dependabot-policy.mjs
@@ -6,6 +6,8 @@ import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { parse } from "yaml";
 
+import { validateRetiredDependencyPolicy } from "./lib/retired-dependency-evidence.mjs";
+
 const SCRIPT_ROOT = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_ROOT, "..");
 const CONFIG_PATH = ".github/dependabot.yml";
@@ -21,7 +23,7 @@ const REQUIRED_LABELS = [
 const OWNERSHIP_SENTENCE =
   "Dependabot is security-only for the active root npm and GitHub Actions surfaces";
 const ROOT_SCRIPT =
-  "node scripts/check-dependabot-policy.mjs && node --test scripts/check-dependabot-policy.test.mjs";
+  "node scripts/check-dependabot-policy.mjs && node --test scripts/check-dependabot-policy.test.mjs scripts/check-retired-dependency-evidence.test.mjs";
 
 function readText(root, relativePath, errors) {
   try {
@@ -195,6 +197,7 @@ export function validateDependabotPolicy(root = REPO_ROOT) {
     ...validateConfig(value, text),
     ...validateRenovate(readJson(root, "renovate.json", errors)),
     ...validateRootScripts(readJson(root, "package.json", errors)),
+    ...validateRetiredDependencyPolicy(root),
   );
   validateDocumentation(root, errors);
   return errors;

--- a/scripts/check-dependabot-policy.test.mjs
+++ b/scripts/check-dependabot-policy.test.mjs
@@ -16,6 +16,7 @@ import { scanForbiddenReferences } from "./check-no-forbidden-refs.mjs";
 
 const RELEVANT_FILES = [
   ".github/dependabot.yml",
+  ".github/retired-dependency-manifests.json",
   "docs/security.md",
   "docs/dependency-lifecycle.md",
   "package.json",

--- a/scripts/check-no-forbidden-refs.mjs
+++ b/scripts/check-no-forbidden-refs.mjs
@@ -70,10 +70,13 @@ const visualStudioHostPattern =
 const allowedDependabotFiles = new Set([
   "docs/dependency-lifecycle.md",
   "docs/security.md",
+  "docs/security/github-security-settings.md",
   "docs/superpowers/plans/2026-07-21-dependabot-security-targets.md",
   "package.json",
   "scripts/check-dependabot-policy.mjs",
   "scripts/check-dependabot-policy.test.mjs",
+  "scripts/check-retired-dependency-evidence.mjs",
+  "scripts/lib/retired-dependency-evidence.mjs",
 ]);
 
 function isOfficialVscodeHostHit(line) {

--- a/scripts/check-retired-dependency-evidence.mjs
+++ b/scripts/check-retired-dependency-evidence.mjs
@@ -65,32 +65,52 @@ function sleep(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
+const GRAPH_ATTEMPT_LIMIT = 4;
+const TRANSIENT_GRAPH_STATUSES = new Set([502, 503, 504]);
+
+function isTimeoutMessage(message) {
+  const normalized = String(message).toLowerCase().replaceAll(" ", "");
+  return normalized.includes("timeout") || normalized.includes("timedout");
+}
+
+export function classifyGraphResponse(response, text) {
+  if (!response.ok) {
+    const failure = `HTTP ${response.status} ${response.statusText}`;
+    return {
+      payload: null,
+      failure,
+      retryable: TRANSIENT_GRAPH_STATUSES.has(response.status),
+    };
+  }
+  const payload = text ? JSON.parse(text) : null;
+  const messages = Array.isArray(payload?.errors)
+    ? payload.errors.map((error) => error.message)
+    : [];
+  if (messages.length === 0) {
+    return { payload, failure: "", retryable: false };
+  }
+  const failure = messages.join("; ");
+  const retryable = messages.some(isTimeoutMessage);
+  return { payload: retryable ? null : payload, failure, retryable };
+}
+
 async function fetchGraphPage(token, owner, name, query, after) {
   let lastFailure = "unknown GraphQL failure";
-  for (let attempt = 0; attempt < 4; attempt += 1) {
+  for (let attempt = 0; attempt < GRAPH_ATTEMPT_LIMIT; attempt += 1) {
     const response = await fetch("https://api.github.com/graphql", {
       method: "POST",
       headers: graphqlHeaders(token),
       body: JSON.stringify({ query, variables: { owner, name, after } }),
     });
-    const text = await response.text();
-    if (response.ok) {
-      const payload = text ? JSON.parse(text) : null;
-      const messages = Array.isArray(payload?.errors)
-        ? payload.errors.map((error) => error.message)
-        : [];
-      if (messages.length === 0) return payload;
-      lastFailure = messages.join("; ");
-      if (!messages.some((message) => /timed?out/iu.test(message))) {
-        return payload;
-      }
-    } else {
-      lastFailure = `HTTP ${response.status} ${response.statusText}`;
-      if (![502, 503, 504].includes(response.status)) {
-        throw new Error(`dependency graph manifests: ${lastFailure}`);
-      }
+    const result = classifyGraphResponse(response, await response.text());
+    if (result.payload) return result.payload;
+    lastFailure = result.failure;
+    if (!result.retryable) {
+      throw new Error(`dependency graph manifests: ${lastFailure}`);
     }
-    if (attempt < 3) await sleep(500 * 2 ** attempt);
+    if (attempt + 1 < GRAPH_ATTEMPT_LIMIT) {
+      await sleep(500 * 2 ** attempt);
+    }
   }
   throw new Error(`dependency graph manifests: ${lastFailure}`);
 }
@@ -134,11 +154,18 @@ async function fetchGraphManifests(token, repository) {
   return manifests;
 }
 
-function nextLink(linkHeader) {
+export function parseNextLinkHeader(linkHeader) {
   if (!linkHeader) return null;
   for (const part of linkHeader.split(",")) {
-    const match = part.match(/<([^>]+)>;\s*rel="next"/u);
-    if (match) return match[1];
+    const segments = part.split(";").map((segment) => segment.trim());
+    const relation = segments
+      .slice(1)
+      .find((segment) => segment === 'rel="next"' || segment === "rel=next");
+    if (!relation) continue;
+    const target = segments[0];
+    if (target.startsWith("<") && target.endsWith(">")) {
+      return target.slice(1, -1);
+    }
   }
   return null;
 }
@@ -148,7 +175,7 @@ async function fetchOpenAlerts(token, repository) {
   let url = `https://api.github.com/repos/${repository}/dependabot/alerts?state=open&per_page=100`;
   while (url) {
     const response = await fetch(url, { headers: requestHeaders(token) });
-    const next = nextLink(response.headers.get("link"));
+    const next = parseNextLinkHeader(response.headers.get("link"));
     const payload = await readJson(response, "open Dependabot alerts");
     alerts.push(
       ...payload.map((alert) => ({

--- a/scripts/check-retired-dependency-evidence.mjs
+++ b/scripts/check-retired-dependency-evidence.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  buildRetiredDependencyEvidenceReport,
+  loadRetiredDependencyPolicy,
+  renderRetiredDependencyEvidenceMarkdown,
+  validateRetiredDependencyPolicy,
+} from "./lib/retired-dependency-evidence.mjs";
+
+const SCRIPT_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_ROOT, "..");
+const API_VERSION = "2022-11-28";
+
+function parseArguments(argv) {
+  const options = { fetch: false, repo: "", json: "", summary: "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--fetch") options.fetch = true;
+    else if (argument === "--repo") options.repo = argv[++index] ?? "";
+    else if (argument === "--json") options.json = argv[++index] ?? "";
+    else if (argument === "--summary") options.summary = argv[++index] ?? "";
+    else throw new Error(`Unknown argument: ${argument}`);
+  }
+  return options;
+}
+
+function repositoryParts(repository) {
+  const [owner, name, ...rest] = repository.split("/");
+  if (!owner || !name || rest.length > 0) {
+    throw new Error("--repo must use owner/repository format");
+  }
+  return { owner, name };
+}
+
+function requestHeaders(token) {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "User-Agent": "kicad-studio-kit-governance-evidence",
+    "X-GitHub-Api-Version": API_VERSION,
+  };
+}
+
+async function readJson(response, label) {
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${label}: HTTP ${response.status} ${response.statusText}`);
+  }
+  return text ? JSON.parse(text) : null;
+}
+
+function graphqlHeaders(token) {
+  const headers = requestHeaders(token);
+  delete headers["X-GitHub-Api-Version"];
+  return headers;
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function fetchGraphPage(token, owner, name, query, after) {
+  let lastFailure = "unknown GraphQL failure";
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const response = await fetch("https://api.github.com/graphql", {
+      method: "POST",
+      headers: graphqlHeaders(token),
+      body: JSON.stringify({ query, variables: { owner, name, after } }),
+    });
+    const text = await response.text();
+    if (response.ok) {
+      const payload = text ? JSON.parse(text) : null;
+      const messages = Array.isArray(payload?.errors)
+        ? payload.errors.map((error) => error.message)
+        : [];
+      if (messages.length === 0) return payload;
+      lastFailure = messages.join("; ");
+      if (!messages.some((message) => /timed?out/iu.test(message))) {
+        return payload;
+      }
+    } else {
+      lastFailure = `HTTP ${response.status} ${response.statusText}`;
+      if (![502, 503, 504].includes(response.status)) {
+        throw new Error(`dependency graph manifests: ${lastFailure}`);
+      }
+    }
+    if (attempt < 3) await sleep(500 * 2 ** attempt);
+  }
+  throw new Error(`dependency graph manifests: ${lastFailure}`);
+}
+
+async function fetchGraphManifests(token, repository) {
+  const { owner, name } = repositoryParts(repository);
+  const query = `query($owner: String!, $name: String!, $after: String) {
+    repository(owner: $owner, name: $name) {
+      dependencyGraphManifests(first: 10, after: $after) {
+        nodes {
+          filename
+          dependenciesCount
+          dependencies(first: 1) { totalCount }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }`;
+  const manifests = [];
+  let after = null;
+  do {
+    const payload = await fetchGraphPage(token, owner, name, query, after);
+    if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
+      throw new Error(
+        `dependency graph manifests: ${payload.errors.map((error) => error.message).join("; ")}`,
+      );
+    }
+    const connection = payload?.data?.repository?.dependencyGraphManifests;
+    if (!connection)
+      throw new Error("dependency graph manifests were unavailable");
+    manifests.push(
+      ...connection.nodes.map((manifest) => ({
+        filename: manifest.filename,
+        dependenciesCount: manifest.dependenciesCount,
+      })),
+    );
+    after = connection.pageInfo.hasNextPage
+      ? connection.pageInfo.endCursor
+      : null;
+  } while (after);
+  return manifests;
+}
+
+function nextLink(linkHeader) {
+  if (!linkHeader) return null;
+  for (const part of linkHeader.split(",")) {
+    const match = part.match(/<([^>]+)>;\s*rel="next"/u);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+async function fetchOpenAlerts(token, repository) {
+  const alerts = [];
+  let url = `https://api.github.com/repos/${repository}/dependabot/alerts?state=open&per_page=100`;
+  while (url) {
+    const response = await fetch(url, { headers: requestHeaders(token) });
+    const next = nextLink(response.headers.get("link"));
+    const payload = await readJson(response, "open Dependabot alerts");
+    alerts.push(
+      ...payload.map((alert) => ({
+        number: alert.number,
+        manifestPath: alert.dependency?.manifest_path ?? "",
+      })),
+    );
+    url = next;
+  }
+  return alerts;
+}
+
+function presentRetiredPaths(policy) {
+  const paths = [];
+  for (const manifest of policy.manifests) {
+    for (const relativePath of [manifest.path, manifest.directory]) {
+      if (fs.existsSync(path.join(REPO_ROOT, relativePath))) {
+        paths.push(relativePath);
+      }
+    }
+  }
+  return paths;
+}
+
+function writeEvidence(options, report) {
+  const markdown = renderRetiredDependencyEvidenceMarkdown(report);
+  process.stdout.write(markdown);
+  if (options.json) {
+    fs.writeFileSync(options.json, `${JSON.stringify(report, null, 2)}\n`);
+  }
+  if (options.summary) fs.appendFileSync(options.summary, markdown);
+}
+
+export async function run(argv = process.argv.slice(2)) {
+  const options = parseArguments(argv);
+  const policy = loadRetiredDependencyPolicy();
+  const policyErrors = validateRetiredDependencyPolicy(REPO_ROOT, policy);
+  if (policyErrors.length > 0) {
+    throw new Error(policyErrors.join("; "));
+  }
+  let graphManifests = [];
+  let openAlerts = [];
+  if (options.fetch) {
+    const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? "";
+    if (!token)
+      throw new Error("GITHUB_TOKEN or GH_TOKEN is required with --fetch");
+    const repository = options.repo || policy.repository;
+    graphManifests = await fetchGraphManifests(token, repository);
+    openAlerts = await fetchOpenAlerts(token, repository);
+  }
+  const report = buildRetiredDependencyEvidenceReport({
+    policy,
+    presentPaths: presentRetiredPaths(policy),
+    graphManifests,
+    openAlerts,
+  });
+  writeEvidence(options, report);
+  return report.exitCode;
+}
+
+async function main() {
+  try {
+    process.exitCode = await run();
+  } catch (error) {
+    console.error(`Retired dependency evidence failed: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/check-retired-dependency-evidence.mjs
+++ b/scripts/check-retired-dependency-evidence.mjs
@@ -160,7 +160,7 @@ export function parseNextLinkHeader(linkHeader) {
     const segments = part.split(";").map((segment) => segment.trim());
     const relation = segments
       .slice(1)
-      .find((segment) => segment === 'rel="next"' || segment === "rel=next");
+      .some((segment) => segment === 'rel="next"' || segment === "rel=next");
     if (!relation) continue;
     const target = segments[0];
     if (target.startsWith("<") && target.endsWith(">")) {

--- a/scripts/check-retired-dependency-evidence.test.mjs
+++ b/scripts/check-retired-dependency-evidence.test.mjs
@@ -10,6 +10,11 @@ import {
   validateRetiredDependencyPolicy,
 } from "./lib/retired-dependency-evidence.mjs";
 
+import {
+  classifyGraphResponse,
+  parseNextLinkHeader,
+} from "./check-retired-dependency-evidence.mjs";
+
 const RETIRED_PATH = "packages/mcp-server/uv.lock";
 
 function currentPolicy() {
@@ -90,4 +95,39 @@ test("#526 no graph residue and no open alert is current", () => {
   });
   assert.equal(report.status, "current");
   assert.equal(report.manifests[0].graphStatus, "absent");
+});
+
+test("#526 GraphQL retry classification distinguishes transient and terminal responses", () => {
+  assert.deepEqual(
+    classifyGraphResponse(
+      { ok: false, status: 502, statusText: "Bad Gateway" },
+      "upstream unavailable",
+    ),
+    { payload: null, failure: "HTTP 502 Bad Gateway", retryable: true },
+  );
+  const timedOut = classifyGraphResponse(
+    { ok: true, status: 200, statusText: "OK" },
+    JSON.stringify({ errors: [{ message: "Query timedout" }] }),
+  );
+  assert.equal(timedOut.payload, null);
+  assert.equal(timedOut.retryable, true);
+  assert.match(timedOut.failure, /timedout/u);
+  const terminalPayload = { errors: [{ message: "Field denied" }] };
+  const terminal = classifyGraphResponse(
+    { ok: true, status: 200, statusText: "OK" },
+    JSON.stringify(terminalPayload),
+  );
+  assert.deepEqual(terminal.payload, terminalPayload);
+  assert.equal(terminal.retryable, false);
+});
+
+test("#526 Link pagination parser avoids ambiguous regular-expression matching", () => {
+  const header =
+    '<https://api.github.com/example?page=2>; rel="next", <https://api.github.com/example?page=4>; rel="last"';
+  assert.equal(
+    parseNextLinkHeader(header),
+    "https://api.github.com/example?page=2",
+  );
+  assert.equal(parseNextLinkHeader("<unterminated; rel=next"), null);
+  assert.equal(parseNextLinkHeader("x".repeat(10000)), null);
 });

--- a/scripts/check-retired-dependency-evidence.test.mjs
+++ b/scripts/check-retired-dependency-evidence.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildRetiredDependencyEvidenceReport,
+  loadRetiredDependencyPolicy,
+  validateRetiredDependencyPolicy,
+} from "./lib/retired-dependency-evidence.mjs";
+
+const RETIRED_PATH = "packages/mcp-server/uv.lock";
+
+function currentPolicy() {
+  return loadRetiredDependencyPolicy();
+}
+
+test("#526 current retired dependency policy is complete", () => {
+  assert.deepEqual(validateRetiredDependencyPolicy(), []);
+});
+
+test("#526 a retired manifest cannot return to the repository tree", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "kicad-retired-manifest-"));
+  try {
+    mkdirSync(path.join(root, "packages/mcp-server"), { recursive: true });
+    writeFileSync(path.join(root, RETIRED_PATH), "version = 1\n");
+    const errors = validateRetiredDependencyPolicy(root, currentPolicy());
+    assert.ok(errors.some((error) => error.includes(RETIRED_PATH)));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("#526 an empty native dependency-graph residue is explicitly reconciled", () => {
+  const report = buildRetiredDependencyEvidenceReport({
+    policy: currentPolicy(),
+    presentPaths: [],
+    graphManifests: [{ filename: RETIRED_PATH, dependenciesCount: 0 }],
+    openAlerts: [],
+    generatedAt: "2026-07-23T00:00:00.000Z",
+  });
+  assert.equal(report.status, "current");
+  assert.equal(report.exitCode, 0);
+  assert.equal(report.manifests[0].graphStatus, "empty-residue");
+});
+
+test("#526 the observed native Python graph residue is frozen", () => {
+  const report = buildRetiredDependencyEvidenceReport({
+    policy: currentPolicy(),
+    presentPaths: [],
+    graphManifests: [{ filename: RETIRED_PATH, dependenciesCount: 183 }],
+    openAlerts: [],
+  });
+  assert.equal(report.status, "current");
+  assert.equal(report.exitCode, 0);
+  assert.equal(report.manifests[0].graphStatus, "frozen-residue");
+});
+
+test("#526 a retired graph manifest with dependencies fails closed", () => {
+  const report = buildRetiredDependencyEvidenceReport({
+    policy: currentPolicy(),
+    presentPaths: [],
+    graphManifests: [{ filename: RETIRED_PATH, dependenciesCount: 1 }],
+    openAlerts: [],
+  });
+  assert.equal(report.status, "drift");
+  assert.equal(report.exitCode, 1);
+  assert.match(report.manifests[0].differences.join("\n"), /dependencies/u);
+});
+
+test("#526 an open alert for an absent retired manifest fails closed", () => {
+  const report = buildRetiredDependencyEvidenceReport({
+    policy: currentPolicy(),
+    presentPaths: [],
+    graphManifests: [{ filename: RETIRED_PATH, dependenciesCount: 0 }],
+    openAlerts: [{ number: 61, manifestPath: RETIRED_PATH }],
+  });
+  assert.equal(report.status, "drift");
+  assert.equal(report.exitCode, 1);
+  assert.equal(report.manifests[0].openAlertCount, 1);
+});
+
+test("#526 no graph residue and no open alert is current", () => {
+  const report = buildRetiredDependencyEvidenceReport({
+    policy: currentPolicy(),
+    presentPaths: [],
+    graphManifests: [],
+    openAlerts: [],
+  });
+  assert.equal(report.status, "current");
+  assert.equal(report.manifests[0].graphStatus, "absent");
+});

--- a/scripts/lib/retired-dependency-evidence.mjs
+++ b/scripts/lib/retired-dependency-evidence.mjs
@@ -1,0 +1,246 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_ROOT, "../..");
+export const RETIRED_DEPENDENCY_POLICY_PATH =
+  ".github/retired-dependency-manifests.json";
+
+function normalizedRelativePath(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const normalized = value.replaceAll("\\", "/").replace(/^\.\//u, "");
+  if (
+    path.posix.isAbsolute(normalized) ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.includes("/../")
+  ) {
+    return null;
+  }
+  return path.posix.normalize(normalized);
+}
+
+function readPolicy(root) {
+  return JSON.parse(
+    fs.readFileSync(path.join(root, RETIRED_DEPENDENCY_POLICY_PATH), "utf8"),
+  );
+}
+
+export function loadRetiredDependencyPolicy(root = REPO_ROOT) {
+  return readPolicy(root);
+}
+
+function validateManifestEntry(entry, index) {
+  const errors = [];
+  const label = `retired dependency manifest #${index + 1}`;
+  const manifestPath = normalizedRelativePath(entry?.path);
+  const directory = normalizedRelativePath(entry?.directory);
+  if (!manifestPath) errors.push(`${label} path must be a safe relative path`);
+  if (!directory)
+    errors.push(`${label} directory must be a safe relative path`);
+  if (manifestPath && directory && !manifestPath.startsWith(`${directory}/`)) {
+    errors.push(`${label} path must be contained by its retired directory`);
+  }
+  if (
+    entry?.ownerDocumentation !== "https://oaslananka.github.io/kicad-mcp-pro/"
+  ) {
+    errors.push(
+      `${label} ownerDocumentation must identify the external KiCad MCP Pro documentation`,
+    );
+  }
+  if (!/^[0-9a-f]{40}$/u.test(entry?.removalCommit ?? "")) {
+    errors.push(`${label} removalCommit must be a full commit SHA`);
+  }
+  if (entry?.dismissalReason !== "not_used") {
+    errors.push(`${label} dismissalReason must be not_used`);
+  }
+  if (
+    !Array.isArray(entry?.allowedResidualDependencyCounts) ||
+    entry.allowedResidualDependencyCounts.length !== 2 ||
+    entry.allowedResidualDependencyCounts[0] !== 0 ||
+    entry.allowedResidualDependencyCounts[1] !== 183
+  ) {
+    errors.push(
+      `${label} allowedResidualDependencyCounts must remain [0, 183]`,
+    );
+  }
+  if (entry?.residueDisposition !== "github-native-python-graph-residue") {
+    errors.push(
+      `${label} residueDisposition must identify the native Python graph residue`,
+    );
+  }
+  return errors;
+}
+
+function validatePolicyHeader(value) {
+  const errors = [];
+  if (value?.schemaVersion !== 1) {
+    errors.push("retired dependency policy schemaVersion must be 1");
+  }
+  if (value?.repository !== "oaslananka/kicad-studio-kit") {
+    errors.push(
+      "retired dependency policy repository must match this repository",
+    );
+  }
+  return errors;
+}
+
+function validateRetiredPathState(root, entry, seenPaths) {
+  const errors = [];
+  const manifestPath = normalizedRelativePath(entry?.path);
+  const directory = normalizedRelativePath(entry?.directory);
+  if (manifestPath) {
+    if (seenPaths.has(manifestPath)) {
+      errors.push(
+        `duplicate retired dependency manifest path: ${manifestPath}`,
+      );
+    }
+    seenPaths.add(manifestPath);
+    if (fs.existsSync(path.join(root, manifestPath))) {
+      errors.push(
+        `${manifestPath} is retired and must not exist in this repository`,
+      );
+    }
+  }
+  if (directory && fs.existsSync(path.join(root, directory))) {
+    errors.push(
+      `${directory} is retired and must not exist in this repository`,
+    );
+  }
+  return errors;
+}
+
+export function validateRetiredDependencyPolicy(
+  root = REPO_ROOT,
+  policy = null,
+) {
+  let value = policy;
+  if (!value) {
+    try {
+      value = readPolicy(root);
+    } catch (error) {
+      return [
+        `Missing or invalid ${RETIRED_DEPENDENCY_POLICY_PATH}: ${error.message}`,
+      ];
+    }
+  }
+  const errors = validatePolicyHeader(value);
+  const manifests = Array.isArray(value?.manifests) ? value.manifests : [];
+  if (manifests.length === 0) {
+    errors.push("retired dependency policy must declare at least one manifest");
+  }
+  const seenPaths = new Set();
+  for (const [index, entry] of manifests.entries()) {
+    errors.push(
+      ...validateManifestEntry(entry, index),
+      ...validateRetiredPathState(root, entry, seenPaths),
+    );
+  }
+  return errors;
+}
+
+function graphStatus(graphManifest, dependencyCount, allowedCounts) {
+  if (!graphManifest) return "absent";
+  if (dependencyCount === 0) return "empty-residue";
+  if (allowedCounts.includes(dependencyCount)) return "frozen-residue";
+  return "unexpected";
+}
+
+function manifestReport(entry, presentPaths, graphManifests, openAlerts) {
+  const graphManifest = graphManifests.find(
+    (manifest) => manifest?.filename === entry.path,
+  );
+  const dependencyCount = Number(graphManifest?.dependenciesCount ?? 0);
+  const openAlertCount = openAlerts.filter(
+    (alert) => alert?.manifestPath === entry.path,
+  ).length;
+  const treePresent =
+    presentPaths.includes(entry.path) || presentPaths.includes(entry.directory);
+  const differences = [];
+  if (treePresent) {
+    differences.push(`${entry.path} is present in the repository tree`);
+  }
+  if (
+    graphManifest &&
+    !entry.allowedResidualDependencyCounts.includes(dependencyCount)
+  ) {
+    differences.push(
+      `${entry.path} has ${dependencyCount} dependency-graph dependencies; expected one of ${entry.allowedResidualDependencyCounts.join(", ")}`,
+    );
+  }
+  if (openAlertCount > 0) {
+    differences.push(
+      `${entry.path} has ${openAlertCount} open Dependabot alert(s) while retired`,
+    );
+  }
+  return {
+    path: entry.path,
+    directory: entry.directory,
+    ownerDocumentation: entry.ownerDocumentation,
+    removalCommit: entry.removalCommit,
+    dismissalReason: entry.dismissalReason,
+    residueDisposition: entry.residueDisposition,
+    allowedResidualDependencyCounts: entry.allowedResidualDependencyCounts,
+    treeStatus: treePresent ? "present" : "absent",
+    graphStatus: graphStatus(
+      graphManifest,
+      dependencyCount,
+      entry.allowedResidualDependencyCounts,
+    ),
+    graphDependencyCount: dependencyCount,
+    openAlertCount,
+    status: differences.length === 0 ? "current" : "drift",
+    differences,
+  };
+}
+
+export function buildRetiredDependencyEvidenceReport({
+  policy,
+  presentPaths = [],
+  graphManifests = [],
+  openAlerts = [],
+  generatedAt = new Date().toISOString(),
+}) {
+  const manifests = policy.manifests.map((entry) =>
+    manifestReport(entry, presentPaths, graphManifests, openAlerts),
+  );
+  const status = manifests.every((manifest) => manifest.status === "current")
+    ? "current"
+    : "drift";
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    repository: policy.repository,
+    status,
+    exitCode: status === "current" ? 0 : 1,
+    manifests,
+  };
+}
+
+function escapeTable(value) {
+  return String(value)
+    .replaceAll("|", String.raw`\|`)
+    .replaceAll("\n", " ");
+}
+
+export function renderRetiredDependencyEvidenceMarkdown(report) {
+  const lines = [
+    "# Retired Dependency Evidence",
+    "",
+    `Overall status: **${report.status}**`,
+    "",
+    "| Manifest | Tree | Dependency graph | Open alerts | Status |",
+    "| --- | --- | --- | ---: | --- |",
+  ];
+  for (const manifest of report.manifests) {
+    lines.push(
+      `| ${escapeTable(manifest.path)} | ${manifest.treeStatus} | ${manifest.graphStatus} (${manifest.graphDependencyCount}) | ${manifest.openAlertCount} | ${manifest.status} |`,
+    );
+    for (const difference of manifest.differences) {
+      lines.push(`- ${difference}`);
+    }
+  }
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}


### PR DESCRIPTION
## Summary

Reconcile GitHub dependency evidence for the Python MCP manifest retired during the repository split, while keeping all active vulnerability signals fail-closed.

## What changed

- adds `.github/retired-dependency-manifests.json` as the checked-in ownership and residue policy for manifests moved to another repository;
- rejects restoration of `packages/mcp-server` or its retired `uv.lock` through the existing root Dependabot policy gate;
- adds focused regression coverage for tree reintroduction, graph-count drift, open-alert drift, and absent/empty native residue states;
- records GitHub's current native Python dependency-graph residue as a frozen platform baseline: 183 dependencies, no default-branch manifest, and no open alert;
- extends the weekly/manual Governance Evidence workflow to query the live dependency graph and open Dependabot alert endpoint with the protected administrative read token;
- uploads sanitized retired-dependency evidence alongside the existing governance artifact;
- updates the public dependency-lifecycle and security documentation with the ownership boundary, dismissal rationale, platform limitation, and recheck conditions;
- narrows the forbidden-reference allowlist only to the exact security-policy implementation and evidence files.

## Evidence and platform behavior

- `packages/mcp-server/uv.lock` was removed in commit `59c971605bc2e4451a622276a992af8d4f5a5fcc` when the Python MCP server moved to KiCad MCP Pro;
- the current default branch contains no `packages/mcp-server` tree or Python dependency manifest;
- the open Dependabot alert endpoint currently returns zero alerts;
- 37 historical alerts reference the retired lockfile and carry `not_used` dispositions;
- GitHub's native dependency graph still retains 183 dependencies for the deleted manifest path;
- a supported Dependency Submission tombstone was accepted by GitHub but did not replace the native parser record, so the repository does not use an undocumented destructive operation;
- the baseline accepts only the observed native states `0` and `183`; any other count, any open alert, or any restored tree path fails closed.

## Validation

- `bash scripts/run-validation-host.sh corepack pnpm run check` — passed, exit 0;
- root Dependabot and retired-manifest policy — 15 focused tests passed;
- branch/governance policy — 13 tests passed;
- extension unit matrix — 106 suites / 868 tests / 2 snapshots passed;
- critical coverage ratchet — 10 suites / 128 tests passed;
- security tests — 12 passed;
- accessibility tests — 76 passed;
- Semgrep 1.170.0 — 229 targets, 0 findings; rule fixtures 3/3 passed;
- `corepack pnpm audit --audit-level high` — no known vulnerabilities;
- repeatable VSIX — 101 entries, normalized SHA-256 `51da9bbb05940dc812d20ed65bde756a8ec45060278591c93a0f1d44bc847fde`;
- live retired-dependency evidence — `current`, tree absent, frozen residue 183, open alerts 0;
- verified GitHub-signed commit: `9cc3eaffbd843a5651ff650028e8382232c18c4a`.

## Review evidence

- **Change risk:** Medium — security evidence and scheduled governance behavior change; extension runtime behavior is unchanged.
- **Automated-review outcome:** `unavailable` — no automated code-review agent artifact or review was produced for final head `50a6aebb76d90bda75b447e1074d51b9c86960ce`. Scanner and specialist-bot results are not represented as an automated code review.
- **Bot and service triage:**
  - SonarQube: three actionable findings were resolved in code; final analysis reports 0 new issues, 0 accepted issues, and 0 security hotspots.
  - DeepScan: final analysis reports 0 issues.
  - Codecov and the GitHub coverage comment: informational; all modified coverable lines are tested, all tests succeeded, and bundle change is 0%.
  - CodeQL, Semgrep Cloud, Socket, Trivy, dependency review, security, mutation, and all Ubuntu/macOS/Windows lanes: resolved/clean on the final head.
  - No review or inline comment remains unresolved.
- **Compensating evidence:** final-head manual diff review; focused negative policy tests (17/17); live API evidence (`current`, tree absent, frozen residue 183, open alerts 0); two full pinned repository gates; verified signed commits; and a fully green final-head GitHub check matrix.

An availability, quota, rate-limit, or capacity notice is not represented as a completed review.

## Risk and rollback

The principal risk is treating a stale graph record as active or, conversely, hiding a real dependency regression. The policy distinguishes tree presence, exact native graph counts, and open alerts independently. Rollback is a normal revert; no alert is dismissed and no repository security feature is disabled by this change.

Closes #526
