### PR TITLE
fix(kicad-studio): validate BoardReadyOps readiness contract

### DIFF
--- a/apps/vscode-extension/src/boardreadyops/contract.ts
+++ b/apps/vscode-extension/src/boardreadyops/contract.ts
@@ -119,7 +119,14 @@ export interface BoardReadyOpsFinding {
   message: string;
   resource: {
     path: string;
-    kind: string;
+    kind:
+      | 'project'
+      | 'schematic'
+      | 'pcb'
+      | 'bom'
+      | 'pinmap'
+      | 'firmware'
+      | 'manifest';
   };
   location?: {
     line?: number;
@@ -130,7 +137,14 @@ export interface BoardReadyOpsFinding {
       startColumn?: number;
       endColumn?: number;
     };
+    boardCoordinates?: {
+      x: number;
+      y: number;
+      layer?: string;
+      units: 'mm' | 'in';
+    };
   };
+  fingerprint: string;
 }
 
 export interface BoardReadyOpsRunResult {
@@ -192,8 +206,35 @@ function isLocation(value: unknown): boolean {
     return false;
   }
 
-  return value['region'] !== undefined || value['line'] !== undefined;
+  if (value['boardCoordinates'] !== undefined) {
+    const coordinates = value['boardCoordinates'];
+    if (!isRecord(coordinates)) return false;
+    if (
+      typeof coordinates['x'] !== 'number' ||
+      !Number.isFinite(coordinates['x']) ||
+      typeof coordinates['y'] !== 'number' ||
+      !Number.isFinite(coordinates['y']) ||
+      (coordinates['layer'] !== undefined &&
+        typeof coordinates['layer'] !== 'string') ||
+      (coordinates['units'] !== 'mm' && coordinates['units'] !== 'in')
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 }
+
+const findingResourceKinds = new Set([
+  'project',
+  'schematic',
+  'pcb',
+  'bom',
+  'pinmap',
+  'firmware',
+  'manifest'
+]);
+const findingFingerprintPattern = /^[a-f0-9]{64}$/;
 
 function isFinding(value: unknown): value is BoardReadyOpsFinding {
   if (!isRecord(value) || !isRecord(value['resource'])) {
@@ -206,11 +247,10 @@ function isFinding(value: unknown): value is BoardReadyOpsFinding {
       String(value['severity'])
     ) &&
     typeof value['message'] === 'string' &&
-    value['message'].length > 0 &&
     typeof value['resource']['path'] === 'string' &&
-    value['resource']['path'].length > 0 &&
-    typeof value['resource']['kind'] === 'string' &&
-    value['resource']['kind'].length > 0 &&
+    findingResourceKinds.has(String(value['resource']['kind'])) &&
+    typeof value['fingerprint'] === 'string' &&
+    findingFingerprintPattern.test(value['fingerprint']) &&
     (value['location'] === undefined || isLocation(value['location']))
   );
 }

--- a/apps/vscode-extension/src/boardreadyops/contract.ts
+++ b/apps/vscode-extension/src/boardreadyops/contract.ts
@@ -163,6 +163,38 @@ function isNonNegativeInteger(value: unknown): value is number {
   return Number.isInteger(value) && Number(value) >= 0;
 }
 
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) >= 1;
+}
+
+function isLocation(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+
+  if (value['region'] !== undefined) {
+    const region = value['region'];
+    if (!isRecord(region)) return false;
+    if (
+      !isPositiveInteger(region['startLine']) ||
+      !isPositiveInteger(region['endLine']) ||
+      (region['startColumn'] !== undefined &&
+        !isPositiveInteger(region['startColumn'])) ||
+      (region['endColumn'] !== undefined &&
+        !isPositiveInteger(region['endColumn']))
+    ) {
+      return false;
+    }
+  }
+
+  if (value['line'] !== undefined && !isPositiveInteger(value['line'])) {
+    return false;
+  }
+  if (value['column'] !== undefined && !isPositiveInteger(value['column'])) {
+    return false;
+  }
+
+  return value['region'] !== undefined || value['line'] !== undefined;
+}
+
 function isFinding(value: unknown): value is BoardReadyOpsFinding {
   if (!isRecord(value) || !isRecord(value['resource'])) {
     return false;
@@ -178,7 +210,8 @@ function isFinding(value: unknown): value is BoardReadyOpsFinding {
     typeof value['resource']['path'] === 'string' &&
     value['resource']['path'].length > 0 &&
     typeof value['resource']['kind'] === 'string' &&
-    value['resource']['kind'].length > 0
+    value['resource']['kind'].length > 0 &&
+    (value['location'] === undefined || isLocation(value['location']))
   );
 }
 

--- a/apps/vscode-extension/src/boardreadyops/contract.ts
+++ b/apps/vscode-extension/src/boardreadyops/contract.ts
@@ -181,48 +181,38 @@ function isPositiveInteger(value: unknown): value is number {
   return Number.isInteger(value) && Number(value) >= 1;
 }
 
+function isRegion(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    isPositiveInteger(value['startLine']) &&
+    isPositiveInteger(value['endLine']) &&
+    (value['startColumn'] === undefined ||
+      isPositiveInteger(value['startColumn'])) &&
+    (value['endColumn'] === undefined || isPositiveInteger(value['endColumn']))
+  );
+}
+
+function isBoardCoordinates(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value['x'] === 'number' &&
+    Number.isFinite(value['x']) &&
+    typeof value['y'] === 'number' &&
+    Number.isFinite(value['y']) &&
+    (value['layer'] === undefined || typeof value['layer'] === 'string') &&
+    (value['units'] === 'mm' || value['units'] === 'in')
+  );
+}
+
 function isLocation(value: unknown): boolean {
   if (!isRecord(value)) return false;
-
-  if (value['region'] !== undefined) {
-    const region = value['region'];
-    if (!isRecord(region)) return false;
-    if (
-      !isPositiveInteger(region['startLine']) ||
-      !isPositiveInteger(region['endLine']) ||
-      (region['startColumn'] !== undefined &&
-        !isPositiveInteger(region['startColumn'])) ||
-      (region['endColumn'] !== undefined &&
-        !isPositiveInteger(region['endColumn']))
-    ) {
-      return false;
-    }
-  }
-
-  if (value['line'] !== undefined && !isPositiveInteger(value['line'])) {
-    return false;
-  }
-  if (value['column'] !== undefined && !isPositiveInteger(value['column'])) {
-    return false;
-  }
-
-  if (value['boardCoordinates'] !== undefined) {
-    const coordinates = value['boardCoordinates'];
-    if (!isRecord(coordinates)) return false;
-    if (
-      typeof coordinates['x'] !== 'number' ||
-      !Number.isFinite(coordinates['x']) ||
-      typeof coordinates['y'] !== 'number' ||
-      !Number.isFinite(coordinates['y']) ||
-      (coordinates['layer'] !== undefined &&
-        typeof coordinates['layer'] !== 'string') ||
-      (coordinates['units'] !== 'mm' && coordinates['units'] !== 'in')
-    ) {
-      return false;
-    }
-  }
-
-  return true;
+  return (
+    (value['region'] === undefined || isRegion(value['region'])) &&
+    (value['line'] === undefined || isPositiveInteger(value['line'])) &&
+    (value['column'] === undefined || isPositiveInteger(value['column'])) &&
+    (value['boardCoordinates'] === undefined ||
+      isBoardCoordinates(value['boardCoordinates']))
+  );
 }
 
 const findingResourceKinds = new Set([

--- a/apps/vscode-extension/src/boardreadyops/contract.ts
+++ b/apps/vscode-extension/src/boardreadyops/contract.ts
@@ -112,3 +112,127 @@ export function discoverBoardReadyOpsContract(
 
   return { compatible: true, schemaVersion, version };
 }
+
+export interface BoardReadyOpsFinding {
+  ruleId: string;
+  severity: 'critical' | 'high' | 'medium' | 'low' | 'info';
+  message: string;
+  resource: {
+    path: string;
+    kind: string;
+  };
+  location?: {
+    line?: number;
+    column?: number;
+    region?: {
+      startLine: number;
+      endLine: number;
+      startColumn?: number;
+      endColumn?: number;
+    };
+  };
+}
+
+export interface BoardReadyOpsRunResult {
+  schemaVersion: number;
+  tool: {
+    name: 'boardreadyops';
+    version: string;
+  };
+  status?: 'passed' | 'failed';
+  exitCode?: number;
+  summary: {
+    total: number;
+    critical: number;
+    high: number;
+    medium: number;
+    low: number;
+    info: number;
+  };
+  findings: BoardReadyOpsFinding[];
+}
+
+const READINESS_CONTRACT_ERROR =
+  'BoardReadyOps returned an unsupported or incomplete readiness result.';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) >= 0;
+}
+
+function isFinding(value: unknown): value is BoardReadyOpsFinding {
+  if (!isRecord(value) || !isRecord(value['resource'])) {
+    return false;
+  }
+  return (
+    typeof value['ruleId'] === 'string' &&
+    value['ruleId'].length > 0 &&
+    ['critical', 'high', 'medium', 'low', 'info'].includes(
+      String(value['severity'])
+    ) &&
+    typeof value['message'] === 'string' &&
+    value['message'].length > 0 &&
+    typeof value['resource']['path'] === 'string' &&
+    value['resource']['path'].length > 0 &&
+    typeof value['resource']['kind'] === 'string' &&
+    value['resource']['kind'].length > 0
+  );
+}
+
+export function parseBoardReadyOpsRunResult(
+  input: unknown
+): BoardReadyOpsRunResult {
+  const value = parseDoctorValue(input);
+  if (value === undefined && typeof input === 'string') {
+    throw new Error('BoardReadyOps returned invalid JSON output.');
+  }
+  if (!isRecord(value)) {
+    throw new Error(READINESS_CONTRACT_ERROR);
+  }
+
+  const tool = value['tool'];
+  const summary = value['summary'];
+  const findings = value['findings'];
+  if (
+    value['schemaVersion'] !==
+      COMPATIBILITY_MATRIX.supportAxes.boardReadyOps.findingsSchema ||
+    !isRecord(tool) ||
+    tool['name'] !== 'boardreadyops' ||
+    typeof tool['version'] !== 'string' ||
+    !semver.valid(tool['version']) ||
+    !semver.satisfies(
+      tool['version'],
+      COMPATIBILITY_MATRIX.supportAxes.boardReadyOps.required
+    ) ||
+    !isRecord(summary) ||
+    !isNonNegativeInteger(summary['total']) ||
+    !isNonNegativeInteger(summary['critical']) ||
+    !isNonNegativeInteger(summary['high']) ||
+    !isNonNegativeInteger(summary['medium']) ||
+    !isNonNegativeInteger(summary['low']) ||
+    !isNonNegativeInteger(summary['info']) ||
+    !Array.isArray(findings) ||
+    !findings.every(isFinding)
+  ) {
+    throw new Error(READINESS_CONTRACT_ERROR);
+  }
+
+  if (
+    value['status'] !== undefined &&
+    value['status'] !== 'passed' &&
+    value['status'] !== 'failed'
+  ) {
+    throw new Error(READINESS_CONTRACT_ERROR);
+  }
+  if (
+    value['exitCode'] !== undefined &&
+    !isNonNegativeInteger(value['exitCode'])
+  ) {
+    throw new Error(READINESS_CONTRACT_ERROR);
+  }
+
+  return value as unknown as BoardReadyOpsRunResult;
+}

