### PR TITLE
fix(repo): keep one release PR open

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,9 +33,9 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       # Release Please's generated commit is not GitHub-signed, while main requires
-      # signed commits. Keep the canonical PR as Release Please's draft generator,
-      # while a parseable shadow PR carries only GitHub-signed commits. Repeated
-      # Release Please updates append signed commits to the same shadow branch.
+      # signed commits. Use the canonical PR only as a short-lived generator: mirror
+      # its complete release tree to one parseable GitHub-signed shadow PR, verify
+      # that shadow, then close and delete the validated generator branch.
       - if: ${{ steps.release.outputs.pr }}
         id: release-pr
         name: Resolve the Release Please branch
@@ -123,6 +123,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           RELEASE_PR_NUMBER: ${{ steps.release-pr.outputs.number }}
+          RELEASE_PR_BRANCH: ${{ steps.release-pr.outputs.branch }}
           RELEASE_TITLE: ${{ steps.release-pr.outputs.title }}
           SIGNED_RELEASE_BRANCH: release-please/branches/main/components/vscode-extension
         shell: bash
@@ -175,9 +176,6 @@ jobs:
               --branch "$SIGNED_RELEASE_BRANCH" \
               --message "chore(kicad-studio): sync signed release surfaces"$'\n\nSigned-off-by: oaslananka <info@oaslananka.dev>' \
               --onto-head "$SIGNED_RELEASE_HEAD"
-            gh pr edit "$SIGNED_RELEASE_PR" \
-              --title "$RELEASE_TITLE" \
-              --body-file "$RELEASE_BODY_FILE"
           else
             node scripts/create-github-signed-commit.mjs \
               --repository "$GITHUB_REPOSITORY" \
@@ -202,15 +200,59 @@ jobs:
               --title "$RELEASE_TITLE" \
               --body-file "$RELEASE_BODY_FILE")"
             SIGNED_RELEASE_PR="${SIGNED_RELEASE_URL##*/}"
-            gh pr edit "$SIGNED_RELEASE_PR" --add-label "autorelease: pending"
-            gh pr comment "$RELEASE_PR_NUMBER" \
-              --body "Merge #$SIGNED_RELEASE_PR for signature-compliant release history; this PR remains the Release Please generator."
-            trap - ERR
           fi
 
-          if [[ "$(gh pr view "$RELEASE_PR_NUMBER" --json isDraft --jq '.isDraft')" != "true" ]]; then
-            gh pr ready --undo "$RELEASE_PR_NUMBER"
+          gh pr edit "$SIGNED_RELEASE_PR" \
+            --title "$RELEASE_TITLE" \
+            --body-file "$RELEASE_BODY_FILE" \
+            --add-label "autorelease: pending"
+
+          FINAL_SIGNED_RELEASE_HEAD="$(gh pr view "$SIGNED_RELEASE_PR" \
+            --json headRefOid \
+            --jq '.headRefOid')"
+          FINAL_SIGNED_RELEASE_VERIFIED="$(gh api \
+            "repos/$GITHUB_REPOSITORY/commits/$FINAL_SIGNED_RELEASE_HEAD" \
+            --jq '.commit.verification.verified')"
+          if [[ "$FINAL_SIGNED_RELEASE_VERIFIED" != "true" ]]; then
+            echo "Final signed release shadow head is not GitHub-verified" >&2
+            exit 1
           fi
