### PR TITLE
chore(kicad-studio): refresh BoardReadyOps 1.37 tested artifact

### DIFF
--- a/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
+++ b/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
@@ -26,7 +26,7 @@ export const COMPATIBILITY_MATRIX = {
     },
     boardReadyOps: {
       required: '>=1.2.0 <2.0.0',
-      testedAgainst: '1.36.0',
+      testedAgainst: '1.37.0',
       findingsSchema: 1,
       evidenceBundleSchema: 2
     }

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -656,9 +656,9 @@ supportAxes:
     package: "boardreadyops"
     required: ">=1.2.0 <2.0.0"
     testedAgainst:
-      version: "1.36.0"
+      version: "1.37.0"
       registry: "npm"
-      source: "https://www.npmjs.com/package/boardreadyops/v/1.36.0"
+      source: "https://www.npmjs.com/package/boardreadyops/v/1.37.0"
     reports:
       findingsSchema: 1
       evidenceBundleSchema: 2

--- a/scripts/check-compatibility-contract.test.mjs
+++ b/scripts/check-compatibility-contract.test.mjs
@@ -75,8 +75,8 @@ test("#621 embedded support axes reject BoardReadyOps required-range drift", () 
 
 test("#621 embedded support axes reject BoardReadyOps contract drift", () => {
   const driftedSource = matrixSource.replace(
+    "testedAgainst: '1.37.0'",
     "testedAgainst: '1.36.0'",
-    "testedAgainst: '1.35.0'",
   );
   assert.notEqual(driftedSource, matrixSource);
   assert.match(


### PR DESCRIPTION
## Summary
- refresh the published BoardReadyOps tested-against artifact from 1.36.0 to 1.37.0
- keep the compatible range and report schema contracts unchanged
- update the embedded extension matrix and drift regression together

## Compatibility evidence
- npm `boardreadyops@1.37.0` keeps the same Node engine (`^22.14.0 || ^24.0.0`), has no dependencies/peers, and keeps the same `boardreadyops` CLI entrypoint as 1.36.0
- published package README delta is release-version/channel copy only; package.json changes only `version`
- RED: `BOARDREADYOPS_PUBLISHED_VERSION=1.37.0 pnpm check:compatibility-contract` rejected testedAgainst 1.36.0
- GREEN: 35 compatibility-contract tests pass against published 1.37.0
- 12 release-surface tests, extension typecheck, Prettier, cross-repo script, and `git diff --check` pass

This unblocks the cross-repo canary currently blocking #640.