### PR TITLE
feat(kicad-studio): surface BoardReadyOps remediation plan

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1125,6 +1125,11 @@
         "icon": "$(list-selection)"
       },
       {
+        "command": "kicadstudio.boardReadyOps.plan",
+        "title": "%kicadstudio.contributes.commands.boardReadyOps.plan.title%",
+        "category": "%kicadstudio.contributes.commands.boardReadyOps.category%"
+      },
+      {
         "command": "kicadstudio.generateKicadDiffReport",
         "title": "%kicadstudio.contributes.commands.diffReport.title%",
         "category": "%kicadstudio.contributes.commands.diffReport.category%",
@@ -1730,6 +1735,10 @@
         {
           "command": "kicadstudio.boardReadyOps.check",
           "when": "kicadstudio.workspaceTrusted"
+        },
+        {
+          "command": "kicadstudio.boardReadyOps.plan",
+          "when": "kicadstudio.workspaceTrusted && kicadstudio.hasProject"
         },
         {
           "command": "kicadstudio.boardReadyOps.configure",

--- a/apps/vscode-extension/package.nls.json
+++ b/apps/vscode-extension/package.nls.json
@@ -397,6 +397,8 @@
   "kicadstudio.contributes.commands.106.category": "KiCad Export",
   "kicadstudio.contributes.commands.107.title": "KiCad: Select Active Project",
   "kicadstudio.contributes.commands.107.category": "KiCad",
+  "kicadstudio.contributes.commands.boardReadyOps.plan.title": "KiCad Studio: Show BoardReadyOps Remediation Plan",
+  "kicadstudio.contributes.commands.boardReadyOps.category": "KiCad Studio",
   "kicadstudio.contributes.commands.diffReport.title": "KiCad: Generate Diff Report",
   "kicadstudio.contributes.commands.diffReport.category": "KiCad",
   "kicadstudio.contributes.languageModelChatProviders.0.displayName": "KiCad Studio",

--- a/apps/vscode-extension/package.nls.tr.json
+++ b/apps/vscode-extension/package.nls.tr.json
@@ -397,6 +397,8 @@
   "kicadstudio.contributes.commands.106.category": "KiCad Dışa Aktarma",
   "kicadstudio.contributes.commands.107.title": "KiCad: Etkin Projeyi Seç",
   "kicadstudio.contributes.commands.107.category": "KiCad",
+  "kicadstudio.contributes.commands.boardReadyOps.plan.title": "KiCad Studio: BoardReadyOps İyileştirme Planını Göster",
+  "kicadstudio.contributes.commands.boardReadyOps.category": "KiCad Studio",
   "kicadstudio.contributes.commands.diffReport.title": "KiCad: Fark Raporu Oluştur",
   "kicadstudio.contributes.commands.diffReport.category": "KiCad",
   "kicadstudio.contributes.languageModelChatProviders.0.displayName": "KiCad Studio",

--- a/apps/vscode-extension/scripts/command-surface.json
+++ b/apps/vscode-extension/scripts/command-surface.json
@@ -393,6 +393,10 @@
       "task": "validate",
       "surface": "contextual"
     },
+    "kicadstudio.boardReadyOps.plan": {
+      "task": "validate",
+      "surface": "contextual"
+    },
     "kicadstudio.export3DStep": {
       "task": "release",
       "surface": "contextual"

--- a/apps/vscode-extension/src/boardreadyops/plan.ts
+++ b/apps/vscode-extension/src/boardreadyops/plan.ts
@@ -1,0 +1,120 @@
+export interface BoardReadyOpsPlanAction {
+  id: string;
+  ruleId: string;
+  severity: 'critical' | 'high' | 'medium' | 'low' | 'info';
+  title: string;
+  fixStrategy: {
+    description: string;
+    steps: string[];
+  };
+}
+
+export interface BoardReadyOpsPlanResult {
+  schemaVersion: 1;
+  tool: { name: 'boardreadyops'; version: string };
+  status: 'passed' | 'failed';
+  nextActions: BoardReadyOpsPlanAction[];
+  releaseActions: BoardReadyOpsPlanAction[];
+}
+
+export function parseBoardReadyOpsPlan(
+  stdout: string
+): BoardReadyOpsPlanResult {
+  let value: unknown;
+  try {
+    value = JSON.parse(stdout.trim());
+  } catch (err) {
+    throw new Error('BoardReadyOps plan returned invalid JSON output.', {
+      cause: err
+    });
+  }
+  if (!value || typeof value !== 'object') {
+    throw new Error('BoardReadyOps plan returned an invalid contract.');
+  }
+  type UnknownRecord = Record<string, unknown>;
+  type UnknownPlan = {
+    schemaVersion?: unknown;
+    tool?: unknown;
+    generatedAt?: unknown;
+    status?: unknown;
+    exitCode?: unknown;
+    summary?: unknown;
+    projectRoot?: unknown;
+    nextActions?: unknown;
+    releaseActions?: unknown;
+  };
+  type UnknownAction = {
+    id?: unknown;
+    ruleId?: unknown;
+    severity?: unknown;
+    title?: unknown;
+    resource?: unknown;
+    evidence?: unknown;
+    whyItMatters?: unknown;
+    fixStrategy?: unknown;
+    safeAutoFixPossible?: unknown;
+    commandsToVerify?: unknown;
+  };
+  const candidate = value as UnknownPlan;
+  const isRecord = (item: unknown): item is UnknownRecord =>
+    !!item && typeof item === 'object' && !Array.isArray(item);
+  const isText = (item: unknown): item is string =>
+    typeof item === 'string' && item.length > 0;
+  const severities = new Set(['critical', 'high', 'medium', 'low', 'info']);
+  const validAction = (action: unknown): action is BoardReadyOpsPlanAction => {
+    if (!isRecord(action)) return false;
+    const item = action as UnknownAction;
+    const fixStrategy = item.fixStrategy;
+    const resource = item.resource;
+    const evidence = item.evidence;
+    return (
+      isText(item.id) &&
+      isText(item.ruleId) &&
+      severities.has(String(item.severity)) &&
+      isText(item.title) &&
+      isRecord(resource) &&
+      isText(resource['path']) &&
+      isText(resource['kind']) &&
+      isRecord(evidence) &&
+      isText(evidence['message']) &&
+      isText(item.whyItMatters) &&
+      isRecord(fixStrategy) &&
+      isText(fixStrategy['description']) &&
+      Array.isArray(fixStrategy['steps']) &&
+      fixStrategy['steps'].every(isText) &&
+      typeof item.safeAutoFixPossible === 'boolean' &&
+      Array.isArray(item.commandsToVerify) &&
+      item.commandsToVerify.length > 0 &&
+      item.commandsToVerify.every(isText)
+    );
+  };
+  const tool = candidate.tool;
+  const summary = candidate.summary;
+  const validSummary =
+    isRecord(summary) &&
+    ['total', 'critical', 'high', 'medium', 'low', 'info'].every(
+      (key) => Number.isInteger(summary[key]) && Number(summary[key]) >= 0
+    ) &&
+    ['critical', 'high', 'medium', 'low', 'info', 'none'].includes(
+      String(summary['maxSeverity'])
+    ) &&
+    typeof summary['failed'] === 'boolean';
+  if (
+    candidate.schemaVersion !== 1 ||
+    !isRecord(tool) ||
+    tool['name'] !== 'boardreadyops' ||
+    !isText(tool['version']) ||
+    !isText(candidate.generatedAt) ||
+    (candidate.status !== 'passed' && candidate.status !== 'failed') ||
+    !Number.isInteger(candidate.exitCode) ||
+    !validSummary ||
+    !isText(candidate.projectRoot) ||
+    !Array.isArray(candidate.nextActions) ||
+    !candidate.nextActions.every(validAction) ||
+    !Array.isArray(candidate.releaseActions) ||
+    !candidate.releaseActions.every(validAction)
+  ) {
+    throw new Error('BoardReadyOps plan returned an invalid contract.');
+  }
+  return candidate as unknown as BoardReadyOpsPlanResult;
+}

--- a/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
+++ b/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
@@ -5,6 +5,7 @@ import { COMMANDS, SETTINGS } from '../constants';
 import { localize } from '../i18n';
 import type { CommandServices } from './types';
 import { discoverBoardReadyOpsContract } from '../boardreadyops/contract';
+import { parseBoardReadyOpsPlan } from '../boardreadyops/plan';
 
 /** URL for BoardReadyOps documentation. */
 export const BOARDREADYOPS_DOCS_URL =
@@ -301,6 +302,86 @@ export function registerBoardReadyOpsCommands(
             services.logger.error('BoardReadyOps check failed', err);
             void vscode.window.showErrorMessage(
               `BoardReadyOps check failed: ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        }
+      );
+    }),
+
+    vscode.commands.registerCommand(COMMANDS.boardReadyOpsPlan, async () => {
+      const enabled = vscode.workspace
+        .getConfiguration()
+        .get<boolean>(SETTINGS.boardReadyOpsEnabled, false);
+      if (!enabled) {
+        void vscode.window.showWarningMessage(
+          localize('boardReadyOpsNotConfigured')
+        );
+        return;
+      }
+      const projectPath = services.projectState.getActiveProject()?.rootPath;
+      if (!projectPath) {
+        void vscode.window.showErrorMessage(
+          'No active KiCad project found. Open a project to plan BoardReadyOps remediation.'
+        );
+        return;
+      }
+      const specFile = vscode.workspace
+        .getConfiguration()
+        .get<string>(SETTINGS.boardReadyOpsSpecFile, '')
+        .trim();
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Building BoardReadyOps remediation plan...',
+          cancellable: true
+        },
+        async (_progress, token) => {
+          try {
+            await assertCompatibleBoardReadyOps(projectPath, token);
+            if (token.isCancellationRequested) return;
+            const args = ['plan', '--format', 'json'];
+            if (specFile) args.push('--config', specFile);
+            args.push(projectPath);
+            const { stdout, exitCode } = await runBoardReadyOpsCommand(
+              projectPath,
+              args,
+              token
+            );
+            if (token.isCancellationRequested) return;
+            if (exitCode !== 0 && exitCode !== 1) {
+              throw new Error(
+                `BoardReadyOps plan exited with code ${exitCode}.`
+              );
+            }
+            const plan = parseBoardReadyOpsPlan(stdout);
+            const actions = plan.nextActions.length
+              ? plan.nextActions
+              : plan.releaseActions;
+            if (actions.length === 0) {
+              void vscode.window.showInformationMessage(
+                'BoardReadyOps did not report any remediation or release actions.'
+              );
+              return;
+            }
+            await vscode.window.showQuickPick(
+              actions.map((action) => ({
+                label: action.title,
+                description: action.ruleId,
+                detail: action.fixStrategy.steps.join(' → ')
+              })),
+              {
+                title: 'BoardReadyOps Remediation Plan',
+                placeHolder: 'Review the shortest deterministic next actions'
+              }
+            );
+          } catch (err) {
+            const safeError =
+              err instanceof Error
+                ? err.message
+                : 'Unknown BoardReadyOps plan error.';
+            services.logger.error('BoardReadyOps plan failed', safeError);
+            void vscode.window.showErrorMessage(
+              `BoardReadyOps plan failed: ${safeError}`
             );
           }
         }

--- a/apps/vscode-extension/src/commands/taskHubCatalog.ts
+++ b/apps/vscode-extension/src/commands/taskHubCatalog.ts
@@ -139,7 +139,7 @@ export const TASK_GROUPS: readonly TaskGroup[] = [
         label: 'Show BoardReadyOps remediation plan',
         description: 'Review deterministic next actions without AI',
         command: COMMANDS.boardReadyOpsPlan,
-        requirements: { all: ['workspaceTrusted'] }
+        requirements: { all: ['workspaceTrusted', 'hasProject'] }
       },
       {
         label: 'Analyze latest DRC results with AI',

--- a/apps/vscode-extension/src/commands/taskHubCatalog.ts
+++ b/apps/vscode-extension/src/commands/taskHubCatalog.ts
@@ -1,11 +1,7 @@
 import { COMMANDS } from '../constants';
 
 export type TaskGroupId =
-  | 'review'
-  | 'validate'
-  | 'release'
-  | 'automate'
-  | 'maintain';
+  'review' | 'validate' | 'release' | 'automate' | 'maintain';
 
 type CommandId = (typeof COMMANDS)[keyof typeof COMMANDS];
 
@@ -31,10 +27,7 @@ export interface TaskRequirements {
 }
 
 export type TaskAvailability =
-  | 'always'
-  | 'project'
-  | 'trusted'
-  | 'trustedProject';
+  'always' | 'project' | 'trusted' | 'trustedProject';
 
 export interface TaskAction {
   readonly label: string;
@@ -140,6 +133,12 @@ export const TASK_GROUPS: readonly TaskGroup[] = [
         label: 'Check board readiness',
         description: 'Run BoardReadyOps checks for manufacturing readiness',
         command: COMMANDS.boardReadyOpsCheck,
+        requirements: { all: ['workspaceTrusted'] }
+      },
+      {
+        label: 'Show BoardReadyOps remediation plan',
+        description: 'Review deterministic next actions without AI',
+        command: COMMANDS.boardReadyOpsPlan,
         requirements: { all: ['workspaceTrusted'] }
       },
       {

--- a/apps/vscode-extension/src/constants.ts
+++ b/apps/vscode-extension/src/constants.ts
@@ -179,6 +179,7 @@ export const COMMANDS = {
   exportTo: 'kicadstudio.exportTo',
   importFrom: 'kicadstudio.importFrom',
   boardReadyOpsCheck: 'kicadstudio.boardReadyOps.check',
+  boardReadyOpsPlan: 'kicadstudio.boardReadyOps.plan',
   boardReadyOpsConfigure: 'kicadstudio.boardReadyOps.configure',
   boardReadyOpsShowReport: 'kicadstudio.boardReadyOps.showReport',
   boardReadyOpsOpenDocs: 'kicadstudio.boardReadyOps.openDocs'

--- a/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
@@ -72,8 +72,13 @@ describe('BoardReadyOps commands', () => {
     };
   });
 
-  function enableBoardReadyOpsProject(): void {
-    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+  function enableBoardReadyOpsProject(
+    extraConfiguration: Record<string, unknown> = {}
+  ): void {
+    __setConfiguration({
+      'kicadstudio.boardReadyOps.enabled': true,
+      ...extraConfiguration
+    });
     mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
   }
 
@@ -190,6 +195,49 @@ describe('BoardReadyOps commands', () => {
     ]);
   });
 
+  it('does not run the BoardReadyOps plan while integration is disabled', async () => {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': false });
+
+    await runCommand(COMMANDS.boardReadyOpsPlan);
+
+    expect(childProcess.spawn).not.toHaveBeenCalled();
+    expect(window.showWarningMessage).toHaveBeenCalled();
+  });
+
+  it('does not run the BoardReadyOps plan without an active project', async () => {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+    mockProjectState.getActiveProject.mockReturnValue(undefined);
+
+    await runCommand(COMMANDS.boardReadyOpsPlan);
+
+    expect(childProcess.spawn).not.toHaveBeenCalled();
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('No active KiCad project')
+    );
+  });
+
+  it('passes the configured BoardReadyOps spec file to the plan command', async () => {
+    enableBoardReadyOpsProject({
+      'kicadstudio.boardReadyOps.specFile': 'boardreadyops.yaml'
+    });
+    const spawnMock = mockCompatibleBoardReadyOpsResponse(
+      boardReadyOpsAgentPlan(),
+      1
+    );
+
+    await runCommand(COMMANDS.boardReadyOpsPlan);
+
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual([
+      'boardreadyops',
+      'plan',
+      '--format',
+      'json',
+      '--config',
+      'boardreadyops.yaml',
+      '/project'
+    ]);
+  });
+
   it('shows the structured BoardReadyOps remediation plan after contract discovery', async () => {
     enableBoardReadyOpsProject();
     const spawnMock = mockCompatibleBoardReadyOpsResponse(
@@ -219,6 +267,57 @@ describe('BoardReadyOps commands', () => {
         })
       ],
       expect.objectContaining({ title: 'BoardReadyOps Remediation Plan' })
+    );
+  });
+
+  it('shows release actions when the remediation plan has no next actions', async () => {
+    enableBoardReadyOpsProject();
+    const plan = boardReadyOpsAgentPlan();
+    const nextActions = plan['nextActions'] as unknown[];
+    const action = nextActions[0];
+    expect(action).toBeDefined();
+    plan['nextActions'] = [];
+    plan['releaseActions'] = [action];
+    mockCompatibleBoardReadyOpsResponse(plan);
+
+    await runCommand(COMMANDS.boardReadyOpsPlan);
+
+    expect(window.showQuickPick).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          label: 'Generate missing manufacturing outputs.'
+        })
+      ],
+      expect.any(Object)
+    );
+  });
+
+  it('reports when the BoardReadyOps plan has no actions', async () => {
+    enableBoardReadyOpsProject();
+    const plan = boardReadyOpsAgentPlan();
+    plan['nextActions'] = [];
+    plan['releaseActions'] = [];
+    mockCompatibleBoardReadyOpsResponse(plan);
+
+    await runCommand(COMMANDS.boardReadyOpsPlan);
+
+    expect(window.showQuickPick).not.toHaveBeenCalled();
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'did not report any remediation or release actions'
+      )
+    );
+  });
+
+  it('fails closed when the BoardReadyOps plan exits unexpectedly', async () => {
+    enableBoardReadyOpsProject();
+    mockCompatibleBoardReadyOpsResponse(boardReadyOpsAgentPlan(), 2);
+
+    await runCommand(COMMANDS.boardReadyOpsPlan);
+
+    expect(window.showQuickPick).not.toHaveBeenCalled();
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'BoardReadyOps plan failed: BoardReadyOps plan exited with code 2.'
     );
   });
 

--- a/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
@@ -7,6 +7,10 @@ import * as childProcess from 'node:child_process';
 import { COMMANDS } from '../../src/constants';
 import { registerBoardReadyOpsCommands } from '../../src/commands/boardReadyOpsCommands';
 import { commands, window, env, __setConfiguration } from './vscodeMock';
+import {
+  boardReadyOpsAgentPlan,
+  boardReadyOpsDoctorContract
+} from './boardReadyOpsFixtures';
 
 function registeredHandler(command: string): () => Promise<void> {
   const registration = (commands.registerCommand as jest.Mock).mock.calls.find(
@@ -67,6 +71,34 @@ describe('BoardReadyOps commands', () => {
       logger: mockLogger
     };
   });
+
+  function enableBoardReadyOpsProject(): void {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
+  }
+
+  function mockCompatibleBoardReadyOpsResponse(
+    response: unknown,
+    exitCode = 0
+  ): jest.Mock {
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(
+          typeof response === 'string' ? response : JSON.stringify(response),
+          exitCode
+        )
+      );
+    return spawnMock;
+  }
+
+  async function runCommand(command: string): Promise<void> {
+    registerBoardReadyOpsCommands(servicesMock);
+    await registeredHandler(command)();
+  }
 
   it('registers five boardReadyOps commands', () => {
     const disposables = registerBoardReadyOpsCommands(servicesMock);
@@ -135,39 +167,13 @@ describe('BoardReadyOps commands', () => {
   });
 
   it('discovers the BoardReadyOps doctor contract before running readiness', async () => {
-    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
-    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
-    const spawnMock = childProcess.spawn as unknown as jest.Mock;
-    spawnMock
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(
-          JSON.stringify({
-            schemaVersion: 1,
-            tool: { name: 'boardreadyops', version: '1.37.0' },
-            checks: []
-          })
-        )
-      )
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(
-          JSON.stringify({
-            status: 'passed',
-            summary: {
-              total: 0,
-              critical: 0,
-              high: 0,
-              medium: 0,
-              low: 0,
-              info: 0
-            },
-            findings: []
-          })
-        )
-      );
-
-    registerBoardReadyOpsCommands(servicesMock);
-    await registeredHandler(COMMANDS.boardReadyOpsCheck)();
-
+    enableBoardReadyOpsProject();
+    const spawnMock = mockCompatibleBoardReadyOpsResponse({
+      status: 'passed',
+      summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, info: 0 },
+      findings: []
+    });
+    await runCommand(COMMANDS.boardReadyOpsCheck);
     expect(spawnMock).toHaveBeenCalledTimes(2);
     expect(spawnMock.mock.calls[0]?.[1]).toEqual([
       'boardreadyops',
@@ -185,66 +191,12 @@ describe('BoardReadyOps commands', () => {
   });
 
   it('shows the structured BoardReadyOps remediation plan after contract discovery', async () => {
-    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
-    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
-    const spawnMock = childProcess.spawn as unknown as jest.Mock;
-    spawnMock
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(
-          JSON.stringify({
-            schemaVersion: 1,
-            tool: { name: 'boardreadyops', version: '1.37.0' },
-            checks: []
-          })
-        )
-      )
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(
-          JSON.stringify({
-            schemaVersion: 1,
-            tool: { name: 'boardreadyops', version: '1.37.0' },
-            generatedAt: '2026-08-31T00:00:00.000Z',
-            status: 'failed',
-            exitCode: 1,
-            summary: {
-              total: 1,
-              critical: 0,
-              high: 1,
-              medium: 0,
-              low: 0,
-              info: 0,
-              maxSeverity: 'high',
-              failed: true
-            },
-            projectRoot: '/project',
-            nextActions: [
-              {
-                id: 'finding-1',
-                ruleId: 'manufacturing.outputs-present',
-                severity: 'high',
-                title: 'Generate missing manufacturing outputs.',
-                resource: { path: 'board.kicad_pcb', kind: 'pcb' },
-                evidence: { message: 'Manufacturing outputs are missing.' },
-                whyItMatters: 'Fabrication requires current outputs.',
-                fixStrategy: {
-                  description: 'Generate current outputs.',
-                  steps: ['Run the KiCad jobset.', 'Re-run BoardReadyOps.']
-                },
-                safeAutoFixPossible: false,
-                commandsToVerify: [
-                  'boardreadyops check --rule manufacturing.outputs-present /project'
-                ]
-              }
-            ],
-            releaseActions: []
-          }),
-          1
-        )
-      );
-
-    registerBoardReadyOpsCommands(servicesMock);
-    await registeredHandler(COMMANDS.boardReadyOpsPlan)();
-
+    enableBoardReadyOpsProject();
+    const spawnMock = mockCompatibleBoardReadyOpsResponse(
+      boardReadyOpsAgentPlan(),
+      1
+    );
+    await runCommand(COMMANDS.boardReadyOpsPlan);
     expect(spawnMock.mock.calls[0]?.[1]).toEqual([
       'boardreadyops',
       'doctor',
@@ -271,26 +223,9 @@ describe('BoardReadyOps commands', () => {
   });
 
   it('does not expose raw BoardReadyOps plan output when the plan is malformed', async () => {
-    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
-    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
-    const spawnMock = childProcess.spawn as unknown as jest.Mock;
-    spawnMock
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(
-          JSON.stringify({
-            schemaVersion: 1,
-            tool: { name: 'boardreadyops', version: '1.37.0' },
-            checks: []
-          })
-        )
-      )
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild('PRIVATE_PLAN_EVIDENCE_SENTINEL')
-      );
-
-    registerBoardReadyOpsCommands(servicesMock);
-    await registeredHandler(COMMANDS.boardReadyOpsPlan)();
-
+    enableBoardReadyOpsProject();
+    mockCompatibleBoardReadyOpsResponse('PRIVATE_PLAN_EVIDENCE_SENTINEL');
+    await runCommand(COMMANDS.boardReadyOpsPlan);
     expect(window.showErrorMessage).toHaveBeenCalledWith(
       expect.stringContaining('invalid JSON')
     );
@@ -304,41 +239,24 @@ describe('BoardReadyOps commands', () => {
   });
 
   it('fails closed on a partial BoardReadyOps plan contract without exposing its payload', async () => {
-    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
-    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
-    const spawnMock = childProcess.spawn as unknown as jest.Mock;
-    spawnMock
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(
-          JSON.stringify({
-            schemaVersion: 1,
-            tool: { name: 'boardreadyops', version: '1.37.0' },
-            checks: []
-          })
-        )
-      )
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(
-          JSON.stringify({
-            schemaVersion: 1,
-            tool: { name: 'boardreadyops', version: '1.37.0' },
-            status: 'failed',
-            nextActions: [
-              {
-                id: 'PRIVATE_PARTIAL_SENTINEL',
-                ruleId: 'config.invalid',
-                title: 'private action'
-              }
-            ],
-            releaseActions: []
-          }),
-          1
-        )
-      );
-
-    registerBoardReadyOpsCommands(servicesMock);
-    await registeredHandler(COMMANDS.boardReadyOpsPlan)();
-
+    enableBoardReadyOpsProject();
+    mockCompatibleBoardReadyOpsResponse(
+      {
+        schemaVersion: 1,
+        tool: { name: 'boardreadyops', version: '1.37.0' },
+        status: 'failed',
+        nextActions: [
+          {
+            id: 'PRIVATE_PARTIAL_SENTINEL',
+            ruleId: 'config.invalid',
+            title: 'private action'
+          }
+        ],
+        releaseActions: []
+      },
+      1
+    );
+    await runCommand(COMMANDS.boardReadyOpsPlan);
     expect(window.showErrorMessage).toHaveBeenCalledWith(
       'BoardReadyOps plan failed: BoardReadyOps plan returned an invalid contract.'
     );
@@ -348,26 +266,9 @@ describe('BoardReadyOps commands', () => {
   });
 
   it('does not expose raw BoardReadyOps output when readiness JSON is malformed', async () => {
-    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
-    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
-    const spawnMock = childProcess.spawn as unknown as jest.Mock;
-    spawnMock
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(
-          JSON.stringify({
-            schemaVersion: 1,
-            tool: { name: 'boardreadyops', version: '1.37.0' },
-            checks: []
-          })
-        )
-      )
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild('PRIVATE_EVIDENCE_SENTINEL')
-      );
-
-    registerBoardReadyOpsCommands(servicesMock);
-    await registeredHandler(COMMANDS.boardReadyOpsCheck)();
-
+    enableBoardReadyOpsProject();
+    mockCompatibleBoardReadyOpsResponse('PRIVATE_EVIDENCE_SENTINEL');
+    await runCommand(COMMANDS.boardReadyOpsCheck);
     expect(window.showErrorMessage).toHaveBeenCalledWith(
       expect.stringContaining('invalid JSON output')
     );
@@ -381,22 +282,13 @@ describe('BoardReadyOps commands', () => {
   });
 
   it('fails closed when BoardReadyOps doctor exits non-zero', async () => {
-    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
-    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
+    enableBoardReadyOpsProject();
     const spawnMock = childProcess.spawn as unknown as jest.Mock;
     spawnMock.mockImplementationOnce(() =>
-      boardReadyOpsChild(
-        JSON.stringify({
-          schemaVersion: 1,
-          tool: { name: 'boardreadyops', version: '1.37.0' },
-          checks: []
-        }),
-        2
-      )
+      boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()), 2)
     );
 
-    registerBoardReadyOpsCommands(servicesMock);
-    await registeredHandler(COMMANDS.boardReadyOpsCheck)();
+    await runCommand(COMMANDS.boardReadyOpsCheck);
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(window.showErrorMessage).toHaveBeenCalledWith(

--- a/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
@@ -68,16 +68,17 @@ describe('BoardReadyOps commands', () => {
     };
   });
 
-  it('registers four boardReadyOps commands', () => {
+  it('registers five boardReadyOps commands', () => {
     const disposables = registerBoardReadyOpsCommands(servicesMock);
 
-    expect(disposables).toHaveLength(4);
+    expect(disposables).toHaveLength(5);
 
     const registeredIds = (
       commands.registerCommand as jest.Mock
     ).mock.calls.map(([id]: [string]) => id);
 
     expect(registeredIds).toContain(COMMANDS.boardReadyOpsCheck);
+    expect(registeredIds).toContain(COMMANDS.boardReadyOpsPlan);
     expect(registeredIds).toContain(COMMANDS.boardReadyOpsConfigure);
     expect(registeredIds).toContain(COMMANDS.boardReadyOpsShowReport);
     expect(registeredIds).toContain(COMMANDS.boardReadyOpsOpenDocs);
@@ -181,6 +182,169 @@ describe('BoardReadyOps commands', () => {
       'json',
       '/project'
     ]);
+  });
+
+  it('shows the structured BoardReadyOps remediation plan after contract discovery', async () => {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(
+          JSON.stringify({
+            schemaVersion: 1,
+            tool: { name: 'boardreadyops', version: '1.37.0' },
+            checks: []
+          })
+        )
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(
+          JSON.stringify({
+            schemaVersion: 1,
+            tool: { name: 'boardreadyops', version: '1.37.0' },
+            generatedAt: '2026-08-31T00:00:00.000Z',
+            status: 'failed',
+            exitCode: 1,
+            summary: {
+              total: 1,
+              critical: 0,
+              high: 1,
+              medium: 0,
+              low: 0,
+              info: 0,
+              maxSeverity: 'high',
+              failed: true
+            },
+            projectRoot: '/project',
+            nextActions: [
+              {
+                id: 'finding-1',
+                ruleId: 'manufacturing.outputs-present',
+                severity: 'high',
+                title: 'Generate missing manufacturing outputs.',
+                resource: { path: 'board.kicad_pcb', kind: 'pcb' },
+                evidence: { message: 'Manufacturing outputs are missing.' },
+                whyItMatters: 'Fabrication requires current outputs.',
+                fixStrategy: {
+                  description: 'Generate current outputs.',
+                  steps: ['Run the KiCad jobset.', 'Re-run BoardReadyOps.']
+                },
+                safeAutoFixPossible: false,
+                commandsToVerify: [
+                  'boardreadyops check --rule manufacturing.outputs-present /project'
+                ]
+              }
+            ],
+            releaseActions: []
+          }),
+          1
+        )
+      );
+
+    registerBoardReadyOpsCommands(servicesMock);
+    await registeredHandler(COMMANDS.boardReadyOpsPlan)();
+
+    expect(spawnMock.mock.calls[0]?.[1]).toEqual([
+      'boardreadyops',
+      'doctor',
+      '--format',
+      'json'
+    ]);
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual([
+      'boardreadyops',
+      'plan',
+      '--format',
+      'json',
+      '/project'
+    ]);
+    expect(window.showQuickPick).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          label: 'Generate missing manufacturing outputs.',
+          description: 'manufacturing.outputs-present',
+          detail: 'Run the KiCad jobset. → Re-run BoardReadyOps.'
+        })
+      ],
+      expect.objectContaining({ title: 'BoardReadyOps Remediation Plan' })
+    );
+  });
+
+  it('does not expose raw BoardReadyOps plan output when the plan is malformed', async () => {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(
+          JSON.stringify({
+            schemaVersion: 1,
+            tool: { name: 'boardreadyops', version: '1.37.0' },
+            checks: []
+          })
+        )
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild('PRIVATE_PLAN_EVIDENCE_SENTINEL')
+      );
+
+    registerBoardReadyOpsCommands(servicesMock);
+    await registeredHandler(COMMANDS.boardReadyOpsPlan)();
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('invalid JSON')
+    );
+    expect(window.showErrorMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining('PRIVATE_PLAN_EVIDENCE_SENTINEL')
+    );
+    expect(mockLogger.error).toHaveBeenCalled();
+    expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain(
+      'PRIVATE_PLAN_EVIDENCE_SENTINEL'
+    );
+  });
+
+  it('fails closed on a partial BoardReadyOps plan contract without exposing its payload', async () => {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+    mockProjectState.getActiveProject.mockReturnValue({ rootPath: '/project' });
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(
+          JSON.stringify({
+            schemaVersion: 1,
+            tool: { name: 'boardreadyops', version: '1.37.0' },
+            checks: []
+          })
+        )
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(
+          JSON.stringify({
+            schemaVersion: 1,
+            tool: { name: 'boardreadyops', version: '1.37.0' },
+            status: 'failed',
+            nextActions: [
+              {
+                id: 'PRIVATE_PARTIAL_SENTINEL',
+                ruleId: 'config.invalid',
+                title: 'private action'
+              }
+            ],
+            releaseActions: []
+          }),
+          1
+        )
+      );
+
+    registerBoardReadyOpsCommands(servicesMock);
+    await registeredHandler(COMMANDS.boardReadyOpsPlan)();
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'BoardReadyOps plan failed: BoardReadyOps plan returned an invalid contract.'
+    );
+    expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain(
+      'PRIVATE_PARTIAL_SENTINEL'
+    );
   });
 
   it('does not expose raw BoardReadyOps output when readiness JSON is malformed', async () => {

--- a/apps/vscode-extension/test/unit/boardReadyOpsFixtures.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsFixtures.ts
@@ -1,0 +1,48 @@
+export function boardReadyOpsDoctorContract(version = '1.37.0') {
+  return {
+    schemaVersion: 1,
+    tool: { name: 'boardreadyops', version },
+    checks: []
+  };
+}
+
+export function boardReadyOpsAgentPlan(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    tool: { name: 'boardreadyops', version: '1.37.0' },
+    generatedAt: '2026-08-31T00:00:00.000Z',
+    status: 'failed',
+    exitCode: 1,
+    summary: {
+      total: 1,
+      critical: 0,
+      high: 1,
+      medium: 0,
+      low: 0,
+      info: 0,
+      maxSeverity: 'high',
+      failed: true
+    },
+    projectRoot: '/project',
+    nextActions: [
+      {
+        id: 'finding-1',
+        ruleId: 'manufacturing.outputs-present',
+        severity: 'high',
+        title: 'Generate missing manufacturing outputs.',
+        resource: { path: 'board.kicad_pcb', kind: 'pcb' },
+        evidence: { message: 'Manufacturing outputs are missing.' },
+        whyItMatters: 'Fabrication requires current outputs.',
+        fixStrategy: {
+          description: 'Generate current outputs.',
+          steps: ['Run the KiCad jobset.', 'Re-run BoardReadyOps.']
+        },
+        safeAutoFixPossible: false,
+        commandsToVerify: [
+          'boardreadyops check --rule manufacturing.outputs-present /project'
+        ]
+      }
+    ],
+    releaseActions: []
+  };
+}

--- a/apps/vscode-extension/test/unit/boardReadyOpsPlan.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsPlan.test.ts
@@ -10,6 +10,15 @@ describe('BoardReadyOps agent plan contract', () => {
     expect(parsed.nextActions[0]?.id).toBe('finding-1');
   });
 
+  it.each([null, [], 42, 'text'])(
+    'rejects non-object plan payloads',
+    (payload) => {
+      expect(() => parseBoardReadyOpsPlan(JSON.stringify(payload))).toThrow(
+        'BoardReadyOps plan returned an invalid contract.'
+      );
+    }
+  );
+
   it('rejects malformed JSON without echoing the payload', () => {
     expect(() => parseBoardReadyOpsPlan('PRIVATE_PLAN_SENTINEL')).toThrow(
       'BoardReadyOps plan returned invalid JSON output.'

--- a/apps/vscode-extension/test/unit/boardReadyOpsPlan.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsPlan.test.ts
@@ -1,0 +1,117 @@
+import { parseBoardReadyOpsPlan } from '../../src/boardreadyops/plan';
+
+function validPlan(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    tool: { name: 'boardreadyops', version: '1.37.0' },
+    generatedAt: '2026-08-31T00:00:00.000Z',
+    status: 'failed',
+    exitCode: 1,
+    summary: {
+      total: 1,
+      critical: 0,
+      high: 1,
+      medium: 0,
+      low: 0,
+      info: 0,
+      maxSeverity: 'high',
+      failed: true
+    },
+    projectRoot: '/project',
+    nextActions: [
+      {
+        id: 'finding-1',
+        ruleId: 'manufacturing.outputs-present',
+        severity: 'high',
+        title: 'Generate missing manufacturing outputs.',
+        resource: { path: 'board.kicad_pcb', kind: 'pcb' },
+        evidence: { message: 'Manufacturing outputs are missing.' },
+        whyItMatters: 'Fabrication requires current outputs.',
+        fixStrategy: {
+          description: 'Generate current outputs.',
+          steps: ['Run the KiCad jobset.', 'Re-run BoardReadyOps.']
+        },
+        safeAutoFixPossible: false,
+        commandsToVerify: [
+          'boardreadyops check --rule manufacturing.outputs-present /project'
+        ]
+      }
+    ],
+    releaseActions: []
+  };
+}
+
+describe('BoardReadyOps agent plan contract', () => {
+  it('accepts the published agent-plan v1 shape', () => {
+    const parsed = parseBoardReadyOpsPlan(JSON.stringify(validPlan()));
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.nextActions[0]?.id).toBe('finding-1');
+  });
+
+  it('rejects malformed JSON without echoing the payload', () => {
+    expect(() => parseBoardReadyOpsPlan('PRIVATE_PLAN_SENTINEL')).toThrow(
+      'BoardReadyOps plan returned invalid JSON output.'
+    );
+  });
+
+  it.each([
+    [
+      'schema version',
+      (plan: Record<string, unknown>) => (plan['schemaVersion'] = 2)
+    ],
+    [
+      'tool name',
+      (plan: Record<string, unknown>) =>
+        (plan['tool'] = { name: 'other', version: '1.37.0' })
+    ],
+    [
+      'generated timestamp',
+      (plan: Record<string, unknown>) => (plan['generatedAt'] = '')
+    ],
+    ['status', (plan: Record<string, unknown>) => (plan['status'] = 'unknown')],
+    ['exit code', (plan: Record<string, unknown>) => (plan['exitCode'] = '1')],
+    [
+      'project root',
+      (plan: Record<string, unknown>) => (plan['projectRoot'] = '')
+    ],
+    [
+      'summary',
+      (plan: Record<string, unknown>) => (plan['summary'] = { total: -1 })
+    ],
+    [
+      'next actions',
+      (plan: Record<string, unknown>) => (plan['nextActions'] = 'invalid')
+    ],
+    [
+      'release actions',
+      (plan: Record<string, unknown>) => (plan['releaseActions'] = 'invalid')
+    ]
+  ])('fails closed on an invalid %s', (_name, mutate) => {
+    const plan = validPlan();
+    mutate(plan);
+    expect(() => parseBoardReadyOpsPlan(JSON.stringify(plan))).toThrow(
+      'BoardReadyOps plan returned an invalid contract.'
+    );
+  });
+
+  it.each([
+    ['id', ''],
+    ['ruleId', ''],
+    ['severity', 'unknown'],
+    ['title', ''],
+    ['resource', null],
+    ['evidence', null],
+    ['whyItMatters', ''],
+    ['fixStrategy', null],
+    ['safeAutoFixPossible', 'false'],
+    ['commandsToVerify', []]
+  ])('fails closed when an action has invalid %s', (field, value) => {
+    const plan = validPlan();
+    const action = (plan['nextActions'] as Array<Record<string, unknown>>)[0];
+    expect(action).toBeDefined();
+    action![field] = value;
+    expect(() => parseBoardReadyOpsPlan(JSON.stringify(plan))).toThrow(
+      'BoardReadyOps plan returned an invalid contract.'
+    );
+  });
+});

--- a/apps/vscode-extension/test/unit/boardReadyOpsPlan.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsPlan.test.ts
@@ -1,49 +1,11 @@
 import { parseBoardReadyOpsPlan } from '../../src/boardreadyops/plan';
-
-function validPlan(): Record<string, unknown> {
-  return {
-    schemaVersion: 1,
-    tool: { name: 'boardreadyops', version: '1.37.0' },
-    generatedAt: '2026-08-31T00:00:00.000Z',
-    status: 'failed',
-    exitCode: 1,
-    summary: {
-      total: 1,
-      critical: 0,
-      high: 1,
-      medium: 0,
-      low: 0,
-      info: 0,
-      maxSeverity: 'high',
-      failed: true
-    },
-    projectRoot: '/project',
-    nextActions: [
-      {
-        id: 'finding-1',
-        ruleId: 'manufacturing.outputs-present',
-        severity: 'high',
-        title: 'Generate missing manufacturing outputs.',
-        resource: { path: 'board.kicad_pcb', kind: 'pcb' },
-        evidence: { message: 'Manufacturing outputs are missing.' },
-        whyItMatters: 'Fabrication requires current outputs.',
-        fixStrategy: {
-          description: 'Generate current outputs.',
-          steps: ['Run the KiCad jobset.', 'Re-run BoardReadyOps.']
-        },
-        safeAutoFixPossible: false,
-        commandsToVerify: [
-          'boardreadyops check --rule manufacturing.outputs-present /project'
-        ]
-      }
-    ],
-    releaseActions: []
-  };
-}
+import { boardReadyOpsAgentPlan } from './boardReadyOpsFixtures';
 
 describe('BoardReadyOps agent plan contract', () => {
   it('accepts the published agent-plan v1 shape', () => {
-    const parsed = parseBoardReadyOpsPlan(JSON.stringify(validPlan()));
+    const parsed = parseBoardReadyOpsPlan(
+      JSON.stringify(boardReadyOpsAgentPlan())
+    );
     expect(parsed.schemaVersion).toBe(1);
     expect(parsed.nextActions[0]?.id).toBe('finding-1');
   });
@@ -87,7 +49,7 @@ describe('BoardReadyOps agent plan contract', () => {
       (plan: Record<string, unknown>) => (plan['releaseActions'] = 'invalid')
     ]
   ])('fails closed on an invalid %s', (_name, mutate) => {
-    const plan = validPlan();
+    const plan = boardReadyOpsAgentPlan();
     mutate(plan);
     expect(() => parseBoardReadyOpsPlan(JSON.stringify(plan))).toThrow(
       'BoardReadyOps plan returned an invalid contract.'
@@ -106,7 +68,7 @@ describe('BoardReadyOps agent plan contract', () => {
     ['safeAutoFixPossible', 'false'],
     ['commandsToVerify', []]
   ])('fails closed when an action has invalid %s', (field, value) => {
-    const plan = validPlan();
+    const plan = boardReadyOpsAgentPlan();
     const action = (plan['nextActions'] as Array<Record<string, unknown>>)[0];
     expect(action).toBeDefined();
     action![field] = value;

--- a/apps/vscode-extension/test/unit/taskHubCommands.test.ts
+++ b/apps/vscode-extension/test/unit/taskHubCommands.test.ts
@@ -162,6 +162,7 @@ describe('task-oriented command hub', () => {
     expect(items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ command: COMMANDS.boardReadyOpsCheck }),
+        expect.objectContaining({ command: COMMANDS.boardReadyOpsPlan }),
         expect.objectContaining({ command: COMMANDS.qualityGateOpenDocs })
       ])
     );

--- a/docs/extension/commands.md
+++ b/docs/extension/commands.md
@@ -3,7 +3,7 @@
 Machine-maintained from `apps/vscode-extension/package.json` and `package.nls.json`.
 Refresh with `corepack pnpm run docs:generate`.
 
-Total contributed commands: 115.
+Total contributed commands: 116.
 
 | Command ID | Title | Category |
 | --- | --- | --- |
@@ -115,6 +115,7 @@ Total contributed commands: 115.
 | `kicadstudio.exportSchPs` | KiCad: Export Schematic PostScript | KiCad Export |
 | `kicadstudio.exportStats` | KiCad: Export Board Statistics | KiCad Export |
 | `kicadstudio.selectActiveProject` | KiCad: Select Active Project | KiCad |
+| `kicadstudio.boardReadyOps.plan` | KiCad Studio: Show BoardReadyOps Remediation Plan | KiCad Studio |
 | `kicadstudio.generateKicadDiffReport` | KiCad: Generate Diff Report | KiCad |
 | `kicadstudio.tasks.open` | KiCad Studio: Open Task Hub | KiCad Studio |
 | `kicadstudio.tasks.review` | KiCad Studio: Review Project | KiCad Studio |


### PR DESCRIPTION
## Summary
- add a BoardReadyOps remediation-plan command to the Task Hub and contextual Command Palette surface
- gate every plan run on the published BoardReadyOps doctor compatibility contract before invoking `plan --format json`
- validate the published agent-plan v1 shape fail-closed and show only deterministic action title, rule ID, and fix steps
- keep malformed/partial/raw BoardReadyOps plan payloads out of user-visible and logged error text
- require a trusted workspace and active KiCad project before surfacing the plan action
- update generated command docs and the command-surface policy classification

## Validation
- repository pre-push quality gate passed end-to-end
- extension unit suite: 131 suites / 1053 tests passed
- focused BoardReadyOps/Task Hub suites passed, including 21 direct agent-plan contract scenarios
- new `plan.ts` unit coverage: 92.59% statements, 96.07% branches, 100% functions, 96.15% lines
- accessibility gate: 76 tests passed
- security tests, coverage ratchet, lint, typecheck, build, package, package validation passed
- repeatable VSIX, dependency/security policy, governance, architecture, docs, compatibility, and command-surface gates passed

Part of #623. This PR covers deterministic no-AI remediation planning and fail-closed plan-contract handling; evidence/review/release-state integration remains open.
