### PR TITLE
fix(repo): stabilize retired dependency evidence collection

### DIFF
--- a/.github/retired-dependency-manifests.json
+++ b/.github/retired-dependency-manifests.json
@@ -9,7 +9,8 @@
       "dismissalReason": "not_used",
       "ownerDocumentation": "https://oaslananka.github.io/kicad-mcp-pro/",
       "allowedResidualDependencyCounts": [0, 183],
-      "residueDisposition": "github-native-python-graph-residue"
+      "residueDisposition": "github-native-python-graph-residue",
+      "graphNodeId": "DGM_kwDOSiap86stMjA5NDM5NjAwNw"
     }
   ]
 }

--- a/docs/dependency-lifecycle.md
+++ b/docs/dependency-lifecycle.md
@@ -10,7 +10,7 @@ GitHub's dependency graph and security alert service remain enabled. Dependabot 
 
 ### Retired manifest reconciliation
 
-`.github/retired-dependency-manifests.json` is the source of truth for dependency manifests that moved to another repository. `check:dependabot-policy` fails if a retired directory or manifest returns to the working tree. The weekly Governance Evidence workflow reads the live dependency graph and open-alert endpoint with the protected administrative read token. An absent graph node, an empty residue, or the frozen 183-dependency native Python graph residue is current while the manifest remains absent and open alerts remain zero. Any other dependency count, any open alert, or restoration of the retired tree fails closed.
+``.github/retired-dependency-manifests.json` is the source of truth for dependency manifests that moved to another repository. `check:dependabot-policy` fails if a retired directory or manifest returns to the working tree. The weekly Governance Evidence workflow reads each recorded native manifest by its exact GitHub GraphQL node ID and separately queries the open-alert endpoint with the protected administrative read token. An absent graph node, an empty residue, or the frozen 183-dependency native Python graph residue is current while the manifest remains absent and open alerts remain zero. Any other dependency count, any open alert, or restoration of the retired tree fails closed. If either live API is unavailable, the job fails and still uploads a sanitized `unavailable` evidence artifact.
 
 ## Update lanes
 

--- a/docs/security/github-security-settings.md
+++ b/docs/security/github-security-settings.md
@@ -54,12 +54,15 @@ correlator. The repository does not depend on an undocumented destructive API or
 on a persistent user-submitted tombstone.
 
 `.github/retired-dependency-manifests.json` records the ownership boundary,
-removal commit, dismissal rationale, and the observed residual dependency counts
-`0` and `183`. The root Dependabot policy rejects restoration of the retired
-directory or lockfile. The scheduled Governance Evidence workflow fails if the
-native residue changes to any other count or if an open alert references the
-absent manifest. A future GitHub cleanup to zero dependencies or complete
-manifest removal remains an accepted improvement.
+removal commit, dismissal rationale, exact native GraphQL node ID, and the
+observed residual dependency counts `0` and `183`. The root Dependabot policy
+rejects restoration of the retired directory or lockfile. The scheduled
+Governance Evidence workflow reads that exact node instead of enumerating the
+repository-wide manifest connection, fails if the native residue changes to any
+other count, and fails if an open alert references the absent manifest. If
+GitHub's graph or alert API is unavailable, the workflow still uploads a
+sanitized `unavailable` artifact before failing. A future GitHub cleanup to zero
+dependencies or complete manifest removal remains an accepted improvement.
 
 This is not a blanket vulnerability waiver: any alert that references a manifest
 present on the default branch must be remediated or separately justified.
@@ -75,6 +78,6 @@ present on the default branch must be remediated or separately justified.
 `.github/workflows/governance-evidence.yml` runs weekly and manually only from
 `main`, with read-only repository contents permission and the protected
 `GH_AUTH_TOKEN` secret for administrative read endpoints. It compares the live
-ruleset and Actions defaults with checked-in policy and reports security settings
-as `confirmed`, `unconfirmed`, or `unavailable`. The JSON artifact intentionally
-excludes alert payloads.
+ruleset, Actions defaults, and retired dependency evidence with checked-in
+policy. It reports confirmed, current, drift, or unavailable states as applicable.
+The JSON artifacts intentionally exclude alert payloads and credentials.

--- a/scripts/check-retired-dependency-evidence.mjs
+++ b/scripts/check-retired-dependency-evidence.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   buildRetiredDependencyEvidenceReport,
+  buildUnavailableRetiredDependencyEvidenceReport,
   loadRetiredDependencyPolicy,
   renderRetiredDependencyEvidenceMarkdown,
   validateRetiredDependencyPolicy,
@@ -94,63 +95,79 @@ export function classifyGraphResponse(response, text) {
   return { payload: retryable ? null : payload, failure, retryable };
 }
 
-async function fetchGraphPage(token, owner, name, query, after) {
+async function fetchGraphRequest(token, query, variables) {
   let lastFailure = "unknown GraphQL failure";
   for (let attempt = 0; attempt < GRAPH_ATTEMPT_LIMIT; attempt += 1) {
     const response = await fetch("https://api.github.com/graphql", {
       method: "POST",
       headers: graphqlHeaders(token),
-      body: JSON.stringify({ query, variables: { owner, name, after } }),
+      body: JSON.stringify({ query, variables }),
     });
     const result = classifyGraphResponse(response, await response.text());
     if (result.payload) return result.payload;
     lastFailure = result.failure;
     if (!result.retryable) {
-      throw new Error(`dependency graph manifests: ${lastFailure}`);
+      throw new Error(`dependency graph manifest: ${lastFailure}`);
     }
     if (attempt + 1 < GRAPH_ATTEMPT_LIMIT) {
       await sleep(500 * 2 ** attempt);
     }
   }
-  throw new Error(`dependency graph manifests: ${lastFailure}`);
+  throw new Error(`dependency graph manifest: ${lastFailure}`);
 }
 
-async function fetchGraphManifests(token, repository) {
-  const { owner, name } = repositoryParts(repository);
-  const query = `query($owner: String!, $name: String!, $after: String) {
-    repository(owner: $owner, name: $name) {
-      dependencyGraphManifests(first: 10, after: $after) {
-        nodes {
+export function buildGraphNodeRequest(graphNodeId) {
+  return {
+    query: `query($id: ID!) {
+      node(id: $id) {
+        ... on DependencyGraphManifest {
+          id
           filename
           dependenciesCount
           dependencies(first: 1) { totalCount }
         }
-        pageInfo { hasNextPage endCursor }
       }
-    }
-  }`;
-  const manifests = [];
-  let after = null;
-  do {
-    const payload = await fetchGraphPage(token, owner, name, query, after);
-    if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
-      throw new Error(
-        `dependency graph manifests: ${payload.errors.map((error) => error.message).join("; ")}`,
-      );
-    }
-    const connection = payload?.data?.repository?.dependencyGraphManifests;
-    if (!connection)
-      throw new Error("dependency graph manifests were unavailable");
-    manifests.push(
-      ...connection.nodes.map((manifest) => ({
-        filename: manifest.filename,
-        dependenciesCount: manifest.dependenciesCount,
-      })),
+    }`,
+    variables: { id: graphNodeId },
+  };
+}
+
+export function graphManifestFromPayload(payload, expectedManifest) {
+  if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
+    throw new Error(
+      `dependency graph manifest: ${payload.errors.map((error) => error.message).join("; ")}`,
     );
-    after = connection.pageInfo.hasNextPage
-      ? connection.pageInfo.endCursor
-      : null;
-  } while (after);
+  }
+  const node = payload?.data?.node ?? null;
+  if (!node) return null;
+  if (node.id !== expectedManifest.graphNodeId) {
+    throw new Error(
+      `dependency graph node ID mismatch for ${expectedManifest.path}`,
+    );
+  }
+  if (node.filename !== expectedManifest.path) {
+    throw new Error(
+      `dependency graph manifest path mismatch: expected ${expectedManifest.path}, received ${node.filename}`,
+    );
+  }
+  return {
+    filename: node.filename,
+    dependenciesCount: Number(node.dependenciesCount ?? 0),
+  };
+}
+
+async function fetchGraphManifests(token, policy) {
+  const manifests = [];
+  for (const expectedManifest of policy.manifests) {
+    const request = buildGraphNodeRequest(expectedManifest.graphNodeId);
+    const payload = await fetchGraphRequest(
+      token,
+      request.query,
+      request.variables,
+    );
+    const manifest = graphManifestFromPayload(payload, expectedManifest);
+    if (manifest) manifests.push(manifest);
+  }
   return manifests;
 }
 
@@ -171,6 +188,7 @@ export function parseNextLinkHeader(linkHeader) {
 }
 
 async function fetchOpenAlerts(token, repository) {
+  repositoryParts(repository);
   const alerts = [];
   let url = `https://api.github.com/repos/${repository}/dependabot/alerts?state=open&per_page=100`;
   while (url) {
@@ -216,19 +234,31 @@ export async function run(argv = process.argv.slice(2)) {
   if (policyErrors.length > 0) {
     throw new Error(policyErrors.join("; "));
   }
+  const presentPaths = presentRetiredPaths(policy);
   let graphManifests = [];
   let openAlerts = [];
   if (options.fetch) {
     const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? "";
-    if (!token)
-      throw new Error("GITHUB_TOKEN or GH_TOKEN is required with --fetch");
     const repository = options.repo || policy.repository;
-    graphManifests = await fetchGraphManifests(token, repository);
-    openAlerts = await fetchOpenAlerts(token, repository);
+    try {
+      if (!token) {
+        throw new Error("GITHUB_TOKEN or GH_TOKEN is required with --fetch");
+      }
+      graphManifests = await fetchGraphManifests(token, policy);
+      openAlerts = await fetchOpenAlerts(token, repository);
+    } catch (error) {
+      const report = buildUnavailableRetiredDependencyEvidenceReport({
+        policy,
+        presentPaths,
+        reason: error.message,
+      });
+      writeEvidence(options, report);
+      return report.exitCode;
+    }
   }
   const report = buildRetiredDependencyEvidenceReport({
     policy,
-    presentPaths: presentRetiredPaths(policy),
+    presentPaths,
     graphManifests,
     openAlerts,
   });

--- a/scripts/check-retired-dependency-evidence.test.mjs
+++ b/scripts/check-retired-dependency-evidence.test.mjs
@@ -6,12 +6,15 @@ import test from "node:test";
 
 import {
   buildRetiredDependencyEvidenceReport,
+  buildUnavailableRetiredDependencyEvidenceReport,
   loadRetiredDependencyPolicy,
   validateRetiredDependencyPolicy,
 } from "./lib/retired-dependency-evidence.mjs";
 
 import {
+  buildGraphNodeRequest,
   classifyGraphResponse,
+  graphManifestFromPayload,
   parseNextLinkHeader,
 } from "./check-retired-dependency-evidence.mjs";
 
@@ -130,4 +133,66 @@ test("#526 Link pagination parser avoids ambiguous regular-expression matching",
   );
   assert.equal(parseNextLinkHeader("<unterminated; rel=next"), null);
   assert.equal(parseNextLinkHeader("x".repeat(10000)), null);
+});
+
+test("#526 exact graph-node request avoids the unstable manifest connection", () => {
+  const manifest = currentPolicy().manifests[0];
+  const request = buildGraphNodeRequest(manifest.graphNodeId);
+  assert.deepEqual(request.variables, { id: manifest.graphNodeId });
+  assert.match(request.query, /node\(id: \$id\)/u);
+  assert.doesNotMatch(request.query, /dependencyGraphManifests/u);
+});
+
+test("#526 exact graph-node payload must retain the expected manifest path", () => {
+  const manifest = currentPolicy().manifests[0];
+  assert.deepEqual(
+    graphManifestFromPayload(
+      {
+        data: {
+          node: {
+            id: manifest.graphNodeId,
+            filename: RETIRED_PATH,
+            dependenciesCount: 183,
+          },
+        },
+      },
+      manifest,
+    ),
+    { filename: RETIRED_PATH, dependenciesCount: 183 },
+  );
+  assert.equal(
+    graphManifestFromPayload({ data: { node: null } }, manifest),
+    null,
+  );
+  assert.throws(
+    () =>
+      graphManifestFromPayload(
+        {
+          data: {
+            node: {
+              id: manifest.graphNodeId,
+              filename: "unexpected/uv.lock",
+              dependenciesCount: 183,
+            },
+          },
+        },
+        manifest,
+      ),
+    /path mismatch/u,
+  );
+});
+
+test("#526 unavailable API evidence fails closed and remains artifact-safe", () => {
+  const report = buildUnavailableRetiredDependencyEvidenceReport({
+    policy: currentPolicy(),
+    presentPaths: [],
+    reason: "dependency graph manifests: HTTP 502 Bad Gateway",
+    generatedAt: "2026-07-23T00:00:00.000Z",
+  });
+  assert.equal(report.status, "unavailable");
+  assert.equal(report.exitCode, 1);
+  assert.equal(report.manifests[0].graphStatus, "unavailable");
+  assert.equal(report.manifests[0].graphDependencyCount, null);
+  assert.equal(report.manifests[0].openAlertCount, null);
+  assert.match(report.manifests[0].differences.join("\n"), /HTTP 502/u);
 });

--- a/scripts/lib/retired-dependency-evidence.mjs
+++ b/scripts/lib/retired-dependency-evidence.mjs
@@ -49,6 +49,11 @@ function validateManifestEntry(entry, index) {
       `${label} ownerDocumentation must identify the external KiCad MCP Pro documentation`,
     );
   }
+  if (!/^DGM_[A-Za-z0-9_-]+$/u.test(entry?.graphNodeId ?? "")) {
+    errors.push(
+      `${label} graphNodeId must be a DependencyGraphManifest node ID`,
+    );
+  }
   if (!/^[0-9a-f]{40}$/u.test(entry?.removalCommit ?? "")) {
     errors.push(`${label} removalCommit must be a full commit SHA`);
   }
@@ -178,6 +183,7 @@ function manifestReport(entry, presentPaths, graphManifests, openAlerts) {
     path: entry.path,
     directory: entry.directory,
     ownerDocumentation: entry.ownerDocumentation,
+    graphNodeId: entry.graphNodeId,
     removalCommit: entry.removalCommit,
     dismissalReason: entry.dismissalReason,
     residueDisposition: entry.residueDisposition,
@@ -218,6 +224,55 @@ export function buildRetiredDependencyEvidenceReport({
   };
 }
 
+function unavailableManifestReport(entry, presentPaths, reason) {
+  const treePresent =
+    presentPaths.includes(entry.path) || presentPaths.includes(entry.directory);
+  const differences = [
+    `Live dependency evidence unavailable: ${String(reason).slice(0, 300)}`,
+  ];
+  if (treePresent) {
+    differences.unshift(`${entry.path} is present in the repository tree`);
+  }
+  return {
+    path: entry.path,
+    directory: entry.directory,
+    ownerDocumentation: entry.ownerDocumentation,
+    graphNodeId: entry.graphNodeId,
+    removalCommit: entry.removalCommit,
+    dismissalReason: entry.dismissalReason,
+    residueDisposition: entry.residueDisposition,
+    allowedResidualDependencyCounts: entry.allowedResidualDependencyCounts,
+    treeStatus: treePresent ? "present" : "absent",
+    graphStatus: "unavailable",
+    graphDependencyCount: null,
+    openAlertCount: null,
+    status: "unavailable",
+    differences,
+  };
+}
+
+export function buildUnavailableRetiredDependencyEvidenceReport({
+  policy,
+  presentPaths = [],
+  reason,
+  generatedAt = new Date().toISOString(),
+}) {
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    repository: policy.repository,
+    status: "unavailable",
+    exitCode: 1,
+    manifests: policy.manifests.map((entry) =>
+      unavailableManifestReport(entry, presentPaths, reason),
+    ),
+  };
+}
+
+function displayEvidenceValue(value) {
+  return value === null || value === undefined ? "unavailable" : String(value);
+}
+
 function escapeTable(value) {
   return String(value)
     .replaceAll("|", String.raw`\|`)
@@ -235,7 +290,7 @@ export function renderRetiredDependencyEvidenceMarkdown(report) {
   ];
   for (const manifest of report.manifests) {
     lines.push(
-      `| ${escapeTable(manifest.path)} | ${manifest.treeStatus} | ${manifest.graphStatus} (${manifest.graphDependencyCount}) | ${manifest.openAlertCount} | ${manifest.status} |`,
+      `| ${escapeTable(manifest.path)} | ${manifest.treeStatus} | ${manifest.graphStatus} (${displayEvidenceValue(manifest.graphDependencyCount)}) | ${displayEvidenceValue(manifest.openAlertCount)} | ${manifest.status} |`,
     );
     for (const difference of manifest.differences) {
       lines.push(`- ${difference}`);


### PR DESCRIPTION
## Summary

Fix the post-merge Governance Evidence failure exposed by PR #540. GitHub's repository-wide `dependencyGraphManifests` connection returned HTTP 502 for every retry on `main`, so the retired-dependency step failed before producing its artifact.

## Root cause

The implementation enumerated the repository-wide native dependency graph even though the retired manifest policy already identifies one known GitHub-native manifest record. That broad connection is comparatively expensive and proved unreliable in the scheduled/manual workflow environment.

## What changed

- records the retired manifest's exact GitHub `DependencyGraphManifest` node ID in `.github/retired-dependency-manifests.json`;
- replaces repository-wide manifest enumeration with a small `node(id: ...)` GraphQL request for each policy entry;
- validates that the returned node ID and manifest path still match the checked-in policy before accepting its dependency count;
- preserves bounded retry behavior for transient GitHub 502/503/504 and timeout responses;
- writes a sanitized `unavailable` JSON/Markdown evidence report before returning failure when the graph API, alert API, or token is unavailable;
- keeps the workflow fail-closed while ensuring the `always()` artifact upload has evidence to publish;
- documents the exact-node and unavailable-artifact behavior.

## Regression evidence

The exact node query was exercised repeatedly against the live repository and returned the frozen residue count of 183 with zero open alerts. A tokens-missing simulation returned exit 1 while still producing a sanitized `unavailable` artifact.

New coverage verifies:

- the request uses `node(id: $id)` and no longer contains `dependencyGraphManifests`;
- node ID and manifest path mismatches fail closed;
- a removed node is treated as an absent graph record;
- unavailable live evidence produces an artifact with status `unavailable`, null live counts, and exit code 1;
- the existing retry and Link-header pagination behavior remains covered.

## Validation

- retired dependency and Dependabot policy: **20/20 tests passed**;
- live exact-node evidence: **current**, tree absent, frozen residue **183**, open alerts **0**;
- no-token simulation: **unavailable artifact produced**, exit **1**;
- `bash scripts/run-validation-host.sh corepack pnpm run check`: **passed, exit 0**;
- extension: **106 suites / 868 tests / 2 snapshots**;
- coverage ratchet: **128 tests**;
- security: **12 tests**;
- accessibility: **76 tests**;
- repeatable VSIX: **101 entries**, normalized SHA-256 `51da9bbb05940dc812d20ed65bde756a8ec45060278591c93a0f1d44bc847fde`;
- Semgrep: **229 targets / 0 findings**;
- verified GitHub-signed commit: `9bd8f36a9000641dfa51cb0de146971e7c265be5`.

## Review evidence

- **Change risk:** Medium — scheduled governance evidence transport and failure reporting change; extension runtime behavior is unchanged.
- **Automated-review outcome:** Unavailable — no automated code-review agent artifact was produced; scanner results were not counted as code-review evidence.
- **Bot and agent triage:** Resolved — SonarQube, DeepScan, CodeQL, Semgrep Cloud, Socket, Trivy, dependency review, and required CI are clean. No review or inline comment remains outstanding.
- **Compensating evidence:** root-cause reproduction on `main`, exact-node live API validation, fail-closed sanitized artifact simulation, 20 focused policy tests, manual final-head diff review, and a full pinned repository gate.

An availability, quota, rate-limit, or capacity notice will not be represented as a completed review.

## Risk and rollback

The main risk is a stale node ID or GitHub API outage. A stale/mismatched node fails closed, while an unavailable API now leaves a sanitized artifact for diagnosis. Rollback is a normal revert, but would restore the broad connection query that already failed on `main`.

Closes #526