### PR TITLE
fix(deps): patch nanoid GHSA-2v37-7h3g-55p8

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,8 @@ overrides:
   brace-expansion@5.0.6: 5.0.9
   brace-expansion@5.0.7: 5.0.9
   postcss@8.5.15: 8.5.24
-  nanoid@3.3.16: 3.3.17
+  nanoid@3.3.16: 3.3.18
+  nanoid@3.3.17: 3.3.18
   '@vscode/vsce>keytar': '-'
   encoding-sniffer: 1.0.2
   js-yaml: 4.3.1
@@ -4068,8 +4069,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -9605,7 +9606,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -9855,13 +9856,13 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ minimumReleaseAgeExclude:
   - js-yaml@4.3.1
   - brace-expansion@2.1.4
   - brace-expansion@5.0.9
-  - nanoid@3.3.17
+  - nanoid@3.3.18
 trustPolicyExclude:
   - "@octokit/endpoint@9.0.6"
   - chokidar@4.0.3
@@ -32,7 +32,8 @@ overrides:
   "brace-expansion@5.0.6": 5.0.9
   "brace-expansion@5.0.7": 5.0.9
   "postcss@8.5.15": 8.5.24
-  "nanoid@3.3.16": 3.3.17
+  "nanoid@3.3.16": 3.3.18
+  "nanoid@3.3.17": 3.3.18
   "@vscode/vsce>keytar": "-"
   encoding-sniffer: 1.0.2
   js-yaml: 4.3.1