+          git fetch --no-tags origin \
+            "refs/heads/main:refs/remotes/origin/main" \
+            "refs/heads/$SIGNED_RELEASE_BRANCH:refs/remotes/origin/$SIGNED_RELEASE_BRANCH"
+          if ! git merge-base --is-ancestor \
+            refs/remotes/origin/main \
+            "refs/remotes/origin/$SIGNED_RELEASE_BRANCH"; then
+            echo "Signed release shadow is not up to date with main" >&2
+            exit 1
+          fi
+          # A newly-created shadow remains rollback-protected until its final
+          # signature and ancestry checks succeed. Generator cleanup is a
+          # separate phase and must never delete an already-valid shadow.
+          trap - ERR
+
+          GENERATOR_PR_BRANCH="$(gh pr view "$RELEASE_PR_NUMBER" \
+            --json headRefName \
+            --jq '.headRefName')"
+          if [[ "$GENERATOR_PR_BRANCH" != "$RELEASE_PR_BRANCH" ]]; then
+            echo "Generator PR branch changed before cleanup" >&2
+            exit 1
+          fi
+          GENERATOR_PR_HEAD="$(gh pr view "$RELEASE_PR_NUMBER" \
+            --json headRefOid \
+            --jq '.headRefOid')"
+          GENERATOR_BRANCH_HEAD="$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$RELEASE_PR_BRANCH" \
+            --jq '.object.sha')"
+          if [[ "$GENERATOR_PR_HEAD" != "$GENERATOR_BRANCH_HEAD" ]]; then
+            echo "Generator branch head changed before cleanup" >&2
+            exit 1
+          fi
+
+          gh pr edit "$RELEASE_PR_NUMBER" --remove-label "autorelease: pending"
+          gh pr close "$RELEASE_PR_NUMBER"
+          gh api --method DELETE \
+            "repos/$GITHUB_REPOSITORY/git/refs/heads/$RELEASE_PR_BRANCH"
 
       # Regenerate changelog docs after a release PR is merged
       - if: ${{ steps.release.outputs.releases_created == 'true' }}

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -6,7 +6,7 @@ KiCad Studio Kit releases the VS Code extension from this repository. The MCP se
 
 ## Release automation
 
-- `release-please.yml` keeps the canonical generated PR as Release Please's draft generator, builds the complete release tree, and mirrors it to `release-please/branches/main/components/vscode-extension`. The mergeable shadow PR contains only GitHub-signed, DCO-signed-off release commits; later generator updates first use GitHub's normal verified `update-branch` merge to make current `main` an ancestor, then append the signed release-tree delta without rewriting either live ref.
+- `release-please.yml` uses the canonical generated PR only as a short-lived generator, builds the complete release tree, and mirrors it to `release-please/branches/main/components/vscode-extension`. After the shadow head is GitHub-verified, current with `main`, and synchronized with the release title/body/label, the workflow closes the generator and deletes only its validated temporary branch. The remaining mergeable PR contains GitHub-signed, DCO-signed-off release commits; later `main` updates can recreate a generator briefly, update the same shadow with GitHub's normal verified `update-branch` merge, append the signed release-tree delta, and close the generator again without rewriting either live ref.
 - `publish-extension.yml` packages the VSIX, validates metadata, stages checksums, SBOM, provenance, and attestations, then publishes to marketplaces from the authenticated release event.
 - `release.yml` is a low-risk release-readiness workflow that validates release evidence without publishing.
 
@@ -27,7 +27,7 @@ Each release should provide:
 
 1. Confirm the release PR includes the intended changelog and version bump.
 2. Confirm CI, CodeQL, Gitleaks, and package validation pass.
-3. Confirm the canonical unsigned Release Please generator PR is draft and the parseable signed shadow PR matches its release tree, then squash-merge the signed shadow PR through GitHub so the commit entering `main` is GitHub-verified.
+3. Confirm there is exactly one open parseable signed release PR and that it matches the generated release tree; the temporary canonical generator should already be closed by the workflow. Then squash-merge the signed shadow PR through GitHub so the commit entering `main` is GitHub-verified.
 4. Confirm release evidence is generated and attached.
 5. Confirm marketplace publish jobs use protected environments and minimum secrets.
 6. Confirm post-release docs and version surfaces are updated.

