### PR TITLE
fix(kicad-studio): retry transient VS Code host downloads

### DIFF
--- a/apps/vscode-extension/test/e2e/vscodeHarness.ts
+++ b/apps/vscode-extension/test/e2e/vscodeHarness.ts
@@ -11,6 +11,7 @@ import {
   type Page
 } from '@playwright/test';
 
+import { downloadVsCodeWithRetry } from '../vscodeTestRuntime';
 import { installFakeKiCadCli } from './fakeKiCadCli';
 
 const VSCODE_VERSION = '1.122.0';
@@ -55,7 +56,10 @@ export async function launchVsCodeWithFixtures(
   }
   writeUserSettings(userDataDir, settings);
 
-  const executablePath = await downloadAndUnzipVSCode(VSCODE_VERSION);
+  const executablePath = await downloadVsCodeWithRetry(
+    VSCODE_VERSION,
+    downloadAndUnzipVSCode
+  );
   const remoteDebuggingPort = await getFreePort();
   const env = { ...process.env };
   delete env.ELECTRON_RUN_AS_NODE;

--- a/apps/vscode-extension/test/runRealPairHostTest.ts
+++ b/apps/vscode-extension/test/runRealPairHostTest.ts
@@ -3,6 +3,8 @@ import { cp, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { downloadAndUnzipVSCode, runTests } from '@vscode/test-electron';
 
+import { downloadVsCodeWithRetry } from './vscodeTestRuntime';
+
 async function main(): Promise<void> {
   const extensionDevelopmentPath = path.resolve(__dirname, '..', '..');
   const extensionTestsPath = path.resolve(__dirname, 'realPairSuite', 'index');
@@ -13,7 +15,10 @@ async function main(): Promise<void> {
     'benchmark_projects',
     'pass_minimal_mcu_board'
   );
-  const vscodeExecutablePath = await downloadAndUnzipVSCode('1.122.0');
+  const vscodeExecutablePath = await downloadVsCodeWithRetry(
+    '1.122.0',
+    downloadAndUnzipVSCode
+  );
   const userDataDir = await mkdtemp(
     path.join(tmpdir(), 'kicadstudio-real-pair-user-')
   );

--- a/apps/vscode-extension/test/runTest.ts
+++ b/apps/vscode-extension/test/runTest.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import { downloadAndUnzipVSCode } from '@vscode/test-electron';
 import {
+  downloadVsCodeWithRetry,
   resolveVsCodeTestSuite,
   resolveVsCodeTestVersion
 } from './vscodeTestRuntime';
@@ -17,8 +18,9 @@ async function main(): Promise<void> {
     'index'
   );
   const workspacePath = path.resolve(__dirname, '..', '..', 'test', 'fixtures');
-  const vscodeExecutablePath = await downloadAndUnzipVSCode(
-    resolveVsCodeTestVersion()
+  const vscodeExecutablePath = await downloadVsCodeWithRetry(
+    resolveVsCodeTestVersion(),
+    downloadAndUnzipVSCode
   );
   const userDataDir = await mkdtemp(
     path.join(tmpdir(), 'kicadstudio-vscode-user-')

--- a/apps/vscode-extension/test/unit/vscodeTestRuntime.test.ts
+++ b/apps/vscode-extension/test/unit/vscodeTestRuntime.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_VSCODE_TEST_VERSION,
+  downloadVsCodeWithRetry,
   resolveVsCodeTestSuite,
   resolveVsCodeTestVersion
 } from '../vscodeTestRuntime';
@@ -20,6 +21,58 @@ describe('VS Code test runtime', () => {
         KICADSTUDIO_VSCODE_VERSION: '1.122.0'
       })
     ).toBe('1.122.0');
+  });
+
+  it('#628 retries transient VS Code host download failures without hiding terminal errors', async () => {
+    const transient = Object.assign(new AggregateError([], 'network timeout'), {
+      code: 'ETIMEDOUT'
+    });
+    const download = jest
+      .fn<Promise<string>, [string]>()
+      .mockRejectedValueOnce(transient)
+      .mockResolvedValue('/tmp/vscode');
+    const delays: number[] = [];
+
+    await expect(
+      downloadVsCodeWithRetry('1.122.0', download, {
+        attempts: 3,
+        baseDelayMs: 10,
+        sleep: async (delayMs: number) => {
+          delays.push(delayMs);
+        }
+      })
+    ).resolves.toBe('/tmp/vscode');
+
+    expect(download).toHaveBeenCalledTimes(2);
+    expect(delays).toEqual([10]);
+
+    const terminal = new Error('Version 9.9.9 is unavailable');
+    download.mockReset();
+    download.mockRejectedValue(terminal);
+    await expect(
+      downloadVsCodeWithRetry('9.9.9', download, {
+        attempts: 3,
+        baseDelayMs: 0
+      })
+    ).rejects.toBe(terminal);
+    expect(download).toHaveBeenCalledTimes(1);
+  });
+
+  it('#628 stops after the bounded VS Code host download retry budget', async () => {
+    const transient = Object.assign(new Error('socket reset'), {
+      code: 'ECONNRESET'
+    });
+    const download = jest
+      .fn<Promise<string>, [string]>()
+      .mockRejectedValue(transient);
+
+    await expect(
+      downloadVsCodeWithRetry('1.122.0', download, {
+        attempts: 3,
+        baseDelayMs: 0
+      })
+    ).rejects.toBe(transient);
+    expect(download).toHaveBeenCalledTimes(3);
   });
 
   it('selects the dedicated canary host suite only when requested', () => {

--- a/apps/vscode-extension/test/vscodeTestRuntime.ts
+++ b/apps/vscode-extension/test/vscodeTestRuntime.ts
@@ -1,8 +1,66 @@
 export const DEFAULT_VSCODE_TEST_VERSION = '1.122.0';
 
+const TRANSIENT_VSCODE_DOWNLOAD_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNABORTED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_SOCKET'
+]);
+
 type TestEnvironment = Record<string, string | undefined>;
