### PR TITLE
feat(kicad-studio): surface BoardReadyOps evidence state

### DIFF
--- a/apps/vscode-extension/src/boardreadyops/evidence.ts
+++ b/apps/vscode-extension/src/boardreadyops/evidence.ts
@@ -1,0 +1,59 @@
+export interface BoardReadyOpsEvidenceVerification {
+  ok: boolean;
+  manifestPath: string;
+  checked: number;
+  errors: string[];
+  signature: {
+    present: boolean;
+    ok: boolean;
+    errors: string[];
+  };
+}
+
+const INVALID_CONTRACT =
+  'BoardReadyOps release verification returned an invalid contract.';
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === 'string')
+  );
+}
+
+export function parseBoardReadyOpsEvidenceVerification(
+  stdout: string
+): BoardReadyOpsEvidenceVerification {
+  let value: unknown;
+  try {
+    value = JSON.parse(stdout.trim());
+  } catch {
+    throw new Error(
+      'BoardReadyOps release verification returned invalid JSON output.'
+    );
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(INVALID_CONTRACT);
+  }
+  const candidate = value as Record<string, unknown>;
+  const signature = candidate['signature'];
+  if (
+    typeof candidate['ok'] !== 'boolean' ||
+    typeof candidate['manifestPath'] !== 'string' ||
+    !Number.isInteger(candidate['checked']) ||
+    Number(candidate['checked']) < 0 ||
+    !isStringArray(candidate['errors']) ||
+    !signature ||
+    typeof signature !== 'object' ||
+    Array.isArray(signature)
+  ) {
+    throw new Error(INVALID_CONTRACT);
+  }
+  const signatureRecord = signature as Record<string, unknown>;
+  if (
+    typeof signatureRecord['present'] !== 'boolean' ||
+    typeof signatureRecord['ok'] !== 'boolean' ||
+    !isStringArray(signatureRecord['errors'])
+  ) {
+    throw new Error(INVALID_CONTRACT);
+  }
+  return value as BoardReadyOpsEvidenceVerification;
+}

--- a/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
+++ b/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
@@ -143,11 +143,12 @@ async function showBoardReadyOpsEvidenceState(
           );
         }
         const verification = parseBoardReadyOpsEvidenceVerification(stdout);
