### PR TITLE
fix(kicad-studio): align MCP profile contract

### DIFF
--- a/.github/workflows/cross-repo-compatibility.yml
+++ b/.github/workflows/cross-repo-compatibility.yml
@@ -136,8 +136,84 @@ jobs:
       - name: Validate published MCP profile vocabulary
         env:
           KICAD_MCP_PRO_VERSION: ${{ steps.pypi-check.outputs.pypi_version }}
+        shell: bash
         run: |
-          PROFILES=$(uv run --quiet --with "kicad-mcp-pro==$KICAD_MCP_PRO_VERSION" --no-project python -c "import json; from kicad_mcp.tools.router import available_profiles; print(json.dumps(available_profiles()))")
+          set -euo pipefail
+          metadata_url="https://pypi.org/pypi/kicad-mcp-pro/${KICAD_MCP_PRO_VERSION}/json"
+          PROFILES=$(python - "$metadata_url" <<'PY'
+          import ast
+          import hashlib
+          import io
+          import json
+          import sys
+          import urllib.parse
+          import urllib.request
+          import zipfile
+
+          metadata_url = sys.argv[1]
+          with urllib.request.urlopen(metadata_url) as response:
+              metadata = json.load(response)
+
+          wheels = [
+              item
+              for item in metadata.get("urls", [])
+              if item.get("filename", "").endswith("py3-none-any.whl")
+          ]
+          if len(wheels) != 1:
+              raise SystemExit(f"expected one universal wheel, found {len(wheels)}")
+
+          wheel = wheels[0]
+          wheel_url = wheel.get("url", "")
+          parsed_url = urllib.parse.urlparse(wheel_url)
+          if parsed_url.scheme != "https" or parsed_url.hostname != "files.pythonhosted.org":
+              raise SystemExit("PyPI returned an unexpected wheel URL")
+
+          with urllib.request.urlopen(wheel_url) as response:
+              wheel_bytes = response.read()
+          expected_sha256 = wheel.get("digests", {}).get("sha256", "")
+          actual_sha256 = hashlib.sha256(wheel_bytes).hexdigest()
+          if not expected_sha256 or actual_sha256 != expected_sha256:
+              raise SystemExit("published wheel SHA256 verification failed")
+
+          with zipfile.ZipFile(io.BytesIO(wheel_bytes)) as archive:
+              router_paths = [
+                  name for name in archive.namelist() if name.endswith("kicad_mcp/tools/router.py")
+              ]
+              if len(router_paths) != 1:
+                  raise SystemExit("published wheel has no unique MCP router source")
+              source = archive.read(router_paths[0]).decode("utf-8")
+
+          module = ast.parse(source)
+          profile_names = None
+          profile_categories = None
+          for node in module.body:
+              if isinstance(node, ast.Assign) and any(
+                  isinstance(target, ast.Name) and target.id == "PROFILE_CATEGORIES"
+                  for target in node.targets
+              ):
+                  if not isinstance(node.value, ast.Dict):
+                      raise SystemExit("PROFILE_CATEGORIES is not a dictionary literal")
+                  profile_categories = {
+                      key.value
+                      for key in node.value.keys
+                      if isinstance(key, ast.Constant) and isinstance(key.value, str)
+                  }
+              if isinstance(node, ast.FunctionDef) and node.name == "available_profiles":
+                  for statement in node.body:
+                      if (
+                          isinstance(statement, ast.Assign)
+                          and any(
+                              isinstance(target, ast.Name) and target.id == "preferred"
+                              for target in statement.targets
+                          )
+                      ):
+                          profile_names = ast.literal_eval(statement.value)
+
+          if not isinstance(profile_names, list) or not profile_categories:
+              raise SystemExit("published wheel profile vocabulary could not be parsed")
+          print(json.dumps([name for name in profile_names if name in profile_categories]))
+          PY
+          )
           KICAD_MCP_PRO_PUBLISHED_PROFILES="$PROFILES" node scripts/check-published-mcp-profiles.mjs
 
       # ── C. Published BoardReadyOps contract ───────────────────────────────

--- a/.github/workflows/cross-repo-compatibility.yml
+++ b/.github/workflows/cross-repo-compatibility.yml
@@ -133,6 +133,13 @@ jobs:
         run: |
           corepack pnpm run check:mcp-2026-rc-artifact -- --version "$KICAD_MCP_PRO_VERSION"
 
+      - name: Validate published MCP profile vocabulary
+        env:
+          KICAD_MCP_PRO_VERSION: ${{ steps.pypi-check.outputs.pypi_version }}
+        run: |
+          PROFILES=$(uv run --quiet --with "kicad-mcp-pro==$KICAD_MCP_PRO_VERSION" --no-project python -c "import json; from kicad_mcp.tools.router import available_profiles; print(json.dumps(available_profiles()))")
+          KICAD_MCP_PRO_PUBLISHED_PROFILES="$PROFILES" node scripts/check-published-mcp-profiles.mjs
+
       # ── C. Published BoardReadyOps contract ───────────────────────────────
       - name: Resolve published BoardReadyOps version
         id: boardreadyops-check

--- a/.github/workflows/cross-repo-compatibility.yml
+++ b/.github/workflows/cross-repo-compatibility.yml
@@ -140,17 +140,18 @@ jobs:
         run: |
           set -euo pipefail
           metadata_url="https://pypi.org/pypi/kicad-mcp-pro/${KICAD_MCP_PRO_VERSION}/json"
-          PROFILES=$(python - "$metadata_url" <<'PY'
-          import ast
+          router_source="$RUNNER_TEMP/kicad-mcp-router.py"
+          python - "$metadata_url" "$router_source" <<'PY'
           import hashlib
           import io
           import json
+          import pathlib
           import sys
           import urllib.parse
           import urllib.request
           import zipfile
 
-          metadata_url = sys.argv[1]
+          metadata_url, output_path = sys.argv[1:3]
           with urllib.request.urlopen(metadata_url) as response:
               metadata = json.load(response)
 
@@ -181,39 +182,9 @@ jobs:
               ]
               if len(router_paths) != 1:
                   raise SystemExit("published wheel has no unique MCP router source")
-              source = archive.read(router_paths[0]).decode("utf-8")
-
-          module = ast.parse(source)
-          profile_names = None
-          profile_categories = None
-          for node in module.body:
-              if isinstance(node, ast.Assign) and any(
-                  isinstance(target, ast.Name) and target.id == "PROFILE_CATEGORIES"
-                  for target in node.targets
-              ):
-                  if not isinstance(node.value, ast.Dict):
-                      raise SystemExit("PROFILE_CATEGORIES is not a dictionary literal")
-                  profile_categories = {
-                      key.value
-                      for key in node.value.keys
-                      if isinstance(key, ast.Constant) and isinstance(key.value, str)
-                  }
-              if isinstance(node, ast.FunctionDef) and node.name == "available_profiles":
-                  for statement in node.body:
-                      if (
-                          isinstance(statement, ast.Assign)
-                          and any(
-                              isinstance(target, ast.Name) and target.id == "preferred"
-                              for target in statement.targets
-                          )
-                      ):
-                          profile_names = ast.literal_eval(statement.value)
-
-          if not isinstance(profile_names, list) or not profile_categories:
-              raise SystemExit("published wheel profile vocabulary could not be parsed")
-          print(json.dumps([name for name in profile_names if name in profile_categories]))
+              pathlib.Path(output_path).write_bytes(archive.read(router_paths[0]))
           PY
