### PR TITLE
test(kicad-studio): cover the cached Workbook loader

### DIFF
--- a/apps/vscode-extension/test/unit/bomExporter.test.ts
+++ b/apps/vscode-extension/test/unit/bomExporter.test.ts
@@ -44,14 +44,19 @@ describe('BomExporter', () => {
     await fs.rm(tempDirectory, { recursive: true, force: true });
   });
 
-  it('builds the XLSX workbook through the lazy Workbook constructor', async () => {
-    const outputFile = path.join(tempDirectory, 'bom.xlsx');
+  it('builds XLSX workbooks through the memoized lazy constructor', async () => {
+    const firstOutputFile = path.join(tempDirectory, 'bom.xlsx');
+    const secondOutputFile = path.join(tempDirectory, 'bom-copy.xlsx');
     const exporter = new BomExporter();
 
-    await expect(exporter.exportXlsx([ENTRY], outputFile)).resolves.toBe(
-      outputFile
+    await expect(exporter.exportXlsx([ENTRY], firstOutputFile)).resolves.toBe(
+      firstOutputFile
+    );
+    await expect(exporter.exportXlsx([ENTRY], secondOutputFile)).resolves.toBe(
+      secondOutputFile
     );
 
+    expect(addWorksheet).toHaveBeenCalledTimes(2);
     expect(addWorksheet).toHaveBeenCalledWith('BOM');
     expect(addRow).toHaveBeenCalledWith({
       reference: 'R1 R2',
@@ -64,7 +69,9 @@ describe('BomExporter', () => {
       description: 'Thick-film resistor',
       dnp: false
     });
+    expect(getRow).toHaveBeenCalledTimes(2);
     expect(getRow).toHaveBeenCalledWith(1);
-    expect(writeFile).toHaveBeenCalledWith(outputFile);
+    expect(writeFile).toHaveBeenNthCalledWith(1, firstOutputFile);
+    expect(writeFile).toHaveBeenNthCalledWith(2, secondOutputFile);
   });
 });


### PR DESCRIPTION
## Summary

- exercise a second XLSX export through the same `BomExporter` instance;
- cover the cached branch of the memoized lazy ExcelJS Workbook loader;
- resolve the final Codecov partial-coverage finding reported after PR #545 merged.

## Validation

- focused BOM exporter test: 1/1 passed;
- full extension unit coverage: 107/107 suites, 872/872 tests;
- LCOV for the loader guard: 2/2 branches covered;
- formatting and `git diff --check` passed;
- commit `b9e3f8f688fe7111a7a21bbd417b59fa22a771f2` is GitHub-signed and verified.

## Review evidence

All current-head checks, bot comments, reviews, and inline findings will be triaged before merge. No additional reviewer is requested; `oaslananka` is the sole maintainer and the live ruleset requires zero approvals.

Closes #531