### PR TITLE
chore(kicad-studio): refresh BoardReadyOps tested artifact

### DIFF
--- a/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
+++ b/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
@@ -26,7 +26,7 @@ export const COMPATIBILITY_MATRIX = {
     },
     boardReadyOps: {
       required: '>=1.2.0 <2.0.0',
-      testedAgainst: '1.35.0',
+      testedAgainst: '1.36.0',
       findingsSchema: 1,
       evidenceBundleSchema: 2
     }

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -656,9 +656,9 @@ supportAxes:
     package: "boardreadyops"
     required: ">=1.2.0 <2.0.0"
     testedAgainst:
-      version: "1.35.0"
+      version: "1.36.0"
       registry: "npm"
-      source: "https://www.npmjs.com/package/boardreadyops/v/1.35.0"
+      source: "https://www.npmjs.com/package/boardreadyops/v/1.36.0"
     reports:
       findingsSchema: 1
       evidenceBundleSchema: 2

--- a/scripts/check-compatibility-contract.test.mjs
+++ b/scripts/check-compatibility-contract.test.mjs
@@ -75,8 +75,8 @@ test("#621 embedded support axes reject BoardReadyOps required-range drift", () 
 
 test("#621 embedded support axes reject BoardReadyOps contract drift", () => {
   const driftedSource = matrixSource.replace(
+    "testedAgainst: '1.36.0'",
     "testedAgainst: '1.35.0'",
-    "testedAgainst: '1.34.0'",
   );
   assert.notEqual(driftedSource, matrixSource);
   assert.match(


### PR DESCRIPTION
## Summary
- refresh the published BoardReadyOps tested-pair evidence from 1.35.0 to 1.36.0
- keep the embedded extension compatibility matrix aligned with the authoritative compatibility contract
- update the drift regression fixture so stale BoardReadyOps evidence still fails closed

## Root cause
The cross-repo compatibility canary resolves the published BoardReadyOps artifact as 1.36.0, while the repository still recorded 1.35.0.

## Verification
- RED: published 1.36.0 contract check failed against the stale 1.35.0 evidence
- GREEN: compatibility contract suite passed 35/35
- extension typecheck passed
- Prettier and `git diff --check` passed