### PR TITLE
fix(repo): preserve live Release Please branches

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -113,17 +113,15 @@ jobs:
       - if: ${{ steps.release.outputs.pr }}
         run: corepack pnpm run docs:generate
       - if: ${{ steps.release.outputs.pr }}
-        name: Create a single GitHub-signed release commit
+        name: Append GitHub-signed release surfaces
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           RELEASE_BRANCH: ${{ steps.release-pr.outputs.branch }}
-          RELEASE_BASE_SHA: ${{ github.sha }}
           RELEASE_TITLE: ${{ steps.release-pr.outputs.title }}
         run: |
           node scripts/create-github-signed-commit.mjs \
             --repository "$GITHUB_REPOSITORY" \
             --branch "$RELEASE_BRANCH" \
-            --base "$RELEASE_BASE_SHA" \
             --message "${RELEASE_TITLE}"$'\n\nSigned-off-by: oaslananka <info@oaslananka.dev>'
 
       # Regenerate changelog docs after a release PR is merged

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -6,7 +6,7 @@ KiCad Studio Kit releases the VS Code extension from this repository. The MCP se
 
 ## Release automation
 
-- `release-please.yml` opens and maintains release PRs with the dedicated `RELEASE_PLEASE_TOKEN`, then collapses each generated branch to one GitHub-signed, DCO-signed-off release commit so the protected default branch can enforce required signatures while preserving read-only default GitHub Actions permissions.
+- `release-please.yml` opens and maintains release PRs with the dedicated `RELEASE_PLEASE_TOKEN`, then appends GitHub-signed, DCO-signed-off generated release surfaces without rewriting the live PR branch. Release PRs are squash-merged through GitHub so protected `main` receives one GitHub-verified commit while default GitHub Actions permissions remain read-only.
 - `publish-extension.yml` packages the VSIX, validates metadata, stages checksums, SBOM, provenance, and attestations, then publishes to marketplaces from the authenticated release event.
 - `release.yml` is a low-risk release-readiness workflow that validates release evidence without publishing.
 
@@ -27,6 +27,7 @@ Each release should provide:
 
 1. Confirm the release PR includes the intended changelog and version bump.
 2. Confirm CI, CodeQL, Gitleaks, and package validation pass.
-3. Confirm release evidence is generated and attached.
-4. Confirm marketplace publish jobs use protected environments and minimum secrets.
-5. Confirm post-release docs and version surfaces are updated.
+3. Squash-merge the release PR through GitHub so the commit entering `main` is GitHub-verified.
+4. Confirm release evidence is generated and attached.
+5. Confirm marketplace publish jobs use protected environments and minimum secrets.
+6. Confirm post-release docs and version surfaces are updated.

--- a/scripts/check-release-please-monorepo.test.mjs
+++ b/scripts/check-release-please-monorepo.test.mjs
@@ -32,7 +32,7 @@ function restoreEnv(name, value) {
   }
 }
 
-test("release workflow uses GitHub-signed commits for generated surfaces", () => {
+test("release workflow appends GitHub-signed generated surfaces without rewriting the PR branch", () => {
   const workflow = fs.readFileSync(
     path.join(REPO_ROOT, ".github/workflows/release-please.yml"),
     "utf8",
@@ -54,7 +54,7 @@ test("release workflow uses GitHub-signed commits for generated surfaces", () =>
   );
   assert.match(
     workflow,
-    /name: Create a single GitHub-signed release commit[\s\S]*?GITHUB_TOKEN: \${{ secrets\.RELEASE_PLEASE_TOKEN }}/,
+    /name: Append GitHub-signed release surfaces[\s\S]*?GITHUB_TOKEN: \${{ secrets\.RELEASE_PLEASE_TOKEN }}/,
   );
   assert.match(
     workflow,
@@ -69,12 +69,12 @@ test("release workflow uses GitHub-signed commits for generated surfaces", () =>
     workflow,
     /RELEASE_BRANCH: \${{ steps\.release-pr\.outputs\.branch }}/,
   );
-  assert.match(workflow, /RELEASE_BASE_SHA: \${{ github\.sha }}/);
+  assert.doesNotMatch(workflow, /RELEASE_BASE_SHA/);
   assert.match(
     workflow,
     /RELEASE_TITLE: \${{ steps\.release-pr\.outputs\.title }}/,
   );
-  assert.match(workflow, /--base "\$RELEASE_BASE_SHA"/);
+  assert.doesNotMatch(workflow, /--base /);
   assert.match(workflow, /Signed-off-by: oaslananka <info@oaslananka\.dev>/);
   assert.doesNotMatch(
     workflow,


### PR DESCRIPTION
## Summary
- stop passing `--base` to the GitHub-signed release-surface commit helper
- append generated surfaces without transiently resetting the live release PR branch to `main`
- document squash-merging release PRs so protected `main` receives a GitHub-verified commit

## Regression evidence
- RED: Release Please governance test failed while `RELEASE_BASE_SHA` / `--base` were present
- GREEN: `check:release-please` and signed-commit tests pass
- `check:docs-site`, Prettier, actionlint, Actions-permissions policy, and `git diff --check` pass
- full pre-push policy suite progressed through release, compatibility, coverage, mutation, supply-chain, governance, security-tooling, repeatable-VSIX and validation-host contracts; host doctor then failed only because this runner has Python 3.12 instead of 3.13 and no `uv`

## Root cause
The old workflow force-reset the Release Please head to the base SHA before creating the signed squash commit. GitHub observed the release PR as temporarily identical to `main` and closed it before the signed commit landed. This change never rewrites the live PR branch.