### PR TITLE
feat(kicad-studio): gate BoardReadyOps readiness by contract

### DIFF
--- a/apps/vscode-extension/src/boardreadyops/contract.ts
+++ b/apps/vscode-extension/src/boardreadyops/contract.ts
@@ -1,0 +1,114 @@
+import semver from 'semver';
+import { COMPATIBILITY_MATRIX } from '../mcp/compatibilityMatrix';
+
+export interface BoardReadyOpsContractDiscovery {
+  compatible: boolean;
+  schemaVersion: number | undefined;
+  version: string;
+  reason?:
+    | 'unsupported doctor schema'
+    | 'malformed doctor payload'
+    | 'unsupported BoardReadyOps version';
+}
+
+function parseDoctorValue(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  try {
+    return JSON.parse(value.trim());
+  } catch {
+    return undefined;
+  }
+}
+
+function readDoctorVersion(value: unknown): string {
+  if (!value || typeof value !== 'object') {
+    return 'unknown';
+  }
+  const tool = (value as { tool?: unknown }).tool;
+  if (!tool || typeof tool !== 'object') {
+    return 'unknown';
+  }
+  const version = (tool as { version?: unknown }).version;
+  return typeof version === 'string' && version.trim()
+    ? version.trim()
+    : 'unknown';
+}
+
+export function discoverBoardReadyOpsContract(
+  input: unknown
+): BoardReadyOpsContractDiscovery {
+  const value = parseDoctorValue(input);
+  if (value === undefined && typeof input === 'string') {
+    return {
+      compatible: false,
+      reason: 'malformed doctor payload',
+      schemaVersion: undefined,
+      version: 'unknown'
+    };
+  }
+
+  const version = readDoctorVersion(value);
+  const schemaVersion =
+    value &&
+    typeof value === 'object' &&
+    typeof (value as { schemaVersion?: unknown }).schemaVersion === 'number'
+      ? (value as { schemaVersion: number }).schemaVersion
+      : undefined;
+
+  if (
+    schemaVersion !==
+    COMPATIBILITY_MATRIX.supportAxes.boardReadyOps.doctorSchema
+  ) {
+    return {
+      compatible: false,
+      reason: 'unsupported doctor schema',
+      schemaVersion,
+      version
+    };
+  }
+
+  const tool =
+    value && typeof value === 'object'
+      ? (value as { tool?: unknown }).tool
+      : undefined;
+  const toolName =
+    tool && typeof tool === 'object'
+      ? (tool as { name?: unknown }).name
+      : undefined;
+  const checks =
+    value && typeof value === 'object'
+      ? (value as { checks?: unknown }).checks
+      : undefined;
+  if (
+    toolName !== 'boardreadyops' ||
+    !Array.isArray(checks) ||
+    version === 'unknown'
+  ) {
+    return {
+      compatible: false,
+      reason: 'malformed doctor payload',
+      schemaVersion,
+      version
+    };
+  }
+
+  const normalized = semver.valid(version) ?? undefined;
+  if (
+    !normalized ||
+    !semver.satisfies(
+      normalized,
+      COMPATIBILITY_MATRIX.supportAxes.boardReadyOps.required
+    )
+  ) {
+    return {
+      compatible: false,
+      reason: 'unsupported BoardReadyOps version',
+      schemaVersion,
+      version
+    };
+  }
+
+  return { compatible: true, schemaVersion, version };
+}

--- a/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
+++ b/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { COMMANDS, SETTINGS } from '../constants';
 import { localize } from '../i18n';
 import type { CommandServices } from './types';
+import { discoverBoardReadyOpsContract } from '../boardreadyops/contract';
 
 /** URL for BoardReadyOps documentation. */
 export const BOARDREADYOPS_DOCS_URL =
