### PR TITLE
feat(kicad-studio): gate manufacturing release on BoardReadyOps

### DIFF
--- a/apps/vscode-extension/src/boardreadyops/cli.ts
+++ b/apps/vscode-extension/src/boardreadyops/cli.ts
@@ -1,0 +1,42 @@
+import { spawn } from 'node:child_process';
+import type * as vscode from 'vscode';
+
+export interface BoardReadyOpsCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export function runBoardReadyOpsCommand(
+  projectPath: string,
+  args: string[],
+  token?: vscode.CancellationToken
+): Promise<BoardReadyOpsCommandResult> {
+  return new Promise((resolve, reject) => {
+    const cmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+    const child = spawn(cmd, ['boardreadyops', ...args], {
+      cwd: projectPath,
+      env: { ...process.env },
+      shell: false
+    });
+
+    let stdout = '';
+    let stderr = '';
+    const disposable = token?.onCancellationRequested(() => child.kill());
+
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      disposable?.dispose();
+      reject(error);
+    });
+    child.on('close', (code) => {
+      disposable?.dispose();
+      resolve({ stdout, stderr, exitCode: code ?? 0 });
+    });
+  });
+}

--- a/apps/vscode-extension/src/boardreadyops/releaseGate.ts
+++ b/apps/vscode-extension/src/boardreadyops/releaseGate.ts
@@ -1,0 +1,121 @@
+import * as path from 'node:path';
+import {
+  discoverBoardReadyOpsContract,
+  parseBoardReadyOpsRunResult
+} from './contract';
+import { parseBoardReadyOpsEvidenceVerification } from './evidence';
+import {
+  runBoardReadyOpsCommand,
+  type BoardReadyOpsCommandResult
+} from './cli';
+
+export type BoardReadyOpsReleaseGateDecision =
+  | {
+      ok: true;
+      checkedArtifacts: number;
+      signatureVerified: boolean;
+    }
+  | {
+      ok: false;
+      reason: string;
+    };
+
+type BoardReadyOpsRunner = (
+  projectPath: string,
+  args: string[]
+) => Promise<BoardReadyOpsCommandResult>;
+
+function hasBlockingReadiness(readiness: {
+  status?: string;
+  findings: Array<{ severity: string }>;
+}): boolean {
+  return (
+    readiness.status !== 'passed' ||
+    readiness.findings.some(
+      (finding) =>
+        finding.severity === 'critical' || finding.severity === 'high'
+    )
+  );
+}
+
+export function evaluateBoardReadyOpsReleaseGate(
+  readiness: { status?: string; findings: Array<{ severity: string }> },
+  evidence: {
+    ok: boolean;
+    checked: number;
+    signature: { present: boolean; ok: boolean };
+  }
+): BoardReadyOpsReleaseGateDecision {
+  if (hasBlockingReadiness(readiness)) {
+    return {
+      ok: false,
+      reason: 'BoardReadyOps readiness has blocking findings.'
+    };
+  }
+
+  if (!evidence.ok) {
+    return {
+      ok: false,
+      reason: 'BoardReadyOps release evidence is not verified.'
+    };
+  }
+
+  return {
+    ok: true,
+    checkedArtifacts: evidence.checked,
+    signatureVerified: evidence.signature.present && evidence.signature.ok
+  };
+}
+
+export async function verifyBoardReadyOpsManufacturingRelease(
+  projectPath: string,
+  specFile?: string,
+  runner: BoardReadyOpsRunner = runBoardReadyOpsCommand
+): Promise<BoardReadyOpsReleaseGateDecision> {
+  const doctor = await runner(projectPath, ['doctor', '--format', 'json']);
+  if (doctor.exitCode !== 0) {
+    throw new Error(
+      `BoardReadyOps doctor exited with code ${doctor.exitCode}.`
+    );
+  }
+  const contract = discoverBoardReadyOpsContract(doctor.stdout);
+  if (!contract.compatible) {
+    throw new Error(
+      `BoardReadyOps is not contract-compatible: ${contract.reason} (version ${contract.version}, doctor schema ${contract.schemaVersion ?? 'missing'}).`
+    );
+  }
+
+  const runArgs = ['run', '--format', 'json'];
+  if (specFile) runArgs.push('--config', specFile);
+  runArgs.push(projectPath);
+  const readinessProcess = await runner(projectPath, runArgs);
+  if (readinessProcess.exitCode !== 0 && readinessProcess.exitCode !== 1) {
+    throw new Error(
+      `BoardReadyOps run exited with code ${readinessProcess.exitCode}.`
+    );
+  }
+  const readiness = parseBoardReadyOpsRunResult(readinessProcess.stdout);
+  if (hasBlockingReadiness(readiness)) {
+    return {
+      ok: false,
+      reason: 'BoardReadyOps readiness has blocking findings.'
+    };
+  }
+
+  const evidenceProcess = await runner(projectPath, [
+    'release',
+    'verify',
+    '--format',
+    'json',
+    path.join(projectPath, 'build', 'boardreadyops-release')
+  ]);
+  if (evidenceProcess.exitCode !== 0 && evidenceProcess.exitCode !== 1) {
+    throw new Error(
+      `BoardReadyOps release verify exited with code ${evidenceProcess.exitCode}.`
+    );
+  }
+  const evidence = parseBoardReadyOpsEvidenceVerification(
+    evidenceProcess.stdout
+  );
+  return evaluateBoardReadyOpsReleaseGate(readiness, evidence);
+}