-          )
+          PROFILES=$(python scripts/extract_published_mcp_profiles.py < "$router_source")
           KICAD_MCP_PRO_PUBLISHED_PROFILES="$PROFILES" node scripts/check-published-mcp-profiles.mjs
 
       # ── C. Published BoardReadyOps contract ───────────────────────────────

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2071,8 +2071,12 @@
         },
         "kicadstudio.mcp.profile": {
           "type": "string",
-          "default": "analysis",
+          "default": "review",
           "enum": [
+            "review",
+            "build",
+            "release",
+            "expert",
             "full",
             "minimal",
             "schematic_only",
@@ -2603,7 +2607,7 @@
     "audit:ci": "pnpm audit --audit-level high",
     "check:staged": "lint-staged",
     "check": "pnpm run check:extension-manifest && pnpm run check:nls-parity && pnpm run check:coverage-scope && pnpm run check:mutation-policy && pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test:unit && pnpm run test:coverage:ratchet && pnpm run test:security && pnpm run test:a11y && pnpm run build && pnpm run package && pnpm run package:validate",
-    "check:extension-manifest": "node --test scripts/command-surface-policy.test.mjs scripts/task-vocabulary.test.mjs && node scripts/check-package-contributions.mjs",
+    "check:extension-manifest": "node --test scripts/command-surface-policy.test.mjs scripts/task-vocabulary.test.mjs scripts/mcp-profile-vocabulary.test.mjs && node scripts/check-package-contributions.mjs",
     "check:nls-parity": "node ../../scripts/check-nls-parity.mjs && node --test ../../scripts/check-nls-parity.test.mjs",
     "check:workspace-trust": "node scripts/check-untrusted-workspace.js",
     "check:ci": "pnpm run audit:ci && pnpm run format:check && pnpm run docs:check && pnpm run check:coverage-scope && pnpm run check:mutation-policy && pnpm run workflows:lint && pnpm run lint && pnpm run typecheck && pnpm run check:workspace-trust && pnpm run test:unit:coverage && pnpm run test:coverage:ratchet && pnpm run test:security && pnpm run test:a11y && pnpm run build && pnpm run test:integration && pnpm run package && pnpm run package:validate && pnpm run release:dry-run && pnpm run check:bundle-size",

--- a/apps/vscode-extension/schemas/vscode-mcp.kicad.json
+++ b/apps/vscode-extension/schemas/vscode-mcp.kicad.json
@@ -41,6 +41,10 @@
               "KICAD_MCP_PROFILE": {
                 "type": "string",
                 "enum": [
+                  "review",
+                  "build",
+                  "release",
+                  "expert",
                   "full",
                   "minimal",
                   "schematic_only",

--- a/apps/vscode-extension/scripts/mcp-profile-vocabulary.test.mjs
+++ b/apps/vscode-extension/scripts/mcp-profile-vocabulary.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(root, 'package.json'), 'utf8')
+);
+const schema = JSON.parse(
+  fs.readFileSync(path.join(root, 'schemas', 'vscode-mcp.kicad.json'), 'utf8')
+);
+const primary = ['review', 'build', 'release', 'expert'];
+
+test('settings manifest uses the task-oriented profile vocabulary', () => {
+  const setting =
+    packageJson.contributes.configuration.properties['kicadstudio.mcp.profile'];
+  assert.equal(setting.default, 'review');
+  assert.deepEqual(setting.enum.slice(0, primary.length), primary);
+});
+
+test('workspace MCP schema accepts the task-oriented profile vocabulary', () => {
+  const profile =
+    schema.properties.servers.additionalProperties.properties.env.properties
+      .KICAD_MCP_PROFILE;
+  for (const id of primary)
+    assert.ok(profile.enum.includes(id), `missing ${id}`);
+});

--- a/apps/vscode-extension/src/activation/workspaceContextController.ts
+++ b/apps/vscode-extension/src/activation/workspaceContextController.ts
@@ -206,7 +206,7 @@ export class WorkspaceContextController implements vscode.Disposable {
     await vscode.commands.executeCommand(
       'setContext',
       CONTEXT_KEYS.mcpProfile,
-      mcpProfile ?? 'review'
+      mcpProfile
     );
     statusBar.update({
       aiConfigured: Boolean(provider?.isConfigured()),

--- a/apps/vscode-extension/src/activation/workspaceContextController.ts
+++ b/apps/vscode-extension/src/activation/workspaceContextController.ts
@@ -206,7 +206,7 @@ export class WorkspaceContextController implements vscode.Disposable {
     await vscode.commands.executeCommand(
       'setContext',
       CONTEXT_KEYS.mcpProfile,
-      mcpProfile ?? 'analysis'
+      mcpProfile ?? 'review'
     );
     statusBar.update({
       aiConfigured: Boolean(provider?.isConfigured()),

--- a/apps/vscode-extension/src/commands/mcpCommands.ts
+++ b/apps/vscode-extension/src/commands/mcpCommands.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { COMMANDS } from '../constants';
 import { McpDetector } from '../mcp/mcpDetector';
+import { KICAD_MCP_PROFILES } from '../mcp/profileCatalog';
 import { DesignIntentPanel } from '../mcp/designIntentPanel';
 import { DrcRuleEditorPanel } from '../drc/drcRuleEditorPanel';
 import { registerTrustedCommand } from '../utils/workspaceTrust';
@@ -98,18 +99,7 @@ export function registerMcpCommands(
         // ── Step 2: profile ───────────────────────────────────────────────────
         const detector = new McpDetector();
         const profile = await vscode.window.showQuickPick(
-          [
-            'analysis',
-            'pcb_only',
-            'schematic_only',
-            'minimal',
-            'manufacturing',
-            'high_speed',
-            'power',
-            'simulation',
-            'full',
-            'agent_full'
-          ],
+          KICAD_MCP_PROFILES.map((profile) => profile.id),
           {
             title: 'Select kicad-mcp-pro profile',
             placeHolder: 'Choose the MCP tool profile'
@@ -148,18 +138,7 @@ export function registerMcpCommands(
           vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd();
         const detector = new McpDetector();
         const profile = await vscode.window.showQuickPick(
-          [
-            'analysis',
-            'pcb_only',
-            'schematic_only',
-            'minimal',
-            'manufacturing',
-            'high_speed',
-            'power',
-            'simulation',
-            'full',
-            'agent_full'
-          ],
+          KICAD_MCP_PROFILES.map((profile) => profile.id),
           {
             title: 'Select kicad-mcp-pro profile',
             placeHolder: 'Profile for the HTTP server'

--- a/apps/vscode-extension/src/commands/mcpProfilePicker.ts
+++ b/apps/vscode-extension/src/commands/mcpProfilePicker.ts
@@ -42,7 +42,7 @@ export async function pickMcpProfile(
   return choice.profile.id;
 }
 
-export function readConfiguredMcpProfile(): string | undefined {
+export function readConfiguredMcpProfile(): KicadMcpProfileId {
   const fromWorkspace = readProfileFromMcpJson();
   if (fromWorkspace) {
     return resolveKicadMcpProfile(fromWorkspace);

--- a/apps/vscode-extension/src/commands/mcpProfilePicker.ts
+++ b/apps/vscode-extension/src/commands/mcpProfilePicker.ts
@@ -5,6 +5,7 @@ import { SETTINGS } from '../constants';
 import { localize } from '../i18n';
 import {
   KICAD_MCP_PROFILES,
+  resolveKicadMcpProfile,
   type KicadMcpProfileId
 } from '../mcp/profileCatalog';
 import type { CommandServices } from './types';
@@ -44,11 +45,13 @@ export async function pickMcpProfile(
 export function readConfiguredMcpProfile(): string | undefined {
   const fromWorkspace = readProfileFromMcpJson();
   if (fromWorkspace) {
-    return fromWorkspace;
+    return resolveKicadMcpProfile(fromWorkspace);
   }
-  return vscode.workspace
-    .getConfiguration()
-    .get<string>(SETTINGS.mcpProfile, 'analysis');
+  return resolveKicadMcpProfile(
+    vscode.workspace
+      .getConfiguration()
+      .get<string>(SETTINGS.mcpProfile, 'review')
+  );
 }
 
 async function writeProfile(profile: KicadMcpProfileId): Promise<void> {

--- a/apps/vscode-extension/src/lm/mcpServerDefinitionProvider.ts
+++ b/apps/vscode-extension/src/lm/mcpServerDefinitionProvider.ts
@@ -64,7 +64,7 @@ export async function createKicadMcpServerDefinition(
       // Default to a focused, read-only posture (least privilege). The profile
       // honours the user's "Pick MCP Profile" choice; write/manufacturing tools
       // require an explicit opt-in via KICAD_MCP_OPERATING_MODE.
-      KICAD_MCP_PROFILE: readConfiguredMcpProfile() ?? 'analysis',
+      KICAD_MCP_PROFILE: readConfiguredMcpProfile() ?? 'review',
       KICAD_MCP_OPERATING_MODE: 'readonly'
     },
     ...(install.version ? { version: install.version } : {})

--- a/apps/vscode-extension/src/lm/mcpServerDefinitionProvider.ts
+++ b/apps/vscode-extension/src/lm/mcpServerDefinitionProvider.ts
@@ -64,7 +64,7 @@ export async function createKicadMcpServerDefinition(
       // Default to a focused, read-only posture (least privilege). The profile
       // honours the user's "Pick MCP Profile" choice; write/manufacturing tools
       // require an explicit opt-in via KICAD_MCP_OPERATING_MODE.
-      KICAD_MCP_PROFILE: readConfiguredMcpProfile() ?? 'review',
+      KICAD_MCP_PROFILE: readConfiguredMcpProfile(),
       KICAD_MCP_OPERATING_MODE: 'readonly'
     },
     ...(install.version ? { version: install.version } : {})

--- a/apps/vscode-extension/src/mcp/mcpDetector.ts
+++ b/apps/vscode-extension/src/mcp/mcpDetector.ts
@@ -189,7 +189,7 @@ export class McpDetector {
   async generateMcpJson(
     projectDir: string,
     status: McpInstallStatus,
-    profile = 'analysis'
+    profile = 'review'
   ): Promise<void> {
     const root =
       vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? projectDir;

--- a/apps/vscode-extension/src/mcp/profileCatalog.ts
+++ b/apps/vscode-extension/src/mcp/profileCatalog.ts
@@ -1,5 +1,27 @@
-export const KICAD_MCP_PROFILES = [
-  { id: 'full', label: 'Full', blurb: 'All tools (heaviest)' },
+export const KICAD_MCP_PRIMARY_PROFILES = [
+  {
+    id: 'review',
+    label: 'Review',
+    blurb: 'Least-privilege design review and validation'
+  },
+  {
+    id: 'build',
+    label: 'Build',
+    blurb: 'Design-authoring workflow; writes still require write mode'
+  },
+  {
+    id: 'release',
+    label: 'Release',
+    blurb: 'Manufacturing validation and gated release export'
+  },
+  {
+    id: 'expert',
+    label: 'Expert',
+    blurb: 'Full tool surface; operating mode still gates risky actions'
+  }
+] as const;
+
+export const KICAD_MCP_ADVANCED_PROFILES = [
   { id: 'minimal', label: 'Minimal', blurb: 'Read + export only' },
   {
     id: 'schematic_only',
@@ -15,16 +37,28 @@ export const KICAD_MCP_PROFILES = [
   { id: 'high_speed', label: 'High-Speed', blurb: 'SI / impedance / tuning' },
   { id: 'power', label: 'Power', blurb: 'PDN, thermal, planes' },
   { id: 'simulation', label: 'Simulation', blurb: 'SPICE OP / AC / TRAN / DC' },
-  { id: 'analysis', label: 'Analysis', blurb: 'Validation gates and reviews' },
-  {
-    id: 'agent_full',
-    label: 'Agent (Full)',
-    blurb: 'Agent-oriented full surface'
-  }
+  { id: 'analysis', label: 'Analysis', blurb: 'Validation gates and reviews' }
+] as const;
+
+export const KICAD_MCP_PROFILES = [
+  ...KICAD_MCP_PRIMARY_PROFILES,
+  ...KICAD_MCP_ADVANCED_PROFILES
 ] as const;
 
 export type KicadMcpProfileId = (typeof KICAD_MCP_PROFILES)[number]['id'];
 
 export function isKicadMcpProfile(value: string): value is KicadMcpProfileId {
   return KICAD_MCP_PROFILES.some((profile) => profile.id === value);
+}
+
+export function resolveKicadMcpProfile(
+  value: string | undefined
+): KicadMcpProfileId {
+  if (value === 'default') {
+    return 'review';
+  }
+  if (value === 'full' || value === 'agent_full') {
+    return 'expert';
+  }
+  return value && isKicadMcpProfile(value) ? value : 'review';
 }

--- a/apps/vscode-extension/src/settings/settingsHtml.ts
+++ b/apps/vscode-extension/src/settings/settingsHtml.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { DOCUMENTATION_URLS } from '../documentation/documentationUrls';
+import { KICAD_MCP_PROFILES } from '../mcp/profileCatalog';
 import { createNonce } from '../utils/nonce';
 import { injectWebviewLocalization } from '../webviewI18n';
 
@@ -25,6 +26,9 @@ export function buildSettingsHtml(options: SettingsHtmlOptions): string {
   const mcpIntegrationDocsUrlJson = JSON.stringify(
     DOCUMENTATION_URLS.mcpIntegration
   );
+  const mcpProfileOptions = KICAD_MCP_PROFILES.map(
+    (profile) => `<option value="${profile.id}">${profile.id}</option>`
+  ).join('\n            ');
 
   return injectWebviewLocalization(
     `<!DOCTYPE html>
@@ -275,16 +279,7 @@ export function buildSettingsHtml(options: SettingsHtmlOptions): string {
         <div class="field">
           <label for="kicadstudio.mcp.profile">Profile</label>
           <select id="kicadstudio.mcp.profile" data-setting="kicadstudio.mcp.profile">
-            <option value="full">full</option>
-            <option value="minimal">minimal</option>
-            <option value="schematic_only">schematic_only</option>
-            <option value="pcb_only">pcb_only</option>
-            <option value="manufacturing">manufacturing</option>
-            <option value="high_speed">high_speed</option>
-            <option value="power">power</option>
-            <option value="simulation">simulation</option>
-            <option value="analysis">analysis</option>
-            <option value="agent_full">agent_full</option>
+            ${mcpProfileOptions}
           </select>
         </div>
         <div class="field">

--- a/apps/vscode-extension/test/unit/languageModelMcpProvider.test.ts
+++ b/apps/vscode-extension/test/unit/languageModelMcpProvider.test.ts
@@ -32,7 +32,7 @@ describe('language model MCP server definition provider', () => {
 
     expect(definition.value.command).toBe('uvx');
     expect(definition.value.args).toEqual(['kicad-mcp-pro']);
-    expect(definition.value.env['KICAD_MCP_PROFILE']).toBe('analysis');
+    expect(definition.value.env['KICAD_MCP_PROFILE']).toBe('review');
     expect(definition.value.env['KICAD_MCP_OPERATING_MODE']).toBe('readonly');
   });
 
@@ -77,7 +77,7 @@ describe('language model MCP server definition provider', () => {
 
       expect(definition.label).toBe('KiCad MCP Pro (detected)');
       expect(definition.command).toBe('kicad-mcp-pro');
-      expect(definition.env['KICAD_MCP_PROFILE']).toBe('analysis');
+      expect(definition.env['KICAD_MCP_PROFILE']).toBe('review');
       expect(definition.env['KICAD_MCP_OPERATING_MODE']).toBe('readonly');
       expect(definition.cwd?.fsPath).toBe(
         workspace.workspaceFolders[0]?.uri.fsPath

--- a/apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts
+++ b/apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts
@@ -389,6 +389,40 @@ describe('MCP command workspace trust guards', () => {
     expect(services.refreshMcpState).toHaveBeenCalled();
   });
 
+  it('#622 launches HTTP with the shared profile catalog choices', async () => {
+    const services = registerWithServices({
+      mcpClient: {
+        detectInstall: jest.fn().mockResolvedValue({
+          found: true,
+          command: 'uvx',
+          source: 'uvx'
+        })
+      }
+    });
+    const generateHttpConfig = jest
+      .spyOn(McpDetector.prototype, 'generateHttpConfig')
+      .mockResolvedValue();
+    (window.showQuickPick as jest.Mock).mockResolvedValueOnce('review');
+
+    await registeredHandler(COMMANDS.launchMcpHttp)();
+
+    const profileChoices = (window.showQuickPick as jest.Mock).mock
+      .calls[0]?.[0];
+    expect(profileChoices.slice(0, 4)).toEqual([
+      'review',
+      'build',
+      'release',
+      'expert'
+    ]);
+    expect(generateHttpConfig).toHaveBeenCalledWith(
+      '/workspace',
+      expect.objectContaining({ command: 'uvx' }),
+      'review',
+      27185
+    );
+    expect(services.refreshMcpState).toHaveBeenCalled();
+  });
+
   it('cancels MCP setup when the transport picker is dismissed', async () => {
     const services = registerWithServices({
       mcpClient: {

--- a/apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts
+++ b/apps/vscode-extension/test/unit/mcpCommandsTrust.test.ts
@@ -351,6 +351,14 @@ describe('MCP command workspace trust guards', () => {
       expect.objectContaining({ command: 'uvx' }),
       'analysis'
     );
+    const profileChoices = (window.showQuickPick as jest.Mock).mock
+      .calls[1]?.[0];
+    expect(profileChoices.slice(0, 4)).toEqual([
+      'review',
+      'build',
+      'release',
+      'expert'
+    ]);
     expect(services.refreshMcpState).toHaveBeenCalled();
   });
 

--- a/apps/vscode-extension/test/unit/mcpProfilePicker.test.ts
+++ b/apps/vscode-extension/test/unit/mcpProfilePicker.test.ts
@@ -131,11 +131,33 @@ describe('mcpProfilePicker', () => {
       expect(readConfiguredMcpProfile()).toBe('manufacturing');
     });
 
-    it('returns the analysis (least-privilege) default when nothing is configured', () => {
+    it('migrates equivalent legacy aliases from workspace configuration', () => {
+      existsSync.mockReturnValue(true);
+      readFileSync.mockReturnValue(
+        JSON.stringify({
+          servers: { kicad: { env: { KICAD_MCP_PROFILE: 'default' } } }
+        })
+      );
+
+      expect(readConfiguredMcpProfile()).toBe('review');
+    });
+
+    it('fails closed when a workspace contains an unsupported profile', () => {
+      existsSync.mockReturnValue(true);
+      readFileSync.mockReturnValue(
+        JSON.stringify({
+          servers: { kicad: { env: { KICAD_MCP_PROFILE: 'future-unsafe' } } }
+        })
+      );
+
+      expect(readConfiguredMcpProfile()).toBe('review');
+    });
+
+    it('returns the review (least-privilege) default when nothing is configured', () => {
       existsSync.mockReturnValue(false);
       __setConfiguration({});
 
-      expect(readConfiguredMcpProfile()).toBe('analysis');
+      expect(readConfiguredMcpProfile()).toBe('review');
     });
 
     it('ignores an unparseable mcp.json and falls back to configuration', () => {

--- a/apps/vscode-extension/test/unit/mcpProfilePicker.test.ts
+++ b/apps/vscode-extension/test/unit/mcpProfilePicker.test.ts
@@ -113,15 +113,19 @@ describe('mcpProfilePicker', () => {
   });
 
   describe('readConfiguredMcpProfile', () => {
-    it('reads the profile from mcp.json when present', () => {
+    it.each([
+      ['supported profile', 'analysis', 'analysis'],
+      ['equivalent legacy alias', 'default', 'review'],
+      ['unsupported profile', 'future-unsafe', 'review']
+    ])('normalizes %s from mcp.json', (_case, configured, expected) => {
       existsSync.mockReturnValue(true);
       readFileSync.mockReturnValue(
         JSON.stringify({
-          servers: { kicad: { env: { KICAD_MCP_PROFILE: 'analysis' } } }
+          servers: { kicad: { env: { KICAD_MCP_PROFILE: configured } } }
         })
       );
 
-      expect(readConfiguredMcpProfile()).toBe('analysis');
+      expect(readConfiguredMcpProfile()).toBe(expected);
     });
 
     it('falls back to the configuration setting when mcp.json is absent', () => {
@@ -129,28 +133,6 @@ describe('mcpProfilePicker', () => {
       __setConfiguration({ 'kicadstudio.mcp.profile': 'manufacturing' });
 
       expect(readConfiguredMcpProfile()).toBe('manufacturing');
-    });
-
-    it('migrates equivalent legacy aliases from workspace configuration', () => {
-      existsSync.mockReturnValue(true);
-      readFileSync.mockReturnValue(
-        JSON.stringify({
-          servers: { kicad: { env: { KICAD_MCP_PROFILE: 'default' } } }
-        })
-      );
-
-      expect(readConfiguredMcpProfile()).toBe('review');
-    });
-
-    it('fails closed when a workspace contains an unsupported profile', () => {
-      existsSync.mockReturnValue(true);
-      readFileSync.mockReturnValue(
-        JSON.stringify({
-          servers: { kicad: { env: { KICAD_MCP_PROFILE: 'future-unsafe' } } }
-        })
-      );
-
-      expect(readConfiguredMcpProfile()).toBe('review');
     });
 
     it('returns the review (least-privilege) default when nothing is configured', () => {

--- a/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
@@ -263,7 +263,7 @@ describe('McpToolsProvider', () => {
         "Compatibility dashboard > Server contract > Server :: kicad-mcp-pro",
         "Compatibility dashboard > Server contract > Endpoint :: http://127.0.0.1:27185/mcp",
         "Compatibility dashboard > Server contract > Transport mode :: streamable-http, stateful",
-        "Compatibility dashboard > Server contract > Profile :: full",
+        "Compatibility dashboard > Server contract > Profile :: expert",
         "Compatibility dashboard > Server contract > Operating mode :: readonly",
         "Compatibility dashboard > Server contract > Protocol version :: 2025-11-25",
         "Compatibility dashboard > Server contract > Tool schema version :: 1.0.0",

--- a/apps/vscode-extension/test/unit/profileCatalog.test.ts
+++ b/apps/vscode-extension/test/unit/profileCatalog.test.ts
@@ -1,6 +1,8 @@
 import {
+  KICAD_MCP_PRIMARY_PROFILES,
   KICAD_MCP_PROFILES,
-  isKicadMcpProfile
+  isKicadMcpProfile,
+  resolveKicadMcpProfile
 } from '../../src/mcp/profileCatalog';
 
 jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
@@ -14,7 +16,10 @@ describe('profileCatalog', () => {
         (p) => p.id
       );
       expect(ids).toEqual([
-        'full',
+        'review',
+        'build',
+        'release',
+        'expert',
         'minimal',
         'schematic_only',
         'pcb_only',
@@ -22,8 +27,7 @@ describe('profileCatalog', () => {
         'high_speed',
         'power',
         'simulation',
-        'analysis',
-        'agent_full'
+        'analysis'
       ]);
     });
 
@@ -52,9 +56,45 @@ describe('profileCatalog', () => {
     });
   });
 
+  describe('primary workflow profiles', () => {
+    it('puts the published task-oriented profiles first', () => {
+      expect(KICAD_MCP_PRIMARY_PROFILES.map((profile) => profile.id)).toEqual([
+        'review',
+        'build',
+        'release',
+        'expert'
+      ]);
+      expect(KICAD_MCP_PROFILES.slice(0, 4)).toEqual(
+        KICAD_MCP_PRIMARY_PROFILES
+      );
+    });
+  });
+
+  describe('resolveKicadMcpProfile', () => {
+    it('migrates only equivalent legacy aliases', () => {
+      expect(resolveKicadMcpProfile('default')).toBe('review');
+      expect(resolveKicadMcpProfile('full')).toBe('expert');
+      expect(resolveKicadMcpProfile('agent_full')).toBe('expert');
+    });
+
+    it('preserves supported specialized profiles without widening scope', () => {
+      expect(resolveKicadMcpProfile('analysis')).toBe('analysis');
+      expect(resolveKicadMcpProfile('manufacturing')).toBe('manufacturing');
+      expect(resolveKicadMcpProfile('pcb_only')).toBe('pcb_only');
+    });
+
+    it('fails closed to review for unknown or missing profile values', () => {
+      expect(resolveKicadMcpProfile('unknown')).toBe('review');
+      expect(resolveKicadMcpProfile(undefined)).toBe('review');
+    });
+  });
+
   describe('isKicadMcpProfile', () => {
     it('returns true for valid profile ids', () => {
-      expect(isKicadMcpProfile('full')).toBe(true);
+      expect(isKicadMcpProfile('review')).toBe(true);
+      expect(isKicadMcpProfile('build')).toBe(true);
+      expect(isKicadMcpProfile('release')).toBe(true);
+      expect(isKicadMcpProfile('expert')).toBe(true);
       expect(isKicadMcpProfile('minimal')).toBe(true);
       expect(isKicadMcpProfile('schematic_only')).toBe(true);
       expect(isKicadMcpProfile('pcb_only')).toBe(true);
@@ -63,7 +103,6 @@ describe('profileCatalog', () => {
       expect(isKicadMcpProfile('power')).toBe(true);
       expect(isKicadMcpProfile('simulation')).toBe(true);
       expect(isKicadMcpProfile('analysis')).toBe(true);
-      expect(isKicadMcpProfile('agent_full')).toBe(true);
     });
 
     it('returns false for invalid profile ids', () => {
@@ -72,6 +111,8 @@ describe('profileCatalog', () => {
       expect(isKicadMcpProfile('FULL')).toBe(false);
       expect(isKicadMcpProfile('full ')).toBe(false);
       expect(isKicadMcpProfile('extra')).toBe(false);
+      expect(isKicadMcpProfile('full')).toBe(false);
+      expect(isKicadMcpProfile('agent_full')).toBe(false);
     });
   });
 });

--- a/apps/vscode-extension/test/unit/settingsPanel.test.ts
+++ b/apps/vscode-extension/test/unit/settingsPanel.test.ts
@@ -99,6 +99,11 @@ describe('settings webview', () => {
     expect(html).toContain('<option value="copilot">GitHub Copilot</option>');
     expect(html).not.toContain('<option value="codex">');
     expect(html).toContain("type: 'requestApiKeyStatus'");
+    expect(html).toContain('<option value="review">review</option>');
+    expect(html).toContain('<option value="build">build</option>');
+    expect(html.indexOf('value="review"')).toBeLessThan(
+      html.indexOf('value="analysis"')
+    );
   });
 
   it('embeds the canonical MCP integration documentation URL (#488)', () => {

--- a/docs/extension/settings.md
+++ b/docs/extension/settings.md
@@ -46,7 +46,7 @@ Total settings: 47.
 | `kicadstudio.mcp.allowLegacySse` | boolean | `false` |  | Allow a best-effort fallback to the legacy /sse MCP transport when Streamable HTTP is unavailable. |
 | `kicadstudio.mcp.timeout` | number | `15` |  | MCP HTTP request timeout in seconds. |
 | `kicadstudio.mcp.pushContext` | boolean | `true` |  | Push active file, DRC summary, and lasso selection context to kicad-mcp-pro. |
-| `kicadstudio.mcp.profile` | string | `analysis` | `full`, `minimal`, `schematic_only`, `pcb_only`, `manufacturing`, `high_speed`, `power`, `simulation`, `analysis`, `agent_full` | Preferred kicad-mcp-pro profile when no workspace .vscode/mcp.json overrides it. |
+| `kicadstudio.mcp.profile` | string | `review` | `review`, `build`, `release`, `expert`, `full`, `minimal`, `schematic_only`, `pcb_only`, `manufacturing`, `high_speed`, `power`, `simulation`, `analysis`, `agent_full` | Preferred kicad-mcp-pro profile when no workspace .vscode/mcp.json overrides it. |
 | `kicadstudio.mcp.logSize` | number | `200` |  | Number of recent MCP request/response log entries retained in memory. |
 | `kicadstudio.exportPresets` | array | `[]` |  | Saved export presets managed by the extension. |
 | `kicadstudio.telemetry.enabled` | boolean | `false` |  | Enable opt-in KiCad Studio usage and error telemetry. Disabled by default and capped by VS Code's telemetry.telemetryLevel setting. |

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:fixtures": "pnpm run check:fixtures",
     "check:kicad-fixtures": "pnpm --dir packages/kicad-fixtures run check",
     "check:protocol-schemas": "node --test scripts/check-protocol-schemas-package.test.mjs && node --input-type=module -e \"import * as pkg from '@oaslananka/kicad-protocol-schemas'; if (typeof pkg.validateProtocolPayload !== 'function') throw new Error('validateProtocolPayload export missing'); console.log('protocol-schemas resolves OK: validateProtocolPayload present')\"",
-    "check:compatibility-contract": "node scripts/check-compatibility-contract.mjs && node --test scripts/check-compatibility-contract.test.mjs scripts/kicad-11-readiness-dashboard.test.mjs",
+    "check:compatibility-contract": "node scripts/check-compatibility-contract.mjs && node --test scripts/check-compatibility-contract.test.mjs scripts/check-published-mcp-profiles.test.mjs scripts/kicad-11-readiness-dashboard.test.mjs",
     "check:codecov": "node scripts/check-codecov-policy.mjs && node --test scripts/check-codecov-policy.test.mjs apps/vscode-extension/scripts/webpack-config-codecov.test.mjs",
     "build:kicad-studio": "pnpm --filter kicadstudiokit run build",
     "package:kicad-studio": "pnpm --filter kicadstudiokit run package",

--- a/scripts/check-published-mcp-profiles.mjs
+++ b/scripts/check-published-mcp-profiles.mjs
@@ -1,0 +1,55 @@
+import { fileURLToPath } from "node:url";
+
+const PRIMARY_PROFILES = ["review", "build", "release", "expert"];
+const MIGRATION_ALIASES = ["default", "full", "agent_full"];
+
+export function parsePublishedProfiles(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `Published MCP profile discovery returned invalid JSON: ${error}`,
+    );
+  }
+  if (
+    !Array.isArray(parsed) ||
+    parsed.some((value) => typeof value !== "string")
+  ) {
+    throw new Error(
+      "Published MCP profile discovery must return a JSON array of strings.",
+    );
+  }
+  return [...new Set(parsed)];
+}
+
+export function validatePublishedProfiles(profiles) {
+  const available = new Set(profiles);
+  for (const profile of [...PRIMARY_PROFILES, ...MIGRATION_ALIASES]) {
+    if (!available.has(profile)) {
+      throw new Error(
+        `Published kicad-mcp-pro is missing required profile: ${profile}`,
+      );
+    }
+  }
+  return {
+    primary: [...PRIMARY_PROFILES],
+    migrationAliases: [...MIGRATION_ALIASES],
+  };
+}
+
+function main() {
+  const raw = process.env.KICAD_MCP_PRO_PUBLISHED_PROFILES;
+  if (!raw) {
+    throw new Error("KICAD_MCP_PRO_PUBLISHED_PROFILES is required.");
+  }
+  const profiles = parsePublishedProfiles(raw);
+  const contract = validatePublishedProfiles(profiles);
+  console.log(
+    `✓ published MCP profiles satisfy Studio contract: ${contract.primary.join(", ")}`,
+  );
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/scripts/check-published-mcp-profiles.test.mjs
+++ b/scripts/check-published-mcp-profiles.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import {
   parsePublishedProfiles,
@@ -61,6 +62,40 @@ test("published profile canary inspects a verified wheel without executing it", 
   );
   assert.match(section, /sha256/u);
   assert.match(section, /zipfile/u);
-  assert.match(section, /ast\.literal_eval/u);
+  const extractor = fs.readFileSync(
+    new URL("./extract_published_mcp_profiles.py", import.meta.url),
+    "utf8",
+  );
+  assert.match(extractor, /ast\.literal_eval/u);
+  assert.match(extractor, /ast\.AnnAssign/u);
   assert.doesNotMatch(section, /uv run[\s\S]*?--with[\s\S]*?kicad-mcp-pro/u);
+});
+
+function extractProfilesFromRouter(source) {
+  const result = spawnSync(
+    "python",
+    [new URL("./extract_published_mcp_profiles.py", import.meta.url).pathname],
+    { input: source, encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+test("extracts profiles from the published router's annotated catalog assignment", () => {
+  const source = `
+PROFILE_CATEGORIES: dict[str, tuple[str, ...]] = {
+    "default": ("project",),
+    "review": ("project",),
+    "expert": ("project",),
+}
+
+def available_profiles():
+    preferred = ["default", "review", "missing", "expert"]
+    return tuple(name for name in preferred if name in PROFILE_CATEGORIES)
+`;
+  assert.deepEqual(extractProfilesFromRouter(source), [
+    "default",
+    "review",
+    "expert",
+  ]);
 });

--- a/scripts/check-published-mcp-profiles.test.mjs
+++ b/scripts/check-published-mcp-profiles.test.mjs
@@ -99,3 +99,26 @@ def available_profiles():
     "expert",
   ]);
 });
+
+test("#628 rejects published migration aliases whose scopes diverge", () => {
+  const source = `
+PROFILE_CATEGORIES = {
+    "default": ("project",),
+    "review": ("project",),
+    "full": ("project", "write"),
+    "expert": ("project", "write", "admin"),
+    "agent_full": ("project", "write"),
+}
+
+def available_profiles():
+    preferred = ["default", "review", "full", "expert", "agent_full"]
+    return tuple(name for name in preferred if name in PROFILE_CATEGORIES)
+`;
+  const result = spawnSync(
+    "python",
+    [new URL("./extract_published_mcp_profiles.py", import.meta.url).pathname],
+    { input: source, encoding: "utf8" },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /migration alias scopes diverge/i);
+});

--- a/scripts/check-published-mcp-profiles.test.mjs
+++ b/scripts/check-published-mcp-profiles.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import test from "node:test";
 import {
   parsePublishedProfiles,
@@ -40,4 +41,26 @@ test("rejects a published artifact missing a primary workflow profile", () => {
 
 test("rejects malformed profile discovery output", () => {
   assert.throws(() => parsePublishedProfiles('{"review":true}'), /JSON array/);
+});
+
+test("published profile canary inspects a verified wheel without executing it", () => {
+  const workflow = fs.readFileSync(
+    new URL(
+      "../.github/workflows/cross-repo-compatibility.yml",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const section = workflow.match(
+    /- name: Validate published MCP profile vocabulary[\s\S]*?(?=\n      - name:|$)/u,
+  )?.[0];
+  assert.ok(section, "published MCP profile vocabulary step is missing");
+  assert.match(
+    section,
+    /pypi\.org\/pypi\/kicad-mcp-pro\/\$\{KICAD_MCP_PRO_VERSION\}\/json/u,
+  );
+  assert.match(section, /sha256/u);
+  assert.match(section, /zipfile/u);
+  assert.match(section, /ast\.literal_eval/u);
+  assert.doesNotMatch(section, /uv run[\s\S]*?--with[\s\S]*?kicad-mcp-pro/u);
 });

--- a/scripts/check-published-mcp-profiles.test.mjs
+++ b/scripts/check-published-mcp-profiles.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parsePublishedProfiles,
+  validatePublishedProfiles,
+} from "./check-published-mcp-profiles.mjs";
+
+test("accepts the supported published profile vocabulary", () => {
+  const profiles = parsePublishedProfiles(
+    JSON.stringify([
+      "default",
+      "review",
+      "build",
+      "release",
+      "expert",
+      "full",
+      "agent_full",
+      "analysis",
+    ]),
+  );
+  assert.deepEqual(validatePublishedProfiles(profiles), {
+    primary: ["review", "build", "release", "expert"],
+    migrationAliases: ["default", "full", "agent_full"],
+  });
+});
+
+test("rejects a published artifact missing a primary workflow profile", () => {
+  assert.throws(
+    () =>
+      validatePublishedProfiles([
+        "default",
+        "review",
+        "build",
+        "expert",
+        "full",
+      ]),
+    /missing required profile: release/,
+  );
+});
+
+test("rejects malformed profile discovery output", () => {
+  assert.throws(() => parsePublishedProfiles('{"review":true}'), /JSON array/);
+});

--- a/scripts/extract_published_mcp_profiles.py
+++ b/scripts/extract_published_mcp_profiles.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Extract the static MCP profile vocabulary without executing server code."""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+
+
+def _assigned_value(node: ast.stmt, name: str) -> ast.expr | None:
+    if isinstance(node, ast.Assign) and any(
+        isinstance(target, ast.Name) and target.id == name for target in node.targets
+    ):
+        return node.value
+    if (
+        isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == name
+    ):
+        return node.value
+    return None
+
+
+def extract_profiles(source: str) -> list[str]:
+    module = ast.parse(source)
+    profile_categories: set[str] | None = None
+    preferred: list[str] | None = None
+
+    for node in module.body:
+        catalog = _assigned_value(node, "PROFILE_CATEGORIES")
+        if catalog is not None:
+            if not isinstance(catalog, ast.Dict):
+                raise ValueError("PROFILE_CATEGORIES is not a dictionary literal")
+            keys = [
+                key.value
+                for key in catalog.keys
+                if isinstance(key, ast.Constant) and isinstance(key.value, str)
+            ]
+            if len(keys) != len(catalog.keys):
+                raise ValueError("PROFILE_CATEGORIES has non-literal keys")
+            profile_categories = set(keys)
+
+        if isinstance(node, ast.FunctionDef) and node.name == "available_profiles":
+            for statement in node.body:
+                value = _assigned_value(statement, "preferred")
+                if value is None:
+                    continue
+                parsed = ast.literal_eval(value)
+                if not isinstance(parsed, list) or not all(
+                    isinstance(item, str) for item in parsed
+                ):
+                    raise ValueError("available_profiles preferred list is not literal")
+                preferred = parsed
+
+    if not profile_categories or preferred is None:
+        raise ValueError("published wheel profile vocabulary could not be parsed")
+    return [name for name in preferred if name in profile_categories]
+
+
+def main() -> None:
+    print(json.dumps(extract_profiles(sys.stdin.read())))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_published_mcp_profiles.py
+++ b/scripts/extract_published_mcp_profiles.py
@@ -22,36 +22,46 @@ def _assigned_value(node: ast.stmt, name: str) -> ast.expr | None:
     return None
 
 
+def _profile_categories(node: ast.stmt) -> set[str] | None:
+    catalog = _assigned_value(node, "PROFILE_CATEGORIES")
+    if catalog is None:
+        return None
+    if not isinstance(catalog, ast.Dict):
+        raise ValueError("PROFILE_CATEGORIES is not a dictionary literal")
+    keys = [
+        key.value
+        for key in catalog.keys
+        if isinstance(key, ast.Constant) and isinstance(key.value, str)
+    ]
+    if len(keys) != len(catalog.keys):
+        raise ValueError("PROFILE_CATEGORIES has non-literal keys")
+    return set(keys)
+
+
+def _preferred_profiles(node: ast.stmt) -> list[str] | None:
+    if not isinstance(node, ast.FunctionDef) or node.name != "available_profiles":
+        return None
+    for statement in node.body:
+        value = _assigned_value(statement, "preferred")
+        if value is None:
+            continue
+        parsed = ast.literal_eval(value)
+        if not isinstance(parsed, list) or not all(
+            isinstance(item, str) for item in parsed
+        ):
+            raise ValueError("available_profiles preferred list is not literal")
+        return parsed
+    return None
+
+
 def extract_profiles(source: str) -> list[str]:
     module = ast.parse(source)
     profile_categories: set[str] | None = None
     preferred: list[str] | None = None
 
     for node in module.body:
-        catalog = _assigned_value(node, "PROFILE_CATEGORIES")
-        if catalog is not None:
-            if not isinstance(catalog, ast.Dict):
-                raise ValueError("PROFILE_CATEGORIES is not a dictionary literal")
-            keys = [
-                key.value
-                for key in catalog.keys
-                if isinstance(key, ast.Constant) and isinstance(key.value, str)
-            ]
-            if len(keys) != len(catalog.keys):
-                raise ValueError("PROFILE_CATEGORIES has non-literal keys")
-            profile_categories = set(keys)
-
-        if isinstance(node, ast.FunctionDef) and node.name == "available_profiles":
-            for statement in node.body:
-                value = _assigned_value(statement, "preferred")
-                if value is None:
-                    continue
-                parsed = ast.literal_eval(value)
-                if not isinstance(parsed, list) or not all(
-                    isinstance(item, str) for item in parsed
-                ):
-                    raise ValueError("available_profiles preferred list is not literal")
-                preferred = parsed
+        profile_categories = _profile_categories(node) or profile_categories
+        preferred = _preferred_profiles(node) or preferred
 
     if not profile_categories or preferred is None:
         raise ValueError("published wheel profile vocabulary could not be parsed")

--- a/scripts/extract_published_mcp_profiles.py
+++ b/scripts/extract_published_mcp_profiles.py
@@ -35,6 +35,17 @@ def _profile_categories(node: ast.stmt) -> set[str] | None:
     ]
     if len(keys) != len(catalog.keys):
         raise ValueError("PROFILE_CATEGORIES has non-literal keys")
+    fingerprints = {
+        key: ast.dump(value, include_attributes=False)
+        for key, value in zip(keys, catalog.values, strict=True)
+    }
+    for aliases in (("default", "review"), ("full", "expert", "agent_full")):
+        if all(alias in fingerprints for alias in aliases) and len(
+            {fingerprints[alias] for alias in aliases}
+        ) != 1:
+            raise ValueError(
+                f"migration alias scopes diverge: {', '.join(aliases)}"
+            )
     return set(keys)
 
 


### PR DESCRIPTION
## Summary

- Make Review / Build / Release / Expert the primary task-oriented MCP profiles and default first-use configuration to least-privilege Review.
- Normalize equivalent legacy profile values safely (`default` -> `review`, `full` / `agent_full` -> `expert`) while preserving specialized profiles without widening privileges.
- Reuse one Studio profile catalog across custom pickers/settings and lock manifest/schema vocabulary with policy tests.
- Validate the exact published `kicad-mcp-pro` profile vocabulary in the cross-repo compatibility canary so server/client drift fails closed.

## Linked issue

Refs #622
Refs #628

This is a bounded regression/contract slice. It intentionally does not close #622; the dedicated Advanced-path UX and remaining extension-host acceptance evidence still need follow-up.

## Type of change

- [ ] type:bug
- [x] type:feature
- [ ] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

TDD/regression evidence:
- Profile catalog contract was introduced RED-first (missing task-oriented exports/resolver), then made green.
- Workspace/global profile migration tests were RED against the legacy behavior, then green after fail-closed normalization.
- Manifest/settings/command vocabulary tests were RED against duplicated legacy lists, then green after catalog consolidation.
- Published-artifact validator was introduced RED-first and then validated against exact PyPI `kicad-mcp-pro==3.33.3`.
- Reviewer TDD on #628: the published extractor initially accepted divergent `full` / `expert` / `agent_full` scopes (RED); it now compares migration-alias AST scope fingerprints without executing server code and fails closed on semantic drift (GREEN).
- Full suite caught the intentional `full` -> `expert` dashboard normalization; the expectation was updated only after verifying equivalent server tool scope.

Original implementation full-gate evidence (before review follow-ups):
- `pnpm` repository pre-push gate: pass (full root/workspace policy suite)
- Extension unit: 127/127 suites, 1001/1001 tests, 2 snapshots
- Coverage ratchet: 10/10 suites, 128/128 tests
- Security: 12/12 tests
- Accessibility: 76/76 tests including Settings dark/light/high-contrast and keyboard/focus checks
- Lint + typecheck + build + VSIX package validation: pass
- Compatibility/manifest/docs/workflow/CI-lane/supply-chain/governance gates: pass
- Published profile contract against `kicad-mcp-pro==3.33.3`: pass
- Latest review follow-up `5e7c261305f1f82cc2ae2752c92da43b0dbda03e`: `check-published-mcp-profiles` 6/6, compatibility contract 41/41, Python syntax, Prettier, and `git diff --check` pass.
- Independently SHA256-verified the published 3.33.3 wheel: `full`, `expert`, and `agent_full` all map to the complete category set; `default` and `review` share the same bounded review scope.
- All PR commits, including the GitHub `update-branch` merge and #628 review fix, are GitHub-verified; non-trivial authored commits are DCO signed-off.

## Protocol / MCP impact

Checklist reference: `docs/architecture/protocol-change-checklist.md`

- [ ] Not applicable; reason:
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [x] Extension MCP adapter updated
- [x] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

No MCP wire protocol/tool schema/transport changes are introduced. This changes Studio profile selection/configuration semantics and adds a published-server compatibility canary.

## Repository maturity impact

- [ ] No repository maturity impact
- [ ] Documentation/community health updated
- [x] CI/quality/release process updated
- [ ] Governance/security/supply-chain process updated
- [ ] Manual GitHub setting or maintainer action required and documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Review evidence

An availability, quota, rate-limit, or capacity notice is not a completed review.

Select exactly one automated-review outcome:

- [ ] Completed with findings; every finding is triaged below
- [ ] Completed with no findings
- [x] Unavailable; reason and compensating evidence recorded below
- [ ] Not applicable; reason:

Latest-head automated static/security providers have run; Sonar, CodeQL, Semgrep, Trivy, dependency review, Socket, DeepScan, release-readiness, metadata, canary, and real-pair are green. Platform matrix completion is tracked before merge.

Select exactly one change risk:

- [ ] Low
- [x] Medium
- [ ] High

Bot and agent triage:

- [x] Every bot and agent comment is classified as actionable, resolved, informational, duplicate, or unavailable
- [x] No actionable finding remains unresolved
- [x] Unavailable notices are recorded as unavailable, not completed review

Compensating evidence (required when automated review is unavailable for medium/high-risk changes):

- [ ] Focused second-agent review
- [ ] Architecture/security checklist
- [x] Additional regression tests
- [x] Documented manual review
- [ ] Not required because review completed, was not applicable, or change risk is low

Evidence links/notes:

Full diff was manually reviewed; no secrets, generated build artifacts, dependency changes, protocol widening, or destructive operations were introduced. Reviewer finding on alias-scope semantic drift was resolved in `5e7c261`; Sonar reports 0 new issues / 0 security hotspots and Codecov reports all modified coverable lines covered on the prior implementation head. Latest hosted matrix is being re-run after the review fix.

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references #622 / #628 in test names or metadata
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval — not applicable; classified as feature/contract alignment with automated regression coverage
- [x] CHANGELOG entry (if user-visible) — release-please derives release notes from the conventional commit; no manual changelog edit
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
- [x] Developer Certificate of Origin sign-off is present on non-trivial commits (`git commit -s`) or not applicable with rationale
- [x] Meets the [Definition of Done](../docs/architecture/definition-of-done.md) for this bounded slice; #622 remains open for acceptance items outside this PR