@@ -45,20 +46,15 @@ interface BoardReadyOpsRunResult {
 let latestReport: BoardReadyOpsRunResult | undefined = undefined;
 const previousDiagnosticUris = new Set<string>();
 
-function runBoardReadyOps(
+function runBoardReadyOpsCommand(
   projectPath: string,
-  specFile: string | undefined,
+  args: string[],
   token: vscode.CancellationToken
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return new Promise((resolve, reject) => {
     const cmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-    const args = ['boardreadyops', 'run', '--format', 'json'];
-    if (specFile) {
-      args.push('--config', specFile);
-    }
-    args.push(projectPath);
 
-    const child = spawn(cmd, args, {
+    const child = spawn(cmd, ['boardreadyops', ...args], {
       cwd: projectPath,
       env: { ...process.env },
       shell: false
@@ -89,6 +85,42 @@ function runBoardReadyOps(
       resolve({ stdout, stderr, exitCode: code ?? 0 });
     });
   });
+}
+
+function runBoardReadyOps(
+  projectPath: string,
+  specFile: string | undefined,
+  token: vscode.CancellationToken
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const args = ['run', '--format', 'json'];
+  if (specFile) {
+    args.push('--config', specFile);
+  }
+  args.push(projectPath);
+  return runBoardReadyOpsCommand(projectPath, args, token);
+}
+
+async function assertCompatibleBoardReadyOps(
+  projectPath: string,
+  token: vscode.CancellationToken
+): Promise<void> {
+  const { stdout, exitCode } = await runBoardReadyOpsCommand(
+    projectPath,
+    ['doctor', '--format', 'json'],
+    token
+  );
+  if (token.isCancellationRequested) {
+    return;
+  }
+  if (exitCode !== 0) {
+    throw new Error(`BoardReadyOps doctor exited with code ${exitCode}.`);
+  }
+  const contract = discoverBoardReadyOpsContract(stdout);
+  if (!contract.compatible) {
+    throw new Error(
+      `BoardReadyOps is not contract-compatible: ${contract.reason} (version ${contract.version}, doctor schema ${contract.schemaVersion ?? 'missing'}).`
+    );
+  }
 }
 
 /**
@@ -136,7 +168,12 @@ export function registerBoardReadyOpsCommands(
         },
         async (progress, token) => {
           try {
-            const { stdout, stderr } = await runBoardReadyOps(
+            await assertCompatibleBoardReadyOps(projectPath, token);
+            if (token.isCancellationRequested) {
+              return;
+            }
+
+            const { stdout } = await runBoardReadyOps(
               projectPath,
               specFile || undefined,
               token
@@ -150,17 +187,19 @@ export function registerBoardReadyOpsCommands(
             try {
               result = JSON.parse(stdout.trim());
             } catch (err) {
-              throw new Error(
-                `BoardReadyOps returned invalid output: ${stdout || '(no output)'}. Stderr: ${stderr}`,
-                { cause: err }
-              );
+              throw new Error('BoardReadyOps returned invalid JSON output.', {
+                cause: err
+              });
             }
 
             latestReport = result;
 
             // Clear previous BoardReadyOps diagnostics
             const aggregator = services.diagnosticsCollection as any;
-            const setDiagnostics = (uri: vscode.Uri, diags: vscode.Diagnostic[]) => {
+            const setDiagnostics = (
+              uri: vscode.Uri,
+              diags: vscode.Diagnostic[]
+            ) => {
               if (typeof aggregator.setForSource === 'function') {
                 aggregator.setForSource(uri, 'other', diags);
               } else {
@@ -214,9 +253,15 @@ export function registerBoardReadyOpsCommands(
                 }
 
                 let severity = vscode.DiagnosticSeverity.Information;
-                if (finding.severity === 'critical' || finding.severity === 'high') {
+                if (
+                  finding.severity === 'critical' ||
+                  finding.severity === 'high'
+                ) {
                   severity = vscode.DiagnosticSeverity.Error;
-                } else if (finding.severity === 'medium' || finding.severity === 'low') {
+                } else if (
+                  finding.severity === 'medium' ||
+                  finding.severity === 'low'
+                ) {
                   severity = vscode.DiagnosticSeverity.Warning;
                 }
 

--- a/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
+++ b/apps/vscode-extension/src/mcp/compatibilityMatrix.ts
@@ -27,6 +27,7 @@ export const COMPATIBILITY_MATRIX = {
     boardReadyOps: {
       required: '>=1.2.0 <2.0.0',
       testedAgainst: '1.37.0',
+      doctorSchema: 1,
       findingsSchema: 1,
       evidenceBundleSchema: 2
     }

--- a/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
+++ b/apps/vscode-extension/src/mcp/mcpToolsProvider.ts
@@ -11,6 +11,7 @@ import type {
 import type { McpConnectionAdapter } from './mcpToolAdapter';
 import { readConfiguredMcpProfile } from '../commands/mcpProfilePicker';
 import { COMPATIBILITY_MATRIX } from './compatibilityMatrix';
+import { discoverBoardReadyOpsContract } from '../boardreadyops/contract';
 
 type McpToolsNode = {
   label: string;
@@ -176,9 +177,20 @@ export class McpToolsProvider implements vscode.TreeDataProvider<McpToolsNode> {
 
     try {
       const { stdout: docStdout } = await runDoctor();
-      const doc = JSON.parse(docStdout.trim());
-      const version = doc.tool?.version ?? 'unknown';
+      const contract = discoverBoardReadyOpsContract(docStdout);
+      const version = contract.version;
+      if (!contract.compatible) {
+        this.broStatus = {
+          installed: true,
+          version,
+          healthy: false,
+          message: `BoardReadyOps compatibility check failed: ${contract.reason}.`,
+          tools: []
+        };
+        return;
+      }
 
+      const doc = JSON.parse(docStdout.trim());
       let healthy = true;
       let message = 'BoardReadyOps is healthy.';
       if (Array.isArray(doc.checks)) {

--- a/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
@@ -1,6 +1,36 @@
+jest.mock('node:child_process', () => ({
+  spawn: jest.fn()
+}));
+
+import { EventEmitter } from 'node:events';
+import * as childProcess from 'node:child_process';
 import { COMMANDS } from '../../src/constants';
 import { registerBoardReadyOpsCommands } from '../../src/commands/boardReadyOpsCommands';
 import { commands, window, env, __setConfiguration } from './vscodeMock';
+
+function registeredHandler(command: string): () => Promise<void> {
+  const registration = (commands.registerCommand as jest.Mock).mock.calls.find(
+    ([id]: [string]) => id === command
+  );
+  expect(registration).toBeDefined();
+  return registration[1] as () => Promise<void>;
+}
+
+function boardReadyOpsChild(stdout: string, exitCode = 0) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: jest.Mock;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = jest.fn();
+  queueMicrotask(() => {
+    child.stdout.emit('data', Buffer.from(stdout));
+    child.emit('close', exitCode);
+  });
+  return child;
+}
 
 describe('BoardReadyOps commands', () => {
   let servicesMock: any;
@@ -10,6 +40,16 @@ describe('BoardReadyOps commands', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (window.withProgress as jest.Mock).mockImplementation(
+      async (_options, task) =>
+        task(
+          { report: jest.fn() },
+          {
+            isCancellationRequested: false,
+            onCancellationRequested: jest.fn(() => ({ dispose: jest.fn() }))
+          }
+        )
+    );
     mockProjectState = {
       getActiveProject: jest.fn()
     };
@@ -91,6 +131,137 @@ describe('BoardReadyOps commands', () => {
     expect(window.showInformationMessage).toHaveBeenCalledWith(
       expect.stringContaining('No BoardReadyOps report')
     );
+  });
+
+  it('discovers the BoardReadyOps doctor contract before running readiness', async () => {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(
+          JSON.stringify({
+            schemaVersion: 1,
+            tool: { name: 'boardreadyops', version: '1.37.0' },
+            checks: []
+          })
+        )
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(
+          JSON.stringify({
+            status: 'passed',
+            summary: {
+              total: 0,
+              critical: 0,
+              high: 0,
+              medium: 0,
+              low: 0,
+              info: 0
+            },
+            findings: []
+          })
+        )
+      );
+
+    registerBoardReadyOpsCommands(servicesMock);
+    await registeredHandler(COMMANDS.boardReadyOpsCheck)();
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(spawnMock.mock.calls[0]?.[1]).toEqual([
+      'boardreadyops',
+      'doctor',
+      '--format',
+      'json'
+    ]);
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual([
+      'boardreadyops',
+      'run',
+      '--format',
+      'json',
+      '/project'
+    ]);
+  });
+
+  it('does not expose raw BoardReadyOps output when readiness JSON is malformed', async () => {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(
+          JSON.stringify({
+            schemaVersion: 1,
+            tool: { name: 'boardreadyops', version: '1.37.0' },
+            checks: []
+          })
+        )
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild('PRIVATE_EVIDENCE_SENTINEL')
+      );
+
+    registerBoardReadyOpsCommands(servicesMock);
+    await registeredHandler(COMMANDS.boardReadyOpsCheck)();
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('invalid JSON output')
+    );
+    expect(window.showErrorMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining('PRIVATE_EVIDENCE_SENTINEL')
+    );
+    expect(mockLogger.error).toHaveBeenCalled();
+    expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain(
+      'PRIVATE_EVIDENCE_SENTINEL'
+    );
+  });
+
+  it('fails closed when BoardReadyOps doctor exits non-zero', async () => {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock.mockImplementationOnce(() =>
+      boardReadyOpsChild(
+        JSON.stringify({
+          schemaVersion: 1,
+          tool: { name: 'boardreadyops', version: '1.37.0' },
+          checks: []
+        }),
+        2
+      )
+    );
+
+    registerBoardReadyOpsCommands(servicesMock);
+    await registeredHandler(COMMANDS.boardReadyOpsCheck)();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('doctor exited with code 2')
+    );
+  });
+
+  it('fails closed before readiness when the doctor contract is incompatible', async () => {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock.mockImplementationOnce(() =>
+      boardReadyOpsChild(
+        JSON.stringify({
+          schemaVersion: 2,
+          tool: { name: 'boardreadyops', version: '1.37.0' },
+          checks: []
+        })
+      )
+    );
+
+    registerBoardReadyOpsCommands(servicesMock);
+    await registeredHandler(COMMANDS.boardReadyOpsCheck)();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('not contract-compatible')
+    );
+    expect(mockLogger.error).toHaveBeenCalled();
   });
 
   it('opens BoardReadyOps docs via env.openExternal', async () => {

--- a/apps/vscode-extension/test/unit/boardReadyOpsContract.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsContract.test.ts
@@ -1,0 +1,105 @@
+import { discoverBoardReadyOpsContract } from '../../src/boardreadyops/contract';
+
+describe('BoardReadyOps contract discovery', () => {
+  it('accepts the supported versioned doctor contract', () => {
+    expect(
+      discoverBoardReadyOpsContract({
+        schemaVersion: 1,
+        tool: { name: 'boardreadyops', version: '1.37.0' },
+        checks: []
+      })
+    ).toEqual({
+      compatible: true,
+      schemaVersion: 1,
+      version: '1.37.0'
+    });
+  });
+
+  it('accepts raw doctor JSON without duplicating parsing at call sites', () => {
+    expect(
+      discoverBoardReadyOpsContract(
+        JSON.stringify({
+          schemaVersion: 1,
+          tool: { name: 'boardreadyops', version: '1.37.0' },
+          checks: []
+        })
+      )
+    ).toEqual({
+      compatible: true,
+      schemaVersion: 1,
+      version: '1.37.0'
+    });
+  });
+
+  it('fails closed when doctor output identifies a different tool', () => {
+    expect(
+      discoverBoardReadyOpsContract({
+        schemaVersion: 1,
+        tool: { name: 'other-tool', version: '1.37.0' },
+        checks: []
+      })
+    ).toEqual({
+      compatible: false,
+      reason: 'malformed doctor payload',
+      schemaVersion: 1,
+      version: '1.37.0'
+    });
+  });
+
+  it('fails closed when the doctor schema is malformed', () => {
+    expect(
+      discoverBoardReadyOpsContract({
+        tool: { name: 'boardreadyops', version: '1.37.0' }
+      })
+    ).toEqual({
+      compatible: false,
+      reason: 'unsupported doctor schema',
+      schemaVersion: undefined,
+      version: '1.37.0'
+    });
+  });
+
+  it('fails closed when the doctor payload is partial', () => {
+    expect(
+      discoverBoardReadyOpsContract({
+        schemaVersion: 1,
+        tool: { name: 'boardreadyops', version: '1.37.0' }
+      })
+    ).toEqual({
+      compatible: false,
+      reason: 'malformed doctor payload',
+      schemaVersion: 1,
+      version: '1.37.0'
+    });
+  });
+
+  it('fails closed for prerelease doctor versions', () => {
+    expect(
+      discoverBoardReadyOpsContract({
+        schemaVersion: 1,
+        tool: { name: 'boardreadyops', version: '1.37.0-rc.1' },
+        checks: []
+      })
+    ).toEqual({
+      compatible: false,
+      reason: 'unsupported BoardReadyOps version',
+      schemaVersion: 1,
+      version: '1.37.0-rc.1'
+    });
+  });
+
+  it('fails closed when the BoardReadyOps version is outside the supported range', () => {
+    expect(
+      discoverBoardReadyOpsContract({
+        schemaVersion: 1,
+        tool: { name: 'boardreadyops', version: '2.0.0' },
+        checks: []
+      })
+    ).toEqual({
+      compatible: false,
+      reason: 'unsupported BoardReadyOps version',
+      schemaVersion: 1,
+      version: '2.0.0'
+    });
+  });
+});

--- a/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
+++ b/apps/vscode-extension/test/unit/mcpToolsProvider.test.ts
@@ -1,9 +1,12 @@
+import * as childProcess from 'node:child_process';
 import { McpToolsProvider } from '../../src/mcp/mcpToolsProvider';
 import type {
   McpConnectionState,
   McpServerInfoContract
 } from '../../src/types';
 import { __setConfiguration } from './vscodeMock';
+
+jest.mock('node:child_process', () => ({ execFile: jest.fn() }));
 
 jest.mock('vscode', () => jest.requireActual('./vscodeMock'), {
   virtual: true
@@ -486,6 +489,41 @@ describe('McpToolsProvider', () => {
       expect(healthItem.description).toBe('degraded');
       expect(healthItem.tooltip).toBe('Doctor failed');
     });
+
+    it('fails closed in the live provider when the doctor contract is incompatible', async () => {
+      const execFileMock = childProcess.execFile as unknown as jest.Mock;
+      execFileMock.mockImplementation(
+        (
+          _command: string,
+          _args: string[],
+          _options: unknown,
+          callback: (err: Error | null, stdout: string, stderr: string) => void
+        ) => {
+          callback(
+            null,
+            JSON.stringify({
+              schemaVersion: 2,
+              tool: { name: 'boardreadyops', version: '1.37.0' },
+              checks: []
+            }),
+            ''
+          );
+        }
+      );
+      const provider = providerForState(connectedState({ tools: [] }));
+
+      await runBoardReadyOpsStatusCheck(provider);
+
+      expect(execFileMock).toHaveBeenCalledTimes(1);
+      expect(provider.broStatus).toEqual({
+        installed: true,
+        version: '1.37.0',
+        healthy: false,
+        message:
+          'BoardReadyOps compatibility check failed: unsupported doctor schema.',
+        tools: []
+      });
+    });
   });
 });
 
@@ -678,4 +716,12 @@ function flattenTree(
       ? [current, ...flattenTree(provider, childNode, `${label} > `)]
       : [current];
   });
+}
+
+async function runBoardReadyOpsStatusCheck(
+  provider: McpToolsProvider
+): Promise<void> {
+  await (
+    provider as unknown as { checkBoardReadyOps(): Promise<void> }
+  ).checkBoardReadyOps();
 }


### PR DESCRIPTION
## Summary
- discover and validate the versioned BoardReadyOps doctor contract before readiness runs
- fail closed on unsupported schema/version, partial payloads, prereleases, and non-zero doctor exits
- reuse the same compatibility contract in the MCP Tools provider
- stop exposing raw malformed BoardReadyOps output in user-visible/logged errors
- replace #667 with a cryptographically signed commit required by the main branch ruleset

## Validation
- repository pre-push quality gate passed end-to-end
- extension unit suite: 130 suites / 1028 tests passed
- accessibility gate: 76 tests passed
- security tests, coverage ratchet, lint, typecheck, build, package, package validation passed
- repeatable VSIX, dependency/security policy, governance, architecture, docs, and compatibility gates passed

Part of #623. This PR addresses explicit version/contract discovery and fail-closed malformed/incompatible states; the broader plan/evidence/review/release workflow acceptance criteria remain open.

Supersedes #667 because its source commits were unsigned and could not satisfy required_signatures without rewriting history.