### PR TITLE
feat(kicad-studio): negotiate advertised MCP profiles

### DIFF
--- a/apps/vscode-extension/src/commands/mcpProfilePicker.ts
+++ b/apps/vscode-extension/src/commands/mcpProfilePicker.ts
@@ -4,7 +4,8 @@ import * as vscode from 'vscode';
 import { SETTINGS } from '../constants';
 import { localize } from '../i18n';
 import {
-  KICAD_MCP_PROFILES,
+  KICAD_MCP_ADVANCED_PROFILES,
+  KICAD_MCP_PRIMARY_PROFILES,
   resolveKicadMcpProfile,
   type KicadMcpProfileId
 } from '../mcp/profileCatalog';
@@ -13,13 +14,25 @@ import type { CommandServices } from './types';
 export async function pickMcpProfile(
   services: Pick<CommandServices, 'refreshMcpState' | 'mcpClient'>
 ): Promise<KicadMcpProfileId | undefined> {
+  const advertisedProfiles =
+    services.mcpClient.getState().server?.capabilities.profiles;
+  const supports = (profile: { id: string }): boolean =>
+    advertisedProfiles === undefined || advertisedProfiles.includes(profile.id);
+  const primary = KICAD_MCP_PRIMARY_PROFILES.filter(supports);
+  const advanced = KICAD_MCP_ADVANCED_PROFILES.filter(supports);
   const choice = await vscode.window.showQuickPick(
-    KICAD_MCP_PROFILES.map((profile) => ({
-      label: profile.label,
-      description: profile.id,
-      detail: localize('mcpProfileDetail', { blurb: profile.blurb }),
-      profile
-    })),
+    [
+      ...primary.map((profile) => profileItem(profile)),
+      ...(advanced.length
+        ? [
+            {
+              label: localize('advancedMcpProfiles'),
+              detail: localize('advancedMcpProfilesDetail'),
+              advanced: true as const
+            }
+          ]
+        : [])
+    ],
     {
       title: localize('selectMcpProfile'),
       placeHolder: localize('chooseMcpProfile')
@@ -29,9 +42,23 @@ export async function pickMcpProfile(
     return undefined;
   }
 
-  await writeProfile(choice.profile.id);
+  const profileChoice =
+    'advanced' in choice
+      ? await vscode.window.showQuickPick(
+          advanced.map((profile) => profileItem(profile)),
+          {
+            title: localize('selectMcpProfile'),
+            placeHolder: localize('chooseAdvancedMcpProfile')
+          }
+        )
+      : choice;
+  if (!profileChoice || !('profile' in profileChoice)) {
+    return undefined;
+  }
+
+  await writeProfile(profileChoice.profile.id);
   const restart = await vscode.window.showInformationMessage(
-    localize('mcpProfileSetRestart', { profile: choice.profile.id }),
+    localize('mcpProfileSetRestart', { profile: profileChoice.profile.id }),
     localize('restart'),
     localize('later')
   );
@@ -39,7 +66,20 @@ export async function pickMcpProfile(
     await services.mcpClient.retryNow();
     await services.refreshMcpState();
   }
-  return choice.profile.id;
+  return profileChoice.profile.id;
+}
+
+function profileItem(
+  profile:
+    | (typeof KICAD_MCP_PRIMARY_PROFILES)[number]
+    | (typeof KICAD_MCP_ADVANCED_PROFILES)[number]
+) {
+  return {
+    label: profile.label,
+    description: profile.id,
+    detail: localize('mcpProfileDetail', { blurb: profile.blurb }),
+    profile
+  };
 }
 
 export function readConfiguredMcpProfile(): KicadMcpProfileId {

--- a/apps/vscode-extension/src/i18n.ts
+++ b/apps/vscode-extension/src/i18n.ts
@@ -3,6 +3,10 @@ export const SOURCE_MESSAGES = {
     '{feature} requires a trusted workspace. Trust this workspace to run KiCad CLI, external KiCad, import, or export tooling.',
   selectMcpProfile: 'Select kicad-mcp-pro profile',
   chooseMcpProfile: 'Choose the MCP profile to use for this workspace',
+  advancedMcpProfiles: 'Advanced profiles…',
+  advancedMcpProfilesDetail:
+    'Specialized profiles for focused or legacy workflows',
+  chooseAdvancedMcpProfile: 'Choose a specialized MCP profile',
   mcpProfileDetail: '{blurb} (as of MCP 1.0.0)',
   mcpProfileSetRestart:
     'MCP profile set to {profile}. Restart the MCP connection now?',
@@ -99,6 +103,9 @@ const TR_MESSAGES: Partial<Record<keyof typeof SOURCE_MESSAGES, string>> = {
     '{feature} güvenilir bir çalışma alanı gerektirir. KiCad CLI, harici KiCad, içe veya dışa aktarma araçlarını çalıştırmak için bu çalışma alanına güvenin.',
   selectMcpProfile: 'kicad-mcp-pro profili seçin',
   chooseMcpProfile: 'Bu çalışma alanı için kullanılacak MCP profilini seçin',
+  advancedMcpProfiles: 'Gelişmiş profiller…',
+  advancedMcpProfilesDetail: 'Odaklı veya eski iş akışları için özel profiller',
+  chooseAdvancedMcpProfile: 'Özel bir MCP profili seçin',
   mcpProfileDetail: '{blurb} (MCP 1.0.0 itibarıyla)',
   mcpProfileSetRestart:
     'MCP profili {profile} olarak ayarlandı. MCP bağlantısı şimdi yeniden başlatılsın mı?',

--- a/apps/vscode-extension/src/mcp/mcpClient.ts
+++ b/apps/vscode-extension/src/mcp/mcpClient.ts
@@ -513,7 +513,8 @@ export class McpClient {
       capabilities: normalizeCapabilities(
         initializeResult?.capabilities,
         serverInfo,
-        diagnostics
+        diagnostics,
+        metadata?.profiles
       ),
       compat,
       capturedAt: new Date().toISOString()
@@ -566,6 +567,7 @@ export class McpClient {
     | {
         version: string;
         serverInfo?: McpServerInfoContract | undefined;
+        profiles?: string[] | undefined;
       }
     | undefined
   > {
@@ -831,13 +833,15 @@ function severityFromText(value: string): FixItem['severity'] {
 function normalizeCapabilities(
   value: unknown,
   serverInfo?: McpServerInfoContract | undefined,
-  diagnostics: string[] = []
+  diagnostics: string[] = [],
+  profiles?: string[] | undefined
 ): McpCapabilityCard {
   const record = isRecord(value) ? value : {};
   return {
     tools: normalizeCapabilityNames(record['tools']),
     resources: normalizeCapabilityNames(record['resources']),
     prompts: normalizeCapabilityNames(record['prompts']),
+    ...(profiles?.length ? { profiles: [...profiles] } : {}),
     ...(serverInfo ? { serverInfo } : {}),
     ...(diagnostics.length ? { diagnostics } : {})
   };
@@ -903,6 +907,9 @@ function cloneConnectionState(state: McpConnectionState): McpConnectionState {
             tools: [...state.server.capabilities.tools],
             resources: [...state.server.capabilities.resources],
             prompts: [...state.server.capabilities.prompts],
+            ...(state.server.capabilities.profiles
+              ? { profiles: [...state.server.capabilities.profiles] }
+              : {}),
             ...(state.server.capabilities.serverInfo
               ? {
                   serverInfo: cloneServerInfoContract(

--- a/apps/vscode-extension/src/mcp/serverMetadata.ts
+++ b/apps/vscode-extension/src/mcp/serverMetadata.ts
@@ -6,6 +6,7 @@ import type { McpServerInfoContract } from '../types';
 export interface WellKnownMcpServerMetadata {
   version: string;
   serverInfo?: McpServerInfoContract | undefined;
+  profiles?: string[] | undefined;
 }
 
 export async function readWellKnownMcpServerVersion(
@@ -33,9 +34,11 @@ export async function readWellKnownMcpServerMetadata(
       if (getMcpCompatStatus(version) !== 'incompatible') {
         logger.debug(`Using MCP server-card version ${version} from ${path}.`);
         const serverInfo = readWellKnownServerInfoContract(payload);
+        const profiles = readWellKnownProfiles(payload);
         return {
           version,
-          ...(serverInfo ? { serverInfo } : {})
+          ...(serverInfo ? { serverInfo } : {}),
+          ...(profiles ? { profiles } : {})
         };
       }
     } catch {
@@ -70,6 +73,21 @@ function readWellKnownServerInfoContract(
   const contract = value['serverInfoContract'];
   const validation = validateMcpServerInfoContract(contract);
   return validation.valid ? validation.data : undefined;
+}
+
+function readWellKnownProfiles(value: unknown): string[] | undefined {
+  if (!isRecord(value) || !isRecord(value['capabilities'])) {
+    return undefined;
+  }
+  const profiles = value['capabilities']['profiles'];
+  if (!Array.isArray(profiles)) {
+    return undefined;
+  }
+  const normalized = profiles.filter(
+    (profile): profile is string =>
+      typeof profile === 'string' && profile.length > 0
+  );
+  return [...new Set(normalized)];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/vscode-extension/src/types.ts
+++ b/apps/vscode-extension/src/types.ts
@@ -342,6 +342,7 @@ export interface McpCapabilityCard {
   tools: string[];
   resources: string[];
   prompts: string[];
+  profiles?: string[] | undefined;
   serverInfo?: McpServerInfoContract | undefined;
   diagnostics?: string[] | undefined;
 }

--- a/apps/vscode-extension/test/unit/mcpProfilePicker.test.ts
+++ b/apps/vscode-extension/test/unit/mcpProfilePicker.test.ts
@@ -3,7 +3,11 @@ import {
   pickMcpProfile,
   readConfiguredMcpProfile
 } from '../../src/commands/mcpProfilePicker';
-import { KICAD_MCP_PROFILES } from '../../src/mcp/profileCatalog';
+import {
+  KICAD_MCP_ADVANCED_PROFILES,
+  KICAD_MCP_PRIMARY_PROFILES,
+  KICAD_MCP_PROFILES
+} from '../../src/mcp/profileCatalog';
 import { __setConfiguration, window, workspace } from './vscodeMock';
 
 jest.mock('node:fs', () => ({
@@ -30,14 +34,84 @@ describe('mcpProfilePicker', () => {
     ];
   });
 
-  function services() {
+  function services(advertisedProfiles?: string[]) {
     return {
-      mcpClient: { retryNow: jest.fn().mockResolvedValue(undefined) },
+      mcpClient: {
+        retryNow: jest.fn().mockResolvedValue(undefined),
+        getState: jest.fn().mockReturnValue({
+          server: advertisedProfiles
+            ? { capabilities: { profiles: advertisedProfiles } }
+            : undefined
+        })
+      },
       refreshMcpState: jest.fn().mockResolvedValue(undefined)
     };
   }
 
   describe('pickMcpProfile', () => {
+    it('#622 uses server profile evidence and keeps specialized choices behind Advanced', async () => {
+      const svc = services(['review', 'build', 'expert', 'pcb_only']);
+      (window.showQuickPick as jest.Mock)
+        .mockResolvedValueOnce({ advanced: true })
+        .mockResolvedValueOnce({
+          profile: KICAD_MCP_ADVANCED_PROFILES.find(
+            (profile) => profile.id === 'pcb_only'
+          )
+        });
+      (window.showInformationMessage as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await pickMcpProfile(svc as never);
+
+      expect(result).toBe('pcb_only');
+      const primaryItems = (window.showQuickPick as jest.Mock).mock
+        .calls[0]?.[0] as Array<{
+        profile?: { id: string };
+        advanced?: boolean;
+      }>;
+      expect(
+        primaryItems
+          .filter((item) => item.profile)
+          .map((item) => item.profile?.id)
+      ).toEqual(['review', 'build', 'expert']);
+      expect(primaryItems.some((item) => item.advanced)).toBe(true);
+
+      const advancedItems = (window.showQuickPick as jest.Mock).mock
+        .calls[1]?.[0] as Array<{
+        profile: { id: string };
+      }>;
+      expect(advancedItems.map((item) => item.profile.id)).toEqual([
+        'pcb_only'
+      ]);
+      expect(KICAD_MCP_PRIMARY_PROFILES.map((profile) => profile.id)).toContain(
+        'release'
+      );
+    });
+
+    it('#622 does not widen an explicit empty server profile advertisement', async () => {
+      (window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
+
+      await pickMcpProfile(services([]) as never);
+
+      const primaryItems = (window.showQuickPick as jest.Mock).mock
+        .calls[0]?.[0] as Array<{ profile?: { id: string } }>;
+      expect(primaryItems).toEqual([]);
+    });
+
+    it('#622 falls back to the checked-in catalog when runtime profile evidence is unavailable', async () => {
+      (window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
+
+      await pickMcpProfile(services() as never);
+
+      const primaryItems = (window.showQuickPick as jest.Mock).mock
+        .calls[0]?.[0] as Array<{
+        profile?: { id: string };
+      }>;
+      expect(
+        primaryItems
+          .filter((item) => item.profile)
+          .map((item) => item.profile?.id)
+      ).toEqual(KICAD_MCP_PRIMARY_PROFILES.map((profile) => profile.id));
+    });
     it('returns undefined and writes nothing when the quick pick is dismissed', async () => {
       (window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
       const svc = services();

--- a/apps/vscode-extension/test/unit/serverMetadata.test.ts
+++ b/apps/vscode-extension/test/unit/serverMetadata.test.ts
@@ -1,0 +1,73 @@
+import { readWellKnownMcpServerMetadata } from '../../src/mcp/serverMetadata';
+
+jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
+  virtual: true
+});
+
+describe('readWellKnownMcpServerMetadata', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('#622 reads the server-advertised MCP profile vocabulary from discovery', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        serverInfo: { name: 'kicad-mcp-pro', version: '3.33.3' },
+        capabilities: {
+          profiles: ['review', 'build', 'release', 'expert', 'pcb_only', 42]
+        }
+      })
+    }) as typeof fetch;
+
+    const metadata = await readWellKnownMcpServerMetadata(
+      'http://127.0.0.1:27185',
+      { debug: jest.fn() }
+    );
+
+    expect(metadata?.profiles).toEqual([
+      'review',
+      'build',
+      'release',
+      'expert',
+      'pcb_only'
+    ]);
+  });
+
+  it('#622 preserves an explicit empty profile advertisement as fail-closed evidence', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        serverInfo: { name: 'kicad-mcp-pro', version: '3.33.3' },
+        capabilities: { profiles: [] }
+      })
+    }) as typeof fetch;
+
+    const metadata = await readWellKnownMcpServerMetadata(
+      'http://127.0.0.1:27185',
+      { debug: jest.fn() }
+    );
+
+    expect(metadata?.profiles).toEqual([]);
+  });
+
+  it('#622 ignores malformed profile evidence instead of widening support', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        serverInfo: { name: 'kicad-mcp-pro', version: '3.33.3' },
+        capabilities: { profiles: 'all' }
+      })
+    }) as typeof fetch;
+
+    const metadata = await readWellKnownMcpServerMetadata(
+      'http://127.0.0.1:27185',
+      { debug: jest.fn() }
+    );
+
+    expect(metadata?.profiles).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- consume the published `/.well-known/mcp-server` `capabilities.profiles` evidence and carry it into the MCP capability card
- keep Review / Build / Release / Expert as the primary picker surface, filtering unsupported entries from live server evidence
- move specialized/legacy profiles behind a dedicated Advanced quick-pick while preserving the checked-in compatibility catalog when discovery is unavailable
- treat an explicitly empty advertised profile set as fail-closed evidence instead of widening to client defaults

## Validation
- TDD RED confirmed missing discovery/profile UX behavior before implementation
- focused profile/discovery suites: 16/16 passing
- `lint` and `typecheck` passing on final tree
- full `pnpm run check:kicad-studio` passed before the final fail-closed refinement: 129 suites / 1010 unit tests, coverage ratchet, security, 76 accessibility tests, production build, VSIX package + validation
- final fail-closed refinement revalidated with focused tests + lint + typecheck + `git diff --check`

## Scope
This is the bounded server-evidence + Advanced UX slice of #622. It intentionally does **not** close #622; remaining acceptance still includes direct Extension Host/user-flow coverage and any cross-surface vocabulary work not already proven.

Refs #622