--- a/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
+++ b/apps/vscode-extension/src/commands/boardReadyOpsCommands.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { spawn } from 'node:child_process';
 import * as path from 'node:path';
 import { COMMANDS, SETTINGS } from '../constants';
 import { localize } from '../i18n';
@@ -12,6 +11,7 @@ import {
 } from '../boardreadyops/contract';
 import { parseBoardReadyOpsPlan } from '../boardreadyops/plan';
 import { parseBoardReadyOpsEvidenceVerification } from '../boardreadyops/evidence';
+import { runBoardReadyOpsCommand } from '../boardreadyops/cli';
 
 /** URL for BoardReadyOps documentation. */
 export const BOARDREADYOPS_DOCS_URL =
@@ -19,47 +19,6 @@ export const BOARDREADYOPS_DOCS_URL =
 
 let latestReport: BoardReadyOpsRunResult | undefined = undefined;
 const previousDiagnosticUris = new Set<string>();
-
-function runBoardReadyOpsCommand(
-  projectPath: string,
-  args: string[],
-  token: vscode.CancellationToken
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  return new Promise((resolve, reject) => {
-    const cmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-
-    const child = spawn(cmd, ['boardreadyops', ...args], {
-      cwd: projectPath,
-      env: { ...process.env },
-      shell: false
-    });
-
-    let stdout = '';
-    let stderr = '';
-
-    const disposable = token.onCancellationRequested(() => {
-      child.kill();
-    });
-
-    child.stdout?.on('data', (chunk) => {
-      stdout += chunk.toString();
-    });
-
-    child.stderr?.on('data', (chunk) => {
-      stderr += chunk.toString();
-    });
-
-    child.on('error', (err) => {
-      disposable.dispose();
-      reject(err);
-    });
-
-    child.on('close', (code) => {
-      disposable.dispose();
-      resolve({ stdout, stderr, exitCode: code ?? 0 });
-    });
-  });
-}
 
 function runBoardReadyOps(
   projectPath: string,

--- a/apps/vscode-extension/src/commands/manufacturingReleaseWizard.ts
+++ b/apps/vscode-extension/src/commands/manufacturingReleaseWizard.ts
@@ -3,6 +3,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { QualityGateResult } from '../types';
+import { SETTINGS } from '../constants';
+import { verifyBoardReadyOpsManufacturingRelease } from '../boardreadyops/releaseGate';
 import {
   showStructuredError,
   structuredErrorFromUnknown,
@@ -41,6 +43,7 @@ export async function runManufacturingReleaseWizard(
     // A manufacturing release writes a bundle to disk; gate it on workspace
     // trust through the centralized guard rather than menu visibility alone.
     assertWorkspaceTrusted('Manufacturing release');
+    const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const gates = await services.mcpAdapter.runProjectQualityGate();
     const blocking = gates.filter((gate) =>
       ['FAIL', 'BLOCKED'].includes(gate.status)
@@ -56,6 +59,35 @@ export async function runManufacturingReleaseWizard(
       status: gate.status,
       summary: gate.summary
     }));
+
+    const boardReadyOpsEnabled = vscode.workspace
+      .getConfiguration()
+      .get<boolean>(SETTINGS.boardReadyOpsEnabled, false);
+    if (boardReadyOpsEnabled) {
+      if (!root) {
+        throw new Error(
+          'BoardReadyOps release verification requires an open workspace.'
+        );
+      }
+      const specFile = vscode.workspace
+        .getConfiguration()
+        .get<string>(SETTINGS.boardReadyOpsSpecFile, '')
+        .trim();
+      const boardReadyOpsGate = await verifyBoardReadyOpsManufacturingRelease(
+        root,
+        specFile || undefined
+      );
+      if (!boardReadyOpsGate.ok) {
+        telemetry.trackEvent('wizard.blocked');
+        void vscode.window.showWarningMessage(boardReadyOpsGate.reason);
+        return;
+      }
+      gateSummaries.push({
+        label: 'BoardReadyOps',
+        status: 'PASS',
+        summary: `Verified ${boardReadyOpsGate.checkedArtifacts} release evidence artifact(s).`
+      });
+    }
 
     const mode = await vscode.window.showQuickPick(
       [
@@ -77,7 +109,6 @@ export async function runManufacturingReleaseWizard(
       return;
     }
 
-    const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const defaultOutput = root
       ? path.join(
           root,
@@ -316,8 +347,7 @@ async function writeReleaseEvidence(
   }
 
   const mcpServerVersion = options.mcpResult?.['serverVersion'] as
-    | string
-    | undefined;
+    string | undefined;
 
   const manifest = buildReleaseManifest({
     extensionVersion,

--- a/apps/vscode-extension/test/unit/boardReadyOpsCli.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsCli.test.ts
@@ -1,0 +1,92 @@
+jest.mock('node:child_process', () => ({
+  spawn: jest.fn()
+}));
+
+import { EventEmitter } from 'node:events';
+import * as childProcess from 'node:child_process';
+import { runBoardReadyOpsCommand } from '../../src/boardreadyops/cli';
+
+function createChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: jest.Mock;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = jest.fn();
+  return child;
+}
+
+describe('runBoardReadyOpsCommand', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('runs BoardReadyOps without a shell and collects process output', async () => {
+    const child = createChild();
+    (childProcess.spawn as unknown as jest.Mock).mockReturnValue(child);
+    const result = runBoardReadyOpsCommand('/project', [
+      'doctor',
+      '--format',
+      'json'
+    ]);
+    child.stdout.emit('data', Buffer.from('{"ok":'));
+    child.stdout.emit('data', Buffer.from('true}'));
+    child.stderr.emit('data', Buffer.from('warning'));
+    child.emit('close', 1);
+
+    await expect(result).resolves.toEqual({
+      stdout: '{"ok":true}',
+      stderr: 'warning',
+      exitCode: 1
+    });
+    expect(childProcess.spawn).toHaveBeenCalledWith(
+      expect.stringMatching(/^npx(?:\.cmd)?$/),
+      ['boardreadyops', 'doctor', '--format', 'json'],
+      expect.objectContaining({ cwd: '/project', shell: false })
+    );
+  });
+
+  it('kills the child on cancellation and disposes the listener on close', async () => {
+    const child = createChild();
+    (childProcess.spawn as unknown as jest.Mock).mockReturnValue(child);
+    let cancel: (() => void) | undefined;
+    const dispose = jest.fn();
+    const token = {
+      onCancellationRequested: jest.fn((handler: () => void) => {
+        cancel = handler;
+        return { dispose };
+      })
+    };
+
+    const result = runBoardReadyOpsCommand('/project', ['run'], token as never);
+    cancel?.();
+    child.emit('close', null);
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    await expect(result).resolves.toEqual({
+      stdout: '',
+      stderr: '',
+      exitCode: 0
+    });
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects spawn errors and disposes the cancellation listener', async () => {
+    const child = createChild();
+    (childProcess.spawn as unknown as jest.Mock).mockReturnValue(child);
+    const dispose = jest.fn();
+    const token = {
+      onCancellationRequested: jest.fn(() => ({ dispose }))
+    };
+
+    const result = runBoardReadyOpsCommand(
+      '/project',
+      ['doctor'],
+      token as never
+    );
+    child.emit('error', new Error('spawn failed'));
+
+    await expect(result).rejects.toThrow('spawn failed');
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/vscode-extension/test/unit/boardReadyOpsReleaseGate.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsReleaseGate.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import {
   evaluateBoardReadyOpsReleaseGate,
   verifyBoardReadyOpsManufacturingRelease
@@ -160,7 +161,7 @@ describe('BoardReadyOps manufacturing release gate', () => {
       'verify',
       '--format',
       'json',
-      '/project/build/boardreadyops-release'
+      path.join('/project', 'build', 'boardreadyops-release')
     ]);
   });
 

--- a/apps/vscode-extension/test/unit/boardReadyOpsReleaseGate.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsReleaseGate.test.ts
@@ -1,0 +1,103 @@
+import {
+  evaluateBoardReadyOpsReleaseGate,
+  verifyBoardReadyOpsManufacturingRelease
+} from '../../src/boardreadyops/releaseGate';
+
+const readiness = (patch: Record<string, unknown> = {}) => ({
+  schemaVersion: 1,
+  tool: { name: 'boardreadyops', version: '1.37.0' },
+  status: 'passed',
+  exitCode: 0,
+  summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, info: 0 },
+  findings: [],
+  ...patch
+});
+
+const evidence = (patch: Record<string, unknown> = {}) => ({
+  ok: true,
+  manifestPath: '/private/release/manifest.json',
+  checked: 3,
+  errors: [],
+  signature: { present: true, ok: true, errors: [] },
+  ...patch
+});
+
+describe('BoardReadyOps manufacturing release gate', () => {
+  it('accepts a passing readiness result with verified evidence', () => {
+    expect(evaluateBoardReadyOpsReleaseGate(readiness(), evidence())).toEqual({
+      ok: true,
+      checkedArtifacts: 3,
+      signatureVerified: true
+    });
+  });
+
+  it('blocks on readiness blockers even when evidence is verified', () => {
+    const result = readiness({
+      status: 'failed',
+      summary: { total: 1, critical: 0, high: 1, medium: 0, low: 0, info: 0 },
+      findings: [{ ruleId: 'manufacturing.blocker', severity: 'high' }]
+    });
+    expect(evaluateBoardReadyOpsReleaseGate(result, evidence())).toEqual({
+      ok: false,
+      reason: 'BoardReadyOps readiness has blocking findings.'
+    });
+  });
+
+  it('blocks when release evidence is not verified', () => {
+    expect(
+      evaluateBoardReadyOpsReleaseGate(readiness(), evidence({ ok: false }))
+    ).toEqual({
+      ok: false,
+      reason: 'BoardReadyOps release evidence is not verified.'
+    });
+  });
+
+  it('stops before evidence verification when readiness is already blocked', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          schemaVersion: 1,
+          tool: { name: 'boardreadyops', version: '1.37.0' },
+          checks: []
+        }),
+        stderr: '',
+        exitCode: 0
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify(
+          readiness({
+            status: 'failed',
+            summary: {
+              total: 1,
+              critical: 0,
+              high: 1,
+              medium: 0,
+              low: 0,
+              info: 0
+            },
+            findings: [
+              {
+                ruleId: 'manufacturing.blocker',
+                severity: 'high',
+                message: 'Blocked',
+                resource: { path: 'board.kicad_pcb', kind: 'pcb' },
+                fingerprint:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+              }
+            ]
+          })
+        ),
+        stderr: '',
+        exitCode: 1
+      });
+
+    await expect(
+      verifyBoardReadyOpsManufacturingRelease('/project', undefined, runner)
+    ).resolves.toEqual({
+      ok: false,
+      reason: 'BoardReadyOps readiness has blocking findings.'
+    });
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/vscode-extension/test/unit/boardReadyOpsReleaseGate.test.ts
+++ b/apps/vscode-extension/test/unit/boardReadyOpsReleaseGate.test.ts
@@ -43,6 +43,18 @@ describe('BoardReadyOps manufacturing release gate', () => {
     });
   });
 
+  it('blocks a passing status when a high-severity finding remains', () => {
+    const result = readiness({
+      status: 'passed',
+      findings: [{ ruleId: 'manufacturing.blocker', severity: 'high' }]
+    });
+
+    expect(evaluateBoardReadyOpsReleaseGate(result, evidence())).toEqual({
+      ok: false,
+      reason: 'BoardReadyOps readiness has blocking findings.'
+    });
+  });
+
   it('blocks when release evidence is not verified', () => {
     expect(
       evaluateBoardReadyOpsReleaseGate(readiness(), evidence({ ok: false }))
@@ -99,5 +111,121 @@ describe('BoardReadyOps manufacturing release gate', () => {
       reason: 'BoardReadyOps readiness has blocking findings.'
     });
     expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  it('verifies compatible readiness and release evidence end to end', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          schemaVersion: 1,
+          tool: { name: 'boardreadyops', version: '1.37.0' },
+          checks: []
+        }),
+        stderr: '',
+        exitCode: 0
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify(readiness()),
+        stderr: '',
+        exitCode: 0
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify(evidence()),
+        stderr: '',
+        exitCode: 0
+      });
+
+    await expect(
+      verifyBoardReadyOpsManufacturingRelease(
+        '/project',
+        'boardreadyops.yml',
+        runner
+      )
+    ).resolves.toEqual({
+      ok: true,
+      checkedArtifacts: 3,
+      signatureVerified: true
+    });
+    expect(runner).toHaveBeenNthCalledWith(2, '/project', [
+      'run',
+      '--format',
+      'json',
+      '--config',
+      'boardreadyops.yml',
+      '/project'
+    ]);
+    expect(runner).toHaveBeenNthCalledWith(3, '/project', [
+      'release',
+      'verify',
+      '--format',
+      'json',
+      '/project/build/boardreadyops-release'
+    ]);
+  });
+
+  it('fails closed when doctor exits unsuccessfully', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValue({ stdout: '', stderr: 'private', exitCode: 2 });
+    await expect(
+      verifyBoardReadyOpsManufacturingRelease('/project', undefined, runner)
+    ).rejects.toThrow('BoardReadyOps doctor exited with code 2.');
+  });
+
+  it('fails closed when the discovered contract is incompatible', async () => {
+    const runner = jest.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        schemaVersion: 99,
+        tool: { name: 'boardreadyops', version: '1.37.0' },
+        checks: []
+      }),
+      stderr: '',
+      exitCode: 0
+    });
+    await expect(
+      verifyBoardReadyOpsManufacturingRelease('/project', undefined, runner)
+    ).rejects.toThrow('BoardReadyOps is not contract-compatible:');
+  });
+
+  it('fails closed when readiness exits outside the documented verdict codes', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          schemaVersion: 1,
+          tool: { name: 'boardreadyops', version: '1.37.0' },
+          checks: []
+        }),
+        stderr: '',
+        exitCode: 0
+      })
+      .mockResolvedValueOnce({ stdout: '', stderr: 'private', exitCode: 2 });
+    await expect(
+      verifyBoardReadyOpsManufacturingRelease('/project', undefined, runner)
+    ).rejects.toThrow('BoardReadyOps run exited with code 2.');
+  });
+
+  it('fails closed when release verification exits outside the documented verdict codes', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          schemaVersion: 1,
+          tool: { name: 'boardreadyops', version: '1.37.0' },
+          checks: []
+        }),
+        stderr: '',
+        exitCode: 0
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify(readiness()),
+        stderr: '',
+        exitCode: 0
+      })
+      .mockResolvedValueOnce({ stdout: '', stderr: 'private', exitCode: 2 });
+    await expect(
+      verifyBoardReadyOpsManufacturingRelease('/project', undefined, runner)
+    ).rejects.toThrow('BoardReadyOps release verify exited with code 2.');
   });
 });

