### PR TITLE
fix(kicad-studio): unify MCP bootstrap flow

### DIFF
--- a/apps/vscode-extension/src/activation/mcpActivationController.ts
+++ b/apps/vscode-extension/src/activation/mcpActivationController.ts
@@ -20,6 +20,8 @@ export interface McpActivationControllerDeps {
  * unchanged from `activate()` as part of the #397 composition-root split.
  */
 export class McpActivationController {
+  private mcpBootstrapOffered = false;
+
   constructor(private readonly deps: McpActivationControllerDeps) {}
 
   async refreshMcpState(): Promise<void> {
@@ -166,6 +168,10 @@ export class McpActivationController {
     if (fs.existsSync(mcpJsonPath)) {
       return;
     }
+    if (this.mcpBootstrapOffered) {
+      return;
+    }
+    this.mcpBootstrapOffered = true;
 
     const choice = await vscode.window.showInformationMessage(
       'kicad-mcp-pro was detected. Create .vscode/mcp.json for this project?',

--- a/apps/vscode-extension/src/activation/mcpActivationController.ts
+++ b/apps/vscode-extension/src/activation/mcpActivationController.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { CONTEXT_KEYS, SETTINGS } from '../constants';
+import { COMMANDS, CONTEXT_KEYS, SETTINGS } from '../constants';
 import type { McpClient } from '../mcp/mcpClient';
 import type { McpDetector } from '../mcp/mcpDetector';
 import type { McpStateStore } from '../state/stateStores';
@@ -173,8 +173,7 @@ export class McpActivationController {
       'Later'
     );
     if (choice === 'Setup MCP') {
-      await this.deps.mcpDetector.generateMcpJson(root, installStatus);
-      await this.refreshMcpState();
+      await vscode.commands.executeCommand(COMMANDS.setupMcpIntegration);
     }
   }
 }

--- a/apps/vscode-extension/test/unit/mcpActivationController.test.ts
+++ b/apps/vscode-extension/test/unit/mcpActivationController.test.ts
@@ -51,4 +51,36 @@ describe('McpActivationController onboarding', () => {
     expect(mcpDetector.generateMcpJson).not.toHaveBeenCalled();
     expect(mcpClient.testConnection).toHaveBeenCalledTimes(1);
   });
+
+  it('#628 offers MCP bootstrap at most once per activation session', async () => {
+    const disconnected = {
+      kind: 'Disconnected' as const,
+      available: true,
+      connected: false,
+      install: {
+        found: true,
+        command: 'kicad-mcp-pro',
+        version: '3.33.3',
+        source: 'global' as const
+      }
+    };
+    const mcpClient = {
+      testConnection: jest.fn().mockResolvedValue(disconnected)
+    };
+    (window.showInformationMessage as jest.Mock).mockResolvedValue('Later');
+
+    const controller = new McpActivationController({
+      mcpClient: mcpClient as never,
+      mcpState: { update: jest.fn() } as never,
+      mcpDetector: { generateMcpJson: jest.fn() } as never
+    });
+
+    await Promise.all([
+      controller.refreshMcpState(),
+      controller.refreshMcpState()
+    ]);
+    await controller.refreshMcpState();
+
+    expect(window.showInformationMessage).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/vscode-extension/test/unit/mcpActivationController.test.ts
+++ b/apps/vscode-extension/test/unit/mcpActivationController.test.ts
@@ -1,0 +1,54 @@
+import { McpActivationController } from '../../src/activation/mcpActivationController';
+import { COMMANDS } from '../../src/constants';
+import { __setConfiguration, commands, window, workspace } from './vscodeMock';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+jest.mock('../../src/workspace/projectContext', () => ({
+  discoverKiCadProjects: jest.fn().mockResolvedValue([{ root: '/workspace' }])
+}));
+
+describe('McpActivationController onboarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    workspace.isTrusted = true;
+    workspace.workspaceFolders = [{ uri: { fsPath: '/workspace' } }];
+    __setConfiguration({ 'kicadstudio.mcp.autoDetect': true });
+  });
+
+  it('#628 delegates detected-server bootstrap to the canonical MCP setup command', async () => {
+    const disconnected = {
+      kind: 'Disconnected' as const,
+      available: true,
+      connected: false,
+      install: {
+        found: true,
+        command: 'kicad-mcp-pro',
+        version: '3.33.3',
+        source: 'global' as const
+      }
+    };
+    const mcpClient = {
+      testConnection: jest.fn().mockResolvedValue(disconnected)
+    };
+    const mcpState = { update: jest.fn() };
+    const mcpDetector = { generateMcpJson: jest.fn() };
+    (window.showInformationMessage as jest.Mock).mockResolvedValue('Setup MCP');
+
+    const controller = new McpActivationController({
+      mcpClient: mcpClient as never,
+      mcpState: mcpState as never,
+      mcpDetector: mcpDetector as never
+    });
+
+    await controller.refreshMcpState();
+
+    expect(commands.executeCommand).toHaveBeenCalledWith(
+      COMMANDS.setupMcpIntegration
+    );
+    expect(mcpDetector.generateMcpJson).not.toHaveBeenCalled();
+    expect(mcpClient.testConnection).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Route the activation-time MCP bootstrap offer through the existing `kicadstudio.setupMcpIntegration` command instead of maintaining a second config-generation path.
- Keep MCP setup/profile/transport decisions authoritative in one command flow shared by Task Hub and activation onboarding.
- Add a focused #628 regression proving bootstrap dispatches the canonical setup command once and does not directly generate `.vscode/mcp.json`.

## Linked issues

Refs #628
Refs #624

This is a bounded onboarding-state regression slice. It does not close #628 or #624; their remaining acceptance criteria stay open.

## Test evidence

TDD:
- RED: the new activation-controller regression failed because bootstrap never dispatched `kicadstudio.setupMcpIntegration` and used the direct config-generation path instead.
- GREEN on final `main` base `1d3d7b9e0093950e278024d1246a2a6bdb2985d6`:
  - `mcpActivationController.test.ts`, `mcpCommandsTrust.test.ts`, `taskHubCommands.test.ts`: 3 suites, 26/26 tests
  - extension TypeScript typecheck: pass
  - extension ESLint: pass
  - Prettier on touched files: pass
  - `git diff --check`: pass

## Risk / compatibility

- Existing command IDs remain unchanged.
- Existing Task Hub setup action continues to call `kicadstudio.setupMcpIntegration`.
- Activation bootstrap now delegates to that same command; install detection, transport/profile selection, config generation, and refresh remain owned by the established command handler.
- No dependency, protocol, schema, release, or user-data migration changes.
