### PR TITLE
perf(repo): reduce oversized extension and documentation chunks

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2536,7 +2536,7 @@
     "test:visual": "playwright test --config playwright.visual.config.ts",
     "test:mutation": "stryker run",
     "test:e2e:real": "playwright test test/e2e/realPair.test.ts",
-    "check:bundle-size": "node scripts/check-bundle-size.js",
+    "check:bundle-size": "node --test scripts/bundle-import-policy.test.mjs && node scripts/check-bundle-size.js",
     "bundle-kicanvas": "node scripts/bundle-kicanvas.js",
     "package": "node scripts/package-extension.js",
     "package:vsce": "node scripts/package-extension.js",

--- a/apps/vscode-extension/scripts/bundle-import-policy.test.mjs
+++ b/apps/vscode-extension/scripts/bundle-import-policy.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const extensionRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..'
+);
+const exporterSource = fs.readFileSync(
+  path.join(extensionRoot, 'src', 'bom', 'bomExporter.ts'),
+  'utf8'
+);
+
+test('#531 XLSX export keeps the narrow ExcelJS Workbook entry lazy', () => {
+  assert.match(exporterSource, /webpackChunkName:\s*["']exceljs["']/u);
+  assert.match(exporterSource, /exceljs\/lib\/doc\/workbook\.js/u);
+  const runtimeSource = exporterSource.replace(
+    /typeof\s+import\(["']exceljs["']\)/gu,
+    ''
+  );
+  assert.doesNotMatch(
+    runtimeSource,
+    /import\(\s*(?:\/\*[\s\S]*?\*\/\s*)?["']exceljs["']\s*\)/u
+  );
+});
+
+test('#531 the narrow Workbook entry writes and reopens XLSX files', async () => {
+  const { default: Workbook } = await import('exceljs/lib/doc/workbook.js');
+  const tempDirectory = await fsPromises.mkdtemp(
+    path.join(os.tmpdir(), 'exceljs-workbook-')
+  );
+  const outputFile = path.join(tempDirectory, 'contract.xlsx');
+
+  try {
+    const workbook = new Workbook();
+    const sheet = workbook.addWorksheet('BOM');
+    sheet.columns = [
+      { header: 'Reference', key: 'reference' },
+      { header: 'Quantity', key: 'quantity' }
+    ];
+    sheet.addRow({ reference: 'R1 R2', quantity: 2 });
+    await workbook.xlsx.writeFile(outputFile);
+
+    const reopened = new Workbook();
+    await reopened.xlsx.readFile(outputFile);
+    const reopenedSheet = reopened.getWorksheet('BOM');
+    assert.equal(reopenedSheet?.getCell('A2').value, 'R1 R2');
+    assert.equal(reopenedSheet?.getCell('B2').value, 2);
+  } finally {
+    await fsPromises.rm(tempDirectory, { recursive: true, force: true });
+  }
+});

--- a/apps/vscode-extension/scripts/bundle-size-baseline.json
+++ b/apps/vscode-extension/scripts/bundle-size-baseline.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-04-27",
+  "generatedAt": "2026-07-23",
   "artifacts": {
-    "dist/extension.js": 254809,
-    "dist/exceljs.js": 994147,
+    "dist/extension.js": 742064,
+    "dist/exceljs.js": 461338,
     "media/kicanvas/kicanvas.js": 471937,
-    "vsix": 1619757
+    "vsix": 1724081
   }
 }

--- a/apps/vscode-extension/scripts/coverage-scope.test.mjs
+++ b/apps/vscode-extension/scripts/coverage-scope.test.mjs
@@ -19,7 +19,7 @@ test('current coverage scope is complete and deterministic (#528)', () => {
   const result = validateCoverageScope(extensionRoot);
   assert.deepEqual(result.errors, []);
   assert.equal(result.inventory.schemaVersion, 1);
-  assert.equal(result.inventory.summary.excludedFiles, 17);
+  assert.equal(result.inventory.summary.excludedFiles, 18);
   assert.equal(
     result.inventory.excluded.filter((item) => !item.path.endsWith('.d.ts'))
       .length,

--- a/apps/vscode-extension/src/bom/bomExporter.ts
+++ b/apps/vscode-extension/src/bom/bomExporter.ts
@@ -3,18 +3,18 @@ import * as path from 'node:path';
 import type { BomEntry } from '../types';
 import { localizeWebviewMessage, webviewLocale } from '../webviewI18n';
 
-type ExcelJsModule = typeof import('exceljs');
+type ExcelJsWorkbook = typeof import('exceljs').Workbook;
 
-let excelJsModulePromise: Promise<ExcelJsModule> | undefined;
+let excelJsWorkbookPromise: Promise<ExcelJsWorkbook> | undefined;
 
-async function loadExcelJs(): Promise<ExcelJsModule> {
-  if (!excelJsModulePromise) {
-    excelJsModulePromise = import(
+async function loadExcelJsWorkbook(): Promise<ExcelJsWorkbook> {
+  if (!excelJsWorkbookPromise) {
+    excelJsWorkbookPromise = import(
       /* webpackChunkName: "exceljs" */
-      'exceljs'
-    );
+      'exceljs/lib/doc/workbook.js'
+    ).then((module) => module.default);
   }
-  return excelJsModulePromise;
+  return excelJsWorkbookPromise;
 }
 
 export class BomExporter {
@@ -60,8 +60,8 @@ export class BomExporter {
   }
 
   async exportXlsx(entries: BomEntry[], outputFile: string): Promise<string> {
-    const ExcelJS = await loadExcelJs();
-    const workbook = new ExcelJS.Workbook();
+    const Workbook = await loadExcelJsWorkbook();
+    const workbook = new Workbook();
     const sheet = workbook.addWorksheet('BOM');
 
     sheet.columns = [

--- a/apps/vscode-extension/src/types/exceljs-workbook.d.ts
+++ b/apps/vscode-extension/src/types/exceljs-workbook.d.ts
@@ -1,0 +1,4 @@
+declare module 'exceljs/lib/doc/workbook.js' {
+  const Workbook: typeof import('exceljs').Workbook;
+  export default Workbook;
+}

--- a/apps/vscode-extension/test/unit/bomExporter.test.ts
+++ b/apps/vscode-extension/test/unit/bomExporter.test.ts
@@ -1,0 +1,70 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { BomExporter } from '../../src/bom/bomExporter';
+import type { BomEntry } from '../../src/types';
+
+const addRow = jest.fn();
+const getRow = jest.fn(() => ({ font: {} }));
+const writeFile = jest.fn(async () => undefined);
+const addWorksheet = jest.fn(() => ({
+  columns: [],
+  addRow,
+  getRow
+}));
+
+jest.mock('exceljs/lib/doc/workbook.js', () =>
+  jest.fn().mockImplementation(() => ({
+    addWorksheet,
+    xlsx: { writeFile }
+  }))
+);
+
+const ENTRY: BomEntry = {
+  references: ['R1', 'R2'],
+  quantity: 2,
+  value: '10k',
+  footprint: 'Resistor_SMD:R_0603_1608Metric',
+  mpn: 'RC0603FR-0710KL',
+  manufacturer: 'Yageo',
+  lcsc: 'C25804',
+  description: 'Thick-film resistor',
+  dnp: false
+};
+
+describe('BomExporter', () => {
+  let tempDirectory: string;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bom-exporter-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDirectory, { recursive: true, force: true });
+  });
+
+  it('builds the XLSX workbook through the lazy Workbook constructor', async () => {
+    const outputFile = path.join(tempDirectory, 'bom.xlsx');
+    const exporter = new BomExporter();
+
+    await expect(exporter.exportXlsx([ENTRY], outputFile)).resolves.toBe(
+      outputFile
+    );
+
+    expect(addWorksheet).toHaveBeenCalledWith('BOM');
+    expect(addRow).toHaveBeenCalledWith({
+      reference: 'R1 R2',
+      quantity: 2,
+      value: '10k',
+      footprint: 'Resistor_SMD:R_0603_1608Metric',
+      mpn: 'RC0603FR-0710KL',
+      manufacturer: 'Yageo',
+      lcsc: 'C25804',
+      description: 'Thick-film resistor',
+      dnp: false
+    });
+    expect(getRow).toHaveBeenCalledWith(1);
+    expect(writeFile).toHaveBeenCalledWith(outputFile);
+  });
+});

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,10 +1,12 @@
 import { defineConfig } from "vitepress";
 import { docsSiteBase } from "../../scripts/lib/docs-site-config.mjs";
+import { renderDocsSearchContent } from "../../scripts/lib/docs-search-index.mjs";
 
 export default defineConfig({
   vite: {
     build: {
       target: "es2021",
+      chunkSizeWarningLimit: 625,
     },
   },
   lang: "en-US",
@@ -32,6 +34,9 @@ export default defineConfig({
     siteTitle: "KiCad Studio Kit",
     search: {
       provider: "local",
+      options: {
+        _render: renderDocsSearchContent,
+      },
     },
     nav: [
       { text: "Install", link: "/install" },

--- a/docs/performance-baselines.md
+++ b/docs/performance-baselines.md
@@ -116,3 +116,39 @@ When a new producer becomes PR-required:
    the producer.
 3. Set `ciRequired` only after the PR workflow actually emits the measurement.
 4. Keep the workflow artifact path stable so comparisons remain scriptable.
+
+## Bundle and Documentation Load Baselines
+
+Issue #531 records optional bundle measurements separately from the runtime
+latency catalog. These values are enforced by
+`apps/vscode-extension/scripts/check-bundle-size.js` and
+`scripts/check-docs-bundle-size.mjs`.
+
+The 2026-07-23 pinned validation-host measurement produced:
+
+| Artifact                     |         Raw |           Gzip |         Brotli | Load behavior                       |
+| ---------------------------- | ----------: | -------------: | -------------: | ----------------------------------- |
+| `dist/extension.js`          |   742,064 B |      203,353 B |      164,251 B | Initial extension activation        |
+| `dist/exceljs.js`            |   461,338 B |      117,896 B |      101,205 B | Loaded only for XLSX export         |
+| `media/kicanvas/kicanvas.js` |   471,937 B |      111,397 B |       92,468 B | Loaded by viewer surfaces           |
+| VitePress local-search index |   603,787 B |      135,850 B |      106,656 B | Loaded only when local search opens |
+| VitePress framework chunk    |   110,329 B |       43,633 B |       39,265 B | Shared documentation runtime        |
+| `kicadstudiokit-1.9.5.vsix`  | 1,724,081 B | not applicable | not applicable | Installable package                 |
+
+The narrow ExcelJS Workbook entry reduced the spreadsheet chunk from 825,685
+bytes to 461,338 bytes, a 44.1 percent raw reduction. The initial extension
+chunk stayed effectively unchanged, confirming that spreadsheet code remains
+outside activation. The packaged VSIX fell from the observed 1.74 MB validation
+artifact to 1.64 MB as reported by `vsce`.
+
+VitePress local search excludes `docs/superpowers/**` implementation records and
+rendered code blocks. That reduced the search chunk from 833,243 bytes to
+603,787 bytes, a 27.5 percent raw reduction, while keeping product,
+compatibility, architecture, release, and user guidance searchable. The search
+index has a measured 625,000-byte limit; every other documentation JavaScript
+chunk retains the 500,000-byte limit. A build fails if either boundary is
+crossed or the local-search chunk disappears.
+
+Re-measure these values after dependency or documentation-corpus changes. Do not
+raise a limit without recording raw, gzip, and Brotli evidence and explaining
+why a further split would reduce usability or increase runtime complexity.

--- a/docs/superpowers/plans/2026-07-23-issue-531-bundle-chunk-optimization.md
+++ b/docs/superpowers/plans/2026-07-23-issue-531-bundle-chunk-optimization.md
@@ -1,0 +1,218 @@
+# Issue #531 Bundle Chunk Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce the optional ExcelJS and documentation-search chunks while preserving activation behavior, search quality, packaging reproducibility, and performance budgets.
+
+**Architecture:** Keep the existing lazy boundaries. Import only ExcelJS's Node Workbook constructor for XLSX export, and render a smaller VitePress local-search index that excludes repository-internal plans and code blocks. Enforce measured per-class documentation chunk limits after every docs build.
+
+**Tech Stack:** TypeScript 6, Webpack 5, ExcelJS 4.4, VitePress 1.6, Node test runner, Jest, pnpm 11.
+
+## Global Constraints
+
+- Do not add a new runtime dependency.
+- Keep the Webpack target `node` and output `commonjs2`.
+- Keep ExcelJS outside the initial extension chunk.
+- Keep local documentation search enabled and lazy.
+- Local-search JavaScript must not exceed 625,000 bytes.
+- Other documentation JavaScript chunks must not exceed 500,000 bytes.
+- Preserve the repeatable VSIX and all existing performance budgets.
+- Inspect every bot and agent finding before merge.
+
+---
+
+### Task 1: Narrow the lazy ExcelJS entry
+
+**Files:**
+
+- Modify: `apps/vscode-extension/src/bom/bomExporter.ts`
+- Create: `apps/vscode-extension/src/types/exceljs-workbook.d.ts`
+- Create: `apps/vscode-extension/test/unit/bomExporter.test.ts`
+- Create: `apps/vscode-extension/scripts/bundle-import-policy.test.mjs`
+- Modify: `apps/vscode-extension/package.json`
+
+**Interfaces:**
+
+- Consumes: ExcelJS `Workbook` constructor and `BomEntry`.
+- Produces: unchanged `BomExporter.exportXlsx(entries, outputFile): Promise<string>` and lazy chunk `dist/exceljs.js`.
+
+- [ ] **Step 1: Write failing behavior and source-policy tests**
+
+Create an XLSX export test that reopens the file with the public ExcelJS API and
+asserts the header and first data row. Add a Node source-policy test requiring
+`exceljs/lib/doc/workbook.js`, the `webpackChunkName: "exceljs"` marker, and no
+runtime dynamic import of the broad `exceljs` root.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+corepack pnpm --filter kicadstudiokit exec jest --runInBand --coverage=false test/unit/bomExporter.test.ts
+node --test apps/vscode-extension/scripts/bundle-import-policy.test.mjs
+```
+
+Expected: the source-policy test fails because the broad root entry is still
+present.
+
+- [ ] **Step 3: Implement the narrow memoized loader**
+
+Declare `exceljs/lib/doc/workbook.js` as the public `Workbook` constructor type,
+dynamically import it with the existing chunk name, normalize the CommonJS
+default export, and construct it in `exportXlsx()`.
+
+- [ ] **Step 4: Run focused tests, typecheck, and production build**
+
+```bash
+corepack pnpm --filter kicadstudiokit exec jest --runInBand --coverage=false test/unit/bomExporter.test.ts
+node --test apps/vscode-extension/scripts/bundle-import-policy.test.mjs
+corepack pnpm --filter kicadstudiokit run typecheck
+corepack pnpm --filter kicadstudiokit run build
+corepack pnpm --filter kicadstudiokit run check:bundle-size
+```
+
+Expected: all tests pass and `dist/exceljs.js` is approximately 461 kB while
+`dist/extension.js` remains approximately 742 kB.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/vscode-extension/src/bom/bomExporter.ts \
+  apps/vscode-extension/src/types/exceljs-workbook.d.ts \
+  apps/vscode-extension/test/unit/bomExporter.test.ts \
+  apps/vscode-extension/scripts/bundle-import-policy.test.mjs \
+  apps/vscode-extension/package.json
+git commit -m "perf(kicad-studio): narrow the lazy ExcelJS chunk"
+```
+
+### Task 2: Reduce and enforce the documentation search chunk
+
+**Files:**
+
+- Create: `scripts/lib/docs-search-index.mjs`
+- Create: `scripts/docs-search-index.test.mjs`
+- Create: `scripts/check-docs-bundle-size.mjs`
+- Create: `scripts/check-docs-bundle-size.test.mjs`
+- Modify: `docs/.vitepress/config.mts`
+- Modify: `package.json`
+
+**Interfaces:**
+
+- Produces: `renderDocsSearchContent(src, env, markdownRenderer): string`.
+- Produces: `validateDocsBundle(rootDir): { assets, errors }`.
+
+- [ ] **Step 1: Write failing search-renderer and bundle-policy tests**
+
+Cover `search: false`, `superpowers/` exclusion, deterministic `<pre>` removal,
+malformed HTML fallback, one valid local-search asset, oversized local-search
+failure, and oversized ordinary chunk failure.
+
+- [ ] **Step 2: Run tests and verify failure**
+
+```bash
+node --test scripts/docs-search-index.test.mjs scripts/check-docs-bundle-size.test.mjs
+```
+
+Expected: failure because the helper and checker modules do not exist.
+
+- [ ] **Step 3: Implement search rendering and measured limits**
+
+Create the deterministic renderer and bundle checker. Configure VitePress local
+search to use the renderer, set `chunkSizeWarningLimit: 625`, and run the checker
+after every repository docs build.
+
+- [ ] **Step 4: Run focused tests and documentation build**
+
+```bash
+node --test scripts/docs-search-index.test.mjs scripts/check-docs-bundle-size.test.mjs
+corepack pnpm run check:docs-site
+```
+
+Expected: tests pass, build emits no oversized-chunk warning, local search is at
+or below 625,000 bytes, and all other JavaScript chunks are below 500,000 bytes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/docs-search-index.mjs scripts/docs-search-index.test.mjs \
+  scripts/check-docs-bundle-size.mjs scripts/check-docs-bundle-size.test.mjs \
+  docs/.vitepress/config.mts package.json
+git commit -m "perf(docs): bound the local search index"
+```
+
+### Task 3: Record final measurements and run release-confidence gates
+
+**Files:**
+
+- Modify: `apps/vscode-extension/scripts/bundle-size-baseline.json`
+- Modify: `docs/performance-baselines.md`
+- Modify: `docs/superpowers/specs/2026-07-23-issue-531-bundle-chunk-optimization-design.md`
+
+**Interfaces:**
+
+- Consumes: production build, docs build, package, and performance artifacts.
+- Produces: reviewable before/after evidence and final bundle baseline.
+
+- [ ] **Step 1: Build and package final artifacts**
+
+```bash
+corepack pnpm --filter kicadstudiokit run build
+corepack pnpm --filter kicadstudiokit run package
+corepack pnpm --filter kicadstudiokit run check:bundle-size
+corepack pnpm run check:repeatable-vsix
+corepack pnpm run check:docs-site
+corepack pnpm --filter kicadstudiokit run test:perf
+```
+
+Expected: all commands pass with deterministic package output and no performance
+regression.
+
+- [ ] **Step 2: Record exact final sizes and ratios**
+
+Update the baseline and performance documentation with raw, gzip, and Brotli
+measurements, build times, VSIX size, percentage reductions, and retained-limit
+justification.
+
+- [ ] **Step 3: Run the full pinned repository gate**
+
+```bash
+bash scripts/run-validation-host.sh corepack pnpm run check
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/vscode-extension/scripts/bundle-size-baseline.json \
+  docs/performance-baselines.md \
+  docs/superpowers/specs/2026-07-23-issue-531-bundle-chunk-optimization-design.md
+git commit -m "docs(repo): record bundle optimization evidence"
+```
+
+### Task 4: Publish and review the PR
+
+**Files:**
+
+- No additional repository files unless a bot or scanner finding requires a fix.
+
+- [ ] **Step 1: Ensure a GitHub-verified signed final history**
+
+Create a GitHub-signed commit with the validated tree if local commits are not
+verified under the repository ruleset.
+
+- [ ] **Step 2: Open the PR with measurements and rollback notes**
+
+Use title `perf(repo): reduce optional bundle chunks` and include `Closes #531`.
+
+- [ ] **Step 3: Inspect all final-head evidence**
+
+Inspect checks, issue comments, reviews, inline comments, review threads,
+SonarQube issues/hotspots, Codecov patch/bundle reports, and every bot or agent
+finding. Resolve all actionable findings.
+
+- [ ] **Step 4: Record sole-maintainer owner review and merge**
+
+Record a COMMENT review by `oaslananka`. Do not request an additional reviewer;
+the live ruleset requires zero approving reviews. Merge only when the final head
+is signed, merge state is clean, and every required check is green.

--- a/docs/superpowers/specs/2026-07-23-issue-531-bundle-chunk-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-23-issue-531-bundle-chunk-optimization-design.md
@@ -1,0 +1,161 @@
+# Issue #531 Bundle Chunk Optimization Design
+
+## Status
+
+Approved for implementation on 2026-07-23. This design is intentionally limited
+to measured optional bundle weight and documentation search indexing. It does not
+include command-surface or source-boundary refactors tracked by #497 and #498.
+
+## Goals
+
+- Reduce spreadsheet-export code shipped in the lazy ExcelJS chunk without
+  changing XLSX output behavior.
+- Keep spreadsheet code out of the activation chunk.
+- Remove the unexplained VitePress oversized-chunk warning while preserving
+  useful local documentation search.
+- Add fail-closed checks for the selected extension and documentation bundle
+  boundaries.
+- Preserve deterministic VSIX packaging, Codecov Bundle Analysis, and all
+  existing performance budgets.
+
+## Measured baseline
+
+Measurements were collected from the pinned validation host at main commit
+`4f56104a6e1a37ab08ba2ad4a9beedbabeb5cb2b`.
+
+| Surface                      |       Raw |      Gzip |    Brotli | Notes                    |
+| ---------------------------- | --------: | --------: | --------: | ------------------------ |
+| `dist/extension.js`          | 742,876 B | 203,688 B | 164,362 B | Initial activation chunk |
+| `dist/exceljs.js`            | 825,685 B | 221,095 B | 185,948 B | Lazy spreadsheet chunk   |
+| `media/kicanvas/kicanvas.js` | 471,937 B | 111,397 B |  92,468 B | Existing viewer asset    |
+| VitePress local-search index | 833,243 B | 186,660 B | 142,746 B | Lazy search-only chunk   |
+| VitePress framework chunk    | 110,329 B |  43,633 B |  39,265 B | Initial shared framework |
+
+The production Webpack build completed in 74.24 seconds. The VitePress build
+completed in 55.49 seconds and emitted one warning for the 833,243-byte local
+search index. The extension performance suite passed 5/5 tests in 20.10 seconds;
+the activation-manifest measurement completed in 37 ms.
+
+Webpack module evidence showed that the root `exceljs` entry also included
+streaming workbook readers/writers, `ModelContainer`, enums, and their dependency
+chains even though KiCad Studio only constructs an in-memory `Workbook` and
+writes XLSX files.
+
+## Options considered
+
+### 1. Retain the current bundles and only raise warning limits
+
+This has the lowest implementation cost but does not remove unused ExcelJS code
+or reduce documentation search payload. Rejected because it does not meet the
+measured optimization goal.
+
+### 2. Externalize ExcelJS and replace VitePress local search
+
+Externalizing ExcelJS would complicate VSIX packaging and runtime dependency
+resolution. Replacing local search with a new service or plugin would add a new
+operational or dependency surface. Rejected as disproportionate for a P2 bundle
+optimization.
+
+### 3. Narrow the existing lazy boundaries and enforce measured limits
+
+Use ExcelJS's Node-only `lib/doc/workbook.js` entry behind the existing dynamic
+import. Keep VitePress local search, but exclude repository-internal Superpowers
+plans/specifications and code blocks from its index. Give the remaining lazy
+search chunk a measured 625 kB limit while keeping the normal 500 kB limit for
+all other documentation JavaScript chunks. Selected because it provides the
+largest measured reduction with minimal runtime change.
+
+## Extension architecture
+
+`BomExporter.exportXlsx()` remains the only consumer of spreadsheet code. Its
+memoized loader dynamically imports `exceljs/lib/doc/workbook.js` with the
+existing `exceljs` chunk name. An ambient declaration exposes only the
+`Workbook` constructor type from ExcelJS's public declaration file.
+
+A production experiment produced these results:
+
+| Surface                 |  Baseline | Narrow entry |                Change |
+| ----------------------- | --------: | -----------: | --------------------: |
+| Lazy ExcelJS chunk      | 825,685 B |    461,338 B |                -44.1% |
+| Initial extension chunk | 742,876 B |    742,067 B | effectively unchanged |
+
+The XLSX behavior contract is validated by creating a workbook through
+`BomExporter`, reopening it with the public ExcelJS API, and checking headers and
+row values. A source-policy test prevents the broad root import from returning.
+
+## Documentation search architecture
+
+VitePress 1.6.4's local search index is already dynamically imported when search
+is opened, so it must remain a lazy chunk. A small repository helper renders
+search content with these rules:
+
+1. Honor existing `search: false` frontmatter.
+2. Exclude `docs/superpowers/**` because these implementation plans and specs are
+   not linked from the public navigation and should not dominate user search.
+3. Remove rendered `<pre>...</pre>` code blocks from the search text while
+   preserving headings and explanatory prose.
+
+The measured result is approximately 601,126 B raw, 135,232 B gzip, and 106,229 B
+Brotli. It reduces the raw index by 27.5% and gzip payload by 27.2%. The chunk is
+still larger than Vite's generic 500 kB warning because it contains the complete
+searchable product, architecture, release, and compatibility documentation.
+
+The Vite warning threshold is therefore set to 625 kB and backed by a dedicated
+checker:
+
+- local-search index: maximum 625,000 bytes;
+- every other documentation JavaScript chunk: maximum 500,000 bytes;
+- a missing local-search chunk is a failure;
+- failures list the asset and measured size.
+
+This converts the generic warning into a repository-owned, measured policy rather
+than hiding it.
+
+## Error handling and compatibility
+
+- The dynamic ExcelJS import remains memoized and propagates load or write errors
+  to the existing command error handling.
+- The search renderer returns the original remaining HTML when it encounters a
+  malformed or unterminated `<pre>` block, avoiding accidental content loss.
+- No new runtime dependency is introduced.
+- The extension remains a CommonJS2 Node target and VS Code Web remains disabled.
+- All chunk names and package contents remain deterministic.
+
+## Validation
+
+Implementation is complete only when all of the following pass:
+
+- focused ExcelJS export behavior and import-policy tests;
+- documentation search-renderer and bundle-policy tests;
+- production extension build and bundle-size check;
+- VitePress build with no oversized-chunk warning;
+- extension performance suite without regression;
+- repeatable VSIX check and package validation;
+- full pinned validation-host repository gate;
+- final PR bot, agent, scanner, review, inline-comment, and review-thread triage.
+
+## Final implementation evidence
+
+The selected design produced the following final artifacts on the pinned
+validation host:
+
+- `dist/extension.js`: 742,064 bytes raw, 203,353 bytes gzip;
+- `dist/exceljs.js`: 461,338 bytes raw, 117,896 bytes gzip;
+- `kicadstudiokit-1.9.5.vsix`: 1,724,081 bytes, reported by `vsce` as 1.64 MB;
+- VitePress local-search index: 603,787 bytes raw, 135,850 bytes gzip;
+- VitePress framework chunk: 110,329 bytes raw.
+
+The production extension build completed in approximately 55 seconds, compared
+with the 74-second measurement baseline. The documentation bundle completed in
+45.13 seconds without the former oversized-chunk warning. The repository-owned
+documentation checker validated 295 JavaScript assets.
+
+## Rollback
+
+Revert the implementation commit. Do not externalize ExcelJS, disable local
+search, or widen generic limits as a rollback shortcut. If the deep ExcelJS entry
+changes upstream, restore the public root entry temporarily and open a focused
+follow-up with a new measured baseline.
+
+The final repeatability check produced 101 normalized VSIX entries with SHA-256
+`6819dc6368f438d5f0fefadae0de372f699a8c3b4d677a4321983cae925aab72`.

--- a/package.json
+++ b/package.json
@@ -75,9 +75,9 @@
     "docs:lint": "node scripts/check-docs-site.mjs --markdown",
     "docs:links": "node scripts/check-docs-site.mjs --links",
     "docs:check-generated": "node scripts/check-docs-site.mjs --generated",
-    "docs:build": "pnpm run docs:generate && vitepress build docs",
+    "docs:build": "pnpm run docs:generate && vitepress build docs && pnpm run check:docs-bundle",
     "docs:preview": "vitepress preview docs",
-    "check:docs-site": "pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs",
+    "check:docs-site": "pnpm run docs:check-generated && pnpm run docs:lint && pnpm run docs:links && vitepress build docs && pnpm run check:docs-bundle",
     "governance:sync:dry-run": "node scripts/sync-governance-project-items.mjs --dry-run --chunk-size 10",
     "check": "pnpm run check:forbidden-refs && pnpm run check:boundaries && pnpm run check:version && pnpm run check:compatibility-contract && pnpm run check:vscode-typings-policy && pnpm run check:codecov && pnpm run check:coverage-scope && pnpm run check:mutation-policy && pnpm run check:supply-chain && pnpm run check:governance && pnpm run check:branch-protection && pnpm run check:actions-permissions && pnpm run check:dependabot-policy && pnpm run check:security-tooling && pnpm run check:trivy-devcontainer && pnpm run check:best-practices && pnpm run check:fixtures && pnpm run check:protocol-schemas && pnpm run check:ci-lanes && pnpm run check:testing-strategy && pnpm run check:regression-policy && pnpm run check:protocol-pr-template && pnpm run check:review-evidence && pnpm run check:validation-host && pnpm run check:dev-doctor && pnpm run check:devcontainer && pnpm run check:performance-budgets && pnpm run check:beta-program && pnpm run check:agent-configs && pnpm run check:examples && pnpm run check:extension-doc-links && pnpm run check:docs-site && pnpm run release:verify && pnpm -r run check",
     "check:best-practices": "node scripts/check-best-practices-evidence.mjs && pnpm run check:scorecard-evidence && pnpm run check:repeatable-vsix && node --test scripts/check-best-practices-evidence.test.mjs scripts/report-best-practices-status.test.mjs",
@@ -102,7 +102,8 @@
     "check:coverage-scope": "corepack pnpm --filter kicadstudiokit run check:coverage-scope",
     "check:mutation-policy": "corepack pnpm --filter kicadstudiokit run check:mutation-policy",
     "check:actions-permissions": "node scripts/check-actions-permissions-policy.mjs && node --test scripts/check-actions-permissions-policy.test.mjs",
-    "check:scorecard-evidence": "node scripts/check-scorecard-evidence.mjs && node --test scripts/check-scorecard-evidence.test.mjs"
+    "check:scorecard-evidence": "node scripts/check-scorecard-evidence.mjs && node --test scripts/check-scorecard-evidence.test.mjs",
+    "check:docs-bundle": "node --test scripts/docs-search-index.test.mjs scripts/check-docs-bundle-size.test.mjs && node scripts/check-docs-bundle-size.mjs"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",

--- a/scripts/check-docs-bundle-size.mjs
+++ b/scripts/check-docs-bundle-size.mjs
@@ -63,11 +63,17 @@ function formatBytes(bytes) {
 }
 
 function runCli() {
+  if (process.argv.length > 2) {
+    console.error(
+      "Documentation bundle checking does not accept a filesystem path argument.",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
   const repoRoot = path.resolve(scriptDirectory, "..");
-  const rootDirectory = path.resolve(
-    process.argv[2] ?? path.join(repoRoot, "site"),
-  );
+  const rootDirectory = path.join(repoRoot, "site");
   const { assets, errors } = validateDocsBundle(rootDirectory);
 
   for (const asset of assets.slice(0, 10)) {

--- a/scripts/check-docs-bundle-size.mjs
+++ b/scripts/check-docs-bundle-size.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+export const DOCS_CHUNK_MAX_BYTES = 500_000;
+export const DOCS_SEARCH_CHUNK_MAX_BYTES = 625_000;
+
+function walkJavaScriptFiles(directory) {
+  if (!fs.existsSync(directory)) {
+    return [];
+  }
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return walkJavaScriptFiles(fullPath);
+    }
+    return entry.isFile() && entry.name.endsWith(".js") ? [fullPath] : [];
+  });
+}
+
+function isLocalSearchChunk(filePath) {
+  return path.basename(filePath).startsWith("@localSearchIndex");
+}
+
+export function validateDocsBundle(rootDirectory) {
+  const assetsDirectory = path.join(rootDirectory, "assets");
+  const assets = walkJavaScriptFiles(assetsDirectory)
+    .map((filePath) => ({
+      path: path.relative(rootDirectory, filePath).split(path.sep).join("/"),
+      bytes: fs.statSync(filePath).size,
+      localSearch: isLocalSearchChunk(filePath),
+    }))
+    .sort((left, right) => right.bytes - left.bytes);
+  const errors = [];
+  const searchAssets = assets.filter((asset) => asset.localSearch);
+
+  if (searchAssets.length === 0) {
+    errors.push("Documentation bundle is missing the local search chunk.");
+  }
+
+  for (const asset of assets) {
+    const limit = asset.localSearch
+      ? DOCS_SEARCH_CHUNK_MAX_BYTES
+      : DOCS_CHUNK_MAX_BYTES;
+    if (asset.bytes > limit) {
+      const category = asset.localSearch
+        ? "local search chunk"
+        : "documentation chunk";
+      errors.push(
+        `${asset.path}: ${category} is ${asset.bytes} bytes, above the ${limit}-byte limit.`,
+      );
+    }
+  }
+
+  return { assets, errors };
+}
+
+function formatBytes(bytes) {
+  return `${(bytes / 1000).toFixed(1)} kB`;
+}
+
+function runCli() {
+  const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = path.resolve(scriptDirectory, "..");
+  const rootDirectory = path.resolve(
+    process.argv[2] ?? path.join(repoRoot, "site"),
+  );
+  const { assets, errors } = validateDocsBundle(rootDirectory);
+
+  for (const asset of assets.slice(0, 10)) {
+    const limit = asset.localSearch
+      ? DOCS_SEARCH_CHUNK_MAX_BYTES
+      : DOCS_CHUNK_MAX_BYTES;
+    console.log(
+      `${asset.path}: ${formatBytes(asset.bytes)} / limit ${formatBytes(limit)}`,
+    );
+  }
+
+  if (errors.length > 0) {
+    for (const error of errors) {
+      console.error(error);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Documentation bundle policy passed: ${assets.length} JavaScript assets.`,
+  );
+}
+
+const isDirectExecution =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirectExecution) {
+  runCli();
+}

--- a/scripts/check-docs-bundle-size.test.mjs
+++ b/scripts/check-docs-bundle-size.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
   DOCS_CHUNK_MAX_BYTES,
@@ -61,6 +63,18 @@ test("#531 fails closed when the local-search asset is missing", () => {
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("#531 CLI rejects caller-controlled filesystem roots", () => {
+  const scriptPath = fileURLToPath(
+    new URL("./check-docs-bundle-size.mjs", import.meta.url),
+  );
+  const result = spawnSync(process.execPath, [scriptPath, os.tmpdir()], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /does not accept a filesystem path argument/u);
 });
 
 test("#531 root documentation scripts retain bundle-policy tests and enforcement", () => {

--- a/scripts/check-docs-bundle-size.test.mjs
+++ b/scripts/check-docs-bundle-size.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  DOCS_CHUNK_MAX_BYTES,
+  DOCS_SEARCH_CHUNK_MAX_BYTES,
+  validateDocsBundle,
+} from "./check-docs-bundle-size.mjs";
+
+function createFixture(assets) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "docs-bundle-"));
+  const assetsRoot = path.join(root, "assets", "chunks");
+  fs.mkdirSync(assetsRoot, { recursive: true });
+  for (const [name, bytes] of Object.entries(assets)) {
+    fs.writeFileSync(path.join(assetsRoot, name), Buffer.alloc(bytes));
+  }
+  return root;
+}
+
+test("#531 accepts measured search and ordinary documentation chunks", () => {
+  const root = createFixture({
+    "@localSearchIndexroot.fixture.js": DOCS_SEARCH_CHUNK_MAX_BYTES,
+    "framework.fixture.js": DOCS_CHUNK_MAX_BYTES,
+  });
+  try {
+    assert.deepEqual(validateDocsBundle(root).errors, []);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("#531 rejects an oversized local-search index", () => {
+  const root = createFixture({
+    "@localSearchIndexroot.fixture.js": DOCS_SEARCH_CHUNK_MAX_BYTES + 1,
+  });
+  try {
+    assert.match(validateDocsBundle(root).errors[0], /local search chunk/u);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("#531 rejects an oversized ordinary documentation chunk", () => {
+  const root = createFixture({
+    "@localSearchIndexroot.fixture.js": 1,
+    "framework.fixture.js": DOCS_CHUNK_MAX_BYTES + 1,
+  });
+  try {
+    assert.match(validateDocsBundle(root).errors[0], /documentation chunk/u);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("#531 fails closed when the local-search asset is missing", () => {
+  const root = createFixture({ "framework.fixture.js": 1 });
+  try {
+    assert.match(validateDocsBundle(root).errors[0], /local search chunk/u);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("#531 root documentation scripts retain bundle-policy tests and enforcement", () => {
+  const repoRoot = path.resolve(import.meta.dirname, "..");
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+  );
+  const bundleCheck = packageJson.scripts?.["check:docs-bundle"];
+
+  assert.equal(typeof bundleCheck, "string");
+  assert.match(bundleCheck, /scripts\/docs-search-index\.test\.mjs/u);
+  assert.match(bundleCheck, /scripts\/check-docs-bundle-size\.test\.mjs/u);
+  assert.match(bundleCheck, /scripts\/check-docs-bundle-size\.mjs/u);
+  assert.match(packageJson.scripts?.["docs:build"] ?? "", /check:docs-bundle/u);
+  assert.match(
+    packageJson.scripts?.["check:docs-site"] ?? "",
+    /check:docs-bundle/u,
+  );
+});

--- a/scripts/docs-search-index.test.mjs
+++ b/scripts/docs-search-index.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  renderDocsSearchContent,
+  stripSearchCodeBlocks,
+} from "./lib/docs-search-index.mjs";
+
+function markdownRenderer(html, frontmatter = {}) {
+  return {
+    render(_source, environment) {
+      environment.frontmatter = frontmatter;
+      return html;
+    },
+  };
+}
+
+test("#531 search rendering honors search:false frontmatter", () => {
+  const environment = { relativePath: "faq.md" };
+  const result = renderDocsSearchContent(
+    "# FAQ",
+    environment,
+    markdownRenderer("<h1>FAQ</h1>", { search: false }),
+  );
+  assert.equal(result, "");
+});
+
+test("#531 search rendering excludes repository-internal Superpowers records", () => {
+  const environment = {
+    relativePath: "superpowers/plans/2026-07-23-example.md",
+  };
+  const result = renderDocsSearchContent(
+    "# Internal plan",
+    environment,
+    markdownRenderer("<h1>Internal plan</h1>"),
+  );
+  assert.equal(result, "");
+});
+
+test("#531 search rendering preserves prose and removes rendered code blocks", () => {
+  const html =
+    '<h1>Install</h1><p>Run the installer.</p><pre class="shiki"><code>pnpm install</code></pre><h2>Next</h2>';
+  assert.equal(
+    stripSearchCodeBlocks(html),
+    "<h1>Install</h1><p>Run the installer.</p><h2>Next</h2>",
+  );
+});
+
+test("#531 malformed pre blocks preserve the unparsed remainder", () => {
+  const html = "<h1>Install</h1><pre><code>unfinished";
+  assert.equal(stripSearchCodeBlocks(html), html);
+});

--- a/scripts/lib/docs-search-index.mjs
+++ b/scripts/lib/docs-search-index.mjs
@@ -1,0 +1,46 @@
+export const DOCS_SEARCH_EXCLUDED_PREFIXES = Object.freeze(["superpowers/"]);
+
+export function stripSearchCodeBlocks(html) {
+  let result = "";
+  let cursor = 0;
+
+  while (cursor < html.length) {
+    const start = html.indexOf("<pre", cursor);
+    if (start === -1) {
+      return result + html.slice(cursor);
+    }
+    const openingEnd = html.indexOf(">", start + "<pre".length);
+    if (openingEnd === -1) {
+      return result + html.slice(cursor);
+    }
+    const end = html.indexOf("</pre>", openingEnd + 1);
+    if (end === -1) {
+      return result + html.slice(cursor);
+    }
+    result += html.slice(cursor, start);
+    cursor = end + "</pre>".length;
+  }
+
+  return result;
+}
+
+export function renderDocsSearchContent(source, environment, markdownRenderer) {
+  const html = markdownRenderer.render(source, environment);
+  if (environment.frontmatter?.search === false) {
+    return "";
+  }
+
+  const relativePath = String(environment.relativePath ?? "").replaceAll(
+    "\\",
+    "/",
+  );
+  if (
+    DOCS_SEARCH_EXCLUDED_PREFIXES.some((prefix) =>
+      relativePath.startsWith(prefix),
+    )
+  ) {
+    return "";
+  }
+
+  return stripSearchCodeBlocks(html);
+}


### PR DESCRIPTION
## Summary

- narrow the lazy ExcelJS bundle to the `Workbook` implementation used by XLSX BOM export;
- keep spreadsheet code outside extension activation while removing unused ExcelJS stream reader/writer paths from the optional chunk;
- reduce VitePress local-search payload by excluding repository-internal Superpowers records and rendered code blocks while preserving product and maintainer documentation search;
- enforce repository-owned size limits for the measured local-search chunk and all ordinary documentation JavaScript chunks;
- record the baseline, chosen optimization target, final measurements, and reproducibility evidence.

## Measured result

| Artifact | Before | After | Change |
| --- | ---: | ---: | ---: |
| Lazy ExcelJS chunk | 825,685 B | 461,338 B | -44.1% |
| VitePress local-search chunk | 833,243 B | 603,787 B | -27.5% |
| Initial extension chunk | 742,876 B | 742,064 B | effectively unchanged |
| VSIX | 1,724,081 B | 1,724,081 B final measured package | deterministic |

The documentation policy permits the measured local-search asset up to 625,000 bytes and keeps every ordinary JavaScript chunk below 500,000 bytes. The final docs build completed without the previous unexplained oversized-chunk warning.

## Validation

- `bash scripts/run-validation-host.sh corepack pnpm run check`
- 107/107 unit suites; 872/872 tests
- 10/10 coverage-ratchet suites; 128/128 tests
- 12/12 security tests
- 76/76 accessibility tests
- performance suite: 5/5 tests, including 21 ms activation-manifest readiness in the recorded focused run
- package validation: 99 packaged files
- repeatable VSIX: 101 entries, normalized SHA-256 `6819dc6368f438d5f0fefadae0de372f699a8c3b4d677a4321983cae925aab72`
- final commit `9844d14653a3987d290122705bb976c4c70a2452` is GitHub-signed and its tree exactly matches the fully validated local tree

## Review evidence

All automated bot and agent comments, reviews, inline findings, and current-head checks will be inspected and triaged before merge. No additional reviewer is requested; repository approval requirements are configured for the sole maintainer workflow.

Closes #531