--- a/scripts/check-release-please-monorepo.test.mjs
+++ b/scripts/check-release-please-monorepo.test.mjs
@@ -89,17 +89,25 @@ test("#645 release workflow promotes a GitHub-signed parseable shadow PR without
   );
   assert.match(
     workflow,
-    /gh pr edit "\$SIGNED_RELEASE_PR" --add-label "autorelease: pending"/,
+    /RELEASE_PR_BRANCH: \${{ steps\.release-pr\.outputs\.branch }}/,
   );
   assert.match(
     workflow,
-    /gh pr view "\$RELEASE_PR_NUMBER" --json isDraft[\s\S]*?gh pr ready --undo "\$RELEASE_PR_NUMBER"/,
+    /FINAL_SIGNED_RELEASE_HEAD=[\s\S]*?commit\.verification\.verified[\s\S]*?Final signed release shadow head is not GitHub-verified/,
   );
-  assert.doesNotMatch(workflow, /gh pr close "\$RELEASE_PR_NUMBER"/);
-  assert.doesNotMatch(
+  assert.match(
     workflow,
-    /gh pr edit "\$RELEASE_PR_NUMBER" --remove-label "autorelease: pending"/,
+    /FINAL_SIGNED_RELEASE_HEAD=[\s\S]*?git merge-base --is-ancestor[\s\S]*?Signed release shadow is not up to date with main/,
   );
+  assert.match(
+    workflow,
+    /gh pr edit "\$SIGNED_RELEASE_PR"[\s\S]*?--add-label "autorelease: pending"[\s\S]*?FINAL_SIGNED_RELEASE_HEAD=[\s\S]*?Final signed release shadow head is not GitHub-verified[\s\S]*?git merge-base --is-ancestor[\s\S]*?GENERATOR_PR_HEAD=[\s\S]*?headRefOid[\s\S]*?GENERATOR_BRANCH_HEAD=[\s\S]*?git\/ref\/heads\/\$RELEASE_PR_BRANCH[\s\S]*?Generator branch head changed before cleanup[\s\S]*?gh pr edit "\$RELEASE_PR_NUMBER" --remove-label "autorelease: pending"[\s\S]*?gh pr close "\$RELEASE_PR_NUMBER"[\s\S]*?git\/refs\/heads\/\$RELEASE_PR_BRANCH/,
+  );
+  assert.match(
+    workflow,
+    /SIGNED_RELEASE_URL=[\s\S]*?SIGNED_RELEASE_PR=[\s\S]*?gh pr edit "\$SIGNED_RELEASE_PR"[\s\S]*?FINAL_SIGNED_RELEASE_HEAD=[\s\S]*?git merge-base --is-ancestor[\s\S]*?trap - ERR[\s\S]*?GENERATOR_PR_BRANCH=/,
+  );
+  assert.doesNotMatch(workflow, /gh pr ready --undo "\$RELEASE_PR_NUMBER"/);
   assert.match(workflow, /gh pr list[\s\S]*?--head "\$SIGNED_RELEASE_BRANCH"/);
   assert.doesNotMatch(workflow, /name: Append GitHub-signed release surfaces/);
   assert.doesNotMatch(workflow, /forceUpdateRef/);


### PR DESCRIPTION
## Summary

- Keep the unsigned Release Please PR as a short-lived generator instead of a second long-lived open release PR.
- After the signed shadow is synchronized, GitHub-verified, and current with `main`, remove the generator lifecycle label, close the generator PR, and delete only its validated head ref.
- Keep newly-created shadow PRs rollback-protected until final signature/ancestry validation completes.

## Why

The current signed-shadow release flow is safe for required commit signatures, but it leaves both the canonical Release Please generator and the signed shadow open with the same release title. This produces duplicate PRs/notifications for every release.

## TDD / verification

- RED: release policy initially required the canonical generator to remain open.
- RED: generator cleanup lacked a PR-head/ref identity check.
- RED: a newly-created shadow disabled rollback before final signature/ancestry validation.
- GREEN: Release Please + signed-commit policy tests: 28/28.
- Actions permissions: 7/7; branch-protection: 13/13; CI-lane policy: 9/9.
- Governance, security-tooling, and quality-gate policy checks pass.
- Prettier and `git diff --check` pass.
- actionlint passes; zizmor 1.28.0 reports 0 findings.

## Risk

Medium. Release orchestration changes only; no product/runtime code, dependency, schema, or public API changes. Cleanup is fail-closed and does not force-push or rewrite history.
