### PR TITLE
fix(kicad-studio): unify MCP bootstrap flow

### DIFF
--- a/apps/vscode-extension/src/activation/mcpActivationController.ts
+++ b/apps/vscode-extension/src/activation/mcpActivationController.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { CONTEXT_KEYS, SETTINGS } from '../constants';
+import { COMMANDS, CONTEXT_KEYS, SETTINGS } from '../constants';
 import type { McpClient } from '../mcp/mcpClient';
 import type { McpDetector } from '../mcp/mcpDetector';
 import type { McpStateStore } from '../state/stateStores';
@@ -20,6 +20,8 @@ export interface McpActivationControllerDeps {
  * unchanged from `activate()` as part of the #397 composition-root split.
  */
 export class McpActivationController {
+  private mcpBootstrapOffered = false;
+
   constructor(private readonly deps: McpActivationControllerDeps) {}
 
   async refreshMcpState(): Promise<void> {
@@ -166,6 +168,10 @@ export class McpActivationController {
     if (fs.existsSync(mcpJsonPath)) {
       return;
     }
+    if (this.mcpBootstrapOffered) {
+      return;
+    }
+    this.mcpBootstrapOffered = true;
 
     const choice = await vscode.window.showInformationMessage(
       'kicad-mcp-pro was detected. Create .vscode/mcp.json for this project?',
@@ -173,8 +179,7 @@ export class McpActivationController {
       'Later'
     );
     if (choice === 'Setup MCP') {
-      await this.deps.mcpDetector.generateMcpJson(root, installStatus);
-      await this.refreshMcpState();
+      await vscode.commands.executeCommand(COMMANDS.setupMcpIntegration);
     }
   }
 }

--- a/apps/vscode-extension/test/unit/mcpActivationController.test.ts
+++ b/apps/vscode-extension/test/unit/mcpActivationController.test.ts
@@ -1,0 +1,86 @@
+import { McpActivationController } from '../../src/activation/mcpActivationController';
+import { COMMANDS } from '../../src/constants';
+import { __setConfiguration, commands, window, workspace } from './vscodeMock';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+jest.mock('../../src/workspace/projectContext', () => ({
+  discoverKiCadProjects: jest.fn().mockResolvedValue([{ root: '/workspace' }])
+}));
+
+describe('McpActivationController onboarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    workspace.isTrusted = true;
+    workspace.workspaceFolders = [{ uri: { fsPath: '/workspace' } }];
+    __setConfiguration({ 'kicadstudio.mcp.autoDetect': true });
+  });
+
+  it('#628 delegates detected-server bootstrap to the canonical MCP setup command', async () => {
+    const disconnected = {
+      kind: 'Disconnected' as const,
+      available: true,
+      connected: false,
+      install: {
+        found: true,
+        command: 'kicad-mcp-pro',
+        version: '3.33.3',
+        source: 'global' as const
+      }
+    };
+    const mcpClient = {
+      testConnection: jest.fn().mockResolvedValue(disconnected)
+    };
+    const mcpState = { update: jest.fn() };
+    const mcpDetector = { generateMcpJson: jest.fn() };
+    (window.showInformationMessage as jest.Mock).mockResolvedValue('Setup MCP');
+
+    const controller = new McpActivationController({
+      mcpClient: mcpClient as never,
+      mcpState: mcpState as never,
+      mcpDetector: mcpDetector as never
+    });
+
+    await controller.refreshMcpState();
+
+    expect(commands.executeCommand).toHaveBeenCalledWith(
+      COMMANDS.setupMcpIntegration
+    );
+    expect(mcpDetector.generateMcpJson).not.toHaveBeenCalled();
+    expect(mcpClient.testConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('#628 offers MCP bootstrap at most once per activation session', async () => {
+    const disconnected = {
+      kind: 'Disconnected' as const,
+      available: true,
+      connected: false,
+      install: {
+        found: true,
+        command: 'kicad-mcp-pro',
+        version: '3.33.3',
+        source: 'global' as const
+      }
+    };
+    const mcpClient = {
+      testConnection: jest.fn().mockResolvedValue(disconnected)
+    };
+    (window.showInformationMessage as jest.Mock).mockResolvedValue('Later');
+
+    const controller = new McpActivationController({
+      mcpClient: mcpClient as never,
+      mcpState: { update: jest.fn() } as never,
+      mcpDetector: { generateMcpJson: jest.fn() } as never
+    });
+
+    await Promise.all([
+      controller.refreshMcpState(),
+      controller.refreshMcpState()
+    ]);
+    await controller.refreshMcpState();
+
+    expect(window.showInformationMessage).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Route activation-time MCP bootstrap through the canonical `kicadstudio.setupMcpIntegration` command already used by Task Hub.
- Suppress duplicate bootstrap prompts when concurrent MCP state refreshes race during one extension activation session.
- Preserve existing command IDs, explicit Task Hub retry behavior, transport/profile selection, and configuration generation ownership.

## Linked issues

Refs #628
Refs #624

This is a bounded onboarding-state regression slice. It does not close #628 or #624; their remaining acceptance criteria stay open.

## TDD / regression evidence

- RED on the prior #652 head: two concurrent `refreshMcpState()` calls plus a subsequent refresh displayed the onboarding prompt 3 times when 1 was expected.
- GREEN: session-scoped bootstrap guard makes that regression pass while the original canonical-command delegation test remains green.
- Focused MCP onboarding/Task Hub suite: 3 suites, 27/27 tests.
- Full extension check: 128/128 suites, 1004/1004 unit tests, 2 snapshots; coverage ratchet 10/10 suites and 128/128 tests; security 12/12; accessibility 76/76; production build, VSIX package, and package metadata validation pass.
- Full repository pre-push gate passed with the supported Python 3.13.15 + uv 0.11.32 validation environment, including architecture, compatibility, release/signature policy, Codecov policy, quality gates, supply-chain, governance, docs, repeatable VSIX, and workspace checks.

## Review / signature evidence

- Replacement tree is byte-for-byte identical to the reviewed latest #652 tree.
- Single branch commit `a06e0a8824432fc1ec9618c4bf6bc060228cf0c6` is GitHub-verified and DCO signed-off, parented directly on current `main` at `1d3d7b9e0093950e278024d1246a2a6bdb2985d6`.
- No dependency, protocol schema, release artifact, user-data migration, or privilege widening changes.

## Reviewer follow-up

- Reviewer TDD found a real activation-session race: two concurrent `refreshMcpState()` calls plus a later refresh could show the MCP bootstrap prompt three times before configuration existed.
- RED on the exact PR tree: expected one onboarding prompt, received three.
- GREEN: `McpActivationController` now offers automatic bootstrap at most once per extension activation; Task Hub remains the explicit retry/setup path.
- Focused MCP onboarding/Task Hub suite: 3 suites, 27/27 tests.
- Extension typecheck, ESLint, Prettier, and `git diff --check`: pass.
- Full extension `check` on the exact replacement tree: exit 0, including production build, VSIX packaging, and package validation.
- The replacement commit/tree (`a06e0a8`, tree `5642162e...`) is GitHub-verified and exactly matches the locally verified tree.

The superseded #652 Ubuntu E2E viewer failure was an unrelated intermittent no-WebGL host flake; the identical #653 tree passed the Ubuntu lane on its latest hosted run.
