### PR TITLE
fix(kicad-studio): sync Marketplace MCP compatibility

### DIFF
--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -95,7 +95,7 @@ Open **KiCad Studio: Open Task Hub** from the Command Palette or use the task bu
 
 ## MCP Compatibility
 
-KiCad Studio 1.10.1 supports `kicad-mcp-pro >=3.5.2 <4.0.0` and was tested against `3.9.2`. If a connected server reports a version outside the required range, MCP-dependent commands are disabled while KiCad-only features continue to work.
+KiCad Studio 1.10.1 supports `kicad-mcp-pro >=3.5.2 <4.0.0` and was tested against `3.33.3`. If a connected server reports a version outside the required range, MCP-dependent commands are disabled while KiCad-only features continue to work.
 
 ## Marketplace Listing Copy
 

--- a/scripts/check-release-surface.test.mjs
+++ b/scripts/check-release-surface.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
+import { parse as parseYaml } from "yaml";
 
 import {
   RELEASE_SURFACES,
@@ -9,6 +10,7 @@ import {
   applyCompatibilityMatrixStudioVersion,
   applyCompatibilityMatrixTestedAgainst,
   applyCompatibilityProductVersion,
+  applyMarketplaceReadmeMcpTestedAgainst,
   applyMarketplaceReadmeVersion,
   applyReadmeBaseline,
   collectDrift,
@@ -50,6 +52,10 @@ function marketplaceReadmeCompatVersion(content) {
   return content.match(
     /^KiCad Studio ([^\s]+) supports `kicad-mcp-pro /mu,
   )?.[1];
+}
+
+function marketplaceReadmeMcpTestedAgainst(content) {
+  return content.match(/was tested against `([^`]+)`/u)?.[1];
 }
 
 test("#395 every known release surface matches the authoritative version", () => {
@@ -110,6 +116,22 @@ test("#431 compatibility.yaml writer bumps only the kicad-studio version", () =>
     next.includes('testedAgainst: "3.33.3"'),
     "compatibility writer must not touch the kicad-mcp-pro testedAgainst version",
   );
+});
+
+test("#431 marketplace README MCP tested-against matches compatibility metadata", () => {
+  const compatibility = parseYaml(COMPATIBILITY_YAML);
+  assert.equal(
+    marketplaceReadmeMcpTestedAgainst(MARKETPLACE_README),
+    compatibility.supportAxes.mcpServer.testedAgainst.version,
+  );
+});
+
+test("#431 marketplace README writer syncs the MCP tested-against version", () => {
+  const next = applyMarketplaceReadmeMcpTestedAgainst(
+    MARKETPLACE_README,
+    "9.9.9",
+  );
+  assert.equal(marketplaceReadmeMcpTestedAgainst(next), "9.9.9");
 });
 
 test("#431 marketplace README writer bumps both visible version fields", () => {

--- a/scripts/lib/release-surface.mjs
+++ b/scripts/lib/release-surface.mjs
@@ -83,6 +83,22 @@ function extractMarketplaceReadmeVersion(content) {
   return match ? match[1] : undefined;
 }
 
+function extractMarketplaceReadmeMcpTestedAgainst(content) {
+  const match = content.match(/was tested against `([^`]+)`/u);
+  return match ? match[1] : undefined;
+}
+
+export function readMcpServerTestedAgainst(root = repoRoot) {
+  const version = parseYaml(readText("compatibility.yaml", root))?.supportAxes
+    ?.mcpServer?.testedAgainst?.version;
+  if (typeof version !== "string" || version.length === 0) {
+    throw new Error(
+      "compatibility.yaml supportAxes.mcpServer.testedAgainst.version is missing",
+    );
+  }
+  return version;
+}
+
 function extractChangelogTopVersion(content) {
   const match = content.match(/^##\s*\[([^\]]+)\]/mu);
   return match ? match[1] : undefined;
@@ -195,6 +211,29 @@ export function collectDrift(root = repoRoot, version = undefined) {
     });
   }
 
+  try {
+    const expectedMcp = readMcpServerTestedAgainst(root);
+    const actualMcp = extractMarketplaceReadmeMcpTestedAgainst(
+      readText("apps/vscode-extension/README.md", root),
+    );
+    if (actualMcp !== expectedMcp) {
+      drift.push({
+        file: "apps/vscode-extension/README.md",
+        label: "Marketplace README MCP tested-against version",
+        expected: expectedMcp,
+        actual:
+          actualMcp ?? "<unreadable: MCP tested-against version not found>",
+      });
+    }
+  } catch (error) {
+    drift.push({
+      file: "apps/vscode-extension/README.md",
+      label: "Marketplace README MCP tested-against version",
+      expected: "<from compatibility.yaml>",
+      actual: `<unreadable: ${error.message}>`,
+    });
+  }
+
   return drift;
 }
 
@@ -269,6 +308,16 @@ export function applyCompatibilityMatrixTestedAgainst(content, version) {
   );
 }
 
+export function applyMarketplaceReadmeMcpTestedAgainst(content, testedAgainst) {
+  return replaceAnchored(
+    content,
+    /(was tested against `)([^`]+)(`)/u,
+    testedAgainst,
+    "apps/vscode-extension/README.md",
+    "marketplace README MCP tested-against version",
+  );
+}
+
 export function applyMarketplaceReadmeVersion(content, version) {
   let next = replaceAnchored(
     content,
@@ -331,11 +380,12 @@ export function writeMarketplaceReadmeVersion(
   const expected = version ?? readAuthoritativeVersion(root);
   const filePath = path.join(root, "apps/vscode-extension/README.md");
   const current = fs.readFileSync(filePath, "utf8");
-  return writeFileIfChanged(
-    filePath,
-    current,
-    applyMarketplaceReadmeVersion(current, expected),
+  let next = applyMarketplaceReadmeVersion(current, expected);
+  next = applyMarketplaceReadmeMcpTestedAgainst(
+    next,
+    readMcpServerTestedAgainst(root),
   );
+  return writeFileIfChanged(filePath, current, next);
 }
 
 // Rewrites every version surface this module owns directly (root README,


### PR DESCRIPTION
## Summary
- make the Marketplace README MCP tested-against claim derive from `compatibility.yaml`
- teach `check:release-surface` to fail when that claim drifts
- correct the stale published-copy value from 3.9.2 to 3.33.3

## Regression evidence
- RED: release-surface regression failed with `3.9.2 !== 3.33.3`
- GREEN: 12/12 release-surface tests pass
- Release Please governance: 25/25 tests pass
- `check:version`, Prettier, and `git diff --check` pass

This prevents #631 from publishing stale MCP compatibility copy.