### PR TITLE
chore(kicad-studio): separate compatibility support axes

### DIFF
--- a/.github/workflows/cross-repo-compatibility.yml
+++ b/.github/workflows/cross-repo-compatibility.yml
@@ -134,8 +134,23 @@ jobs:
         run: |
           corepack pnpm run check:mcp-2026-rc-artifact -- --version "$KICAD_MCP_PRO_VERSION"
 
-      # ── C. Studio compatibility checks ──────────────────────────────────
+      # ── C. Published BoardReadyOps contract ───────────────────────────────
+      - name: Resolve published BoardReadyOps version
+        id: boardreadyops-check
+        run: |
+          VERSION=$(npm view boardreadyops version --json | node -e "let s=''; process.stdin.on('data', c => s += c); process.stdin.on('end', () => { const v = JSON.parse(s); process.stdout.write(Array.isArray(v) ? v.at(-1) : v); });")
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::boardreadyops returned an invalid stable version from npm: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "✓ boardreadyops resolves from npm registry (v$VERSION)"
+
+      # ── D. Studio compatibility checks ──────────────────────────────────
       - name: Run check:compatibility-contract (compatibility contract validation)
+        env:
+          KICAD_MCP_PRO_PUBLISHED_VERSION: ${{ steps.pypi-check.outputs.pypi_version }}
+          BOARDREADYOPS_PUBLISHED_VERSION: ${{ steps.boardreadyops-check.outputs.version }}
         run: pnpm run check:compatibility-contract
 
       - name: Run compatibility summary script
@@ -143,10 +158,11 @@ jobs:
         run: |
           node scripts/check-cross-repo-compatibility.mjs
 
-      # ── D. Summary ──────────────────────────────────────────────────────
+      # ── E. Summary ──────────────────────────────────────────────────────
       - name: Compatibility summary
         run: |
           echo "━━━ Cross-repo Compatibility Canary ━━━"
           echo "npm  @oaslananka/kicad-protocol-schemas: v${{ steps.npm-check.outputs.version }}"
           echo "PyPI kicad-mcp-pro:                     v${{ steps.pypi-check.outputs.pypi_version }}"