+type VsCodeDownloader = (version: string) => Promise<string>;
+
+interface VsCodeDownloadRetryOptions {
+  attempts?: number;
+  baseDelayMs?: number;
+  sleep?: (delayMs: number) => Promise<void>;
+}
 
 export type VsCodeTestSuite = 'suite' | 'canarySuite';
+
+export async function downloadVsCodeWithRetry(
+  version: string,
+  download: VsCodeDownloader,
+  options: VsCodeDownloadRetryOptions = {}
+): Promise<string> {
+  const attempts = options.attempts ?? 3;
+  const baseDelayMs = options.baseDelayMs ?? 1000;
+  const sleep =
+    options.sleep ??
+    ((delayMs: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, delayMs)));
+
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new RangeError('VS Code download attempts must be at least 1');
+  }
+  if (!Number.isFinite(baseDelayMs) || baseDelayMs < 0) {
+    throw new RangeError('VS Code download retry delay must be non-negative');
+  }
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await download(version);
+    } catch (error) {
+      if (attempt === attempts || !isTransientDownloadError(error)) {
+        throw error;
+      }
+      const delayMs = baseDelayMs * attempt;
+      console.warn(
+        `Transient VS Code host download failure; retrying in ${delayMs}ms (${attempt}/${attempts - 1}).`
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error('VS Code host download retry budget was exhausted');
+}
 
 export function resolveVsCodeTestVersion(
   env: TestEnvironment = process.env
@@ -18,4 +76,31 @@ export function resolveVsCodeTestSuite(
   return env['KICADSTUDIO_VSCODE_TEST_SUITE']?.trim() === 'canary'
     ? 'canarySuite'
     : 'suite';
+}
+
+function isTransientDownloadError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const candidate = error as {
+    code?: unknown;
+    cause?: unknown;
+    errors?: unknown;
+  };
+  if (
+    typeof candidate.code === 'string' &&
+    TRANSIENT_VSCODE_DOWNLOAD_CODES.has(candidate.code)
+  ) {
+    return true;
+  }
+  if (
+    Array.isArray(candidate.errors) &&
+    candidate.errors.some(isTransientDownloadError)
+  ) {
+    return true;
+  }
+  return (
+    candidate.cause !== undefined && isTransientDownloadError(candidate.cause)
+  );
 }


### PR DESCRIPTION
## Summary
- retry VS Code test-host downloads only for transient network failures
- keep deterministic/version failures fail-fast
- share the bounded retry path across real-pair, normal Extension Host, and Playwright VS Code harnesses

## Root cause
GitHub Actions run `33338683484` failed before Extension Host assertions while `@vscode/test-electron` was resolving VS Code 1.122.0. The Microsoft endpoint connection returned IPv4 `ETIMEDOUT` plus IPv6 `ENETUNREACH`. A subsequent latest-head real-pair run passed unchanged, confirming external network intermittency rather than a product regression.

Refs #628

## TDD / verification
- RED: unit test could not import the retry helper before implementation
- GREEN: VS Code runtime unit tests 5/5
- transient `ETIMEDOUT` / `ECONNRESET` retries are bounded to 3 attempts
- terminal version errors are not retried
- exact main-based tree: typecheck, ESLint, Prettier, `git diff --check` pass
- full extension `check`: exit 0; 128 suites / 1006 tests, 128 coverage-ratchet tests, 12 security tests, 76 accessibility tests, production build and VSIX/package validation pass

## Risk
Low. Test infrastructure only; production extension behavior is unchanged. Retry is bounded and only applies to known transient network error codes.
