### PR TITLE
fix(repo): synchronize Renovate uv toolchain ownership

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 24.18.0
+          node-version-file: .node-version
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           enable-cache: true

--- a/renovate.json
+++ b/renovate.json
@@ -123,6 +123,23 @@
       "prPriority": 3
     },
     {
+      "description": "Disable setup-uv uses-with updates so the repository-wide custom manager can update every uv pin atomically.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["astral-sh/uv"],
+      "enabled": false
+    },
+    {
+      "description": "Update every repository-owned uv toolchain pin in one reviewed pull request.",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["astral-sh/uv"],
+      "groupName": "repository uv toolchain",
+      "semanticCommitScope": "repo",
+      "addLabels": ["ci", "risk:medium"],
+      "dependencyDashboardApproval": true,
+      "automerge": false,
+      "prPriority": 4
+    },
+    {
       "matchPackageNames": ["@types/vscode"],
       "allowedVersions": "<=1.101.0",
       "description": "Keep VS Code typings at the engines.vscode minimum until the extension engine, compatibility metadata, and typings are intentionally raised together."
@@ -169,6 +186,26 @@
     "addLabels": ["risk:low"]
   },
   "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Keep all repository-owned uv toolchain pins synchronized from GitHub releases.",
+      "managerFilePatterns": [
+        "/^\\.devcontainer\\/(Dockerfile|devcontainer\\.json)$/",
+        "/^\\.github\\/workflows\\/(ci|cross-repo-compatibility|docs|performance-nightly|security)\\.yml$/",
+        "/^docs\\/validation-host\\.md$/",
+        "/^mise\\.toml$/",
+        "/^scripts\\/check-(devcontainer|security-tooling|validation-host)\\.mjs$/"
+      ],
+      "matchStrings": [
+        "uses:\\s+astral-sh/setup-uv@[^\\n]+\\n\\s+with:\\n(?:\\s+[^\\n]+\\n)*?\\s+version:\\s+(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+        "UV_VERSION(?:=|\"\\s*:\\s*\"|\\s*=\\s*\")(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+        "uv\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+        "\\buv\\s+(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "astral-sh/uv",
+      "versioningTemplate": "semver-coerced"
+    },
     {
       "customType": "regex",
       "managerFilePatterns": ["/^\\.github\\/workflows\\/security\\.yml$/"],

--- a/scripts/check-security-tooling.test.mjs
+++ b/scripts/check-security-tooling.test.mjs
@@ -4,21 +4,43 @@ import {
   mkdtempSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { validateSecurityTooling } from "./check-security-tooling.mjs";
 
-const RELEVANT_FILES = [
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const MISE_TEXT = readFileSync(path.join(REPO_ROOT, "mise.toml"), "utf8");
+const UV_VERSION = /\buv\s*=\s*"(?<version>\d+\.\d+\.\d+)"/u.exec(MISE_TEXT)
+  ?.groups?.version;
+assert.ok(UV_VERSION, "mise.toml must expose the canonical uv version");
+
+const UV_PIN_SURFACES = [
+  ".devcontainer/Dockerfile",
+  ".devcontainer/devcontainer.json",
   ".github/workflows/ci.yml",
   ".github/workflows/cross-repo-compatibility.yml",
   ".github/workflows/docs.yml",
   ".github/workflows/performance-nightly.yml",
   ".github/workflows/security.yml",
+  "docs/validation-host.md",
+  "mise.toml",
+  "scripts/check-devcontainer.mjs",
+  "scripts/check-security-tooling.mjs",
+  "scripts/check-validation-host.mjs",
+];
+
+const RELEVANT_FILES = [
+  ...UV_PIN_SURFACES,
   "apps/vscode-extension/scripts/local-security.sh",
   "apps/vscode-extension/scripts/local-security.ps1",
   ".github/zizmor.yml",
@@ -34,7 +56,7 @@ const RELEVANT_FILES = [
 function createFixture() {
   const root = mkdtempSync(path.join(os.tmpdir(), "kicad-security-tooling-"));
   for (const relativePath of RELEVANT_FILES) {
-    const source = path.resolve(relativePath);
+    const source = path.join(REPO_ROOT, relativePath);
     const target = path.join(root, relativePath);
     mkdirSync(path.dirname(target), { recursive: true });
     try {
@@ -52,6 +74,115 @@ function replaceInFixture(root, relativePath, before, after) {
   assert.ok(source.includes(before), `${relativePath} must contain ${before}`);
   writeFileSync(filePath, source.replace(before, after));
 }
+
+function renovateFilePattern(pattern) {
+  assert.match(pattern, /^\/.+\/[a-z]*$/u);
+  const delimiter = pattern.lastIndexOf("/");
+  const source = pattern.slice(1, delimiter);
+  const flags = pattern.slice(delimiter + 1);
+  return new RegExp(source, flags.includes("u") ? flags : `${flags}u`);
+}
+
+function countManagedUvPins(manager, text) {
+  return manager.matchStrings.reduce((count, pattern) => {
+    const regex = new RegExp(pattern, "gmu");
+    return (
+      count +
+      [...text.matchAll(regex)].filter(
+        (match) => match.groups?.currentValue === UV_VERSION,
+      ).length
+    );
+  }, 0);
+}
+
+test("Renovate owns every repository uv pin surface", () => {
+  const renovate = JSON.parse(
+    readFileSync(path.join(REPO_ROOT, "renovate.json"), "utf8"),
+  );
+  const uvManagers = (renovate.customManagers ?? []).filter(
+    (manager) =>
+      manager.customType === "regex" &&
+      manager.datasourceTemplate === "github-releases" &&
+      manager.depNameTemplate === "astral-sh/uv",
+  );
+  assert.equal(uvManagers.length, 1);
+  const manager = uvManagers[0];
+  assert.equal(manager.versioningTemplate, "semver-coerced");
+  assert.ok(Array.isArray(manager.managerFilePatterns));
+  assert.ok(Array.isArray(manager.matchStrings));
+
+  const nativeManagerDisabled = (renovate.packageRules ?? []).some(
+    (rule) =>
+      rule.enabled === false &&
+      rule.matchManagers?.includes("github-actions") &&
+      rule.matchPackageNames?.includes("astral-sh/uv"),
+  );
+  assert.equal(
+    nativeManagerDisabled,
+    true,
+    "the native github-actions uses-with update must be disabled for astral-sh/uv",
+  );
+
+  const atomicUpdateRule = (renovate.packageRules ?? []).some(
+    (rule) =>
+      rule.matchManagers?.includes("custom.regex") &&
+      rule.matchPackageNames?.includes("astral-sh/uv") &&
+      rule.groupName === "repository uv toolchain" &&
+      rule.semanticCommitScope === "repo" &&
+      rule.dependencyDashboardApproval === true &&
+      rule.automerge === false,
+  );
+  assert.equal(
+    atomicUpdateRule,
+    true,
+    "the uv custom manager must produce one manually reviewed repository-scoped PR",
+  );
+
+  for (const relativePath of UV_PIN_SURFACES) {
+    assert.ok(
+      manager.managerFilePatterns.some((pattern) =>
+        renovateFilePattern(pattern).test(relativePath),
+      ),
+      `${relativePath} must be included in the uv custom manager`,
+    );
+    const contents = readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+    const expectedMatches = contents.split(UV_VERSION).length - 1;
+    assert.ok(
+      expectedMatches > 0,
+      `${relativePath} must contain ${UV_VERSION}`,
+    );
+    assert.equal(
+      countManagedUvPins(manager, contents),
+      expectedMatches,
+      `${relativePath} must expose every uv pin to Renovate`,
+    );
+  }
+});
+
+test("every setup-node workflow reads the canonical .node-version file", () => {
+  const workflowRoot = path.join(REPO_ROOT, ".github/workflows");
+  for (const entry of readdirSync(workflowRoot, { withFileTypes: true })) {
+    if (!entry.isFile() || !/\.ya?ml$/u.test(entry.name)) continue;
+    const relativePath = `.github/workflows/${entry.name}`;
+    const workflow = readFileSync(path.join(workflowRoot, entry.name), "utf8");
+    if (!workflow.includes("actions/setup-node@")) continue;
+    assert.doesNotMatch(
+      workflow,
+      /^\s*node-version:\s*\d/mu,
+      `${relativePath} must not duplicate the Node runtime pin`,
+    );
+    const setupNodeSteps =
+      workflow.match(/actions\/setup-node@/gu)?.length ?? 0;
+    const nodeVersionFiles =
+      workflow.match(/^\s*node-version-file:\s*\.node-version\s*$/gmu)
+        ?.length ?? 0;
+    assert.equal(
+      nodeVersionFiles,
+      setupNodeSteps,
+      `${relativePath} must source every setup-node step from .node-version`,
+    );
+  }
+});
 
 test("#508 repository security-tooling policy is complete", () => {
   assert.deepEqual(validateSecurityTooling(), []);
@@ -169,20 +300,21 @@ test("#555 every setup-uv action pins the repository uv version", () => {
     replaceInFixture(
       root,
       ".github/workflows/cross-repo-compatibility.yml",
-      "          version: 0.11.32\n",
+      `          version: ${UV_VERSION}\n`,
       "          version: latest\n",
     );
     replaceInFixture(
       root,
       ".github/workflows/docs.yml",
-      "          version: 0.11.32\n",
+      `          version: ${UV_VERSION}\n`,
       "",
     );
     const errors = validateSecurityTooling(root);
     for (const workflow of ["cross-repo-compatibility.yml", "docs.yml"]) {
       assert.ok(
         errors.some(
-          (error) => error.includes(workflow) && error.includes("uv 0.11.32"),
+          (error) =>
+            error.includes(workflow) && error.includes(`uv ${UV_VERSION}`),
         ),
       );
     }

--- a/scripts/check-security-tooling.test.mjs
+++ b/scripts/check-security-tooling.test.mjs
@@ -22,7 +22,9 @@ const REPO_ROOT = path.resolve(
 const MISE_TEXT = readFileSync(path.join(REPO_ROOT, "mise.toml"), "utf8");
 const UV_VERSION = /\buv\s*=\s*"(?<version>\d+\.\d+\.\d+)"/u.exec(MISE_TEXT)
   ?.groups?.version;
-assert.ok(UV_VERSION, "mise.toml must expose the canonical uv version");
+if (!UV_VERSION) {
+  throw new Error("mise.toml must expose the canonical uv version");
+}
 
 const UV_PIN_SURFACES = [
   ".devcontainer/Dockerfile",


### PR DESCRIPTION
## Summary

- make one custom Renovate manager own every repository uv toolchain pin
- disable the duplicate `github-actions` uses-with update for `astral-sh/uv`
- group uv changes into one manually reviewed `repo`-scoped update
- make the docs workflow read the canonical `.node-version` file
- add regression coverage for uv pin ownership and setup-node runtime drift

## Verification

- TDD: new policy tests failed for the missing manager and fixed Node pin, then passed after implementation
- `corepack pnpm run check:security-tooling`
- `corepack pnpm run check:governance`
- `corepack pnpm run check:validation-host`
- `corepack pnpm run check:devcontainer`
- validation-host `security:workflows` with actionlint 1.7.12 and zizmor 1.28.0
- full `corepack pnpm run validation-host:check`, including workspace tests, accessibility checks, build, repeatable VSIX packaging, and package validation

## Supply-chain note

The standalone Renovate CLI validator was not installed by weakening policy: the current release was inside the seven-day minimum release age, while the latest mature candidate hit pnpm's trust-downgrade protection. GitHub CI and the installed Renovate app remain authoritative for integration validation.