### PR TITLE
fix(kicad-studio): make MCP installer Python-aware

### DIFF
--- a/apps/vscode-extension/src/commands/mcpCommands.ts
+++ b/apps/vscode-extension/src/commands/mcpCommands.ts
@@ -4,6 +4,7 @@ import { McpDetector } from '../mcp/mcpDetector';
 import { DesignIntentPanel } from '../mcp/designIntentPanel';
 import { DrcRuleEditorPanel } from '../drc/drcRuleEditorPanel';
 import { registerTrustedCommand } from '../utils/workspaceTrust';
+import { DOCUMENTATION_URLS } from '../documentation/documentationUrls';
 import {
   showStructuredError,
   structuredErrorFromUnknown,
@@ -11,6 +12,26 @@ import {
 } from '../utils/notifications';
 import type { CommandServices } from './types';
 import type { FixItem } from '../types';
+
+function createTaskProcessCompletion(task: vscode.Task): {
+  promise: Promise<number | undefined>;
+  dispose(): void;
+} {
+  let disposable: vscode.Disposable | undefined;
+  const promise = new Promise<number | undefined>((resolve) => {
+    disposable = vscode.tasks.onDidEndTaskProcess((event) => {
+      if (event.execution.task !== task) {
+        return;
+      }
+      disposable?.dispose();
+      resolve(event.exitCode);
+    });
+  });
+  return {
+    promise,
+    dispose: () => disposable?.dispose()
+  };
+}
 
 /**
  * Register MCP integration commands.
@@ -163,6 +184,19 @@ export function registerMcpCommands(
       async () => {
         const detector = new McpDetector();
         const candidates = await detector.detectInstallers();
+        if (candidates.length === 0) {
+          const action = await vscode.window.showWarningMessage(
+            'kicad-mcp-pro requires Python 3.13 or newer. Install Python 3.13+ or uv, then retry.',
+            'Open install docs'
+          );
+          if (action === 'Open install docs') {
+            await vscode.env.openExternal(
+              vscode.Uri.parse(DOCUMENTATION_URLS.mcpServerInstallation)
+            );
+          }
+          return;
+        }
+
         const choice = await vscode.window.showQuickPick(
           [
             ...candidates.map((candidate) => ({
@@ -203,15 +237,25 @@ export function registerMcpCommands(
             choice.candidate.args
           )
         );
-        await vscode.tasks.executeTask(task);
-        const followUp = await vscode.window.showInformationMessage(
-          'Install task started. Re-run MCP detection when it finishes?',
-          'Detect',
-          'Later'
-        );
-        if (followUp === 'Detect') {
-          await services.refreshMcpState();
+        const completion = createTaskProcessCompletion(task);
+        let exitCode: number | undefined;
+        try {
+          await vscode.tasks.executeTask(task);
+          exitCode = await completion.promise;
+        } finally {
+          completion.dispose();
         }
+        if (exitCode === 0) {
+          await services.refreshMcpState();
+          void vscode.window.showInformationMessage(
+            'kicad-mcp-pro installation completed. MCP detection refreshed.'
+          );
+          return;
+        }
+
+        void vscode.window.showErrorMessage(
+          'kicad-mcp-pro installation failed. Review the install task output and retry after resolving the prerequisite.'
+        );
       },
       'Install kicad-mcp-pro'
     ),
@@ -223,9 +267,7 @@ export function registerMcpCommands(
 
     vscode.commands.registerCommand(COMMANDS.openMcpUpgradeGuide, () =>
       vscode.env.openExternal(
-        vscode.Uri.parse(
-          'https://github.com/oaslananka/kicad-studio-kit#installation'
-        )
+        vscode.Uri.parse(DOCUMENTATION_URLS.mcpServerInstallation)
       )
     ),
 

--- a/apps/vscode-extension/src/documentation/documentationUrls.ts
+++ b/apps/vscode-extension/src/documentation/documentationUrls.ts
@@ -1,6 +1,8 @@
 export const DOCUMENTATION_URLS = {
   mcpIntegration:
     'https://github.com/oaslananka/kicad-studio-kit/blob/main/apps/vscode-extension/docs/INTEGRATION.md',
+  mcpServerInstallation:
+    'https://oaslananka.github.io/kicad-mcp-pro/tutorials/getting-started/',
   kicadCliInstallation:
     'https://github.com/oaslananka/kicad-studio-kit/blob/main/docs/install.md'
 } as const;

--- a/apps/vscode-extension/src/mcp/mcpDetector.ts
+++ b/apps/vscode-extension/src/mcp/mcpDetector.ts
@@ -20,6 +20,30 @@ export interface McpDoctorResult {
   error?: string | undefined;
 }
 
+const MCP_MINIMUM_PYTHON = { major: 3, minor: 13 } as const;
+const PYTHON_RUNTIME_SCRIPT =
+  'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}"); print(sys.executable)';
+
+interface PythonRuntimeProbe {
+  command: string;
+  prefixArgs: string[];
+}
+
+interface CompatiblePythonRuntime {
+  executable: string;
+  version: string;
+}
+
+const PYTHON_RUNTIME_PROBES: readonly PythonRuntimeProbe[] = [
+  { command: 'python3.13', prefixArgs: [] },
+  { command: 'python3.14', prefixArgs: [] },
+  { command: 'python3', prefixArgs: [] },
+  { command: 'python', prefixArgs: [] },
+  { command: 'py', prefixArgs: ['-3.13'] },
+  { command: 'py', prefixArgs: ['-3.14'] },
+  { command: 'py', prefixArgs: ['-3'] }
+];
+
 function runExecFile(
   command: string,
   args: string[],
@@ -64,6 +88,44 @@ async function run(
     const message = error instanceof Error ? error.message : String(error);
     return { ok: false, output: message };
   }
+}
+
+function isCompatiblePythonVersion(version: string): boolean {
+  const match = /^(\d+)\.(\d+)$/.exec(version.trim());
+  if (!match) {
+    return false;
+  }
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  return (
+    major > MCP_MINIMUM_PYTHON.major ||
+    (major === MCP_MINIMUM_PYTHON.major && minor >= MCP_MINIMUM_PYTHON.minor)
+  );
+}
+
+async function detectCompatiblePythonRuntime(): Promise<
+  CompatiblePythonRuntime | undefined
+> {
+  for (const probe of PYTHON_RUNTIME_PROBES) {
+    const result = await run(probe.command, [
+      ...probe.prefixArgs,
+      '-c',
+      PYTHON_RUNTIME_SCRIPT
+    ]);
+    if (!result.ok) {
+      continue;
+    }
+
+    const [version, executable] = result.output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (!version || !executable || !isCompatiblePythonVersion(version)) {
+      continue;
+    }
+    return { executable, version };
+  }
+  return undefined;
 }
 
 export class McpDetector {
@@ -321,45 +383,41 @@ export class McpDetector {
 
   async detectInstallers(): Promise<McpInstallerCandidate[]> {
     const candidates: McpInstallerCandidate[] = [];
-    if (
-      (await run('uvx', ['--version'])).ok ||
-      (await run('uv', ['--version'])).ok
-    ) {
+    if ((await run('uv', ['--version'])).ok) {
       candidates.push({
         id: 'uvx',
         label: 'uv tool install kicad-mcp-pro',
         description: 'Recommended isolated Python tool install',
         command: 'uv',
-        args: ['tool', 'install', 'kicad-mcp-pro']
+        args: ['tool', 'install', '--python', '3.13', 'kicad-mcp-pro']
       });
     }
-    if ((await run('pipx', ['--version'])).ok) {
+
+    const pythonRuntime = await detectCompatiblePythonRuntime();
+    if ((await run('pipx', ['--version'])).ok && pythonRuntime) {
       candidates.push({
         id: 'pipx',
         label: 'pipx install kicad-mcp-pro',
-        description: 'Install as an isolated Python app with pipx',
+        description: `Install with Python ${pythonRuntime.version}`,
         command: 'pipx',
-        args: ['install', 'kicad-mcp-pro']
+        args: ['install', '--python', pythonRuntime.executable, 'kicad-mcp-pro']
       });
     }
-    for (const command of ['pip', 'pip3', 'python', 'python3']) {
-      const result = await run(
-        command,
-        command.startsWith('python')
-          ? ['-m', 'pip', '--version']
-          : ['--version']
-      );
-      if (result.ok) {
+
+    if (pythonRuntime) {
+      const pipResult = await run(pythonRuntime.executable, [
+        '-m',
+        'pip',
+        '--version'
+      ]);
+      if (pipResult.ok) {
         candidates.push({
           id: 'pip',
-          label: `${command} install --user kicad-mcp-pro`,
-          description: 'Fallback user-site Python install',
-          command,
-          args: command.startsWith('python')
-            ? ['-m', 'pip', 'install', '--user', 'kicad-mcp-pro']
-            : ['install', '--user', 'kicad-mcp-pro']
+          label: `${pythonRuntime.executable} -m pip install --user kicad-mcp-pro`,
+          description: `Fallback user-site install with Python ${pythonRuntime.version}`,
+          command: pythonRuntime.executable,
+          args: ['-m', 'pip', 'install', '--user', 'kicad-mcp-pro']
         });
-        break;
       }
     }
     return candidates;

--- a/apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts
+++ b/apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts
@@ -5,6 +5,7 @@ import {
   commands,
   createExtensionContextMock,
   env,
+  tasks,
   window,
   workspace
 } from './vscodeMock';
@@ -124,6 +125,152 @@ describe('MCP command workspace trust guards', () => {
     await registeredHandler(COMMANDS.setupMcpIntegration)();
 
     expect(commands.executeCommand).toHaveBeenCalledWith(COMMANDS.installMcp);
+  });
+
+  it('#620 shows Python prerequisite guidance when no safe installer exists', async () => {
+    registerWithServices();
+    jest.spyOn(McpDetector.prototype, 'detectInstallers').mockResolvedValue([]);
+    (window.showWarningMessage as jest.Mock).mockResolvedValue(undefined);
+
+    await registeredHandler(COMMANDS.installMcp)();
+
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Python 3.13'),
+      'Open install docs'
+    );
+    expect(tasks.executeTask).not.toHaveBeenCalled();
+  });
+
+  it('#620 opens the current MCP server getting-started guide from prerequisite guidance', async () => {
+    registerWithServices();
+    jest.spyOn(McpDetector.prototype, 'detectInstallers').mockResolvedValue([]);
+    (window.showWarningMessage as jest.Mock).mockResolvedValue(
+      'Open install docs'
+    );
+
+    await registeredHandler(COMMANDS.installMcp)();
+
+    expect(env.openExternal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fsPath:
+          'https://oaslananka.github.io/kicad-mcp-pro/tutorials/getting-started/'
+      })
+    );
+  });
+
+  it('#620 refreshes MCP state automatically after a successful install task', async () => {
+    const services = registerWithServices();
+    const candidate = {
+      id: 'pipx' as const,
+      label: 'pipx install kicad-mcp-pro',
+      description: 'Install with Python 3.13',
+      command: 'pipx',
+      args: ['install', '--python', '/usr/bin/python3.13', 'kicad-mcp-pro']
+    };
+    jest
+      .spyOn(McpDetector.prototype, 'detectInstallers')
+      .mockResolvedValue([candidate]);
+    (window.showQuickPick as jest.Mock).mockResolvedValue({
+      label: candidate.label,
+      description: candidate.description,
+      candidate
+    });
+
+    let endListener:
+      | ((event: { execution: { task: unknown }; exitCode: number }) => void)
+      | undefined;
+    (tasks.onDidEndTaskProcess as jest.Mock).mockImplementation((listener) => {
+      endListener = listener;
+      return { dispose: jest.fn() };
+    });
+    (tasks.executeTask as jest.Mock).mockImplementation(async (task) => {
+      const execution = { task };
+      queueMicrotask(() => endListener?.({ execution, exitCode: 0 }));
+      return execution;
+    });
+
+    await registeredHandler(COMMANDS.installMcp)();
+
+    expect(tasks.onDidEndTaskProcess).toHaveBeenCalled();
+    expect(services.refreshMcpState).toHaveBeenCalledTimes(1);
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('installation completed')
+    );
+  });
+
+  it('#620 reports a failed install task without refreshing MCP state', async () => {
+    const services = registerWithServices();
+    const candidate = {
+      id: 'pipx' as const,
+      label: 'pipx install kicad-mcp-pro',
+      description: 'Install with Python 3.13',
+      command: 'pipx',
+      args: ['install', '--python', '/usr/bin/python3.13', 'kicad-mcp-pro']
+    };
+    jest
+      .spyOn(McpDetector.prototype, 'detectInstallers')
+      .mockResolvedValue([candidate]);
+    (window.showQuickPick as jest.Mock).mockResolvedValue({
+      label: candidate.label,
+      description: candidate.description,
+      candidate
+    });
+
+    let endListener:
+      | ((event: { execution: { task: unknown }; exitCode: number }) => void)
+      | undefined;
+    (tasks.onDidEndTaskProcess as jest.Mock).mockImplementation((listener) => {
+      endListener = listener;
+      return { dispose: jest.fn() };
+    });
+    (tasks.executeTask as jest.Mock).mockImplementation(async (task) => {
+      const execution = { task };
+      queueMicrotask(() => endListener?.({ execution, exitCode: 1 }));
+      return execution;
+    });
+
+    await registeredHandler(COMMANDS.installMcp)();
+
+    expect(services.refreshMcpState).not.toHaveBeenCalled();
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('installation failed')
+    );
+  });
+
+  it('#620 observes installer completion even when the task exits before executeTask resolves', async () => {
+    const services = registerWithServices();
+    const candidate = {
+      id: 'pipx' as const,
+      label: 'pipx install kicad-mcp-pro',
+      description: 'Install with Python 3.13',
+      command: 'pipx',
+      args: ['install', '--python', '/usr/bin/python3.13', 'kicad-mcp-pro']
+    };
+    jest
+      .spyOn(McpDetector.prototype, 'detectInstallers')
+      .mockResolvedValue([candidate]);
+    (window.showQuickPick as jest.Mock).mockResolvedValue({
+      label: candidate.label,
+      description: candidate.description,
+      candidate
+    });
+
+    let endListener:
+      | ((event: { execution: { task: unknown }; exitCode: number }) => void)
+      | undefined;
+    (tasks.onDidEndTaskProcess as jest.Mock).mockImplementation((listener) => {
+      endListener = listener;
+      return { dispose: jest.fn() };
+    });
+    (tasks.executeTask as jest.Mock).mockImplementation(async (task) => {
+      const execution = { task };
+      endListener?.({ execution, exitCode: 0 });
+      return execution;
+    });
+
+    await registeredHandler(COMMANDS.installMcp)();
+
+    expect(services.refreshMcpState).toHaveBeenCalledTimes(1);
   });
 
   it('stops MCP setup when no workspace folder is open', async () => {

--- a/apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts
+++ b/apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts
@@ -59,6 +59,48 @@ describe('MCP command workspace trust guards', () => {
     return entry[1] as (...args: unknown[]) => unknown;
   }
 
+  const pipxInstallCandidate = {
+    id: 'pipx' as const,
+    label: 'pipx install kicad-mcp-pro',
+    description: 'Install with Python 3.13',
+    command: 'pipx',
+    args: ['install', '--python', '/usr/bin/python3.13', 'kicad-mcp-pro']
+  };
+
+  function mockInstallerSelection(): void {
+    jest
+      .spyOn(McpDetector.prototype, 'detectInstallers')
+      .mockResolvedValue([pipxInstallCandidate]);
+    (window.showQuickPick as jest.Mock).mockResolvedValue({
+      label: pipxInstallCandidate.label,
+      description: pipxInstallCandidate.description,
+      candidate: pipxInstallCandidate
+    });
+  }
+
+  function mockInstallerTaskExit(
+    exitCode: number,
+    timing: 'microtask' | 'immediate' = 'microtask'
+  ): void {
+    let endListener:
+      | ((event: { execution: { task: unknown }; exitCode: number }) => void)
+      | undefined;
+    (tasks.onDidEndTaskProcess as jest.Mock).mockImplementation((listener) => {
+      endListener = listener;
+      return { dispose: jest.fn() };
+    });
+    (tasks.executeTask as jest.Mock).mockImplementation(async (task) => {
+      const execution = { task };
+      const emit = () => endListener?.({ execution, exitCode });
+      if (timing === 'immediate') {
+        emit();
+      } else {
+        queueMicrotask(emit);
+      }
+      return execution;
+    });
+  }
+
   it('blocks mutating fix queue commands in untrusted workspaces', async () => {
     workspace.isTrusted = false;
     const services = registerWithServices();
@@ -160,34 +202,8 @@ describe('MCP command workspace trust guards', () => {
 
   it('#620 refreshes MCP state automatically after a successful install task', async () => {
     const services = registerWithServices();
-    const candidate = {
-      id: 'pipx' as const,
-      label: 'pipx install kicad-mcp-pro',
-      description: 'Install with Python 3.13',
-      command: 'pipx',
-      args: ['install', '--python', '/usr/bin/python3.13', 'kicad-mcp-pro']
-    };
-    jest
-      .spyOn(McpDetector.prototype, 'detectInstallers')
-      .mockResolvedValue([candidate]);
-    (window.showQuickPick as jest.Mock).mockResolvedValue({
-      label: candidate.label,
-      description: candidate.description,
-      candidate
-    });
-
-    let endListener:
-      | ((event: { execution: { task: unknown }; exitCode: number }) => void)
-      | undefined;
-    (tasks.onDidEndTaskProcess as jest.Mock).mockImplementation((listener) => {
-      endListener = listener;
-      return { dispose: jest.fn() };
-    });
-    (tasks.executeTask as jest.Mock).mockImplementation(async (task) => {
-      const execution = { task };
-      queueMicrotask(() => endListener?.({ execution, exitCode: 0 }));
-      return execution;
-    });
+    mockInstallerSelection();
+    mockInstallerTaskExit(0);
 
     await registeredHandler(COMMANDS.installMcp)();
 
@@ -200,34 +216,8 @@ describe('MCP command workspace trust guards', () => {
 
   it('#620 reports a failed install task without refreshing MCP state', async () => {
     const services = registerWithServices();
-    const candidate = {
-      id: 'pipx' as const,
-      label: 'pipx install kicad-mcp-pro',
-      description: 'Install with Python 3.13',
-      command: 'pipx',
-      args: ['install', '--python', '/usr/bin/python3.13', 'kicad-mcp-pro']
-    };
-    jest
-      .spyOn(McpDetector.prototype, 'detectInstallers')
-      .mockResolvedValue([candidate]);
-    (window.showQuickPick as jest.Mock).mockResolvedValue({
-      label: candidate.label,
-      description: candidate.description,
-      candidate
-    });
-
-    let endListener:
-      | ((event: { execution: { task: unknown }; exitCode: number }) => void)
-      | undefined;
-    (tasks.onDidEndTaskProcess as jest.Mock).mockImplementation((listener) => {
-      endListener = listener;
-      return { dispose: jest.fn() };
-    });
-    (tasks.executeTask as jest.Mock).mockImplementation(async (task) => {
-      const execution = { task };
-      queueMicrotask(() => endListener?.({ execution, exitCode: 1 }));
-      return execution;
-    });
+    mockInstallerSelection();
+    mockInstallerTaskExit(1);
 
     await registeredHandler(COMMANDS.installMcp)();
 
@@ -239,34 +229,8 @@ describe('MCP command workspace trust guards', () => {
 
   it('#620 observes installer completion even when the task exits before executeTask resolves', async () => {
     const services = registerWithServices();
-    const candidate = {
-      id: 'pipx' as const,
-      label: 'pipx install kicad-mcp-pro',
-      description: 'Install with Python 3.13',
-      command: 'pipx',
-      args: ['install', '--python', '/usr/bin/python3.13', 'kicad-mcp-pro']
-    };
-    jest
-      .spyOn(McpDetector.prototype, 'detectInstallers')
-      .mockResolvedValue([candidate]);
-    (window.showQuickPick as jest.Mock).mockResolvedValue({
-      label: candidate.label,
-      description: candidate.description,
-      candidate
-    });
-
-    let endListener:
-      | ((event: { execution: { task: unknown }; exitCode: number }) => void)
-      | undefined;
-    (tasks.onDidEndTaskProcess as jest.Mock).mockImplementation((listener) => {
-      endListener = listener;
-      return { dispose: jest.fn() };
-    });
-    (tasks.executeTask as jest.Mock).mockImplementation(async (task) => {
-      const execution = { task };
-      endListener?.({ execution, exitCode: 0 });
-      return execution;
-    });
+    mockInstallerSelection();
+    mockInstallerTaskExit(0, 'immediate');
 
     await registeredHandler(COMMANDS.installMcp)();
 

--- a/apps/vscode-extension/test/unit/mcpDetector.test.ts
+++ b/apps/vscode-extension/test/unit/mcpDetector.test.ts
@@ -300,19 +300,31 @@ describe('McpDetector.generateMcpJson', () => {
     );
   });
 
-  it('discovers installer candidates in uvx, pipx, then pip order', async () => {
+  it('#620 discovers installer candidates in uv, pipx, then pip order', async () => {
     execFileMock.mockImplementation(
       (
         command: string,
-        _args: string[],
+        args: string[],
         _opts: unknown,
         callback: (err: Error | null, stdout: string, stderr: string) => void
       ) => {
-        if (['uvx', 'pipx', 'pip'].includes(command)) {
-          callback(null, `${command} version`, '');
-        } else {
-          callback(new Error('missing'), '', 'missing');
+        if (command === 'uv' && args[0] === '--version') {
+          callback(null, 'uv 0.8.0', '');
+          return;
         }
+        if (command === 'pipx' && args[0] === '--version') {
+          callback(null, 'pipx 1.8.0', '');
+          return;
+        }
+        if (command === 'python3.13' && args[0] === '-c') {
+          callback(null, '3.13\n/usr/bin/python3.13\n', '');
+          return;
+        }
+        if (command === '/usr/bin/python3.13' && args[0] === '-m') {
+          callback(null, 'pip 25.2', '');
+          return;
+        }
+        callback(new Error('missing'), '', 'missing');
       }
     );
 
@@ -323,22 +335,88 @@ describe('McpDetector.generateMcpJson', () => {
       'pipx',
       'pip'
     ]);
-    expect(candidates[0]?.args).toEqual(['tool', 'install', 'kicad-mcp-pro']);
+    expect(candidates[0]?.args).toEqual([
+      'tool',
+      'install',
+      '--python',
+      '3.13',
+      'kicad-mcp-pro'
+    ]);
   });
 
-  it('discovers python -m pip as installer fallback', async () => {
+  it('#620 pins pipx to a compatible Python interpreter', async () => {
     execFileMock.mockImplementation(
       (
         command: string,
-        _args: string[],
+        args: string[],
         _opts: unknown,
         callback: (err: Error | null, stdout: string, stderr: string) => void
       ) => {
-        if (command === 'python') {
-          callback(null, 'pip 25', '');
-        } else {
-          callback(new Error('missing'), '', 'missing');
+        if (command === 'pipx' && args[0] === '--version') {
+          callback(null, '1.8.0', '');
+          return;
         }
+        if (command === 'python3.13' && args[0] === '-c') {
+          callback(null, '3.13\n/usr/bin/python3.13\n', '');
+          return;
+        }
+        callback(new Error('missing'), '', 'missing');
+      }
+    );
+
+    const candidates = await new McpDetector().detectInstallers();
+
+    expect(candidates).toContainEqual(
+      expect.objectContaining({
+        id: 'pipx',
+        command: 'pipx',
+        args: ['install', '--python', '/usr/bin/python3.13', 'kicad-mcp-pro']
+      })
+    );
+  });
+
+  it('#620 does not offer pipx when only an incompatible Python is available', async () => {
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        args: string[],
+        _opts: unknown,
+        callback: (err: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        if (command === 'pipx' && args[0] === '--version') {
+          callback(null, '1.8.0', '');
+          return;
+        }
+        if (command === 'python3' && args[0] === '-c') {
+          callback(null, '3.12\n/usr/bin/python3\n', '');
+          return;
+        }
+        callback(new Error('missing'), '', 'missing');
+      }
+    );
+
+    const candidates = await new McpDetector().detectInstallers();
+
+    expect(candidates.some((candidate) => candidate.id === 'pipx')).toBe(false);
+  });
+
+  it('#620 discovers a compatible python -m pip as installer fallback', async () => {
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        args: string[],
+        _opts: unknown,
+        callback: (err: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        if (command === 'python' && args[0] === '-c') {
+          callback(null, '3.13\npython\n', '');
+          return;
+        }
+        if (command === 'python' && args[0] === '-m') {
+          callback(null, 'pip 25', '');
+          return;
+        }
+        callback(new Error('missing'), '', 'missing');
       }
     );
 

--- a/apps/vscode-extension/test/unit/mcpDetector.test.ts
+++ b/apps/vscode-extension/test/unit/mcpDetector.test.ts
@@ -35,6 +35,25 @@ describe('McpDetector.generateMcpJson', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
+  function mockExecResponses(responses: Record<string, string>): void {
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        args: string[],
+        _opts: unknown,
+        callback: (err: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        const key = `${command} ${args[0] ?? ''}`;
+        const stdout = responses[key];
+        if (stdout === undefined) {
+          callback(new Error('missing'), '', 'missing');
+          return;
+        }
+        callback(null, stdout, '');
+      }
+    );
+  }
+
   it('creates a stdio MCP configuration for uvx installs', async () => {
     const detector = new McpDetector();
 
@@ -301,32 +320,12 @@ describe('McpDetector.generateMcpJson', () => {
   });
 
   it('#620 discovers installer candidates in uv, pipx, then pip order', async () => {
-    execFileMock.mockImplementation(
-      (
-        command: string,
-        args: string[],
-        _opts: unknown,
-        callback: (err: Error | null, stdout: string, stderr: string) => void
-      ) => {
-        if (command === 'uv' && args[0] === '--version') {
-          callback(null, 'uv 0.8.0', '');
-          return;
-        }
-        if (command === 'pipx' && args[0] === '--version') {
-          callback(null, 'pipx 1.8.0', '');
-          return;
-        }
-        if (command === 'python3.13' && args[0] === '-c') {
-          callback(null, '3.13\n/usr/bin/python3.13\n', '');
-          return;
-        }
-        if (command === '/usr/bin/python3.13' && args[0] === '-m') {
-          callback(null, 'pip 25.2', '');
-          return;
-        }
-        callback(new Error('missing'), '', 'missing');
-      }
-    );
+    mockExecResponses({
+      'uv --version': 'uv 0.8.0',
+      'pipx --version': 'pipx 1.8.0',
+      'python3.13 -c': '3.13\n/usr/bin/python3.13\n',
+      '/usr/bin/python3.13 -m': 'pip 25.2'
+    });
 
     const candidates = await new McpDetector().detectInstallers();
 
@@ -345,24 +344,10 @@ describe('McpDetector.generateMcpJson', () => {
   });
 
   it('#620 pins pipx to a compatible Python interpreter', async () => {
-    execFileMock.mockImplementation(
-      (
-        command: string,
-        args: string[],
-        _opts: unknown,
-        callback: (err: Error | null, stdout: string, stderr: string) => void
-      ) => {
-        if (command === 'pipx' && args[0] === '--version') {
-          callback(null, '1.8.0', '');
-          return;
-        }
-        if (command === 'python3.13' && args[0] === '-c') {
-          callback(null, '3.13\n/usr/bin/python3.13\n', '');
-          return;
-        }
-        callback(new Error('missing'), '', 'missing');
-      }
-    );
+    mockExecResponses({
+      'pipx --version': '1.8.0',
+      'python3.13 -c': '3.13\n/usr/bin/python3.13\n'
+    });
 
     const candidates = await new McpDetector().detectInstallers();
 
@@ -376,24 +361,10 @@ describe('McpDetector.generateMcpJson', () => {
   });
 
   it('#620 does not offer pipx when only an incompatible Python is available', async () => {
-    execFileMock.mockImplementation(
-      (
-        command: string,
-        args: string[],
-        _opts: unknown,
-        callback: (err: Error | null, stdout: string, stderr: string) => void
-      ) => {
-        if (command === 'pipx' && args[0] === '--version') {
-          callback(null, '1.8.0', '');
-          return;
-        }
-        if (command === 'python3' && args[0] === '-c') {
-          callback(null, '3.12\n/usr/bin/python3\n', '');
-          return;
-        }
-        callback(new Error('missing'), '', 'missing');
-      }
-    );
+    mockExecResponses({
+      'pipx --version': '1.8.0',
+      'python3 -c': '3.12\n/usr/bin/python3\n'
+    });
 
     const candidates = await new McpDetector().detectInstallers();
 
@@ -401,24 +372,10 @@ describe('McpDetector.generateMcpJson', () => {
   });
 
   it('#620 discovers a compatible python -m pip as installer fallback', async () => {
-    execFileMock.mockImplementation(
-      (
-        command: string,
-        args: string[],
-        _opts: unknown,
-        callback: (err: Error | null, stdout: string, stderr: string) => void
-      ) => {
-        if (command === 'python' && args[0] === '-c') {
-          callback(null, '3.13\npython\n', '');
-          return;
-        }
-        if (command === 'python' && args[0] === '-m') {
-          callback(null, 'pip 25', '');
-          return;
-        }
-        callback(new Error('missing'), '', 'missing');
-      }
-    );
+    mockExecResponses({
+      'python -c': '3.13\npython\n',
+      'python -m': 'pip 25'
+    });
 
     const candidates = await new McpDetector().detectInstallers();
 

--- a/apps/vscode-extension/test/unit/vscodeMock.ts
+++ b/apps/vscode-extension/test/unit/vscodeMock.ts
@@ -202,7 +202,8 @@ export const lm = {
 
 export const tasks = {
   registerTaskProvider: jest.fn(() => createDisposable()),
-  executeTask: jest.fn()
+  executeTask: jest.fn(),
+  onDidEndTaskProcess: jest.fn(() => createDisposable())
 };
 
 export const env = {
@@ -217,8 +218,7 @@ export const l10n = {
   t: jest.fn(
     (
       messageOrOptions:
-        | string
-        | { message: string; args?: Record<string, unknown> },
+        string | { message: string; args?: Record<string, unknown> },
       ...args: unknown[]
     ): string => {
       if (typeof messageOrOptions === 'string') {


### PR DESCRIPTION
## Summary

Fix the KiCad Studio `kicad-mcp-pro` installer so it does not offer installation commands that are known to use an incompatible Python runtime.

The installer now probes compatible Python runtimes, pins `pipx`/pip fallback commands to Python >=3.13, prefers `uv` when available, reports actionable prerequisite guidance when no safe installer exists, and refreshes MCP detection only after a successful install task.

## Linked issue

Closes #620

## Type of change

- [x] type:bug
- [ ] type:feature
- [ ] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

Regression coverage includes `#620` in the installer-detection and command tests and was developed red -> green for the reproduced Python 3.12/pipx failure.

- `pnpm --filter kicadstudiokit run check` — passed on final candidate: 986 unit, 128 coverage-ratchet, 12 security, 76 accessibility tests; lint, typecheck, production build, VSIX package and package validation passed.
- `pnpm --filter kicadstudiokit run test:integration` under the authorized desktop X session — 26 Extension Development Host integration tests passed on VS Code 1.122.0.
- Focused `mcpDetector` + `mcpCommandsTrust` regression suite — 36 tests passed on final commit.
- Repository pre-push gate — passed after using an isolated PATH with Python 3.13.15 and repository-pinned `uv 0.11.32`; this includes compatibility, Codecov policy, supply-chain, governance, branch-protection, security-tooling, dev-doctor, release and workspace checks.
- `test:integration:real:host` Extension Host harness started successfully, but its real-server body reported `uv is not available on PATH` in the original host environment and therefore skipped the server spawn. This is recorded as a limitation rather than counted as real-pair evidence.

## Protocol / MCP impact

- [x] Not applicable; reason: installer/runtime selection and post-install detection only. No MCP tool/schema, protocol negotiation, transport, server-info or compatibility metadata changes.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [ ] Docs updated
- [ ] Release notes considered for both products
- [x] Backward compatibility impact documented

Backward compatibility: existing `uv`, `pipx`, and Python fallback installation paths remain available when they satisfy the declared Python floor; unsupported Python runtimes are no longer presented as viable one-click installers.

## Repository maturity impact

- [x] No repository maturity impact
- [ ] Documentation/community health updated
- [ ] CI/quality/release process updated
- [ ] Governance/security/supply-chain process updated
- [ ] Manual GitHub setting or maintainer action required and documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Review evidence

- [ ] Completed with findings; every finding is triaged below
- [ ] Completed with no findings
- [x] Unavailable; reason and compensating evidence recorded below
- [ ] Not applicable; reason:

- [ ] Low
- [x] Medium
- [ ] High

Bot and agent triage:

- [x] Every bot and agent comment is classified as actionable, resolved, informational, duplicate, or unavailable
- [x] No actionable finding remains unresolved
- [x] Unavailable notices are recorded as unavailable, not completed review

Compensating evidence:

- [ ] Focused second-agent review
- [x] Architecture/security checklist
- [x] Additional regression tests
- [x] Documented manual review
- [ ] Not required because review completed, was not applicable, or change risk is low

Evidence links/notes:

Final-head triage: SonarCloud's initial test-duplication finding was resolved by commit `58c490d`; the final SonarCloud quality gate passes with 0 new issues and 0.0% new-code duplication. Codecov patch coverage/bundle reports are informational under the checked-in policy and their checks pass. DeepScan, Semgrep, CodeQL, Trivy, Socket Security, dependency review, and Mergify summary report no actionable findings. No review threads or automated code-review findings were produced; review remains recorded as unavailable with the compensating evidence above.

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue in the test name or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [ ] CHANGELOG entry (if user-visible)
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
- [x] Developer Certificate of Origin sign-off is present on non-trivial commits (`git commit -s`) or not applicable with rationale
- [x] Meets the Definition of Done for this change type; not-applicable items are justified

CHANGELOG is intentionally not edited in this implementation PR because the repository's Release Please flow owns product changelog/version updates in the release PR.