--- a/apps/vscode-extension/test/unit/manufacturingReleaseWizard.test.ts
+++ b/apps/vscode-extension/test/unit/manufacturingReleaseWizard.test.ts
@@ -1,10 +1,21 @@
+jest.mock('../../src/boardreadyops/releaseGate', () => ({
+  verifyBoardReadyOpsManufacturingRelease: jest.fn()
+}));
+
 import * as vscode from 'vscode';
 import { runManufacturingReleaseWizard } from '../../src/commands/manufacturingReleaseWizard';
-import { window } from './vscodeMock';
+import { verifyBoardReadyOpsManufacturingRelease } from '../../src/boardreadyops/releaseGate';
+import { window, __setConfiguration } from './vscodeMock';
 
 describe('runManufacturingReleaseWizard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': false });
+    (verifyBoardReadyOpsManufacturingRelease as jest.Mock).mockResolvedValue({
+      ok: true,
+      checkedArtifacts: 2,
+      signatureVerified: true
+    });
   });
 
   function createServices(overrides?: {
@@ -79,6 +90,35 @@ describe('runManufacturingReleaseWizard', () => {
     expect(
       services.mcpAdapter.exportManufacturingPackage
     ).not.toHaveBeenCalled();
+  });
+
+  it('blocks manufacturing release when BoardReadyOps readiness has blockers', async () => {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+    (
+      verifyBoardReadyOpsManufacturingRelease as jest.Mock
+    ).mockResolvedValueOnce({
+      ok: false,
+      reason: 'BoardReadyOps readiness has blocking findings.'
+    });
+    const services = createServices();
+
+    await runManufacturingReleaseWizard(services as never);
+
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      'BoardReadyOps readiness has blocking findings.'
+    );
+    expect(
+      services.mcpAdapter.exportManufacturingPackage
+    ).not.toHaveBeenCalled();
+  });
+
+  it('keeps BoardReadyOps optional for manufacturing release', async () => {
+    const services = createServices();
+    (window.showQuickPick as jest.Mock).mockResolvedValueOnce(undefined);
+
+    await runManufacturingReleaseWizard(services as never);
+
+    expect(verifyBoardReadyOpsManufacturingRelease).not.toHaveBeenCalled();
   });
 
   it('blocks the release when a quality gate fails', async () => {

--- a/apps/vscode-extension/test/unit/manufacturingReleaseWizard.test.ts
+++ b/apps/vscode-extension/test/unit/manufacturingReleaseWizard.test.ts
@@ -112,6 +112,31 @@ describe('runManufacturingReleaseWizard', () => {
     ).not.toHaveBeenCalled();
   });
 
+  it('includes verified BoardReadyOps evidence in the dry-run gate summary', async () => {
+    __setConfiguration({ 'kicadstudio.boardReadyOps.enabled': true });
+    const services = createServices();
+    (window.showQuickPick as jest.Mock).mockResolvedValueOnce({
+      label: 'Preview (dry run)',
+      dryRun: true
+    });
+    (window.showInputBox as jest.Mock).mockResolvedValueOnce(process.cwd());
+
+    await runManufacturingReleaseWizard(services as never);
+
+    expect(verifyBoardReadyOpsManufacturingRelease).toHaveBeenCalledWith(
+      process.cwd(),
+      undefined
+    );
+    expect(window.showInformationMessage).toHaveBeenCalledWith(
+      'Manufacturing release preview',
+      expect.objectContaining({
+        modal: true,
+        detail: expect.stringContaining('BoardReadyOps=PASS')
+      }),
+      'OK'
+    );
+  });
+
   it('keeps BoardReadyOps optional for manufacturing release', async () => {
     const services = createServices();
     (window.showQuickPick as jest.Mock).mockResolvedValueOnce(undefined);

--- a/docs/board-ready-ops.md
+++ b/docs/board-ready-ops.md
@@ -22,12 +22,13 @@ Open VS Code Settings (`Ctrl+,`) and search for `boardreadyops`.
 
 All commands are available from the Command Palette (`Ctrl+Shift+P`) or the KiCad Studio panel.
 
-| Command ID                             | Title                                | Action                            |
-| -------------------------------------- | ------------------------------------ | --------------------------------- |
-| `kicadstudio.boardReadyOps.check`      | BoardReadyOps: Check Board Readiness | Run checks on the active project. |
-| `kicadstudio.boardReadyOps.configure`  | BoardReadyOps: Configure Checks      | Open BoardReadyOps settings.      |
-| `kicadstudio.boardReadyOps.showReport` | BoardReadyOps: Show Readiness Report | Display the last check report.    |
-| `kicadstudio.boardReadyOps.openDocs`   | BoardReadyOps: Open Documentation    | Open this page in a browser.      |
+| Command ID                             | Title                                | Action                                                     |
+| -------------------------------------- | ------------------------------------ | ---------------------------------------------------------- |
+| `kicadstudio.boardReadyOps.check`      | BoardReadyOps: Check Board Readiness | Run checks on the active project.                          |
+| `kicadstudio.boardReadyOps.plan`       | BoardReadyOps: Plan Remediation      | Build a structured remediation plan from current findings. |
+| `kicadstudio.boardReadyOps.configure`  | BoardReadyOps: Configure Checks      | Open BoardReadyOps settings.                               |
+| `kicadstudio.boardReadyOps.showReport` | BoardReadyOps: Show Readiness Report | Display the last check report.                             |
+| `kicadstudio.boardReadyOps.openDocs`   | BoardReadyOps: Open Documentation    | Open this page in a browser.                               |
 
 ## Usage
 
@@ -88,3 +89,26 @@ The score never hides a hard failure: any failed dimension or any
 numeric score is high. Each dimension and finding carries a remediation hint, and
 reports export to both Markdown and HTML so CI can publish the scorecard as an
 artifact. Any AI-generated remediation plan must be grounded in these findings.
+
+## Manufacturing release gate
+
+When `kicadstudio.boardReadyOps.enabled` is `true`, the Manufacturing Release
+Wizard treats BoardReadyOps as a release gate in addition to the existing
+project quality gates. Before any manufacturing package is exported, KiCad
+Studio:
+
+1. runs `boardreadyops doctor --format json` and rejects unsupported or
+   malformed contracts;
+2. runs the structured readiness check and blocks on a failed readiness result
+   or any `critical`/`high` finding; and
+3. verifies the project's `build/boardreadyops-release` evidence bundle.
+
+A numeric readiness score cannot override a blocking finding. Missing, stale,
+malformed, or unverified evidence fails closed while BoardReadyOps is enabled.
+If BoardReadyOps is disabled, the Manufacturing Release Wizard keeps its
+existing behavior and does not require BoardReadyOps.
+
+A successful verification is recorded as a `BoardReadyOps` quality-gate entry
+in the generated release manifest and summary. The release UI reports counts
+and verification state only; it does not surface raw CLI payloads or private
+artifact paths.


### PR DESCRIPTION
## Summary

Advance #623 by making the existing Manufacturing Release Wizard consume BoardReadyOps readiness and release-evidence state when the integration is enabled.

- share the existing BoardReadyOps CLI runner instead of duplicating process handling
- fail closed on incompatible/malformed readiness contracts, critical/high blockers, and unverified release evidence
- stop before evidence verification when readiness is already blocked
- record a successful BoardReadyOps verification in the generated release gate summary
- preserve the existing manufacturing release behavior when BoardReadyOps is disabled
- document the remediation command and manufacturing release gate

## Linked issue

Advances #623

## Type of change

- [ ] type:bug
- [x] type:feature
- [x] type:docs
- [ ] type:refactor
- [ ] type:perf
- [ ] type:security
- [ ] type:chore
- [ ] breaking

## Test evidence

- TDD: the new release-gate test first failed because the implementation did not exist; the early-block regression then failed until the verifier stopped before evidence verification.
- Focused BoardReadyOps/manufacturing tests: 3 suites, 35 tests passed.
- Full extension unit suite: 133/133 suites, 1133/1133 tests, 2/2 snapshots passed.
- Extension lint, typecheck, formatting, coverage ratchet, security, accessibility, build, package, and package validation passed.
- Repository-wide pre-push gate passed on the final head, including architecture boundaries, governance, dependency/security policy, release provenance, docs, repeatable VSIX, and shared packages.
- Repeatable VSIX normalized SHA-256: `6e57b90c99704a9eac3fa3cfc7d8a2ea82b31b623e416512d4b5f831df03e55f`.

## Protocol / MCP impact

- [x] Not applicable; reason: this consumes the external BoardReadyOps CLI contract and does not change MCP tool names, schemas, capability metadata, transport behavior, server-info payloads, or the MCP adapter contract.
- [ ] Protocol schema updated
- [ ] MCP server implementation updated
- [ ] Extension MCP adapter updated
- [ ] Contract tests updated
- [ ] Compatibility matrix updated
- [ ] Server-info/capabilities payload updated
- [x] Docs updated
- [x] Release notes considered for both products
- [x] Backward compatibility impact documented

Backward compatibility: BoardReadyOps remains opt-in. With `kicadstudio.boardReadyOps.enabled=false`, the existing manufacturing release flow is unchanged.

## Repository maturity impact

- [ ] No repository maturity impact
- [x] Documentation/community health updated
- [x] CI/quality/release process updated
- [ ] Governance/security/supply-chain process updated
- [ ] Manual GitHub setting or maintainer action required and documented

## Automation evidence

- [x] Review-thread gate checked or not applicable
- [x] Draft PR kept draft until cheap gates are clean
- [x] No publish workflow was triggered
- [x] No secrets were printed or changed

## Review evidence

An availability, quota, rate-limit, or capacity notice is not a completed review.

Select exactly one automated-review outcome:

- [ ] Completed with findings; every finding is triaged below
- [ ] Completed with no findings
- [x] Unavailable; reason and compensating evidence recorded below
- [ ] Not applicable; reason:

No final-head automated reviewer result exists yet at PR creation time; this will be updated after the PR review bots complete.

Select exactly one change risk:

- [ ] Low
- [x] Medium
- [ ] High

Bot and agent triage:

- [ ] Every bot and agent comment is classified as actionable, resolved, informational, duplicate, or unavailable
- [ ] No actionable finding remains unresolved
- [x] Unavailable notices are recorded as unavailable, not completed review

Compensating evidence (required when automated review is unavailable for medium/high-risk changes):

- [ ] Focused second-agent review
- [x] Architecture/security checklist
- [x] Additional regression tests
- [x] Documented manual review
- [ ] Not required because review completed, was not applicable, or change risk is low

Evidence links/notes:

Final-head diff was reviewed file-by-file before opening this PR. The release gate does not expose raw CLI stdout/stderr or private evidence paths, does not weaken the existing project quality gates, and preserves the disabled-by-default compatibility path.

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass
- [x] Bug fixes include automated regression coverage that references the related issue in the test name or metadata — not applicable; this is a feature slice with dedicated regression coverage.
- [x] Bug-fix exceptions explain why automation is not practical and have maintainer approval — not applicable; this is not a bug-fix exception.
- [ ] CHANGELOG entry (if user-visible) — deferred until #623 feature completion; this PR documents the behavior directly.
- [x] Docs updated (if user-visible)
- [x] No new committed secrets or build artifacts
- [ ] Developer Certificate of Origin sign-off is present on non-trivial commits (`git commit -s`) or not applicable with rationale — the code commit is GPG-signed but predates the sign-off trailer; the docs follow-up is signed off. Existing pushed history was not rewritten solely to add a trailer.
- [x] Meets the [Definition of Done](../docs/architecture/definition-of-done.md) for this change type; #623 remains open for its remaining review/governance acceptance work.
