### PR TITLE
test(kicad-studio): complete BoardReadyOps plan branch coverage

### DIFF
--- a/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
@@ -216,6 +216,56 @@ describe('BoardReadyOps commands', () => {
     );
   });
 
+  it('stops after contract discovery when plan execution is cancelled', async () => {
+    enableBoardReadyOpsProject();
+    (window.withProgress as jest.Mock).mockImplementation(
+      async (_options, task) =>
+        task(
+          { report: jest.fn() },
+          {
+            isCancellationRequested: true,
+            onCancellationRequested: jest.fn(() => ({ dispose: jest.fn() }))
+          }
+        )
+    );
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock.mockImplementationOnce(() =>
+      boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
+    );
+
+    await runCommand(COMMANDS.boardReadyOpsPlan);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(window.showQuickPick).not.toHaveBeenCalled();
+  });
+
+  it('stops after plan execution when cancellation arrives during the plan', async () => {
+    enableBoardReadyOpsProject();
+    let cancellationRead = 0;
+    (window.withProgress as jest.Mock).mockImplementation(
+      async (_options, task) =>
+        task(
+          { report: jest.fn() },
+          {
+            get isCancellationRequested() {
+              cancellationRead += 1;
+              return cancellationRead >= 3;
+            },
+            onCancellationRequested: jest.fn(() => ({ dispose: jest.fn() }))
+          }
+        )
+    );
+    const spawnMock = mockCompatibleBoardReadyOpsResponse(
+      boardReadyOpsAgentPlan(),
+      1
+    );
+
+    await runCommand(COMMANDS.boardReadyOpsPlan);
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(window.showQuickPick).not.toHaveBeenCalled();
+  });
+
   it('passes the configured BoardReadyOps spec file to the plan command', async () => {
     enableBoardReadyOpsProject({
       'kicadstudio.boardReadyOps.specFile': 'boardreadyops.yaml'
@@ -306,6 +356,27 @@ describe('BoardReadyOps commands', () => {
       expect.stringContaining(
         'did not report any remediation or release actions'
       )
+    );
+  });
+
+  it('uses a sanitized fallback for non-Error plan failures', async () => {
+    enableBoardReadyOpsProject();
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
+      )
+      .mockImplementationOnce(() => {
+        throw 'PRIVATE_NON_ERROR_SENTINEL';
+      });
+
+    await runCommand(COMMANDS.boardReadyOpsPlan);
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'BoardReadyOps plan failed: Unknown BoardReadyOps plan error.'
+    );
+    expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain(
+      'PRIVATE_NON_ERROR_SENTINEL'
     );
   });
 

--- a/apps/vscode-extension/test/unit/boardReadyOpsPlan.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsPlan.test.ts
@@ -25,6 +25,15 @@ describe('BoardReadyOps agent plan contract', () => {
     );
   });
 
+  it('rejects non-object actions in the plan', () => {
+    const plan = boardReadyOpsAgentPlan();
+    plan['nextActions'] = [null];
+
+    expect(() => parseBoardReadyOpsPlan(JSON.stringify(plan))).toThrow(
+      'BoardReadyOps plan returned an invalid contract.'
+    );
+  });
+
   it.each([
     [
       'schema version',


### PR DESCRIPTION
## Summary
- cover the four remaining partial branches reported by Codecov after #671
- exercise non-object plan actions, cancellation after compatibility discovery, cancellation after plan execution, and non-Error failure sanitization
- preserve fail-closed behavior and keep raw failure payloads out of logs/UI

## Validation
- this commit produces the exact same repository tree as the fully validated `9d3b162` tree from the #671 branch (`83b07622856dae61b2b5b9611756499e72db62e2`)
- focused BoardReadyOps tests: 49/49 passed
- added production lines: 100% line coverage locally
- added production branches: no uncovered/partial branches locally
- prior full repository pre-push gate on the identical tree passed: 131 suites / 1067 tests, a11y 76/76, security, coverage ratchet, repeatable VSIX, package validation and policy gates

Follow-up to #671 and part of #623.