--- a/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
+++ b/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
@@ -4,45 +4,17 @@ import * as path from 'node:path';
 import { COMMANDS, SETTINGS } from '../constants';
 import { localize } from '../i18n';
 import type { CommandServices } from './types';
-import { discoverBoardReadyOpsContract } from '../boardreadyops/contract';
+import {
+  discoverBoardReadyOpsContract,
+  parseBoardReadyOpsRunResult,
+  type BoardReadyOpsFinding,
+  type BoardReadyOpsRunResult
+} from '../boardreadyops/contract';
 import { parseBoardReadyOpsPlan } from '../boardreadyops/plan';
 
 /** URL for BoardReadyOps documentation. */
 export const BOARDREADYOPS_DOCS_URL =
   'https://github.com/oaslananka/kicad-studio-kit/blob/main/docs/board-ready-ops.md';
-
-interface BoardReadyOpsFinding {
-  ruleId: string;
-  severity: 'critical' | 'high' | 'medium' | 'low' | 'info';
-  message: string;
-  resource: {
-    path: string;
-    kind: string;
-  };
-  location?: {
-    line?: number;
-    column?: number;
-    region?: {
-      startLine: number;
-      endLine: number;
-      startColumn?: number;
-      endColumn?: number;
-    };
-  };
-}
-
-interface BoardReadyOpsRunResult {
-  status?: 'passed' | 'failed';
-  summary: {
-    total: number;
-    critical: number;
-    high: number;
-    medium: number;
-    low: number;
-    info: number;
-  };
-  findings: BoardReadyOpsFinding[];
-}
 
 let latestReport: BoardReadyOpsRunResult | undefined = undefined;
 const previousDiagnosticUris = new Set<string>();
