### PR TITLE
fix(kicad-studio): make MCP installer Python-aware

### DIFF
--- a/apps/vscode-extension/src/commands/mcpCommands.ts
+++ b/apps/vscode-extension/src/commands/mcpCommands.ts
@@ -4,6 +4,7 @@ import { McpDetector } from '../mcp/mcpDetector';
 import { DesignIntentPanel } from '../mcp/designIntentPanel';
 import { DrcRuleEditorPanel } from '../drc/drcRuleEditorPanel';
 import { registerTrustedCommand } from '../utils/workspaceTrust';
+import { DOCUMENTATION_URLS } from '../documentation/documentationUrls';
 import {
   showStructuredError,
   structuredErrorFromUnknown,
@@ -11,6 +12,26 @@ import {
 } from '../utils/notifications';
 import type { CommandServices } from './types';
 import type { FixItem } from '../types';
+
+function createTaskProcessCompletion(task: vscode.Task): {
+  promise: Promise<number | undefined>;
+  dispose(): void;
+} {
+  let disposable: vscode.Disposable | undefined;
+  const promise = new Promise<number | undefined>((resolve) => {
+    disposable = vscode.tasks.onDidEndTaskProcess((event) => {
+      if (event.execution.task !== task) {
+        return;
+      }
+      disposable?.dispose();
+      resolve(event.exitCode);
+    });
+  });
+  return {
+    promise,
+    dispose: () => disposable?.dispose()
+  };
+}
 
 /**
  * Register MCP integration commands.
@@ -163,6 +184,19 @@ export function registerMcpCommands(
       async () => {
         const detector = new McpDetector();
         const candidates = await detector.detectInstallers();
+        if (candidates.length === 0) {
+          const action = await vscode.window.showWarningMessage(
+            'kicad-mcp-pro requires Python 3.13 or newer. Install Python 3.13+ or uv, then retry.',
+            'Open install docs'
+          );
+          if (action === 'Open install docs') {
+            await vscode.env.openExternal(
+              vscode.Uri.parse(DOCUMENTATION_URLS.mcpServerInstallation)
+            );
+          }
+          return;
+        }
+
         const choice = await vscode.window.showQuickPick(
           [
             ...candidates.map((candidate) => ({
@@ -203,15 +237,25 @@ export function registerMcpCommands(
             choice.candidate.args
           )
         );
-        await vscode.tasks.executeTask(task);
-        const followUp = await vscode.window.showInformationMessage(
-          'Install task started. Re-run MCP detection when it finishes?',
-          'Detect',
-          'Later'
-        );
-        if (followUp === 'Detect') {
-          await services.refreshMcpState();
+        const completion = createTaskProcessCompletion(task);
+        let exitCode: number | undefined;
+        try {
+          await vscode.tasks.executeTask(task);
+          exitCode = await completion.promise;
+        } finally {
+          completion.dispose();
         }
+        if (exitCode === 0) {
+          await services.refreshMcpState();
+          void vscode.window.showInformationMessage(
+            'kicad-mcp-pro installation completed. MCP detection refreshed.'
+          );
+          return;
+        }
+
+        void vscode.window.showErrorMessage(
+          'kicad-mcp-pro installation failed. Review the install task output and retry after resolving the prerequisite.'
+        );
       },
       'Install kicad-mcp-pro'
     ),
@@ -223,9 +267,7 @@ export function registerMcpCommands(
 
     vscode.commands.registerCommand(COMMANDS.openMcpUpgradeGuide, () =>
       vscode.env.openExternal(
-        vscode.Uri.parse(
-          'https://github.com/oaslananka/kicad-studio-kit#installation'
-        )
+        vscode.Uri.parse(DOCUMENTATION_URLS.mcpServerInstallation)
       )
     ),
 

--- a/apps/vscode-extension/src/documentation/documentationUrls.ts
+++ b/apps/vscode-extension/src/documentation/documentationUrls.ts
@@ -1,6 +1,8 @@
 export const DOCUMENTATION_URLS = {
   mcpIntegration:
     'https://github.com/oaslananka/kicad-studio-kit/blob/main/apps/vscode-extension/docs/INTEGRATION.md',
+  mcpServerInstallation:
+    'https://oaslananka.github.io/kicad-mcp-pro/tutorials/getting-started/',
   kicadCliInstallation:
     'https://github.com/oaslananka/kicad-studio-kit/blob/main/docs/install.md'
 } as const;

--- a/apps/vscode-extension/src/mcp/mcpDetector.ts
+++ b/apps/vscode-extension/src/mcp/mcpDetector.ts
@@ -20,6 +20,30 @@ export interface McpDoctorResult {
   error?: string | undefined;
 }
 
+const MCP_MINIMUM_PYTHON = { major: 3, minor: 13 } as const;
+const PYTHON_RUNTIME_SCRIPT =
+  'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}"); print(sys.executable)';
+
+interface PythonRuntimeProbe {
+  command: string;
+  prefixArgs: string[];
+}
+
+interface CompatiblePythonRuntime {
+  executable: string;
+  version: string;
+}
+
+const PYTHON_RUNTIME_PROBES: readonly PythonRuntimeProbe[] = [
+  { command: 'python3.13', prefixArgs: [] },
+  { command: 'python3.14', prefixArgs: [] },
+  { command: 'python3', prefixArgs: [] },
+  { command: 'python', prefixArgs: [] },
+  { command: 'py', prefixArgs: ['-3.13'] },
+  { command: 'py', prefixArgs: ['-3.14'] },
+  { command: 'py', prefixArgs: ['-3'] }
+];
+
 function runExecFile(
   command: string,
   args: string[],
@@ -64,6 +88,44 @@ async function run(
     const message = error instanceof Error ? error.message : String(error);
     return { ok: false, output: message };
   }
+}
+
+function isCompatiblePythonVersion(version: string): boolean {
+  const match = /^(\d+)\.(\d+)$/.exec(version.trim());
+  if (!match) {
+    return false;
+  }
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  return (
+    major > MCP_MINIMUM_PYTHON.major ||
+    (major === MCP_MINIMUM_PYTHON.major && minor >= MCP_MINIMUM_PYTHON.minor)
+  );
+}
+
+async function detectCompatiblePythonRuntime(): Promise<
+  CompatiblePythonRuntime | undefined
+> {
+  for (const probe of PYTHON_RUNTIME_PROBES) {
+    const result = await run(probe.command, [
+      ...probe.prefixArgs,
+      '-c',
+      PYTHON_RUNTIME_SCRIPT
+    ]);
+    if (!result.ok) {
+      continue;
+    }
+
+    const [version, executable] = result.output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (!version || !executable || !isCompatiblePythonVersion(version)) {
+      continue;
+    }
+    return { executable, version };
+  }
+  return undefined;
 }
 
 export class McpDetector {
@@ -321,45 +383,41 @@ export class McpDetector {
 
   async detectInstallers(): Promise<McpInstallerCandidate[]> {
     const candidates: McpInstallerCandidate[] = [];
-    if (
-      (await run('uvx', ['--version'])).ok ||
-      (await run('uv', ['--version'])).ok
-    ) {
+    if ((await run('uv', ['--version'])).ok) {
       candidates.push({
         id: 'uvx',
         label: 'uv tool install kicad-mcp-pro',
         description: 'Recommended isolated Python tool install',
         command: 'uv',
-        args: ['tool', 'install', 'kicad-mcp-pro']
+        args: ['tool', 'install', '--python', '3.13', 'kicad-mcp-pro']
       });
     }
-    if ((await run('pipx', ['--version'])).ok) {
+
+    const pythonRuntime = await detectCompatiblePythonRuntime();
+    if ((await run('pipx', ['--version'])).ok && pythonRuntime) {
       candidates.push({
         id: 'pipx',
         label: 'pipx install kicad-mcp-pro',
-        description: 'Install as an isolated Python app with pipx',
+        description: `Install with Python ${pythonRuntime.version}`,
         command: 'pipx',
-        args: ['install', 'kicad-mcp-pro']
+        args: ['install', '--python', pythonRuntime.executable, 'kicad-mcp-pro']
       });
     }
-    for (const command of ['pip', 'pip3', 'python', 'python3']) {
-      const result = await run(
-        command,
-        command.startsWith('python')
-          ? ['-m', 'pip', '--version']
-          : ['--version']
-      );
-      if (result.ok) {
+
+    if (pythonRuntime) {
+      const pipResult = await run(pythonRuntime.executable, [
+        '-m',
+        'pip',
+        '--version'
+      ]);
+      if (pipResult.ok) {
         candidates.push({
           id: 'pip',
-          label: `${command} install --user kicad-mcp-pro`,
-          description: 'Fallback user-site Python install',
-          command,
-          args: command.startsWith('python')
-            ? ['-m', 'pip', 'install', '--user', 'kicad-mcp-pro']
-            : ['install', '--user', 'kicad-mcp-pro']
+          label: `${pythonRuntime.executable} -m pip install --user kicad-mcp-pro`,
+          description: `Fallback user-site install with Python ${pythonRuntime.version}`,
+          command: pythonRuntime.executable,
+          args: ['-m', 'pip', 'install', '--user', 'kicad-mcp-pro']
         });
-        break;
       }
     }
     return candidates;

--- a/apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts
+++ b/apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts
@@ -5,6 +5,7 @@ import {
   commands,
   createExtensionContextMock,
   env,
+  tasks,
   window,
   workspace
 } from './vscodeMock';
@@ -56,6 +57,48 @@ describe('MCP command workspace trust guards', () => {
       throw new Error(`Command was not registered: ${commandId}`);
     }
     return entry[1] as (...args: unknown[]) => unknown;
+  }
+
+  const pipxInstallCandidate = {
+    id: 'pipx' as const,
+    label: 'pipx install kicad-mcp-pro',
+    description: 'Install with Python 3.13',
+    command: 'pipx',
+    args: ['install', '--python', '/usr/bin/python3.13', 'kicad-mcp-pro']
+  };
+
+  function mockInstallerSelection(): void {
+    jest
+      .spyOn(McpDetector.prototype, 'detectInstallers')
+      .mockResolvedValue([pipxInstallCandidate]);
+    (window.showQuickPick as jest.Mock).mockResolvedValue({
+      label: pipxInstallCandidate.label,
+      description: pipxInstallCandidate.description,
+      candidate: pipxInstallCandidate
+    });
+  }
+
+  function mockInstallerTaskExit(
+    exitCode: number,
+    timing: 'microtask' | 'immediate' = 'microtask'
+  ): void {
+    let endListener:
+      | ((event: { execution: { task: unknown }; exitCode: number }) => void)
+      | undefined;
+    (tasks.onDidEndTaskProcess as jest.Mock).mockImplementation((listener) => {
+      endListener = listener;
+      return { dispose: jest.fn() };
+    });
+    (tasks.executeTask as jest.Mock).mockImplementation(async (task) => {
+      const execution = { task };
+      const emit = () => endListener?.({ execution, exitCode });
+      if (timing === 'immediate') {
+        emit();
+      } else {
+        queueMicrotask(emit);
+      }
+      return execution;
+    });
   }
 
   it('blocks mutating fix queue commands in untrusted workspaces', async () => {
@@ -124,6 +167,74 @@ describe('MCP command workspace trust guards', () => {
     await registeredHandler(COMMANDS.setupMcpIntegration)();
 
     expect(commands.executeCommand).toHaveBeenCalledWith(COMMANDS.installMcp);
+  });
+
+  it('#620 shows Python prerequisite guidance when no safe installer exists', async () => {
+    registerWithServices();
+    jest.spyOn(McpDetector.prototype, 'detectInstallers').mockResolvedValue([]);
+    (window.showWarningMessage as jest.Mock).mockResolvedValue(undefined);
+
+    await registeredHandler(COMMANDS.installMcp)();
+
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Python 3.13'),
+      'Open install docs'
+    );
+    expect(tasks.executeTask).not.toHaveBeenCalled();
+  });
+
+  it('#620 opens the current MCP server getting-started guide from prerequisite guidance', async () => {
+    registerWithServices();
+    jest.spyOn(McpDetector.prototype, 'detectInstallers').mockResolvedValue([]);
+    (window.showWarningMessage as jest.Mock).mockResolvedValue(
+      'Open install docs'
+    );
+
+    await registeredHandler(COMMANDS.installMcp)();
+
+    expect(env.openExternal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fsPath:
+          'https://oaslananka.github.io/kicad-mcp-pro/tutorials/getting-started/'
+      })
+    );
+  });
+
+  it('#620 refreshes MCP state automatically after a successful install task', async () => {
+    const services = registerWithServices();
+    mockInstallerSelection();
+    mockInstallerTaskExit(0);
+
+    await registeredHandler(COMMANDS.installMcp)();
+
+    expect(tasks.onDidEndTaskProcess).toHaveBeenCalled();
+    expect(services.refreshMcpState).toHaveBeenCalledTimes(1);
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('installation completed')
+    );
+  });
+
+  it('#620 reports a failed install task without refreshing MCP state', async () => {
+    const services = registerWithServices();
+    mockInstallerSelection();
+    mockInstallerTaskExit(1);
+
+    await registeredHandler(COMMANDS.installMcp)();
+
+    expect(services.refreshMcpState).not.toHaveBeenCalled();
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('installation failed')
+    );
+  });
+
+  it('#620 observes installer completion even when the task exits before executeTask resolves', async () => {
+    const services = registerWithServices();
+    mockInstallerSelection();
+    mockInstallerTaskExit(0, 'immediate');
+
+    await registeredHandler(COMMANDS.installMcp)();
+
+    expect(services.refreshMcpState).toHaveBeenCalledTimes(1);
   });
 
   it('stops MCP setup when no workspace folder is open', async () => {

--- a/apps/vscode-extension/test/unit/mcpDetector.test.ts
+++ b/apps/vscode-extension/test/unit/mcpDetector.test.ts
@@ -35,6 +35,25 @@ describe('McpDetector.generateMcpJson', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
+  function mockExecResponses(responses: Record<string, string>): void {
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        args: string[],
+        _opts: unknown,
+        callback: (err: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        const key = `${command} ${args[0] ?? ''}`;
+        const stdout = responses[key];
+        if (stdout === undefined) {
+          callback(new Error('missing'), '', 'missing');
+          return;
+        }
+        callback(null, stdout, '');
+      }
+    );
+  }
+
   it('creates a stdio MCP configuration for uvx installs', async () => {
     const detector = new McpDetector();
 
@@ -300,21 +319,13 @@ describe('McpDetector.generateMcpJson', () => {
     );
   });
 
-  it('discovers installer candidates in uvx, pipx, then pip order', async () => {
-    execFileMock.mockImplementation(
-      (
-        command: string,
-        _args: string[],
-        _opts: unknown,
-        callback: (err: Error | null, stdout: string, stderr: string) => void
-      ) => {
-        if (['uvx', 'pipx', 'pip'].includes(command)) {
-          callback(null, `${command} version`, '');
-        } else {
-          callback(new Error('missing'), '', 'missing');
-        }
-      }
-    );
+  it('#620 discovers installer candidates in uv, pipx, then pip order', async () => {
+    mockExecResponses({
+      'uv --version': 'uv 0.8.0',
+      'pipx --version': 'pipx 1.8.0',
+      'python3.13 -c': '3.13\n/usr/bin/python3.13\n',
+      '/usr/bin/python3.13 -m': 'pip 25.2'
+    });
 
     const candidates = await new McpDetector().detectInstallers();
 
@@ -323,24 +334,48 @@ describe('McpDetector.generateMcpJson', () => {
       'pipx',
       'pip'
     ]);
-    expect(candidates[0]?.args).toEqual(['tool', 'install', 'kicad-mcp-pro']);
+    expect(candidates[0]?.args).toEqual([
+      'tool',
+      'install',
+      '--python',
+      '3.13',
+      'kicad-mcp-pro'
+    ]);
   });
 
-  it('discovers python -m pip as installer fallback', async () => {
-    execFileMock.mockImplementation(
-      (
-        command: string,
-        _args: string[],
-        _opts: unknown,
-        callback: (err: Error | null, stdout: string, stderr: string) => void
-      ) => {
-        if (command === 'python') {
-          callback(null, 'pip 25', '');
-        } else {
-          callback(new Error('missing'), '', 'missing');
-        }
-      }
+  it('#620 pins pipx to a compatible Python interpreter', async () => {
+    mockExecResponses({
+      'pipx --version': '1.8.0',
+      'python3.13 -c': '3.13\n/usr/bin/python3.13\n'
+    });
+
+    const candidates = await new McpDetector().detectInstallers();
+
+    expect(candidates).toContainEqual(
+      expect.objectContaining({
+        id: 'pipx',
+        command: 'pipx',
+        args: ['install', '--python', '/usr/bin/python3.13', 'kicad-mcp-pro']
+      })
     );
+  });
+
+  it('#620 does not offer pipx when only an incompatible Python is available', async () => {
+    mockExecResponses({
+      'pipx --version': '1.8.0',
+      'python3 -c': '3.12\n/usr/bin/python3\n'
+    });
+
+    const candidates = await new McpDetector().detectInstallers();
+
+    expect(candidates.some((candidate) => candidate.id === 'pipx')).toBe(false);
+  });
+
+  it('#620 discovers a compatible python -m pip as installer fallback', async () => {
+    mockExecResponses({
+      'python -c': '3.13\npython\n',
+      'python -m': 'pip 25'
+    });
 
     const candidates = await new McpDetector().detectInstallers();
 

--- a/apps/vscode-extension/test/unit/vscodeMock.ts
+++ b/apps/vscode-extension/test/unit/vscodeMock.ts
@@ -202,7 +202,8 @@ export const lm = {
 
 export const tasks = {
   registerTaskProvider: jest.fn(() => createDisposable()),
-  executeTask: jest.fn()
+  executeTask: jest.fn(),
+  onDidEndTaskProcess: jest.fn(() => createDisposable())
 };
 
 export const env = {
@@ -217,8 +218,7 @@ export const l10n = {
   t: jest.fn(
     (
       messageOrOptions:
-        | string
-        | { message: string; args?: Record<string, unknown> },
+        string | { message: string; args?: Record<string, unknown> },
       ...args: unknown[]
     ): string => {
       if (typeof messageOrOptions === 'string') {


### PR DESCRIPTION
## Summary

Fix the KiCad Studio `kicad-mcp-pro` installer so it does not offer installation commands that are known to use an incompatible Python runtime.

The installer now probes compatible Python runtimes, pins `pipx`/pip fallback commands to Python >=3.13, prefers `uv` when available, reports actionable prerequisite guidance when no safe installer exists, and refreshes MCP detection only after a successful install task.

This PR replaces #629 with the exact same source/test tree as its final reviewed head, but on a single GitHub-verified commit so the repository's `required_signatures` ruleset can be satisfied without rewriting or force-pushing the original branch.

## Linked issue

Closes #620

## Type of change

- [x] type:bug
- [ ] type:feature
- [ ] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

Regression coverage includes `#620` in the installer-detection and command tests and was developed red -> green for the reproduced Python 3.12/pipx failure.

Fresh verification on the signed tree (`22f15ed`) before opening this PR:

- `pnpm --filter kicadstudiokit run check` — exit 0.
- Unit suite: 125 suites / 986 tests passed.
- Critical coverage ratchet: 10 suites / 128 tests passed.
- Security suite: 12 tests passed.
- Accessibility suite: 76 tests passed.
- Format, ESLint, TypeScript typecheck, production build, VSIX packaging, package validation, and VSIX metadata validation passed.
- VSIX identity verified as `oaslananka.kicadstudiokit@1.10.1`.

Evidence inherited from the exact same source/test tree on #629 and to be re-verified by this PR's CI:

- VS Code Extension Development Host integration: 26 tests passed.
- GitHub real-pair compatibility passed against the current server artifact.
- SonarCloud Quality Gate passed after the test-fixture duplication finding was fixed at source; new-code duplication was 0.0% and there were 0 new issues/security hotspots.
- CodeQL, Semgrep, Trivy, Gitleaks, dependency review, Socket Security, DeepScan, mutation, performance budgets, and all Linux/macOS/Windows extension lanes passed.

## Protocol / MCP impact

- [x] Not applicable; installer/runtime selection and post-install detection only. No MCP tool/schema, protocol negotiation, transport, server-info, or compatibility metadata changes.
- [x] Backward compatibility impact documented

Backward compatibility: existing `uv`, `pipx`, and Python fallback installation paths remain available when they satisfy the declared Python floor; unsupported Python runtimes are no longer presented as viable one-click installers.

## Repository maturity impact

- [x] No repository maturity impact

## Automation / review evidence

- [x] Review-thread gate checked; no unresolved review threads existed on the final #629 tree.
- [x] No publish workflow was triggered.
- [x] No secrets were printed or changed.
- [x] Sonar's original duplication finding was actionable and resolved at source before this signed replacement.
- [x] Codecov patch coverage report was reviewed; configured coverage gates passed and no quality threshold was weakened.
- [x] No actionable bot/reviewer finding remained on the final #629 tree.

This replacement will remain unmerged until its own latest-head required checks and security/quality integrations complete successfully.

## Checklist

- [x] Tests pass locally on the signed tree
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue
- [x] Docs/install-help target updated where user-visible
- [x] No new committed secrets or build artifacts
- [x] Commit is GitHub verified and includes DCO `Signed-off-by`
- [x] CHANGELOG intentionally left to Release Please, per repository release workflow
