### PR TITLE
fix(repo): promote signed Release Please shadow PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,12 +32,10 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # When Release Please has an OPEN release PR, sync the version surfaces it
-      # does not bump itself (compatibility metadata + the generated docs tables)
-      # onto its branch. Release Please only updates package.json, the manifest,
-      # and the changelog, so without this the release PR's own CI fails on
-      # compatibility.yaml / compatibilityMatrix.ts / generated-docs version
-      # drift and the release can never be merged.
+      # Release Please's generated commit is not GitHub-signed, while main requires
+      # signed commits. Build the complete release tree from the canonical PR, then
+      # promote it to a parseable Release Please shadow PR with one GitHub-signed
+      # commit. The canonical PR is closed only after the shadow PR is ready.
       - if: ${{ steps.release.outputs.pr }}
         id: release-pr
         name: Resolve the Release Please branch
@@ -50,6 +48,7 @@ jobs:
           const releasePr = JSON.parse(process.env.RELEASE_PR_JSON ?? "");
           const branch = releasePr.headBranchName;
           const title = releasePr.title;
+          const number = releasePr.number;
           const invalidBranchCharacter =
             typeof branch === "string" &&
             [...branch].some((character) => {
@@ -82,15 +81,19 @@ jobs:
           ) {
             throw new Error("Release Please returned an unsafe release PR title");
           }
-          process.stdout.write(`${branch}\n${title}\n`);
+          if (!Number.isSafeInteger(number) || number <= 0) {
+            throw new Error("Release Please returned an invalid PR number");
+          }
+          process.stdout.write(`${branch}\n${title}\n${number}\n`);
           NODE
           )
-          if [[ "${#release_metadata[@]}" -ne 2 ]]; then
+          if [[ "${#release_metadata[@]}" -ne 3 ]]; then
             echo "Release Please returned incomplete PR metadata" >&2
             exit 1
           fi
           printf 'branch=%s\n' "${release_metadata[0]}" >> "$GITHUB_OUTPUT"
           printf 'title=%s\n' "${release_metadata[1]}" >> "$GITHUB_OUTPUT"
+          printf 'number=%s\n' "${release_metadata[2]}" >> "$GITHUB_OUTPUT"
       - if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -113,16 +116,52 @@ jobs:
       - if: ${{ steps.release.outputs.pr }}
         run: corepack pnpm run docs:generate
       - if: ${{ steps.release.outputs.pr }}