@@ -184,14 +156,7 @@ export function registerBoardReadyOpsCommands(
               return;
             }
 
-            let result: BoardReadyOpsRunResult;
-            try {
-              result = JSON.parse(stdout.trim());
-            } catch (err) {
-              throw new Error('BoardReadyOps returned invalid JSON output.', {
-                cause: err
-              });
-            }
+            const result = parseBoardReadyOpsRunResult(stdout);
 
             latestReport = result;
 

--- a/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
@@ -174,7 +174,10 @@ describe('BoardReadyOps commands', () => {
   it('discovers the BoardReadyOps doctor contract before running readiness', async () => {
     enableBoardReadyOpsProject();
     const spawnMock = mockCompatibleBoardReadyOpsResponse({
+      schemaVersion: 1,
+      tool: { name: 'boardreadyops', version: '1.37.0' },
       status: 'passed',
+      exitCode: 0,
       summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, info: 0 },
       findings: []
     });
@@ -193,6 +196,33 @@ describe('BoardReadyOps commands', () => {
       'json',
       '/project'
     ]);
+  });
+
+  it('fails closed when readiness JSON is structurally incomplete', async () => {
+    enableBoardReadyOpsProject();
+    mockCompatibleBoardReadyOpsResponse(
+      {
+        schemaVersion: 1,
+        tool: { name: 'boardreadyops', version: '1.37.0' },
+        status: 'failed',
+        summary: {
+          total: 1,
+          critical: 0,
+          high: 1,
+          medium: 0,
+          low: 0,
+          info: 0
+        }
+      },
+      1
+    );
+
+    await runCommand(COMMANDS.boardReadyOpsCheck);
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('unsupported or incomplete readiness result')
+    );
+    expect(mockDiagnosticsCollection.setForSource).not.toHaveBeenCalled();
   });
 
   it('does not run the BoardReadyOps plan while integration is disabled', async () => {

--- a/apps/vscode-extension/test/unit/boardReadyOpsContract.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsContract.test.ts
@@ -1,4 +1,7 @@
-import { discoverBoardReadyOpsContract } from '../../src/boardreadyops/contract';
+import {
+  discoverBoardReadyOpsContract,
+  parseBoardReadyOpsRunResult
+} from '../../src/boardreadyops/contract';
 
 describe('BoardReadyOps contract discovery', () => {
   it('accepts the supported versioned doctor contract', () => {
@@ -101,5 +104,61 @@ describe('BoardReadyOps contract discovery', () => {
       schemaVersion: 1,
       version: '2.0.0'
     });
+  });
+});
+
+describe('BoardReadyOps readiness result contract', () => {
+  const supportedResult = {
+    schemaVersion: 1,
+    tool: { name: 'boardreadyops', version: '1.37.0' },
+    status: 'failed' as const,
+    exitCode: 2,
+    summary: {
+      total: 1,
+      critical: 0,
+      high: 1,
+      medium: 0,
+      low: 0,
+      info: 0
+    },
+    findings: [
+      {
+        ruleId: 'fab.test',
+        severity: 'high' as const,
+        message: 'Blocking fabrication issue',
+        resource: { path: 'board.kicad_pcb', kind: 'pcb' }
+      }
+    ]
+  };
+
+  it('accepts the supported findings schema', () => {
+    expect(
+      parseBoardReadyOpsRunResult(JSON.stringify(supportedResult))
+    ).toEqual(supportedResult);
+  });
+
+  it('fails closed when findings payload is partial', () => {
+    expect(() =>
+      parseBoardReadyOpsRunResult(
+        JSON.stringify({
+          schemaVersion: 1,
+          tool: { name: 'boardreadyops', version: '1.37.0' },
+          status: 'failed',
+          summary: supportedResult.summary
+        })
+      )
+    ).toThrow(
+      'BoardReadyOps returned an unsupported or incomplete readiness result.'
+    );
+  });
+
+  it('fails closed when findings payload uses an unsupported schema', () => {
+    expect(() =>
+      parseBoardReadyOpsRunResult(
+        JSON.stringify({ ...supportedResult, schemaVersion: 2 })
+      )
+    ).toThrow(
+      'BoardReadyOps returned an unsupported or incomplete readiness result.'
+    );
   });
 });

--- a/apps/vscode-extension/test/unit/boardReadyOpsContract.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsContract.test.ts
@@ -123,10 +123,11 @@ describe('BoardReadyOps readiness result contract', () => {
     },
     findings: [
       {
-        ruleId: 'fab.test',
+        ruleId: 'manufacturing.outputs-present',
         severity: 'high' as const,
         message: 'Blocking fabrication issue',
-        resource: { path: 'board.kicad_pcb', kind: 'pcb' }
+        resource: { path: 'board.kicad_pcb', kind: 'pcb' },
+        fingerprint: 'a'.repeat(64)
       }
     ]
   };
@@ -152,6 +153,68 @@ describe('BoardReadyOps readiness result contract', () => {
     );
   });
 
+  it('accepts valid line and region finding locations', () => {
+    const withLocation = {
+      ...supportedResult,
+      findings: [
+        {
+          ...supportedResult.findings[0],
+          location: {
+            line: 1,
+            column: 2,
+            region: {
+              startLine: 1,
+              endLine: 2,
+              startColumn: 1,
+              endColumn: 4
+            }
+          }
+        }
+      ]
+    };
+
+    expect(parseBoardReadyOpsRunResult(JSON.stringify(withLocation))).toEqual(
+      withLocation
+    );
+  });
+
+  it('accepts board-coordinate-only finding locations from the published core contract', () => {
+    const withBoardCoordinates = {
+      ...supportedResult,
+      findings: [
+        {
+          ...supportedResult.findings[0],
+          location: { boardCoordinates: { x: 10.5, y: 20.25, units: 'mm' } }
+        }
+      ]
+    };
+
+    expect(
+      parseBoardReadyOpsRunResult(JSON.stringify(withBoardCoordinates))
+    ).toEqual(withBoardCoordinates);
+  });
+
+  it.each([
+    [
+      'unknown resource kind',
+      { resource: { path: 'board.kicad_pcb', kind: 'unknown' } }
+    ],
+    ['missing fingerprint', { fingerprint: undefined }],
+    ['malformed fingerprint', { fingerprint: 'not-a-sha256' }]
+  ])('fails closed when a finding has %s', (_name, patch) => {
+    const finding = { ...supportedResult.findings[0], ...patch };
+    if ('fingerprint' in patch && patch.fingerprint === undefined)
+      delete (finding as { fingerprint?: string }).fingerprint;
+
+    expect(() =>
+      parseBoardReadyOpsRunResult(
+        JSON.stringify({ ...supportedResult, findings: [finding] })
+      )
+    ).toThrow(
+      'BoardReadyOps returned an unsupported or incomplete readiness result.'
+    );
+  });
+
   it('fails closed when a finding contains malformed location data', () => {
     const malformed = {
       ...supportedResult,
@@ -168,6 +231,165 @@ describe('BoardReadyOps readiness result contract', () => {
     ).toThrow(
       'BoardReadyOps returned an unsupported or incomplete readiness result.'
     );
+  });
+
+  it.each([
+    ['invalid JSON', 'PRIVATE_READINESS_SENTINEL'],
+    ['null payload', JSON.stringify(null)],
+    ['array payload', JSON.stringify([])]
+  ])('fails closed for %s', (_name, payload) => {
+    expect(() => parseBoardReadyOpsRunResult(payload)).toThrow();
+  });
+
+  it.each([
+    ['tool object', { tool: null }],
+    ['tool name', { tool: { name: 'other', version: '1.37.0' } }],
+    ['tool version type', { tool: { name: 'boardreadyops', version: 137 } }],
+    [
+      'tool semantic version',
+      { tool: { name: 'boardreadyops', version: 'invalid' } }
+    ],
+    [
+      'tool supported range',
+      { tool: { name: 'boardreadyops', version: '2.0.0' } }
+    ],
+    ['summary object', { summary: null }],
+    ['summary total', { summary: { ...supportedResult.summary, total: -1 } }],
+    [
+      'summary critical',
+      { summary: { ...supportedResult.summary, critical: -1 } }
+    ],
+    ['summary high', { summary: { ...supportedResult.summary, high: -1 } }],
+    ['summary medium', { summary: { ...supportedResult.summary, medium: -1 } }],
+    ['summary low', { summary: { ...supportedResult.summary, low: -1 } }],
+    ['summary info', { summary: { ...supportedResult.summary, info: -1 } }],
+    ['findings array', { findings: null }],
+    ['status', { status: 'unknown' }],
+    ['exit code', { exitCode: -1 }]
+  ])('fails closed when readiness has invalid %s', (_name, patch) => {
+    expect(() =>
+      parseBoardReadyOpsRunResult(
+        JSON.stringify({ ...supportedResult, ...patch })
+      )
+    ).toThrow(
+      'BoardReadyOps returned an unsupported or incomplete readiness result.'
+    );
+  });
+
+  it.each([
+    ['non-object finding', null],
+    ['non-object resource', { ...supportedResult.findings[0], resource: null }],
+    ['invalid rule id', { ...supportedResult.findings[0], ruleId: '' }],
+    [
+      'invalid severity',
+      { ...supportedResult.findings[0], severity: 'unknown' }
+    ],
+    ['invalid message type', { ...supportedResult.findings[0], message: 42 }],
+    [
+      'invalid path type',
+      { ...supportedResult.findings[0], resource: { path: 42, kind: 'pcb' } }
+    ],
+    [
+      'invalid location object',
+      { ...supportedResult.findings[0], location: null }
+    ],
+    [
+      'invalid region object',
+      { ...supportedResult.findings[0], location: { region: null } }
+    ],
+    [
+      'invalid region start line',
+      {
+        ...supportedResult.findings[0],
+        location: { region: { startLine: 0, endLine: 2 } }
+      }
+    ],
+    [
+      'invalid region end line',
+      {
+        ...supportedResult.findings[0],
+        location: { region: { startLine: 1, endLine: 0 } }
+      }
+    ],
+    [
+      'invalid region start column',
+      {
+        ...supportedResult.findings[0],
+        location: { region: { startLine: 1, endLine: 2, startColumn: 0 } }
+      }
+    ],
+    [
+      'invalid region end column',
+      {
+        ...supportedResult.findings[0],
+        location: { region: { startLine: 1, endLine: 2, endColumn: 0 } }
+      }
+    ],
+    ['invalid line', { ...supportedResult.findings[0], location: { line: 0 } }],
+    [
+      'invalid column',
+      { ...supportedResult.findings[0], location: { line: 1, column: 0 } }
+    ],
+    [
+      'invalid board coordinates object',
+      { ...supportedResult.findings[0], location: { boardCoordinates: null } }
+    ],
+    [
+      'invalid board x type',
+      {
+        ...supportedResult.findings[0],
+        location: { boardCoordinates: { x: '1', y: 2, units: 'mm' } }
+      }
+    ],
+    [
+      'invalid board x finite value',
+      {
+        ...supportedResult.findings[0],
+        location: { boardCoordinates: { x: null, y: 2, units: 'mm' } }
+      }
+    ],
+    [
+      'invalid board y type',
+      {
+        ...supportedResult.findings[0],
+        location: { boardCoordinates: { x: 1, y: '2', units: 'mm' } }
+      }
+    ],
+    [
+      'invalid board layer',
+      {
+        ...supportedResult.findings[0],
+        location: { boardCoordinates: { x: 1, y: 2, layer: 42, units: 'mm' } }
+      }
+    ],
+    [
+      'invalid board units',
+      {
+        ...supportedResult.findings[0],
+        location: { boardCoordinates: { x: 1, y: 2, units: 'cm' } }
+      }
+    ]
+  ])('fails closed for %s', (_name, finding) => {
+    expect(() =>
+      parseBoardReadyOpsRunResult(
+        JSON.stringify({ ...supportedResult, findings: [finding] })
+      )
+    ).toThrow(
+      'BoardReadyOps returned an unsupported or incomplete readiness result.'
+    );
+  });
+
+  it('accepts optional empty finding message and resource path allowed by findings schema v1', () => {
+    const finding = {
+      ...supportedResult.findings[0],
+      message: '',
+      resource: { path: '', kind: 'pcb' }
+    };
+    expect(
+      parseBoardReadyOpsRunResult(
+        JSON.stringify({ ...supportedResult, findings: [finding] })
+      ).findings[0]
+    ).toEqual(finding);
   });
 
   it('fails closed when findings payload uses an unsupported schema', () => {

--- a/apps/vscode-extension/test/unit/boardReadyOpsContract.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsContract.test.ts
@@ -152,6 +152,24 @@ describe('BoardReadyOps readiness result contract', () => {
     );
   });
 
+  it('fails closed when a finding contains malformed location data', () => {
+    const malformed = {
+      ...supportedResult,
+      findings: [
+        {
+          ...supportedResult.findings[0],
+          location: { region: { startLine: 1, endLine: '2' } }
+        }
+      ]
+    };
+
+    expect(() =>
+      parseBoardReadyOpsRunResult(JSON.stringify(malformed))
+    ).toThrow(
+      'BoardReadyOps returned an unsupported or incomplete readiness result.'
+    );
+  });
+
   it('fails closed when findings payload uses an unsupported schema', () => {
     expect(() =>
       parseBoardReadyOpsRunResult(


### PR DESCRIPTION
## Summary
- validate the versioned BoardReadyOps readiness/findings JSON contract before diagnostics consume it
- fail closed on unsupported schema/tool/version, incomplete summary/findings, and malformed location metadata
- keep malformed/private BoardReadyOps payloads out of user-visible and logged error text
- preserve the existing diagnostics mapping while moving contract ownership into the BoardReadyOps adapter layer

## Validation
- repository pre-push quality gate passed end-to-end
- extension unit suite: 131 suites / 1068 tests passed
- focused BoardReadyOps contract/command suites: 32 tests passed
- lint and typecheck passed
- coverage ratchet, security tests, accessibility gate, build, package, package validation, repeatable VSIX, governance, compatibility, supply-chain, and release checks passed
- regression test proved malformed finding location data failed before the fix and passes after validation was added

Part of #623. Evidence/review/release-state visibility and release-path integration remain open.