--- a/scripts/check-pnpm-supply-chain.mjs
+++ b/scripts/check-pnpm-supply-chain.mjs
@@ -14,7 +14,7 @@ const ALLOWED_MINIMUM_RELEASE_AGE_EXCLUDES = [
   "js-yaml@4.3.1",
   "brace-expansion@2.1.4",
   "brace-expansion@5.0.9",
-  "nanoid@3.3.17",
+  "nanoid@3.3.18",
 ];
 const ALLOWED_TRUST_POLICY_EXCLUDES = [
   "@octokit/endpoint@9.0.6",
@@ -26,7 +26,8 @@ const REQUIRED_SECURITY_OVERRIDES = Object.freeze({
   "brace-expansion@5.0.6": "5.0.9",
   "brace-expansion@5.0.7": "5.0.9",
   "postcss@8.5.15": "8.5.24",
-  "nanoid@3.3.16": "3.3.17",
+  "nanoid@3.3.16": "3.3.18",
+  "nanoid@3.3.17": "3.3.18",
   "js-yaml": "4.3.1",
   tar: "7.5.22",
   "fast-uri": "3.1.5",
@@ -113,7 +114,7 @@ function validateWorkspace(errors, workspace) {
       workspace?.minimumReleaseAgeExclude,
       ALLOWED_MINIMUM_RELEASE_AGE_EXCLUDES,
     ),
-    "pnpm-workspace.yaml minimumReleaseAgeExclude must be limited to version-scoped security exceptions: tmp@0.2.7, fast-uri@3.1.5, js-yaml@4.3.1, brace-expansion@2.1.4, brace-expansion@5.0.9, nanoid@3.3.17",
+    "pnpm-workspace.yaml minimumReleaseAgeExclude must be limited to version-scoped security exceptions: tmp@0.2.7, fast-uri@3.1.5, js-yaml@4.3.1, brace-expansion@2.1.4, brace-expansion@5.0.9, nanoid@3.3.18",
   );
   assertCondition(
     errors,

--- a/scripts/check-pnpm-supply-chain.test.mjs
+++ b/scripts/check-pnpm-supply-chain.test.mjs
@@ -30,7 +30,7 @@ function createFixture(overrides = {}) {
         "  - js-yaml@4.3.1",
         "  - brace-expansion@2.1.4",
         "  - brace-expansion@5.0.9",
-        "  - nanoid@3.3.17",
+        "  - nanoid@3.3.18",
         "trustPolicyExclude:",
         '  - "@octokit/endpoint@9.0.6"',
         "  - chokidar@4.0.3",
@@ -41,7 +41,8 @@ function createFixture(overrides = {}) {
         '  "brace-expansion@5.0.6": "5.0.9"',
         '  "brace-expansion@5.0.7": "5.0.9"',
         '  "postcss@8.5.15": "8.5.24"',
-        '  "nanoid@3.3.16": "3.3.17"',
+        '  "nanoid@3.3.16": "3.3.18"',
+        '  "nanoid@3.3.17": "3.3.18"',
         "  js-yaml: 4.3.1",
         "  tar: 7.5.22",
         "  fast-uri: 3.1.5",
@@ -138,13 +139,14 @@ test("mature PostCSS and tar releases cannot remain age exceptions", () => {
       "  tar: 7.5.22",
       "  fast-uri: 3.1.5",
       "  linkify-it: 5.0.2",
-      '  "nanoid@3.3.16": "3.3.17"',
+      '  "nanoid@3.3.16": "3.3.18"',
+      '  "nanoid@3.3.17": "3.3.18"',
       "",
     ].join("\n"),
   });
   try {
     assert.deepEqual(validatePnpmSupplyChain(repoRoot), [
-      "pnpm-workspace.yaml minimumReleaseAgeExclude must be limited to version-scoped security exceptions: tmp@0.2.7, fast-uri@3.1.5, js-yaml@4.3.1, brace-expansion@2.1.4, brace-expansion@5.0.9, nanoid@3.3.17",
+      "pnpm-workspace.yaml minimumReleaseAgeExclude must be limited to version-scoped security exceptions: tmp@0.2.7, fast-uri@3.1.5, js-yaml@4.3.1, brace-expansion@2.1.4, brace-expansion@5.0.9, nanoid@3.3.18",
     ]);
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
@@ -172,7 +174,8 @@ test("disabled pnpm supply-chain controls fail validation", () => {
       "  tar: 7.5.22",
       "  fast-uri: 3.1.5",
       "  linkify-it: 5.0.2",
-      '  "nanoid@3.3.16": "3.3.17"',
+      '  "nanoid@3.3.16": "3.3.18"',
+      '  "nanoid@3.3.17": "3.3.18"',
       "",
     ].join("\n"),
   });
@@ -182,7 +185,7 @@ test("disabled pnpm supply-chain controls fail validation", () => {
       "pnpm-workspace.yaml must set trustPolicy: no-downgrade",
       "pnpm-workspace.yaml must set blockExoticSubdeps: true",
       "pnpm-workspace.yaml must not enable trustLockfile for public PR CI",
-      "pnpm-workspace.yaml minimumReleaseAgeExclude must be limited to version-scoped security exceptions: tmp@0.2.7, fast-uri@3.1.5, js-yaml@4.3.1, brace-expansion@2.1.4, brace-expansion@5.0.9, nanoid@3.3.17",
+      "pnpm-workspace.yaml minimumReleaseAgeExclude must be limited to version-scoped security exceptions: tmp@0.2.7, fast-uri@3.1.5, js-yaml@4.3.1, brace-expansion@2.1.4, brace-expansion@5.0.9, nanoid@3.3.18",
       "pnpm-workspace.yaml trustPolicyExclude must be limited to reviewed version-scoped exceptions: @octokit/endpoint@9.0.6, chokidar@4.0.3, semver@5.7.2 || 6.3.1",
     ]);
   } finally {
@@ -256,7 +259,7 @@ test("#506 missing brace-expansion security overrides fail validation", () => {
       "  - js-yaml@4.3.1",
       "  - brace-expansion@2.1.4",
       "  - brace-expansion@5.0.9",
-      "  - nanoid@3.3.17",
+      "  - nanoid@3.3.18",
       "trustPolicyExclude:",
       '  - "@octokit/endpoint@9.0.6"',
       "  - chokidar@4.0.3",
@@ -267,7 +270,8 @@ test("#506 missing brace-expansion security overrides fail validation", () => {
       "  tar: 7.5.22",
       "  fast-uri: 3.1.5",
       "  linkify-it: 5.0.2",
-      '  "nanoid@3.3.16": "3.3.17"',
+      '  "nanoid@3.3.16": "3.3.18"',
+      '  "nanoid@3.3.17": "3.3.18"',
       "",
     ].join("\n"),
   });
@@ -295,7 +299,7 @@ test("#506 stale js-yaml security override fails validation", () => {
       "  - js-yaml@4.3.1",
       "  - brace-expansion@2.1.4",
       "  - brace-expansion@5.0.9",
-      "  - nanoid@3.3.17",
+      "  - nanoid@3.3.18",
       "trustPolicyExclude:",
       '  - "@octokit/endpoint@9.0.6"',
       "  - chokidar@4.0.3",
@@ -310,7 +314,8 @@ test("#506 stale js-yaml security override fails validation", () => {
       "  tar: 7.5.22",
       "  fast-uri: 3.1.5",
       "  linkify-it: 5.0.2",
-      '  "nanoid@3.3.16": "3.3.17"',
+      '  "nanoid@3.3.16": "3.3.18"',
+      '  "nanoid@3.3.17": "3.3.18"',
       "",
     ].join("\n"),
   });
@@ -335,7 +340,7 @@ test("#506 stale tar security override fails validation", () => {
       "  - js-yaml@4.3.1",
       "  - brace-expansion@2.1.4",
       "  - brace-expansion@5.0.9",
-      "  - nanoid@3.3.17",
+      "  - nanoid@3.3.18",
       "trustPolicyExclude:",
       '  - "@octokit/endpoint@9.0.6"',
       "  - chokidar@4.0.3",
@@ -350,7 +355,8 @@ test("#506 stale tar security override fails validation", () => {
       "  tar: 7.5.18",
       "  fast-uri: 3.1.5",
       "  linkify-it: 5.0.2",
-      '  "nanoid@3.3.16": "3.3.17"',
+      '  "nanoid@3.3.16": "3.3.18"',
+      '  "nanoid@3.3.17": "3.3.18"',
       "",
     ].join("\n"),
   });
@@ -375,7 +381,7 @@ test("#508 newly disclosed transitive security fixes stay pinned", () => {
       "  - js-yaml@4.3.1",
       "  - brace-expansion@2.1.4",
       "  - brace-expansion@5.0.9",
-      "  - nanoid@3.3.17",
+      "  - nanoid@3.3.18",
       "trustPolicyExclude:",
       '  - "@octokit/endpoint@9.0.6"',
       "  - chokidar@4.0.3",
@@ -390,7 +396,8 @@ test("#508 newly disclosed transitive security fixes stay pinned", () => {
       "  tar: 7.5.22",
       "  fast-uri: 3.1.2",
       "  linkify-it: 5.0.1",
-      '  "nanoid@3.3.16": "3.3.17"',
+      '  "nanoid@3.3.16": "3.3.18"',
+      '  "nanoid@3.3.17": "3.3.18"',
       "",
     ].join("\n"),
   });
@@ -404,7 +411,7 @@ test("#508 newly disclosed transitive security fixes stay pinned", () => {
   }
 });
 
-test("newly disclosed nanoid fix stays pinned", () => {
+test("GHSA-2v37-7h3g-55p8 nanoid fix stays pinned", () => {
   const repoRoot = createFixture({
     workspace: [
       "packages:",
@@ -435,8 +442,9 @@ test("newly disclosed nanoid fix stays pinned", () => {
   });
   try {
     assert.deepEqual(validatePnpmSupplyChain(repoRoot), [
-      "pnpm-workspace.yaml minimumReleaseAgeExclude must be limited to version-scoped security exceptions: tmp@0.2.7, fast-uri@3.1.5, js-yaml@4.3.1, brace-expansion@2.1.4, brace-expansion@5.0.9, nanoid@3.3.17",
-      "pnpm-workspace.yaml overrides must pin nanoid@3.3.16 to 3.3.17",
+      "pnpm-workspace.yaml minimumReleaseAgeExclude must be limited to version-scoped security exceptions: tmp@0.2.7, fast-uri@3.1.5, js-yaml@4.3.1, brace-expansion@2.1.4, brace-expansion@5.0.9, nanoid@3.3.18",
+      "pnpm-workspace.yaml overrides must pin nanoid@3.3.16 to 3.3.18",
+      "pnpm-workspace.yaml overrides must pin nanoid@3.3.17 to 3.3.18",
     ]);
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
@@ -465,13 +473,14 @@ test("#554 newly disclosed PostCSS and brace-expansion fixes stay pinned", () =>
       "  tar: 7.5.22",
       "  fast-uri: 3.1.5",
       "  linkify-it: 5.0.2",
-      '  "nanoid@3.3.16": "3.3.17"',
+      '  "nanoid@3.3.16": "3.3.18"',
+      '  "nanoid@3.3.17": "3.3.18"',
       "",
     ].join("\n"),
   });
   try {
     assert.deepEqual(validatePnpmSupplyChain(repoRoot), [
-      "pnpm-workspace.yaml minimumReleaseAgeExclude must be limited to version-scoped security exceptions: tmp@0.2.7, fast-uri@3.1.5, js-yaml@4.3.1, brace-expansion@2.1.4, brace-expansion@5.0.9, nanoid@3.3.17",
+      "pnpm-workspace.yaml minimumReleaseAgeExclude must be limited to version-scoped security exceptions: tmp@0.2.7, fast-uri@3.1.5, js-yaml@4.3.1, brace-expansion@2.1.4, brace-expansion@5.0.9, nanoid@3.3.18",
       "pnpm-workspace.yaml overrides must pin brace-expansion@5.0.6 to 5.0.9",
       "pnpm-workspace.yaml overrides must pin brace-expansion@5.0.7 to 5.0.9",
       "pnpm-workspace.yaml overrides must pin postcss@8.5.15 to 8.5.24",
@@ -493,7 +502,7 @@ test("#554 active advisory suppressions fail validation", () => {
       "  - js-yaml@4.3.1",
       "  - brace-expansion@2.1.4",
       "  - brace-expansion@5.0.9",
-      "  - nanoid@3.3.17",
+      "  - nanoid@3.3.18",
       "trustPolicyExclude:",
       '  - "@octokit/endpoint@9.0.6"',
       "  - chokidar@4.0.3",
@@ -511,7 +520,8 @@ test("#554 active advisory suppressions fail validation", () => {
       "  tar: 7.5.22",
       "  fast-uri: 3.1.5",
       "  linkify-it: 5.0.2",
-      '  "nanoid@3.3.16": "3.3.17"',
+      '  "nanoid@3.3.16": "3.3.18"',
+      '  "nanoid@3.3.17": "3.3.18"',
       "",
     ].join("\n"),
   });


### PR DESCRIPTION
## Summary

Patch the transitive `nanoid` dependency from 3.3.17 to 3.3.18 for GHSA-2v37-7h3g-55p8, and update the repository's fail-closed pnpm supply-chain policy so both 3.3.16 and 3.3.17 resolve to the patched release.

The change is intentionally limited to the lockfile, pnpm security override/age exception, and the associated supply-chain policy regression test.

## Linked issue

No repository issue. Security advisory: GHSA-2v37-7h3g-55p8.

## Type of change

- [ ] type:bug
- [ ] type:feature
- [ ] type:docs
- [ ] type:refactor
- [ ] type:perf
- [x] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- Regression: `GHSA-2v37-7h3g-55p8 nanoid fix stays pinned` failed against the old 3.3.17 policy and passes with this patch.
- `corepack pnpm audit --audit-level high` -> `No known vulnerabilities found`.
- `corepack pnpm run check:supply-chain` -> pass (14/14 supply-chain tests).
- `corepack pnpm run check` -> pass on final HEAD, including Trivy devcontainer policy, security tests, lint, typecheck, build, package validation, docs, and 125/125 unit suites (979/979 tests).
- GitHub PR checks -> all required checks pass, including CI, CodeQL, Dependency Review, Gitleaks, SonarCloud, Semgrep, Socket and Trivy.
- Security run 32321960624 -> success. `pnpm audit` passed; development-container Trivy scan passed; SARIF upload and artifact storage passed; the fail-on-findings step was skipped because there were no HIGH/CRITICAL findings.

## Protocol / MCP impact

- [x] Not applicable; reason: dependency-only security patch; no MCP tool/schema/transport/capability/adapter behavior changes.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [ ] Docs updated
- [ ] Release notes considered for both products
- [ ] Backward compatibility impact documented

## Repository maturity impact

- [ ] No repository maturity impact
- [ ] Documentation/community health updated
- [ ] CI/quality/release process updated
- [x] Governance/security/supply-chain process updated
- [ ] Manual GitHub setting or maintainer action required and documented

## Automation evidence

- [x] Review-thread gate checked; current bot comments are informational and no actionable finding is open
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Review evidence

An availability, quota, rate-limit, or capacity notice is not a completed review.

Select exactly one automated-review outcome:

- [ ] Completed with findings; every finding is triaged below
- [ ] Completed with no findings
- [x] Unavailable; Jules PR-review dispatch is disabled by control-plane policy. Compensating evidence is recorded below.
- [ ] Not applicable; reason:

Select exactly one change risk:

- [x] Low
- [ ] Medium
- [ ] High

Bot and agent triage:

- [x] Every bot and agent comment is classified as actionable, resolved, informational, duplicate, or unavailable
- [x] No actionable finding remains unresolved
- [x] Unavailable notices are recorded as unavailable, not completed review

Compensating evidence:

- [ ] Focused second-agent review
- [x] Architecture/security checklist
- [x] Additional regression tests
- [x] Documented manual review
- [x] Not required for merge solely on review availability because the change risk is low

Evidence links/notes:

- Final-head local verification and regression evidence are recorded above.
- GitHub checks are terminal and passing.
- SonarCloud reports 0 new issues and 0 security hotspots; Codecov reports all modified coverable lines covered.
- Security workflow confirms Trivy scan and SARIF upload both succeeded.
- Independent Jules review was attempted but dispatch is disabled by policy; it is recorded as unavailable rather than completed review.

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related advisory in the test name
- [x] Bug-fix automation is practical and present; no exception is being claimed
- [x] CHANGELOG entry not required: no user-visible behavior change
- [x] Docs update not required: dependency-only security patch
- [x] No new committed secrets or build artifacts
- [x] Developer Certificate of Origin sign-off is present on the commit
- [x] Definition of Done security/test requirements are covered by local and GitHub checks