-        const signatureText = verification.signature.present
-          ? verification.signature.ok
+        let signatureText = ' Bundle is unsigned.';
+        if (verification.signature.present) {
+          signatureText = verification.signature.ok
             ? ' Signature verified.'
-            : ' Signature verification failed.'
-          : ' Bundle is unsigned.';
+            : ' Signature verification failed.';
+        }
         if (verification.ok) {
           void vscode.window.showInformationMessage(
             `BoardReadyOps release evidence verified: ${verification.checked} artifact(s).${signatureText}`

--- a/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
+++ b/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
@@ -11,6 +11,7 @@ import {
   type BoardReadyOpsRunResult
 } from '../boardreadyops/contract';
 import { parseBoardReadyOpsPlan } from '../boardreadyops/plan';
+import { parseBoardReadyOpsEvidenceVerification } from '../boardreadyops/evidence';
 
 /** URL for BoardReadyOps documentation. */
 export const BOARDREADYOPS_DOCS_URL =
@@ -94,6 +95,83 @@ async function assertCompatibleBoardReadyOps(
       `BoardReadyOps is not contract-compatible: ${contract.reason} (version ${contract.version}, doctor schema ${contract.schemaVersion ?? 'missing'}).`
     );
   }
+}
+
+async function showBoardReadyOpsEvidenceState(
+  services: CommandServices
+): Promise<void> {
+  const enabled = vscode.workspace
+    .getConfiguration()
+    .get<boolean>(SETTINGS.boardReadyOpsEnabled, false);
+  if (!enabled) {
+    void vscode.window.showWarningMessage(
+      localize('boardReadyOpsNotConfigured')
+    );
+    return;
+  }
+  const projectPath = services.projectState.getActiveProject()?.rootPath;
+  if (!projectPath) {
+    void vscode.window.showErrorMessage(
+      'No active KiCad project found. Open a project to verify BoardReadyOps release evidence.'
+    );
+    return;
+  }
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: 'Verifying BoardReadyOps release evidence...',
+      cancellable: true
+    },
+    async (_progress, token) => {
+      try {
+        await assertCompatibleBoardReadyOps(projectPath, token);
+        if (token.isCancellationRequested) return;
+        const bundlePath = path.join(
+          projectPath,
+          'build',
+          'boardreadyops-release'
+        );
+        const { stdout, exitCode } = await runBoardReadyOpsCommand(
+          projectPath,
+          ['release', 'verify', '--format', 'json', bundlePath],
+          token
+        );
+        if (token.isCancellationRequested) return;
+        if (exitCode !== 0 && exitCode !== 1) {
+          throw new Error(
+            `BoardReadyOps release verify exited with code ${exitCode}.`
+          );
+        }
+        const verification = parseBoardReadyOpsEvidenceVerification(stdout);
+        const signatureText = verification.signature.present
+          ? verification.signature.ok
+            ? ' Signature verified.'
+            : ' Signature verification failed.'
+          : ' Bundle is unsigned.';
+        if (verification.ok) {
+          void vscode.window.showInformationMessage(
+            `BoardReadyOps release evidence verified: ${verification.checked} artifact(s).${signatureText}`
+          );
+        } else {
+          void vscode.window.showWarningMessage(
+            `BoardReadyOps release evidence is not verified (${verification.checked} artifact(s) checked).${signatureText} Run BoardReadyOps release prepare/verify to refresh the bundle.`
+          );
+        }
+      } catch (err) {
+        const safeError =
+          err instanceof Error
+            ? err.message
+            : 'Unknown BoardReadyOps release verification error.';
+        services.logger.error(
+          'BoardReadyOps release verification failed',
+          safeError
+        );
+        void vscode.window.showErrorMessage(
+          `BoardReadyOps release verification failed: ${safeError}`
+        );
+      }
+    }
+  );
 }
 
 /**
@@ -379,15 +457,24 @@ export function registerBoardReadyOpsCommands(
         if (summary.total > 0) {
           const choice = await vscode.window.showInformationMessage(
             summaryText,
-            'Show Problems'
+            'Show Problems',
+            'Verify Release Evidence'
           );
           if (choice === 'Show Problems') {
             await vscode.commands.executeCommand(
               'workbench.actions.view.problems'
             );
+          } else if (choice === 'Verify Release Evidence') {
+            await showBoardReadyOpsEvidenceState(services);
           }
         } else {
-          await vscode.window.showInformationMessage(summaryText);
+          const choice = await vscode.window.showInformationMessage(
+            summaryText,
+            'Verify Release Evidence'
+          );
+          if (choice === 'Verify Release Evidence') {
+            await showBoardReadyOpsEvidenceState(services);
+          }
         }
       }
     ),

--- a/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
@@ -171,6 +171,109 @@ describe('BoardReadyOps commands', () => {
     );
   });
 
+  it('verifies local release evidence from the report without exposing manifest paths', async () => {
+    enableBoardReadyOpsProject();
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    const readiness = {
+      schemaVersion: 1,
+      tool: { name: 'boardreadyops', version: '1.37.0' },
+      status: 'passed',
+      exitCode: 0,
+      summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, info: 0 },
+      findings: []
+    };
+    spawnMock
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(readiness))
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(
+          JSON.stringify({
+            ok: true,
+            manifestPath: '/private/evidence/manifest.json',
+            checked: 4,
+            errors: [],
+            signature: { present: true, ok: true, errors: [] }
+          })
+        )
+      );
+
+    await runCommand(COMMANDS.boardReadyOpsCheck);
+    (window.showInformationMessage as jest.Mock).mockResolvedValueOnce(
+      'Verify Release Evidence'
+    );
+    await runCommand(COMMANDS.boardReadyOpsShowReport);
+
+    expect(spawnMock.mock.calls[3]?.[1]).toEqual([
+      'boardreadyops',
+      'release',
+      'verify',
+      '--format',
+      'json',
+      '/project/build/boardreadyops-release'
+    ]);
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      'BoardReadyOps release evidence verified: 4 artifact(s). Signature verified.'
+    );
+    expect(
+      JSON.stringify((window.showInformationMessage as jest.Mock).mock.calls)
+    ).not.toContain('/private/evidence/manifest.json');
+  });
+
+  it('summarizes failed evidence verification without exposing CLI error details', async () => {
+    enableBoardReadyOpsProject();
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    const readiness = {
+      schemaVersion: 1,
+      tool: { name: 'boardreadyops', version: '1.37.0' },
+      status: 'passed',
+      exitCode: 0,
+      summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, info: 0 },
+      findings: []
+    };
+    spawnMock
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(readiness))
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(
+          JSON.stringify({
+            ok: false,
+            manifestPath: '/private/evidence/manifest.json',
+            checked: 2,
+            errors: ['PRIVATE_EVIDENCE_SENTINEL: checksum mismatch'],
+            signature: { present: false, ok: true, errors: [] }
+          }),
+          1
+        )
+      );
+
+    await runCommand(COMMANDS.boardReadyOpsCheck);
+    (window.showInformationMessage as jest.Mock).mockResolvedValueOnce(
+      'Verify Release Evidence'
+    );
+    await runCommand(COMMANDS.boardReadyOpsShowReport);
+
+    const warningCalls = JSON.stringify(
+      (window.showWarningMessage as jest.Mock).mock.calls
+    );
+    expect(warningCalls).toContain('release evidence is not verified');
+    expect(warningCalls).not.toContain('PRIVATE_EVIDENCE_SENTINEL');
+    expect(warningCalls).not.toContain('/private/evidence/manifest.json');
+  });
+
   it('discovers the BoardReadyOps doctor contract before running readiness', async () => {
     enableBoardReadyOpsProject();
     const spawnMock = mockCompatibleBoardReadyOpsResponse({

--- a/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
@@ -4,6 +4,7 @@ jest.mock('node:child_process', () => ({
 
 import { EventEmitter } from 'node:events';
 import * as childProcess from 'node:child_process';
+import * as path from 'node:path';
 import { COMMANDS } from '../../src/constants';
 import { registerBoardReadyOpsCommands } from '../../src/commands/boardReadyOpsCommands';
 import { commands, window, env, __setConfiguration } from './vscodeMock';
@@ -229,7 +230,7 @@ describe('BoardReadyOps commands', () => {
       'verify',
       '--format',
       'json',
-      '/project/build/boardreadyops-release'
+      path.join('/project', 'build', 'boardreadyops-release')
     ]);
     expect(window.showInformationMessage).toHaveBeenCalledWith(
       'BoardReadyOps release evidence verified: 4 artifact(s). Signature verified.'

--- a/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsCommands.test.ts
@@ -100,6 +100,42 @@ describe('BoardReadyOps commands', () => {
     return spawnMock;
   }
 
+  function mockReadinessAndEvidence(
+    evidence: unknown,
+    evidenceExitCode = 0
+  ): jest.Mock {
+    const readiness = {
+      schemaVersion: 1,
+      tool: { name: 'boardreadyops', version: '1.37.0' },
+      status: 'passed',
+      exitCode: 0,
+      summary: {
+        total: 0,
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        info: 0
+      },
+      findings: []
+    };
+    const spawnMock = childProcess.spawn as unknown as jest.Mock;
+    spawnMock
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(readiness))
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
+      )
+      .mockImplementationOnce(() =>
+        boardReadyOpsChild(JSON.stringify(evidence), evidenceExitCode)
+      );
+    return spawnMock;
+  }
+
   async function runCommand(command: string): Promise<void> {
     registerBoardReadyOpsCommands(servicesMock);
     await registeredHandler(command)();
@@ -173,36 +209,13 @@ describe('BoardReadyOps commands', () => {
 
   it('verifies local release evidence from the report without exposing manifest paths', async () => {
     enableBoardReadyOpsProject();
-    const spawnMock = childProcess.spawn as unknown as jest.Mock;
-    const readiness = {
-      schemaVersion: 1,
-      tool: { name: 'boardreadyops', version: '1.37.0' },
-      status: 'passed',
-      exitCode: 0,
-      summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, info: 0 },
-      findings: []
-    };
-    spawnMock
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
-      )
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(JSON.stringify(readiness))
-      )
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
-      )
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(
-          JSON.stringify({
-            ok: true,
-            manifestPath: '/private/evidence/manifest.json',
-            checked: 4,
-            errors: [],
-            signature: { present: true, ok: true, errors: [] }
-          })
-        )
-      );
+    const spawnMock = mockReadinessAndEvidence({
+      ok: true,
+      manifestPath: '/private/evidence/manifest.json',
+      checked: 4,
+      errors: [],
+      signature: { present: true, ok: true, errors: [] }
+    });
 
     await runCommand(COMMANDS.boardReadyOpsCheck);
     (window.showInformationMessage as jest.Mock).mockResolvedValueOnce(
@@ -228,37 +241,16 @@ describe('BoardReadyOps commands', () => {
 
   it('summarizes failed evidence verification without exposing CLI error details', async () => {
     enableBoardReadyOpsProject();
-    const spawnMock = childProcess.spawn as unknown as jest.Mock;
-    const readiness = {
-      schemaVersion: 1,
-      tool: { name: 'boardreadyops', version: '1.37.0' },
-      status: 'passed',
-      exitCode: 0,
-      summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, info: 0 },
-      findings: []
-    };
-    spawnMock
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
-      )
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(JSON.stringify(readiness))
-      )
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(JSON.stringify(boardReadyOpsDoctorContract()))
-      )
-      .mockImplementationOnce(() =>
-        boardReadyOpsChild(
-          JSON.stringify({
-            ok: false,
-            manifestPath: '/private/evidence/manifest.json',
-            checked: 2,
-            errors: ['PRIVATE_EVIDENCE_SENTINEL: checksum mismatch'],
-            signature: { present: false, ok: true, errors: [] }
-          }),
-          1
-        )
-      );
+    mockReadinessAndEvidence(
+      {
+        ok: false,
+        manifestPath: '/private/evidence/manifest.json',
+        checked: 2,
+        errors: ['PRIVATE_EVIDENCE_SENTINEL: checksum mismatch'],
+        signature: { present: false, ok: true, errors: [] }
+      },
+      1
+    );
 
     await runCommand(COMMANDS.boardReadyOpsCheck);
     (window.showInformationMessage as jest.Mock).mockResolvedValueOnce(

--- a/apps/vscode-extension/test/unit/boardReadyOpsEvidence.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsEvidence.test.ts
@@ -1,0 +1,54 @@
+import { parseBoardReadyOpsEvidenceVerification } from '../../src/boardreadyops/evidence';
+
+const validResult = () => ({
+  ok: true,
+  manifestPath: '/private/workspace/build/boardreadyops-release/manifest.json',
+  checked: 3,
+  errors: [],
+  signature: { present: true, ok: true, errors: [] }
+});
+
+describe('BoardReadyOps release evidence verification contract', () => {
+  it('accepts the published release verify JSON shape', () => {
+    expect(
+      parseBoardReadyOpsEvidenceVerification(JSON.stringify(validResult()))
+    ).toEqual(validResult());
+  });
+
+  it.each([
+    ['ok', { ok: 'yes' }],
+    ['checked', { checked: -1 }],
+    ['errors', { errors: 'private' }],
+    ['signature', { signature: null }],
+    [
+      'signature present',
+      { signature: { present: 'yes', ok: true, errors: [] } }
+    ],
+    ['signature ok', { signature: { present: true, ok: 'yes', errors: [] } }],
+    [
+      'signature errors',
+      { signature: { present: true, ok: true, errors: [42] } }
+    ]
+  ])('fails closed for invalid %s', (_name, patch) => {
+    expect(() =>
+      parseBoardReadyOpsEvidenceVerification(
+        JSON.stringify({ ...validResult(), ...patch })
+      )
+    ).toThrow(
+      'BoardReadyOps release verification returned an invalid contract.'
+    );
+  });
+
+  it('rejects malformed JSON without echoing private output', () => {
+    expect(() =>
+      parseBoardReadyOpsEvidenceVerification('PRIVATE_EVIDENCE_SENTINEL')
+    ).toThrow(
+      'BoardReadyOps release verification returned invalid JSON output.'
+    );
+    try {
+      parseBoardReadyOpsEvidenceVerification('PRIVATE_EVIDENCE_SENTINEL');
+    } catch (error) {
+      expect(String(error)).not.toContain('PRIVATE_EVIDENCE_SENTINEL');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a strict parser for the current BoardReadyOps 1.37.0 release-evidence verification JSON contract
- expose evidence verification from the latest BoardReadyOps report without surfacing manifest paths or CLI-private errors
- rediscover the BoardReadyOps doctor contract before advanced release verification and fail closed on incompatible tools
- distinguish verified, unsigned, signature-failed, and unverified evidence states in user-facing status

## Validation
- published `boardreadyops@1.37.0` release verify implementation inspected against the parsed JSON shape
- focused BoardReadyOps suites: 35/35 tests passed with coverage disabled for focused execution
- extension lint passed
- extension typecheck passed
- full unit suite: 132/132 suites, 1127/1127 tests, 2/2 snapshots passed
- `git diff --check` passed

Part of #623. Review/release-handoff visibility and release-path gate integration remain open.