-        name: Append GitHub-signed release surfaces
+        name: Create signed Release Please shadow PR
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          RELEASE_BRANCH: ${{ steps.release-pr.outputs.branch }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          RELEASE_PR_NUMBER: ${{ steps.release-pr.outputs.number }}
           RELEASE_TITLE: ${{ steps.release-pr.outputs.title }}
+          SIGNED_RELEASE_BRANCH: release-please/branches/main/components/vscode-extension
+        shell: bash
         run: |
+          set -euo pipefail
+          RELEASE_BASE_SHA="$(git rev-parse origin/main)"
+          RELEASE_BODY_FILE="$RUNNER_TEMP/release-pr-body.md"
+          SIGNED_RELEASE_PR=""
+
+          cleanup_shadow() {
+            set +e
+            if [[ -n "$SIGNED_RELEASE_PR" ]]; then
+              gh pr close "$SIGNED_RELEASE_PR" >/dev/null 2>&1 || true
+            fi
+            gh api --method DELETE \
+              "repos/$GITHUB_REPOSITORY/git/refs/heads/$SIGNED_RELEASE_BRANCH" \
+              >/dev/null 2>&1 || true
+          }
+
+          gh pr view "$RELEASE_PR_NUMBER" --json body --jq '.body // ""' \
+            > "$RELEASE_BODY_FILE"
           node scripts/create-github-signed-commit.mjs \
             --repository "$GITHUB_REPOSITORY" \
-            --branch "$RELEASE_BRANCH" \
-            --message "${RELEASE_TITLE}"$'\n\nSigned-off-by: oaslananka <info@oaslananka.dev>'
+            --branch "$SIGNED_RELEASE_BRANCH" \
+            --message "chore(kicad-studio): prepare signed release surfaces"$'\n\nSigned-off-by: oaslananka <info@oaslananka.dev>' \
+            --create-from-base "$RELEASE_BASE_SHA"
+
+          trap cleanup_shadow ERR
+          SIGNED_RELEASE_URL="$(gh pr create \
+            --draft \
+            --base main \
+            --head "$SIGNED_RELEASE_BRANCH" \
+            --title "$RELEASE_TITLE" \
+            --body-file "$RELEASE_BODY_FILE")"
+          SIGNED_RELEASE_PR="${SIGNED_RELEASE_URL##*/}"
+          gh pr edit "$SIGNED_RELEASE_PR" --add-label "autorelease: pending"
+          gh pr comment "$RELEASE_PR_NUMBER" \
+            --body "Superseded by #$SIGNED_RELEASE_PR, the GitHub-signed release PR required by branch protection."
+          gh pr close "$RELEASE_PR_NUMBER"
+          gh pr edit "$RELEASE_PR_NUMBER" --remove-label "autorelease: pending" || true
+          trap - ERR
 
       # Regenerate changelog docs after a release PR is merged
       - if: ${{ steps.release.outputs.releases_created == 'true' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -150,8 +150,26 @@ jobs:
               exit 1
             fi
             SIGNED_RELEASE_PR="${signed_release_prs[0]}"
+            gh pr update-branch "$SIGNED_RELEASE_PR"
+            SIGNED_RELEASE_HEAD="$(gh pr view "$SIGNED_RELEASE_PR" \
+              --json headRefOid \
+              --jq '.headRefOid')"
+            SIGNED_RELEASE_VERIFIED="$(gh api \
+              "repos/$GITHUB_REPOSITORY/commits/$SIGNED_RELEASE_HEAD" \
+              --jq '.commit.verification.verified')"
+            if [[ "$SIGNED_RELEASE_VERIFIED" != "true" ]]; then
+              echo "Signed release shadow head is not GitHub-verified" >&2
+              exit 1
+            fi
             git fetch --no-tags origin \
+              "refs/heads/main:refs/remotes/origin/main" \
               "refs/heads/$SIGNED_RELEASE_BRANCH:refs/remotes/origin/$SIGNED_RELEASE_BRANCH"
+            if ! git merge-base --is-ancestor \
+              refs/remotes/origin/main \
+              "refs/remotes/origin/$SIGNED_RELEASE_BRANCH"; then
+              echo "Signed release shadow is not up to date with main" >&2
+              exit 1
+            fi
             node scripts/create-github-signed-commit.mjs \
               --repository "$GITHUB_REPOSITORY" \
               --branch "$SIGNED_RELEASE_BRANCH" \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -91,9 +91,11 @@ jobs:
             echo "Release Please returned incomplete PR metadata" >&2
             exit 1
           fi
-          printf 'branch=%s\n' "${release_metadata[0]}" >> "$GITHUB_OUTPUT"
-          printf 'title=%s\n' "${release_metadata[1]}" >> "$GITHUB_OUTPUT"
-          printf 'number=%s\n' "${release_metadata[2]}" >> "$GITHUB_OUTPUT"
+          {
+            printf 'branch=%s\n' "${release_metadata[0]}"
+            printf 'title=%s\n' "${release_metadata[1]}"
+            printf 'number=%s\n' "${release_metadata[2]}"
+          } >> "$GITHUB_OUTPUT"
       - if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,9 +33,9 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       # Release Please's generated commit is not GitHub-signed, while main requires
-      # signed commits. Build the complete release tree from the canonical PR, then
-      # promote it to a parseable Release Please shadow PR with one GitHub-signed
-      # commit. The canonical PR is closed only after the shadow PR is ready.
+      # signed commits. Keep the canonical PR as Release Please's draft generator,
+      # while a parseable shadow PR carries only GitHub-signed commits. Repeated
+      # Release Please updates append signed commits to the same shadow branch.
       - if: ${{ steps.release.outputs.pr }}
         id: release-pr
         name: Resolve the Release Please branch
@@ -118,7 +118,7 @@ jobs:
       - if: ${{ steps.release.outputs.pr }}
         run: corepack pnpm run docs:generate
       - if: ${{ steps.release.outputs.pr }}
-        name: Create signed Release Please shadow PR
+        name: Sync signed Release Please shadow PR
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -132,38 +132,67 @@ jobs:
           RELEASE_BODY_FILE="$RUNNER_TEMP/release-pr-body.md"
           SIGNED_RELEASE_PR=""
 
-          cleanup_shadow() {
-            set +e
-            if [[ -n "$SIGNED_RELEASE_PR" ]]; then
-              gh pr close "$SIGNED_RELEASE_PR" >/dev/null 2>&1 || true
-            fi
-            gh api --method DELETE \
-              "repos/$GITHUB_REPOSITORY/git/refs/heads/$SIGNED_RELEASE_BRANCH" \
-              >/dev/null 2>&1 || true
-          }
-
           gh pr view "$RELEASE_PR_NUMBER" --json body --jq '.body // ""' \
             > "$RELEASE_BODY_FILE"
-          node scripts/create-github-signed-commit.mjs \
-            --repository "$GITHUB_REPOSITORY" \
-            --branch "$SIGNED_RELEASE_BRANCH" \
-            --message "chore(kicad-studio): prepare signed release surfaces"$'\n\nSigned-off-by: oaslananka <info@oaslananka.dev>' \
-            --create-from-base "$RELEASE_BASE_SHA"
 
-          trap cleanup_shadow ERR
-          SIGNED_RELEASE_URL="$(gh pr create \
-            --draft \
-            --base main \
-            --head "$SIGNED_RELEASE_BRANCH" \
-            --title "$RELEASE_TITLE" \
-            --body-file "$RELEASE_BODY_FILE")"
-          SIGNED_RELEASE_PR="${SIGNED_RELEASE_URL##*/}"
-          gh pr edit "$SIGNED_RELEASE_PR" --add-label "autorelease: pending"
-          gh pr comment "$RELEASE_PR_NUMBER" \
-            --body "Superseded by #$SIGNED_RELEASE_PR, the GitHub-signed release PR required by branch protection."
-          gh pr close "$RELEASE_PR_NUMBER"
-          gh pr edit "$RELEASE_PR_NUMBER" --remove-label "autorelease: pending" || true
-          trap - ERR
+          if SIGNED_RELEASE_HEAD="$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$SIGNED_RELEASE_BRANCH" \
+            --jq '.object.sha' 2>/dev/null)"; then
+            mapfile -t signed_release_prs < <(
+              gh pr list \
+                --state open \
+                --head "$SIGNED_RELEASE_BRANCH" \
+                --json number \
+                --jq '.[].number'
+            )
+            if [[ "${#signed_release_prs[@]}" -ne 1 ]]; then
+              echo "Expected exactly one open signed release PR for existing shadow branch" >&2
+              exit 1
+            fi
+            SIGNED_RELEASE_PR="${signed_release_prs[0]}"
+            git fetch --no-tags origin \
+              "refs/heads/$SIGNED_RELEASE_BRANCH:refs/remotes/origin/$SIGNED_RELEASE_BRANCH"
+            node scripts/create-github-signed-commit.mjs \
+              --repository "$GITHUB_REPOSITORY" \
+              --branch "$SIGNED_RELEASE_BRANCH" \
+              --message "chore(kicad-studio): sync signed release surfaces"$'\n\nSigned-off-by: oaslananka <info@oaslananka.dev>' \
+              --onto-head "$SIGNED_RELEASE_HEAD"
+            gh pr edit "$SIGNED_RELEASE_PR" \
+              --title "$RELEASE_TITLE" \
+              --body-file "$RELEASE_BODY_FILE"
+          else
+            node scripts/create-github-signed-commit.mjs \
+              --repository "$GITHUB_REPOSITORY" \
+              --branch "$SIGNED_RELEASE_BRANCH" \
+              --message "chore(kicad-studio): prepare signed release surfaces"$'\n\nSigned-off-by: oaslananka <info@oaslananka.dev>' \
+              --create-from-base "$RELEASE_BASE_SHA"
+
+            cleanup_new_shadow() {
+              set +e
+              if [[ -n "$SIGNED_RELEASE_PR" ]]; then
+                gh pr close "$SIGNED_RELEASE_PR" >/dev/null 2>&1 || true
+              fi
+              gh api --method DELETE \
+                "repos/$GITHUB_REPOSITORY/git/refs/heads/$SIGNED_RELEASE_BRANCH" \
+                >/dev/null 2>&1 || true
+            }
+            trap cleanup_new_shadow ERR
+
+            SIGNED_RELEASE_URL="$(gh pr create \
+              --base main \
+              --head "$SIGNED_RELEASE_BRANCH" \
+              --title "$RELEASE_TITLE" \
+              --body-file "$RELEASE_BODY_FILE")"
+            SIGNED_RELEASE_PR="${SIGNED_RELEASE_URL##*/}"
+            gh pr edit "$SIGNED_RELEASE_PR" --add-label "autorelease: pending"
+            gh pr comment "$RELEASE_PR_NUMBER" \
+              --body "Merge #$SIGNED_RELEASE_PR for signature-compliant release history; this PR remains the Release Please generator."
+            trap - ERR
+          fi
+
+          if [[ "$(gh pr view "$RELEASE_PR_NUMBER" --json isDraft --jq '.isDraft')" != "true" ]]; then
+            gh pr ready --undo "$RELEASE_PR_NUMBER"
+          fi
 
       # Regenerate changelog docs after a release PR is merged
       - if: ${{ steps.release.outputs.releases_created == 'true' }}

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -6,7 +6,7 @@ KiCad Studio Kit releases the VS Code extension from this repository. The MCP se
 
 ## Release automation
 
-- `release-please.yml` opens and maintains release PRs with the dedicated `RELEASE_PLEASE_TOKEN`, then appends GitHub-signed, DCO-signed-off generated release surfaces without rewriting the live PR branch. Release PRs are squash-merged through GitHub so protected `main` receives one GitHub-verified commit while default GitHub Actions permissions remain read-only.
+- `release-please.yml` opens the canonical generated PR with the dedicated `RELEASE_PLEASE_TOKEN`, builds the complete release tree, and promotes it to a draft `release-please/branches/main/components/vscode-extension` shadow PR containing one GitHub-signed, DCO-signed-off commit. The unsigned canonical PR is closed only after the shadow PR is ready; no live ref is force-rewritten.
 - `publish-extension.yml` packages the VSIX, validates metadata, stages checksums, SBOM, provenance, and attestations, then publishes to marketplaces from the authenticated release event.
 - `release.yml` is a low-risk release-readiness workflow that validates release evidence without publishing.
 
@@ -27,7 +27,7 @@ Each release should provide:
 
 1. Confirm the release PR includes the intended changelog and version bump.
 2. Confirm CI, CodeQL, Gitleaks, and package validation pass.
-3. Squash-merge the release PR through GitHub so the commit entering `main` is GitHub-verified.
+3. Confirm the canonical unsigned Release Please PR has been superseded by the parseable signed shadow PR, then squash-merge the signed shadow PR through GitHub so the commit entering `main` is GitHub-verified.
 4. Confirm release evidence is generated and attached.
 5. Confirm marketplace publish jobs use protected environments and minimum secrets.
 6. Confirm post-release docs and version surfaces are updated.

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -6,7 +6,7 @@ KiCad Studio Kit releases the VS Code extension from this repository. The MCP se
 
 ## Release automation
 
-- `release-please.yml` opens the canonical generated PR with the dedicated `RELEASE_PLEASE_TOKEN`, builds the complete release tree, and promotes it to a draft `release-please/branches/main/components/vscode-extension` shadow PR containing one GitHub-signed, DCO-signed-off commit. The unsigned canonical PR is closed only after the shadow PR is ready; no live ref is force-rewritten.
+- `release-please.yml` keeps the canonical generated PR as Release Please's draft generator, builds the complete release tree, and mirrors it to `release-please/branches/main/components/vscode-extension`. The mergeable shadow PR contains only GitHub-signed, DCO-signed-off commits; later generator updates append signed commits without rewriting either live ref.
 - `publish-extension.yml` packages the VSIX, validates metadata, stages checksums, SBOM, provenance, and attestations, then publishes to marketplaces from the authenticated release event.
 - `release.yml` is a low-risk release-readiness workflow that validates release evidence without publishing.
 
@@ -27,7 +27,7 @@ Each release should provide:
 
 1. Confirm the release PR includes the intended changelog and version bump.
 2. Confirm CI, CodeQL, Gitleaks, and package validation pass.
-3. Confirm the canonical unsigned Release Please PR has been superseded by the parseable signed shadow PR, then squash-merge the signed shadow PR through GitHub so the commit entering `main` is GitHub-verified.
+3. Confirm the canonical unsigned Release Please generator PR is draft and the parseable signed shadow PR matches its release tree, then squash-merge the signed shadow PR through GitHub so the commit entering `main` is GitHub-verified.
 4. Confirm release evidence is generated and attached.
 5. Confirm marketplace publish jobs use protected environments and minimum secrets.
 6. Confirm post-release docs and version surfaces are updated.

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -6,7 +6,7 @@ KiCad Studio Kit releases the VS Code extension from this repository. The MCP se
 
 ## Release automation
 
-- `release-please.yml` keeps the canonical generated PR as Release Please's draft generator, builds the complete release tree, and mirrors it to `release-please/branches/main/components/vscode-extension`. The mergeable shadow PR contains only GitHub-signed, DCO-signed-off commits; later generator updates append signed commits without rewriting either live ref.
+- `release-please.yml` keeps the canonical generated PR as Release Please's draft generator, builds the complete release tree, and mirrors it to `release-please/branches/main/components/vscode-extension`. The mergeable shadow PR contains only GitHub-signed, DCO-signed-off release commits; later generator updates first use GitHub's normal verified `update-branch` merge to make current `main` an ancestor, then append the signed release-tree delta without rewriting either live ref.
 - `publish-extension.yml` packages the VSIX, validates metadata, stages checksums, SBOM, provenance, and attestations, then publishes to marketplaces from the authenticated release event.
 - `release.yml` is a low-risk release-readiness workflow that validates release evidence without publishing.
 

--- a/scripts/check-release-please-monorepo.test.mjs
+++ b/scripts/check-release-please-monorepo.test.mjs
@@ -73,6 +73,14 @@ test("release workflow promotes a GitHub-signed parseable shadow PR without rewr
   assert.match(workflow, /--onto-head "\$SIGNED_RELEASE_HEAD"/);
   assert.match(
     workflow,
+    /gh pr update-branch "\$SIGNED_RELEASE_PR"[\s\S]*?SIGNED_RELEASE_HEAD=[\s\S]*?headRefOid[\s\S]*?--onto-head "\$SIGNED_RELEASE_HEAD"/,
+  );
+  assert.match(
+    workflow,
+    /commit\.verification\.verified[\s\S]*?Signed release shadow head is not GitHub-verified/,
+  );
+  assert.match(
+    workflow,
     /gh pr create[\s\S]*?--head "\$SIGNED_RELEASE_BRANCH"/,
   );
   assert.doesNotMatch(

--- a/scripts/check-release-please-monorepo.test.mjs
+++ b/scripts/check-release-please-monorepo.test.mjs
@@ -32,7 +32,7 @@ function restoreEnv(name, value) {
   }
 }
 
-test("release workflow appends GitHub-signed generated surfaces without rewriting the PR branch", () => {
+test("release workflow promotes a GitHub-signed parseable shadow PR without rewriting refs", () => {
   const workflow = fs.readFileSync(
     path.join(REPO_ROOT, ".github/workflows/release-please.yml"),
     "utf8",
@@ -54,7 +54,7 @@ test("release workflow appends GitHub-signed generated surfaces without rewritin
   );
   assert.match(
     workflow,
-    /name: Append GitHub-signed release surfaces[\s\S]*?GITHUB_TOKEN: \${{ secrets\.RELEASE_PLEASE_TOKEN }}/,
+    /name: Create signed Release Please shadow PR[\s\S]*?GITHUB_TOKEN: \${{ secrets\.RELEASE_PLEASE_TOKEN }}/,
   );
   assert.match(
     workflow,
@@ -67,23 +67,22 @@ test("release workflow appends GitHub-signed generated surfaces without rewritin
   assert.match(workflow, /ref: \${{ steps\.release-pr\.outputs\.branch }}/);
   assert.match(
     workflow,
-    /RELEASE_BRANCH: \${{ steps\.release-pr\.outputs\.branch }}/,
+    /SIGNED_RELEASE_BRANCH: release-please\/branches\/main\/components\/vscode-extension/,
   );
-  assert.doesNotMatch(workflow, /RELEASE_BASE_SHA/);
+  assert.match(workflow, /--create-from-base "\$RELEASE_BASE_SHA"/);
   assert.match(
     workflow,
-    /RELEASE_TITLE: \${{ steps\.release-pr\.outputs\.title }}/,
+    /gh pr create[\s\S]*?--draft[\s\S]*?--head "\$SIGNED_RELEASE_BRANCH"/,
   );
-  assert.doesNotMatch(workflow, /--base /);
-  assert.match(workflow, /Signed-off-by: oaslananka <info@oaslananka\.dev>/);
-  assert.doesNotMatch(
+  assert.match(
     workflow,
-    /--message "chore\(repo\): sync release surfaces for the pending release"/,
+    /gh pr edit "\$SIGNED_RELEASE_PR" --add-label "autorelease: pending"/,
   );
-  assert.doesNotMatch(workflow, /fromJSON\(steps\.release\.outputs\.pr\)/);
-  assert.doesNotMatch(workflow, /git commit/);
+  assert.match(workflow, /gh pr close "\$RELEASE_PR_NUMBER"/);
+  assert.doesNotMatch(workflow, /name: Append GitHub-signed release surfaces/);
+  assert.doesNotMatch(workflow, /forceUpdateRef/);
   assert.doesNotMatch(workflow, /git push/);
-  assert.doesNotMatch(workflow, /gh workflow run publish-extension\.yml/);
+  assert.match(workflow, /Signed-off-by: oaslananka <info@oaslananka\.dev>/);
   assert.match(publishWorkflow, /release:\n\s+types: \[published\]/);
 });
 

--- a/scripts/check-release-please-monorepo.test.mjs
+++ b/scripts/check-release-please-monorepo.test.mjs
@@ -45,7 +45,7 @@ test("release workflow promotes a GitHub-signed parseable shadow PR without rewr
   assert.equal(
     (workflow.match(/node scripts\/create-github-signed-commit\.mjs/g) ?? [])
       .length,
-    2,
+    3,
   );
   assert.match(workflow, /token: \${{ secrets\.RELEASE_PLEASE_TOKEN }}/);
   assert.doesNotMatch(
@@ -54,7 +54,7 @@ test("release workflow promotes a GitHub-signed parseable shadow PR without rewr
   );
   assert.match(
     workflow,
-    /name: Create signed Release Please shadow PR[\s\S]*?GITHUB_TOKEN: \${{ secrets\.RELEASE_PLEASE_TOKEN }}/,
+    /name: Sync signed Release Please shadow PR[\s\S]*?GITHUB_TOKEN: \${{ secrets\.RELEASE_PLEASE_TOKEN }}/,
   );
   assert.match(
     workflow,
@@ -70,7 +70,12 @@ test("release workflow promotes a GitHub-signed parseable shadow PR without rewr
     /SIGNED_RELEASE_BRANCH: release-please\/branches\/main\/components\/vscode-extension/,
   );
   assert.match(workflow, /--create-from-base "\$RELEASE_BASE_SHA"/);
+  assert.match(workflow, /--onto-head "\$SIGNED_RELEASE_HEAD"/);
   assert.match(
+    workflow,
+    /gh pr create[\s\S]*?--head "\$SIGNED_RELEASE_BRANCH"/,
+  );
+  assert.doesNotMatch(
     workflow,
     /gh pr create[\s\S]*?--draft[\s\S]*?--head "\$SIGNED_RELEASE_BRANCH"/,
   );
@@ -78,7 +83,16 @@ test("release workflow promotes a GitHub-signed parseable shadow PR without rewr
     workflow,
     /gh pr edit "\$SIGNED_RELEASE_PR" --add-label "autorelease: pending"/,
   );
-  assert.match(workflow, /gh pr close "\$RELEASE_PR_NUMBER"/);
+  assert.match(
+    workflow,
+    /gh pr view "\$RELEASE_PR_NUMBER" --json isDraft[\s\S]*?gh pr ready --undo "\$RELEASE_PR_NUMBER"/,
+  );
+  assert.doesNotMatch(workflow, /gh pr close "\$RELEASE_PR_NUMBER"/);
+  assert.doesNotMatch(
+    workflow,
+    /gh pr edit "\$RELEASE_PR_NUMBER" --remove-label "autorelease: pending"/,
+  );
+  assert.match(workflow, /gh pr list[\s\S]*?--head "\$SIGNED_RELEASE_BRANCH"/);
   assert.doesNotMatch(workflow, /name: Append GitHub-signed release surfaces/);
   assert.doesNotMatch(workflow, /forceUpdateRef/);
   assert.doesNotMatch(workflow, /git push/);

--- a/scripts/check-release-please-monorepo.test.mjs
+++ b/scripts/check-release-please-monorepo.test.mjs
@@ -32,7 +32,7 @@ function restoreEnv(name, value) {
   }
 }
 
-test("release workflow promotes a GitHub-signed parseable shadow PR without rewriting refs", () => {
+test("#645 release workflow promotes a GitHub-signed parseable shadow PR without rewriting refs", () => {
   const workflow = fs.readFileSync(
     path.join(REPO_ROOT, ".github/workflows/release-please.yml"),
     "utf8",

--- a/scripts/create-github-signed-commit.mjs
+++ b/scripts/create-github-signed-commit.mjs
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import process from "node:process";
 
 import {
+  appendReleaseBranchCommit,
   buildCreateCommitRequest,
   createReleaseBranchFromBase,
   parseGitNameStatus,
@@ -18,6 +19,7 @@ const branch = options.branch;
 const headline = options.message;
 const baseOid = options.base;
 const createFromBaseOid = options["create-from-base"];
+const ontoHeadOid = options["onto-head"];
 const token = process.env.GITHUB_TOKEN;
 
 if (!repository || !branch || !headline || !token) {
@@ -26,11 +28,31 @@ if (!repository || !branch || !headline || !token) {
   );
 }
 
-if (baseOid && createFromBaseOid) {
-  throw new Error("--base and --create-from-base are mutually exclusive");
+const branchModes = [baseOid, createFromBaseOid, ontoHeadOid].filter(Boolean);
+if (branchModes.length > 1) {
+  throw new Error(
+    "--base, --create-from-base, and --onto-head are mutually exclusive",
+  );
 }
 
-if (createFromBaseOid) {
+if (ontoHeadOid) {
+  assertLocalCommit(ontoHeadOid, "--onto-head");
+  const descriptors = collectReleaseChanges(ontoHeadOid, { allowEmpty: true });
+  if (descriptors.length === 0) {
+    console.log(
+      "Signed release shadow already matches the generated release tree.",
+    );
+    process.exit(0);
+  }
+  await appendReleaseBranchCommit({
+    repository,
+    branch,
+    expectedHeadOid: ontoHeadOid,
+    headline,
+    changes: readChanges(descriptors),
+    createCommit: createGitHubCommit,
+  });
+} else if (createFromBaseOid) {
   const localHeadOid = git(["rev-parse", "HEAD"]).trim();
   ensureBaseIsAncestor(createFromBaseOid, localHeadOid);
   const descriptors = collectReleaseChanges(createFromBaseOid);
@@ -86,7 +108,7 @@ if (createFromBaseOid) {
 
 console.log("Created a verified GitHub commit on the requested branch.");
 
-function collectReleaseChanges(baseOid) {
+function collectReleaseChanges(baseOid, { allowEmpty = false } = {}) {
   const tracked = parseGitNameStatus(
     git(["diff", "--name-status", "--no-renames", "-z", baseOid, "--"]),
   );
@@ -97,7 +119,7 @@ function collectReleaseChanges(baseOid) {
   for (const filePath of untracked) {
     byPath.set(filePath, { path: filePath, deleted: false });
   }
-  if (byPath.size === 0) {
+  if (byPath.size === 0 && !allowEmpty) {
     throw new Error("release branch has no changes relative to the base SHA");
   }
   return [...byPath.values()].sort((left, right) =>
@@ -111,6 +133,17 @@ function readChanges(descriptors) {
       ? descriptor
       : { ...descriptor, contents: fs.readFileSync(descriptor.path) },
   );
+}
+
+function assertLocalCommit(oid, label) {
+  if (!/^[0-9a-f]{40}$/iu.test(oid ?? "")) {
+    throw new Error(`${label} must be a 40-character Git SHA`);
+  }
+  try {
+    git(["cat-file", "-e", `${oid}^{commit}`]);
+  } catch {
+    throw new Error(`${label} must name a local commit`);
+  }
 }
 
 function ensureBaseIsAncestor(baseOid, expectedHeadOid) {
@@ -260,6 +293,7 @@ function parseArguments(args) {
         "message",
         "base",
         "create-from-base",
+        "onto-head",
       ]).has(name)
     ) {
       throw new Error(`Unknown argument: ${flag}`);

--- a/scripts/create-github-signed-commit.mjs
+++ b/scripts/create-github-signed-commit.mjs
@@ -6,6 +6,7 @@ import process from "node:process";
 
 import {
   buildCreateCommitRequest,
+  createReleaseBranchFromBase,
   parseGitNameStatus,
   parseGitStatus,
   rewriteReleaseBranch,
@@ -16,6 +17,7 @@ const repository = options.repository ?? process.env.GITHUB_REPOSITORY;
 const branch = options.branch;
 const headline = options.message;
 const baseOid = options.base;
+const createFromBaseOid = options["create-from-base"];
 const token = process.env.GITHUB_TOKEN;
 
 if (!repository || !branch || !headline || !token) {
@@ -24,7 +26,25 @@ if (!repository || !branch || !headline || !token) {
   );
 }
 
-if (baseOid) {
+if (baseOid && createFromBaseOid) {
+  throw new Error("--base and --create-from-base are mutually exclusive");
+}
+
+if (createFromBaseOid) {
+  const localHeadOid = git(["rev-parse", "HEAD"]).trim();
+  ensureBaseIsAncestor(createFromBaseOid, localHeadOid);
+  const descriptors = collectReleaseChanges(createFromBaseOid);
+  await createReleaseBranchFromBase({
+    repository,
+    branch,
+    baseOid: createFromBaseOid,
+    headline,
+    changes: readChanges(descriptors),
+    createRef,
+    deleteRef,
+    createCommit: createGitHubCommit,
+  });
+} else if (baseOid) {
   const expectedHeadOid = git(["rev-parse", "HEAD"]).trim();
   ensureBaseIsAncestor(baseOid, expectedHeadOid);
   const descriptors = collectReleaseChanges(baseOid);
@@ -105,6 +125,24 @@ function ensureBaseIsAncestor(baseOid, expectedHeadOid) {
   } catch {
     throw new Error("--base must be an ancestor of the release branch HEAD");
   }
+}
+
+async function createRef({
+  repository: repositorySlug,
+  branch: branchName,
+  sha,
+}) {
+  await githubRestRequest(`/repos/${repositorySlug}/git/refs`, {
+    method: "POST",
+    body: JSON.stringify({ ref: `refs/heads/${branchName}`, sha }),
+  });
+}
+
+async function deleteRef({ repository: repositorySlug, branch: branchName }) {
+  await githubRestRequest(
+    `/repos/${repositorySlug}/git/refs/heads/${encodeBranchPath(branchName)}`,
+    { method: "DELETE" },
+  );
 }
 
 async function getRemoteHead({
@@ -192,7 +230,8 @@ async function githubApiRequest(url, init) {
       ...init.headers,
     },
   });
-  const payload = await response.json();
+  const responseText = await response.text();
+  const payload = responseText ? JSON.parse(responseText) : null;
   if (!response.ok) {
     throw new Error(
       `GitHub API ${response.status} ${response.statusText}: ${JSON.stringify(payload)}`,
@@ -214,7 +253,15 @@ function parseArguments(args) {
       throw new Error(`Invalid argument sequence near ${flag ?? "(end)"}`);
     }
     const name = flag.slice(2);
-    if (!new Set(["repository", "branch", "message", "base"]).has(name)) {
+    if (
+      !new Set([
+        "repository",
+        "branch",
+        "message",
+        "base",
+        "create-from-base",
+      ]).has(name)
+    ) {
       throw new Error(`Unknown argument: ${flag}`);
     }
     parsed[name] = value;

--- a/scripts/create-github-signed-commit.test.mjs
+++ b/scripts/create-github-signed-commit.test.mjs
@@ -128,7 +128,7 @@ test("release diff parser captures tracked additions and deletions", () => {
   );
 });
 
-test("signed release shadow branch is created from the base without rewriting refs", async () => {
+test("#645 signed release shadow branch is created from the base without rewriting refs", async () => {
   assert.equal(
     typeof signedCommitHelpers.createReleaseBranchFromBase,
     "function",
@@ -201,7 +201,7 @@ test("signed release shadow branch cleans up its new ref when commit creation fa
   assert.deepEqual(calls, ["createRef", "createCommit", "deleteRef"]);
 });
 
-test("signed release shadow updates append from its current verified head", async () => {
+test("#645 signed release shadow updates append from its current verified head", async () => {
   assert.equal(
     typeof signedCommitHelpers.appendReleaseBranchCommit,
     "function",

--- a/scripts/create-github-signed-commit.test.mjs
+++ b/scripts/create-github-signed-commit.test.mjs
@@ -201,6 +201,33 @@ test("signed release shadow branch cleans up its new ref when commit creation fa
   assert.deepEqual(calls, ["createRef", "createCommit", "deleteRef"]);
 });
 
+test("signed release shadow updates append from its current verified head", async () => {
+  assert.equal(
+    typeof signedCommitHelpers.appendReleaseBranchCommit,
+    "function",
+  );
+  const calls = [];
+  const result = await signedCommitHelpers.appendReleaseBranchCommit({
+    repository: "oaslananka/kicad-studio-kit",
+    branch: "release-please/branches/main/components/vscode-extension",
+    expectedHeadOid: "2".repeat(40),
+    headline: "chore(kicad-studio): sync signed release surfaces",
+    changes: [{ path: "docs/versions.md", contents: Buffer.from("1.10.4\n") }],
+    createCommit: async (request) => {
+      calls.push(request.variables.input);
+      return { oid: "3".repeat(40) };
+    },
+  });
+
+  assert.deepEqual(result, { oid: "3".repeat(40) });
+  assert.equal(calls.length, 1);
+  assert.equal(
+    calls[0].branch.branchName,
+    "release-please/branches/main/components/vscode-extension",
+  );
+  assert.equal(calls[0].expectedHeadOid, "2".repeat(40));
+});
+
 test("release branch rewrite creates one commit from the base ref", async () => {
   assert.equal(typeof signedCommitHelpers.rewriteReleaseBranch, "function");
   const calls = [];

--- a/scripts/create-github-signed-commit.test.mjs
+++ b/scripts/create-github-signed-commit.test.mjs
@@ -128,6 +128,79 @@ test("release diff parser captures tracked additions and deletions", () => {
   );
 });
 
+test("signed release shadow branch is created from the base without rewriting refs", async () => {
+  assert.equal(
+    typeof signedCommitHelpers.createReleaseBranchFromBase,
+    "function",
+  );
+
+  const calls = [];
+  const result = await signedCommitHelpers.createReleaseBranchFromBase({
+    repository: "oaslananka/kicad-studio-kit",
+    branch: "release-please/branches/main/components/vscode-extension",
+    baseOid: "1111111111111111111111111111111111111111",
+    headline: "chore(kicad-studio): release vscode-extension 1.10.3",
+    changes: [
+      {
+        path: "apps/vscode-extension/package.json",
+        contents: Buffer.from("{}"),
+      },
+    ],
+    createRef: async (input) => calls.push(["createRef", input]),
+    deleteRef: async (input) => calls.push(["deleteRef", input]),
+    createCommit: async (request) => {
+      calls.push(["createCommit", request]);
+      return { oid: "2222222222222222222222222222222222222222" };
+    },
+  });
+
+  assert.equal(result.oid, "2222222222222222222222222222222222222222");
+  assert.equal(calls[0][0], "createRef");
+  assert.deepEqual(calls[0][1], {
+    repository: "oaslananka/kicad-studio-kit",
+    branch: "release-please/branches/main/components/vscode-extension",
+    sha: "1111111111111111111111111111111111111111",
+  });
+  assert.equal(calls[1][0], "createCommit");
+  assert.equal(
+    calls[1][1].variables.input.expectedHeadOid,
+    "1111111111111111111111111111111111111111",
+  );
+  assert.equal(
+    calls.some(([name]) => name === "deleteRef"),
+    false,
+  );
+});
+
+test("signed release shadow branch cleans up its new ref when commit creation fails", async () => {
+  const calls = [];
+  const failure = new Error("commit failed");
+
+  await assert.rejects(
+    signedCommitHelpers.createReleaseBranchFromBase({
+      repository: "oaslananka/kicad-studio-kit",
+      branch: "release-please/branches/main/components/vscode-extension",
+      baseOid: "1111111111111111111111111111111111111111",
+      headline: "chore(kicad-studio): release vscode-extension 1.10.3",
+      changes: [
+        {
+          path: "apps/vscode-extension/package.json",
+          contents: Buffer.from("{}"),
+        },
+      ],
+      createRef: async () => calls.push("createRef"),
+      deleteRef: async () => calls.push("deleteRef"),
+      createCommit: async () => {
+        calls.push("createCommit");
+        throw failure;
+      },
+    }),
+    (error) => error === failure,
+  );
+
+  assert.deepEqual(calls, ["createRef", "createCommit", "deleteRef"]);
+});
+
 test("release branch rewrite creates one commit from the base ref", async () => {
   assert.equal(typeof signedCommitHelpers.rewriteReleaseBranch, "function");
   const calls = [];

--- a/scripts/lib/github-signed-commit.mjs
+++ b/scripts/lib/github-signed-commit.mjs
@@ -174,6 +174,32 @@ export async function createReleaseBranchFromBase({
   }
 }
 
+export async function appendReleaseBranchCommit({
+  repository,
+  branch,
+  expectedHeadOid,
+  headline,
+  changes,
+  createCommit,
+}) {
+  assertRepositorySlug(repository);
+  assertBranchName(branch);
+  assertReleaseShadowBranchName(branch);
+  assertOid(expectedHeadOid, "expectedHeadOid");
+  if (typeof createCommit !== "function") {
+    throw new TypeError("createCommit must be a function");
+  }
+
+  const request = buildCreateCommitRequest({
+    repository,
+    branch,
+    expectedHeadOid,
+    headline,
+    changes,
+  });
+  return await createCommit(request);
+}
+
 export function buildCreateCommitRequest({
   repository,
   branch,

--- a/scripts/lib/github-signed-commit.mjs
+++ b/scripts/lib/github-signed-commit.mjs
@@ -125,6 +125,55 @@ export async function rewriteReleaseBranch({
   }
 }
 
+export async function createReleaseBranchFromBase({
+  repository,
+  branch,
+  baseOid,
+  headline,
+  changes,
+  createRef,
+  deleteRef,
+  createCommit,
+}) {
+  assertRepositorySlug(repository);
+  assertBranchName(branch);
+  assertReleaseShadowBranchName(branch);
+  assertOid(baseOid, "baseOid");
+  if (typeof createRef !== "function") {
+    throw new TypeError("createRef must be a function");
+  }
+  if (typeof deleteRef !== "function") {
+    throw new TypeError("deleteRef must be a function");
+  }
+  if (typeof createCommit !== "function") {
+    throw new TypeError("createCommit must be a function");
+  }
+
+  const request = buildCreateCommitRequest({
+    repository,
+    branch,
+    expectedHeadOid: baseOid,
+    headline,
+    changes,
+  });
+
+  await createRef({ repository, branch, sha: baseOid });
+  try {
+    return await createCommit(request);
+  } catch (error) {
+    try {
+      await deleteRef({ repository, branch });
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        "signed release branch creation failed and cleanup failed",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+}
+
 export function buildCreateCommitRequest({
   repository,
   branch,
@@ -185,6 +234,14 @@ function assertReleaseBranchName(branch) {
   if (!branch.startsWith("release-please--branches--")) {
     throw new Error(
       "release history rewrites are restricted to Release Please branches",
+    );
+  }
+}
+
+function assertReleaseShadowBranchName(branch) {
+  if (!/^release-please\/branches\/[^/]+\/components\/[^/]+$/u.test(branch)) {
+    throw new Error(
+      "signed release branches must use the Release Please component branch format",
     );
   }
 }


### PR DESCRIPTION
## Summary

- keep the canonical unsigned Release Please PR as a draft generator and mirror its complete tree to parseable `release-please/branches/main/components/vscode-extension`
- create the shadow from `main` with a GitHub-verified commit; on later generator updates, use GitHub `update-branch` first so current `main` remains an ancestor, then append only GitHub-verified release-tree deltas
- fail closed on ambiguous shadow PRs, unverified update-branch heads, stale base ancestry, or promotion failure; no force-push/history rewrite

This fixes the release-policy conflict observed while releasing v1.10.3 from #647: `required_signatures` rejects the canonical unsigned generated commit, while appending a signed child still leaves that unsigned parent in PR history.

## Linked issue

Closes #645

## Type of change

- [x] type:bug
- [ ] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [x] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- TDD RED: release workflow contract failed because no parseable signed shadow branch existed; helper contract failed because `createReleaseBranchFromBase` was absent
- GREEN: `node --test scripts/check-release-please-monorepo.test.mjs scripts/create-github-signed-commit.test.mjs` — 28/28 PASS
- TDD ancestry RED→GREEN: existing shadow sync previously appended without making latest `main` an ancestor; workflow now performs GitHub `update-branch`, verifies the resulting GitHub signature, validates `merge-base --is-ancestor`, then appends the signed release delta
- `corepack pnpm run check:release-please` — PASS
- `corepack pnpm run check:actions-permissions` — PASS
- `corepack pnpm run check:ci-lanes` — PASS
- `corepack pnpm run check:repo-governance` — PASS
- `corepack pnpm run check:security-tooling` — PASS
- `corepack pnpm run security:workflows` — actionlint + zizmor 1.28.0, 0 findings
- focused Prettier + `git diff --check` — PASS

## Protocol / MCP impact

- [x] Not applicable; reason: release governance only; no MCP schema, transport, capabilities, compatibility, or adapter behavior changes
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [ ] Docs updated
- [ ] Release notes considered for both products
- [ ] Backward compatibility impact documented

## Repository maturity impact

- [ ] No repository maturity impact
- [x] Documentation/community health updated
- [x] CI/quality/release process updated
- [x] Governance/security/supply-chain process updated
- [ ] Manual GitHub setting or maintainer action required and documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Review evidence

- [ ] Completed with findings; every finding is triaged below
- [ ] Completed with no findings
- [x] Unavailable; reason and compensating evidence recorded below
- [ ] Not applicable; reason:

- [ ] Low
- [ ] Medium
- [x] High

Bot and agent triage:

- [x] Every bot and agent comment is classified as actionable, resolved, informational, duplicate, or unavailable
- [x] No actionable finding remains unresolved
- [x] Unavailable notices are recorded as unavailable, not completed review

Compensating evidence:

- [ ] Focused second-agent review
- [x] Architecture/security checklist
- [x] Additional regression tests
- [x] Documented manual review
- [ ] Not required because review completed, was not applicable, or change risk is low

Evidence links/notes: manual final-diff review found no force-update/ref rewrite, debug code, secrets, generated build artifacts, or unrelated changes. Hosted security initially found ShellCheck SC2129; commit b2e8d26 grouped the GITHUB_OUTPUT writes and the rerun passed. Commit 553fb64 made repeated shadow sync append-only; commit cbe2cc8 added strict-base ancestry refresh and verified-head checks. Sonar Quality Gate passed with 0 new issues, 0 security hotspots, and 0.0% duplication. CodeQL, Semgrep, Trivy, DeepScan, dependency review, Socket, release-readiness, metadata, and security are green on the latest head; platform matrix is completing. The separate v1.10.3 recovery release event triggered publish successfully; PR #649 itself did not trigger publishing.

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass (changed files are JS/YAML/docs; repository policy/static checks pass)
- [x] Bug-fix regression coverage references #645 in the release topology/helper test names
- [ ] Bug-fix exceptions explain why automation is not practical and have maintainer approval
- [x] CHANGELOG entry not applicable; repository release plumbing only
- [x] Docs updated
- [x] No new committed secrets or build artifacts
- [x] Developer Certificate of Origin sign-off is present
- [ ] Meets Definition of Done after hosted CI/review is terminal



