### PR TITLE
fix(repo): wait for signed release branch updates

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -164,6 +164,7 @@ jobs:
                 SIGNED_RELEASE_SETTLED=true
                 break
               fi
+              echo "Signed release shadow update not settled (attempt $attempt/15); retrying" >&2
               sleep 2
             done
             if [[ "$SIGNED_RELEASE_SETTLED" != "true" ]]; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -152,23 +152,29 @@ jobs:
             fi
             SIGNED_RELEASE_PR="${signed_release_prs[0]}"
             gh pr update-branch "$SIGNED_RELEASE_PR"
-            SIGNED_RELEASE_HEAD="$(gh pr view "$SIGNED_RELEASE_PR" \
-              --json headRefOid \
-              --jq '.headRefOid')"
+            SIGNED_RELEASE_SETTLED=false
+            for attempt in $(seq 1 15); do
+              git fetch --no-tags origin \
+                "refs/heads/$SIGNED_RELEASE_BRANCH:refs/remotes/origin/$SIGNED_RELEASE_BRANCH"
+              SIGNED_RELEASE_HEAD="$(git rev-parse \
+                "refs/remotes/origin/$SIGNED_RELEASE_BRANCH")"
+              if git merge-base --is-ancestor \
+                "$RELEASE_BASE_SHA" \
+                "$SIGNED_RELEASE_HEAD"; then
+                SIGNED_RELEASE_SETTLED=true
+                break
+              fi
+              sleep 2
+            done
+            if [[ "$SIGNED_RELEASE_SETTLED" != "true" ]]; then
+              echo "Timed out waiting for signed release shadow to include current main" >&2
+              exit 1
+            fi
             SIGNED_RELEASE_VERIFIED="$(gh api \
               "repos/$GITHUB_REPOSITORY/commits/$SIGNED_RELEASE_HEAD" \
               --jq '.commit.verification.verified')"
             if [[ "$SIGNED_RELEASE_VERIFIED" != "true" ]]; then
               echo "Signed release shadow head is not GitHub-verified" >&2
-              exit 1
-            fi
-            git fetch --no-tags origin \
-              "refs/heads/main:refs/remotes/origin/main" \
-              "refs/heads/$SIGNED_RELEASE_BRANCH:refs/remotes/origin/$SIGNED_RELEASE_BRANCH"
-            if ! git merge-base --is-ancestor \
-              refs/remotes/origin/main \
-              "refs/remotes/origin/$SIGNED_RELEASE_BRANCH"; then
-              echo "Signed release shadow is not up to date with main" >&2
               exit 1
             fi
             node scripts/create-github-signed-commit.mjs \

--- a/scripts/check-release-please-monorepo.test.mjs
+++ b/scripts/check-release-please-monorepo.test.mjs
@@ -73,7 +73,7 @@ test("#645 release workflow promotes a GitHub-signed parseable shadow PR without
   assert.match(workflow, /--onto-head "\$SIGNED_RELEASE_HEAD"/);
   assert.match(
     workflow,
-    /gh pr update-branch "\$SIGNED_RELEASE_PR"[\s\S]*?SIGNED_RELEASE_HEAD=[\s\S]*?headRefOid[\s\S]*?--onto-head "\$SIGNED_RELEASE_HEAD"/,
+    /gh pr update-branch "\$SIGNED_RELEASE_PR"[\s\S]*?for attempt in[\s\S]*?git fetch --no-tags origin[\s\S]*?git merge-base --is-ancestor[\s\S]*?"\$RELEASE_BASE_SHA"[\s\S]*?"\$SIGNED_RELEASE_HEAD"[\s\S]*?sleep 2[\s\S]*?Timed out waiting for signed release shadow to include current main[\s\S]*?--onto-head "\$SIGNED_RELEASE_HEAD"/,
   );
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary
- wait for GitHub `update-branch` to settle before reading the signed Release Please shadow head
- poll the remote signed branch until the exact release base SHA is an ancestor
- fail closed after a bounded timeout instead of appending release surfaces to a stale head

## Why
Production cleanup of #654/#655 showed `gh pr update-branch` can return before `headRefOid`/the remote branch has advanced. The workflow previously read the old SHA immediately, creating a race before `--onto-head`.

## Verification
- RED: release workflow regression test rejected the immediate post-`update-branch` head read
- GREEN: release/signing policy tests 28/28
- Actions permissions tests 7/7
- Prettier + `git diff --check`
- actionlint
- zizmor 1.28.0: 0 findings

## Risk
Low. Release-governance only; bounded polling is fail-closed and does not rewrite refs or weaken signatures/rulesets.