+          echo "npm  boardreadyops:                      v${{ steps.boardreadyops-check.outputs.version }}"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/apps/vscode-extension/src/cli/kicadCliSupport.ts
+++ b/apps/vscode-extension/src/cli/kicadCliSupport.ts
@@ -70,7 +70,7 @@ export function describeKiCadSupportLine(
     return {
       state: 'primary',
       label: `${cli.versionLabel} primary`,
-      detail: `Primary release-blocking KiCad line: ${KI_CAD_PRIMARY_RANGE}.`
+      detail: `Primary release-blocking KiCad CLI line: ${KI_CAD_PRIMARY_RANGE}. MCP support is evaluated separately.`
     };
   }
   if (major >= 11) {

--- a/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
+++ b/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
@@ -5,6 +5,32 @@ export const COMPATIBILITY_MATRIX = {
     supported: ['10.0.x', '9.x', '8.x'],
     deprecated: ['9.x', '8.x']
   },
+  supportAxes: {
+    studioCli: {
+      kicad: {
+        stable: ['10.0.x'],
+        deprecated: ['9.x', '8.x'],
+        preview: ['11.0.x'],
+        dropped: []
+      }
+    },
+    mcpServer: {
+      required: '>=3.5.2 <4.0.0',
+      recommended: '>=3.5.2 <4.0.0',
+      testedAgainst: '3.33.3'
+    },
+    mcpProtocol: {
+      active: '2025-11-25',
+      next: '2026-07-28',
+      activationState: 'blocked'
+    },
+    boardReadyOps: {
+      required: '>=1.2.0 <2.0.0',
+      testedAgainst: '1.35.0',
+      findingsSchema: 1,
+      evidenceBundleSchema: 2
+    }
+  },
   mcp: {
     protocolVersion: '2025-11-25',
     toolSchema: '1.0'
@@ -15,11 +41,11 @@ export const COMPATIBILITY_MATRIX = {
       compatibleMcpPro: {
         required: '>=3.5.2 <4.0.0',
         recommended: '>=3.5.2 <4.0.0',
-        testedAgainst: '3.9.2'
+        testedAgainst: '3.33.3'
       }
     },
     kicadMcpPro: {
-      version: '3.9.2',
+      version: '3.33.3',
       compatibleExtension: {
         required: '>=1.0.0 <2.0.0',
         testedAgainst: '1.10.1'

--- a/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
@@ -24,10 +24,7 @@ type McpToolsNode = {
 };
 
 type DashboardStatus =
-  | 'compatible'
-  | 'degraded'
-  | 'incompatible'
-  | 'disconnected';
+  'compatible' | 'degraded' | 'incompatible' | 'disconnected';
 
 type CompatibilityDashboard = {
   status: DashboardStatus;
@@ -1186,7 +1183,7 @@ function boardReadyOpsNode(status: {
       statusLabel,
       status.message ||
         (isOld
-          ? `BoardReadyOps version ${status.version ?? 'unknown'} is outside the required range ${COMPATIBILITY_MATRIX.supportAxes.boardReadyOps.required}. Install or upgrade BoardReadyOps before running readiness checks.`
+          ? `BoardReadyOps version ${status.version} is outside the required range ${COMPATIBILITY_MATRIX.supportAxes.boardReadyOps.required}. Install or upgrade BoardReadyOps before running readiness checks.`
           : undefined),
       statusIcon
     ),

--- a/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { execFile } from 'node:child_process';
+import semver from 'semver';
 import { COMMANDS, SETTINGS } from '../constants';
 import type {
   McpCapabilityCard,
@@ -9,6 +10,7 @@ import type {
 } from '../types';
 import type { McpConnectionAdapter } from './mcpToolAdapter';
 import { readConfiguredMcpProfile } from '../commands/mcpProfilePicker';
+import { COMPATIBILITY_MATRIX } from './compatibilityMatrix';
 
 type McpToolsNode = {
   label: string;
@@ -1108,16 +1110,14 @@ function isVersionDegraded(version: string): boolean {
   if (version === 'unknown') {
     return false;
   }
-  const match = version.match(/^v?(\d+)\.(\d+)\.(\d+)/);
-  if (!match) {
+  const normalized = semver.coerce(version)?.version;
+  if (!normalized) {
     return false;
   }
-  const major = parseInt(match[1] ?? '0', 10);
-  const minor = parseInt(match[2] ?? '0', 10);
-  if (major < 1 || (major === 1 && minor < 2)) {
-    return true;
-  }
-  return false;
+  return !semver.satisfies(
+    normalized,
+    COMPATIBILITY_MATRIX.supportAxes.boardReadyOps.required
+  );
 }
 
 function boardReadyOpsNode(status: {
@@ -1186,7 +1186,7 @@ function boardReadyOpsNode(status: {
       statusLabel,
       status.message ||
         (isOld
-          ? 'Please upgrade BoardReadyOps to v1.2.0 or newer.'
+          ? `BoardReadyOps version ${status.version ?? 'unknown'} is outside the required range ${COMPATIBILITY_MATRIX.supportAxes.boardReadyOps.required}. Install or upgrade BoardReadyOps before running readiness checks.`
           : undefined),
       statusIcon
     ),

--- a/apps/vscode-extension/test/unit/kicadCliSupport.test.ts
+++ b/apps/vscode-extension/test/unit/kicadCliSupport.test.ts
@@ -45,6 +45,15 @@ describe('kicadCliSupport', () => {
     );
   });
 
+  it('labels KiCad CLI support as independent from MCP support', () => {
+    const support = describeKiCadSupportLine({
+      version: '10.0.5',
+      versionLabel: 'KiCad 10.0.5'
+    });
+
+    expect(support.detail).toContain('MCP support is evaluated separately');
+  });
+
   it('reports feature availability from version line plus capability probes', () => {
     const features = buildKiCadFeatureSupport({
       cli: {

--- a/apps/vscode-extension/test/unit/mcpCompat.test.ts
+++ b/apps/vscode-extension/test/unit/mcpCompat.test.ts
@@ -11,7 +11,7 @@ describe('MCP compatibility helpers', () => {
     expect(MCP_COMPAT).toEqual({
       required: '>=3.5.2 <4.0.0',
       recommended: '>=3.5.2 <4.0.0',
-      testedAgainst: '3.9.2'
+      testedAgainst: '3.33.3'
     });
   });
 

--- a/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
@@ -447,6 +447,24 @@ describe('McpToolsProvider', () => {
       expect(healthItem.tooltip).toContain('>=1.2.0 <2.0.0');
     });
 
+    it('does not mark an unparseable BoardReadyOps version as an old-version failure', () => {
+      __setConfiguration({
+        'kicadstudio.boardReadyOps.enabled': true
+      });
+      const provider = providerForState(connectedState({ tools: [] }), {
+        installed: true,
+        version: 'dev-build',
+        healthy: true,
+        tools: ['bom.missing-mpn']
+      });
+      const broNode = child(provider.getChildren(), 'BoardReadyOps');
+      const healthItem = provider.getTreeItem(
+        child(provider.getChildren(broNode), 'Health')
+      );
+
+      expect(healthItem.description).toBe('healthy');
+    });
+
     it('handles degraded state due to unhealthy doctor checks', () => {
       __setConfiguration({
         'kicadstudio.boardReadyOps.enabled': true

--- a/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
@@ -427,6 +427,26 @@ describe('McpToolsProvider', () => {
       expect(healthItem.tooltip).toContain('upgrade BoardReadyOps');
     });
 
+    it('uses the compatibility contract for the minimum BoardReadyOps version', () => {
+      __setConfiguration({
+        'kicadstudio.boardReadyOps.enabled': true
+      });
+      const provider = providerForState(connectedState({ tools: [] }), {
+        installed: true,
+        version: '1.1.9',
+        healthy: true,
+        tools: ['bom.missing-mpn']
+      });
+      const children = provider.getChildren();
+      const broNode = child(children, 'BoardReadyOps');
+      const healthItem = provider.getTreeItem(
+        child(provider.getChildren(broNode), 'Health')
+      );
+
+      expect(healthItem.description).toBe('degraded (old version)');
+      expect(healthItem.tooltip).toContain('>=1.2.0 <2.0.0');
+    });
+
     it('handles degraded state due to unhealthy doctor checks', () => {
       __setConfiguration({
         'kicadstudio.boardReadyOps.enabled': true

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -630,6 +630,40 @@ python:
     - "3.13"
     - "3.14"
 
+supportAxes:
+  studioCli:
+    kicad:
+      stable: ["10.0.x"]
+      deprecated: ["9.x", "8.x"]
+      preview: ["11.0.x"]
+      dropped: []
+    remediation: "Install/configure a KiCad CLI line supported by Studio; MCP availability is evaluated separately."
+  mcpServer:
+    package: "kicad-mcp-pro"
+    required: ">=3.5.2 <4.0.0"
+    recommended: ">=3.5.2 <4.0.0"
+    testedAgainst:
+      version: "3.33.3"
+      registry: "pypi"
+      source: "https://pypi.org/project/kicad-mcp-pro/3.33.3/"
+    remediation: "Install a published kicad-mcp-pro version inside the supported range and re-run compatibility diagnostics."
+  mcpProtocol:
+    active: "2025-11-25"
+    next: "2026-07-28"
+    activationState: "blocked"
+    remediation: "Use a server that negotiates the active protocol; protocol activation remains evidence-gated by ADR 0008."
+  boardReadyOps:
+    package: "boardreadyops"
+    required: ">=1.2.0 <2.0.0"
+    testedAgainst:
+      version: "1.35.0"
+      registry: "npm"
+      source: "https://www.npmjs.com/package/boardreadyops/v/1.35.0"
+    reports:
+      findingsSchema: 1
+      evidenceBundleSchema: 2
+    remediation: "Install or upgrade the published BoardReadyOps CLI to a compatible version before running readiness checks."
+
 runtimePolicy:
   reviewed: "2026-07-20"
   sources:
@@ -679,7 +713,7 @@ products:
     compatibleMcpPro:
       required: ">=3.5.2 <4.0.0"
       recommended: ">=3.5.2 <4.0.0"
-      testedAgainst: "3.9.2"
+      testedAgainst: "3.33.3"
 
 featureGates:
   projectDiscovery:

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -7,4 +7,4 @@ documentation site always follows the same release history as the repository.
 | --- | ---: | --- |
 | Monorepo | `1.0.0` | [Root changelog](root.md) |
 | KiCad Studio extension | `1.10.1` | [Extension changelog](kicad-studio.md) |
-| kicad-mcp-pro Python server | `3.9.2` | [MCP server changelog](kicad-mcp-pro.md) |
+| kicad-mcp-pro Python server | `3.33.3` | [MCP server changelog](kicad-mcp-pro.md) |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,6 +1,6 @@
 # Integration
 
-KiCad Studio discovers `kicad-mcp-pro` from `uvx`, direct executables, `pipx`, or `pip`. The supported server range is `>=3.5.2 <4.0.0`; the tested server version is `3.9.2`.
+KiCad Studio discovers `kicad-mcp-pro` from `uvx`, direct executables, `pipx`, or `pip`. The supported server range is `>=3.5.2 <4.0.0`; the tested server version is `3.33.3`.
 
 Documentation URLs use the canonical Pages site:
 

--- a/docs/mcp/api-reference.md
+++ b/docs/mcp/api-reference.md
@@ -10,7 +10,7 @@ and `compatibility.yaml`. Refresh with `corepack pnpm run docs:generate`.
 | MCP protocol version | `2025-11-25` |
 | Tool schema version | `1.0` |
 | Registry schema version | `2025-12-11` |
-| Server package version | `3.9.2` |
+| Server package version | `3.33.3` |
 
 ## Server Info Fields
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -47,6 +47,25 @@ Machine-maintained from `compatibility.yaml`. Refresh with
 
 <!-- docs-site:compatibility:end -->
 
+## Independent Support Axes
+
+KiCad Studio evaluates four compatibility axes independently. A green KiCad CLI
+line does **not** imply that MCP integration or BoardReadyOps is available. The
+authoritative values live under `supportAxes` in `compatibility.yaml`, and the
+cross-repository gate compares tested-pair values with published registry
+artifacts.
+
+| Axis | Current contract | Evidence / remediation |
+| --- | --- | --- |
+| Studio CLI / KiCad | stable `10.0.x`; deprecated `9.x`, `8.x`; preview `11.0.x`; no dropped lines | CLI support is capability-probed. If unsupported, install/configure a supported `kicad-cli`. MCP is evaluated separately. |
+| MCP server product | required/recommended `>=3.5.2 <4.0.0`; tested against published `kicad-mcp-pro` `3.33.3` | PyPI is the published-artifact source. Install a server inside the supported range and re-run diagnostics. |
+| MCP protocol | active `2025-11-25`; next `2026-07-28`; activation `blocked` | Protocol activation is independent from server semver and remains gated by ADR 0008 evidence. |
+| BoardReadyOps | required `>=1.2.0 <2.0.0`; tested against npm `1.35.0`; findings schema `1`; evidence bundle schema `2` | npm is the published-artifact source. Upgrade the CLI when the detected version is outside the supported range. |
+
+This split is deliberate: Studio can continue to offer CLI/viewer workflows for a
+KiCad line even when the installed MCP server is unsupported, and an MCP server
+version can remain in-range while protocol activation is still blocked.
+
 ## MCP Compatibility Contract
 
 The product version and runtime ranges above describe the **VS Code extension**,

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -7,7 +7,7 @@ Refresh with `corepack pnpm run docs:generate`.
 | --- | --- |
 | Monorepo baseline | `1.0.0` |
 | KiCad Studio extension | `1.10.1` |
-| kicad-mcp-pro Python server | `3.9.2` |
+| kicad-mcp-pro Python server | `3.33.3` |
 | VS Code engine | `^1.101.0` |
 | Node | `>=24.11.0 <25` |
 | pnpm | `>=11.0.0 <12` |

--- a/scripts/check-compatibility-contract.mjs
+++ b/scripts/check-compatibility-contract.mjs
@@ -179,6 +179,9 @@ export function validateEmbeddedExtensionCompatibilityMatrix({
     mcpTestedAgainst: compatibleMcpPro.testedAgainst,
     kicadMcpProVersion: compatibleMcpPro.testedAgainst,
     compatibleExtensionTestedAgainst: extensionPackage.version,
+    boardReadyOpsRequired: compatibility.supportAxes?.boardReadyOps?.required,
+    boardReadyOpsTestedAgainst:
+      compatibility.supportAxes?.boardReadyOps?.testedAgainst?.version,
   };
 
   const actualValues = {
@@ -234,6 +237,18 @@ export function validateEmbeddedExtensionCompatibilityMatrix({
       matrixSource,
       /compatibleExtension:\s*\{[\s\S]*?testedAgainst:\s*'([^']+)'/u,
       "products.kicadMcpPro.compatibleExtension.testedAgainst",
+      errors,
+    ),
+    boardReadyOpsRequired: extractTsStringLiteral(
+      matrixSource,
+      /boardReadyOps:\s*\{[\s\S]*?required:\s*'([^']+)'/u,
+      "supportAxes.boardReadyOps.required",
+      errors,
+    ),
+    boardReadyOpsTestedAgainst: extractTsStringLiteral(
+      matrixSource,
+      /boardReadyOps:\s*\{[\s\S]*?testedAgainst:\s*'([^']+)'/u,
+      "supportAxes.boardReadyOps.testedAgainst",
       errors,
     ),
   };
@@ -456,6 +471,165 @@ export function validateKiCadPatchBaseline({
   return errors;
 }
 
+function validateStudioCliAxis({ compatibility, cli }) {
+  const errors = [];
+  const stable = Array.isArray(cli?.stable) ? cli.stable : [];
+  if (stable.length !== 1 || stable[0] !== compatibility?.kicad?.primary) {
+    errors.push(
+      `supportAxes.studioCli.kicad.stable must contain only kicad.primary (${String(compatibility?.kicad?.primary)})`,
+    );
+  }
+  for (const state of ["stable", "deprecated", "preview", "dropped"]) {
+    if (!Array.isArray(cli?.[state])) {
+      errors.push(`supportAxes.studioCli.kicad.${state} must be an array`);
+    }
+  }
+  const lifecycleRanges = [
+    "stable",
+    "deprecated",
+    "preview",
+    "dropped",
+  ].flatMap((state) => (Array.isArray(cli?.[state]) ? cli[state] : []));
+  if (new Set(lifecycleRanges).size !== lifecycleRanges.length) {
+    errors.push(
+      "supportAxes.studioCli.kicad lifecycle ranges must not overlap",
+    );
+  }
+  const legacyDeprecated = (compatibility?.kicad?.supported ?? [])
+    .filter((entry) => entry?.state === "deprecated")
+    .map((entry) => entry.range);
+  if (
+    JSON.stringify(cli?.deprecated ?? []) !== JSON.stringify(legacyDeprecated)
+  ) {
+    errors.push(
+      "supportAxes.studioCli.kicad.deprecated must match deprecated kicad.supported lines",
+    );
+  }
+  return errors;
+}
+
+function validateMcpServerAxis({
+  compatibility,
+  mcpServer,
+  publishedArtifacts,
+}) {
+  const errors = [];
+  const legacyMcp =
+    compatibility?.products?.["kicad-studio"]?.compatibleMcpPro ?? {};
+  for (const key of ["required", "recommended"]) {
+    if (mcpServer[key] !== legacyMcp[key]) {
+      errors.push(
+        `supportAxes.mcpServer.${key} must match products.kicad-studio.compatibleMcpPro.${key}`,
+      );
+    }
+  }
+  if (mcpServer.testedAgainst?.version !== legacyMcp.testedAgainst) {
+    errors.push(
+      "supportAxes.mcpServer.testedAgainst.version must match products.kicad-studio.compatibleMcpPro.testedAgainst",
+    );
+  }
+  if (mcpServer.testedAgainst?.registry !== "pypi") {
+    errors.push("supportAxes.mcpServer.testedAgainst.registry must be pypi");
+  }
+  if (
+    publishedArtifacts.mcpServerVersion &&
+    mcpServer.testedAgainst?.version !== publishedArtifacts.mcpServerVersion
+  ) {
+    errors.push(
+      `supportAxes.mcpServer.testedAgainst.version must match published artifact ${publishedArtifacts.mcpServerVersion}`,
+    );
+  }
+  return errors;
+}
+
+function validateMcpProtocolAxis({ compatibility, protocol }) {
+  const errors = [];
+  if (protocol.active !== compatibility?.mcp?.protocolVersion) {
+    errors.push(
+      "supportAxes.mcpProtocol.active must match mcp.protocolVersion",
+    );
+  }
+  if (protocol.next !== compatibility?.mcp?.nextProtocolVersion) {
+    errors.push(
+      "supportAxes.mcpProtocol.next must match mcp.nextProtocolVersion",
+    );
+  }
+  if (protocol.activationState !== compatibility?.mcp?.activation?.state) {
+    errors.push(
+      "supportAxes.mcpProtocol.activationState must match mcp.activation.state",
+    );
+  }
+  return errors;
+}
+
+function validateBoardReadyOpsAxis({ boardReadyOps, publishedArtifacts }) {
+  const errors = [];
+  if (boardReadyOps.package !== "boardreadyops") {
+    errors.push("supportAxes.boardReadyOps.package must be boardreadyops");
+  }
+  if (boardReadyOps.testedAgainst?.registry !== "npm") {
+    errors.push("supportAxes.boardReadyOps.testedAgainst.registry must be npm");
+  }
+  if (boardReadyOps.reports?.findingsSchema !== 1) {
+    errors.push("supportAxes.boardReadyOps.reports.findingsSchema must be 1");
+  }
+  if (boardReadyOps.reports?.evidenceBundleSchema !== 2) {
+    errors.push(
+      "supportAxes.boardReadyOps.reports.evidenceBundleSchema must be 2",
+    );
+  }
+  if (
+    publishedArtifacts.boardReadyOpsVersion &&
+    boardReadyOps.testedAgainst?.version !==
+      publishedArtifacts.boardReadyOpsVersion
+  ) {
+    errors.push(
+      `supportAxes.boardReadyOps.testedAgainst.version must match published artifact ${publishedArtifacts.boardReadyOpsVersion}`,
+    );
+  }
+  return errors;
+}
+
+export function validateCompatibilityAxes({
+  compatibility,
+  publishedArtifacts = {},
+} = {}) {
+  const errors = [];
+  const axes = compatibility?.supportAxes;
+  for (const axis of [
+    "studioCli",
+    "mcpServer",
+    "mcpProtocol",
+    "boardReadyOps",
+  ]) {
+    if (!axes?.[axis]) {
+      errors.push(`supportAxes.${axis} is required`);
+    }
+  }
+  if (!axes) return errors;
+
+  errors.push(
+    ...validateStudioCliAxis({
+      compatibility,
+      cli: axes.studioCli?.kicad,
+    }),
+    ...validateMcpServerAxis({
+      compatibility,
+      mcpServer: axes.mcpServer ?? {},
+      publishedArtifacts,
+    }),
+    ...validateMcpProtocolAxis({
+      compatibility,
+      protocol: axes.mcpProtocol ?? {},
+    }),
+    ...validateBoardReadyOpsAxis({
+      boardReadyOps: axes.boardReadyOps ?? {},
+      publishedArtifacts,
+    }),
+  );
+  return errors;
+}
+
 function checkRuntimePolicyMetadata(errors, options = {}) {
   if (
     !fileExists("compatibility.yaml") ||
@@ -509,6 +683,13 @@ export function validateCompatibilityContract(options = {}) {
     const compatibility = parseYaml(readFile("compatibility.yaml"));
     errors.push(
       ...validateKiCadPatchBaseline({ compatibility }),
+      ...validateCompatibilityAxes({
+        compatibility,
+        publishedArtifacts: options.publishedArtifacts ?? {
+          mcpServerVersion: process.env.KICAD_MCP_PRO_PUBLISHED_VERSION,
+          boardReadyOpsVersion: process.env.BOARDREADYOPS_PUBLISHED_VERSION,
+        },
+      }),
       ...validateMcpProtocolActivation({
         compatibility,
         repoRoot: REPO_ROOT,

--- a/scripts/check-compatibility-contract.test.mjs
+++ b/scripts/check-compatibility-contract.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 import { parse as parseYaml } from "yaml";
 
 import {
+  validateCompatibilityAxes,
   validateCompatibilityContract,
   validateEmbeddedExtensionCompatibilityMatrix,
   validateKiCadPatchBaseline,
@@ -56,8 +57,94 @@ test("embedded extension compatibility matrix rejects product-version drift", ()
   );
 });
 
+test("#621 embedded support axes reject BoardReadyOps required-range drift", () => {
+  const driftedSource = matrixSource.replace(
+    "required: '>=1.2.0 <2.0.0'",
+    "required: '>=1.3.0 <2.0.0'",
+  );
+  assert.notEqual(driftedSource, matrixSource);
+  assert.match(
+    validateEmbeddedExtensionCompatibilityMatrix({
+      compatibility,
+      extensionPackage,
+      matrixSource: driftedSource,
+    }).join("\n"),
+    /boardReadyOpsRequired/u,
+  );
+});
+
+test("#621 embedded support axes reject BoardReadyOps contract drift", () => {
+  const driftedSource = matrixSource.replace(
+    "testedAgainst: '1.35.0'",
+    "testedAgainst: '1.34.0'",
+  );
+  assert.notEqual(driftedSource, matrixSource);
+  assert.match(
+    validateEmbeddedExtensionCompatibilityMatrix({
+      compatibility,
+      extensionPackage,
+      matrixSource: driftedSource,
+    }).join("\n"),
+    /boardReadyOpsTestedAgainst/u,
+  );
+});
+
 test("repository compatibility contract validates current state", () => {
   assert.deepEqual(validateCompatibilityContract(), []);
+});
+
+test("#621 support axes are independent, complete, and internally consistent", () => {
+  assert.deepEqual(validateCompatibilityAxes({ compatibility }), []);
+});
+
+test("#621 rejects a missing product support axis", () => {
+  const drifted = structuredClone(compatibility);
+  delete drifted.supportAxes.mcpServer;
+
+  assert.match(
+    validateCompatibilityAxes({ compatibility: drifted }).join("\n"),
+    /supportAxes\.mcpServer/u,
+  );
+});
+
+test("#621 rejects contradictory Studio CLI lifecycle claims", () => {
+  const drifted = structuredClone(compatibility);
+  drifted.supportAxes.studioCli.kicad.stable = ["9.x"];
+
+  assert.match(
+    validateCompatibilityAxes({ compatibility: drifted }).join("\n"),
+    /studioCli.*stable.*kicad\.primary/iu,
+  );
+});
+
+test("#621 rejects stale published kicad-mcp-pro tested-pair evidence", () => {
+  assert.match(
+    validateCompatibilityAxes({
+      compatibility,
+      publishedArtifacts: { mcpServerVersion: "99.0.0" },
+    }).join("\n"),
+    /mcpServer.*testedAgainst.*99\.0\.0/iu,
+  );
+});
+
+test("#621 rejects stale published BoardReadyOps contract evidence", () => {
+  assert.match(
+    validateCompatibilityAxes({
+      compatibility,
+      publishedArtifacts: { boardReadyOpsVersion: "99.0.0" },
+    }).join("\n"),
+    /boardReadyOps.*testedAgainst.*99\.0\.0/iu,
+  );
+});
+
+test("#621 keeps protocol activation separate from product semver compatibility", () => {
+  const drifted = structuredClone(compatibility);
+  drifted.supportAxes.mcpProtocol.active = "2026-07-28";
+
+  assert.match(
+    validateCompatibilityAxes({ compatibility: drifted }).join("\n"),
+    /mcpProtocol\.active.*mcp\.protocolVersion/u,
+  );
 });
 
 test("#494 compatibility contract rejects malformed runtime policy metadata", () => {

--- a/scripts/check-release-surface.test.mjs
+++ b/scripts/check-release-surface.test.mjs
@@ -107,7 +107,7 @@ test("#431 compatibility.yaml writer bumps only the kicad-studio version", () =>
   assert.equal(compatibilityProductVersion(next), "9.9.9");
   // The kicad-mcp-pro testedAgainst field shares the block but must be left alone.
   assert.ok(
-    next.includes('testedAgainst: "3.9.2"'),
+    next.includes('testedAgainst: "3.33.3"'),
     "compatibility writer must not touch the kicad-mcp-pro testedAgainst version",
   );
 });
@@ -127,7 +127,7 @@ test("#431 compatibilityMatrix.ts writer bumps both extension version fields onl
   assert.equal(matrixStudioVersion(next), "9.9.9");
   assert.equal(matrixTestedAgainst(next), "9.9.9");
   // kicadMcpPro.version must remain the MCP server version, not the extension's.
-  assert.match(next, /kicadMcpPro: \{\s*\n\s*version: '3\.9\.2'/u);
+  assert.match(next, /kicadMcpPro: \{\s*\n\s*version: '3\.33\.3'/u);
 });
 
 test("#431 version writers are idempotent at the authoritative version", () => {


### PR DESCRIPTION
## Summary

- split Studio CLI/KiCad, MCP server, MCP protocol, and BoardReadyOps compatibility into independent support axes
- validate published `kicad-mcp-pro` and BoardReadyOps tested-pair evidence in the cross-repo compatibility gate
- surface axis-specific remediation in docs and BoardReadyOps health diagnostics
- replace #632 with cryptographically signed commits so the repository signed-commit ruleset can be satisfied without rewriting history

## Validation

- full repository pre-push `pnpm run check` passed, including 989 extension unit tests, coverage ratchet, security, 76 accessibility checks, repeatable VSIX packaging, docs, release provenance, and package validation
- `corepack pnpm run check:compatibility-contract` — 35 tests passed
- `corepack pnpm run check:release-surface` — 10 tests passed
- `git diff --check origin/main...HEAD` — passed
- replacement patch is content-equivalent to #632; only commit signatures/metadata differ

Closes #621
Supersedes #632
