### PR TITLE
fix(repo): sample CodeQL evidence on first-parent main

### DIFF
--- a/scripts/check-scorecard-evidence.mjs
+++ b/scripts/check-scorecard-evidence.mjs
@@ -89,18 +89,44 @@ function apiUrl(relativePath) {
   return `${root}${relativePath}`;
 }
 
+export async function collectDefaultBranchFirstParentCommits({
+  sampleSize,
+  fetchCommit,
+}) {
+  const commits = [];
+  let ref = "main";
+  while (ref && commits.length < sampleSize) {
+    const commit = await fetchCommit(ref);
+    if (!commit || typeof commit.sha !== "string" || commit.sha.trim() === "") {
+      throw new TypeError(
+        `default-branch commit ${ref}: expected a commit object`,
+      );
+    }
+    commits.push({ sha: commit.sha });
+    const firstParent = Array.isArray(commit.parents)
+      ? commit.parents[0]?.sha
+      : null;
+    ref =
+      typeof firstParent === "string" && firstParent.trim() !== ""
+        ? firstParent
+        : "";
+  }
+  return commits;
+}
+
 async function collectLiveEvidence(options, policy, token) {
   const repoPath = `/repos/${options.repository}`;
-  const commitsResult = await fetchJson(
-    apiUrl(`${repoPath}/commits?sha=main&per_page=${policy.sampleSize}`),
-    token,
-    "recent default-branch commits",
-  );
-  if (!Array.isArray(commitsResult.data)) {
-    throw new TypeError(
-      "recent default-branch commits: expected an array response",
-    );
-  }
+  const recentCommits = await collectDefaultBranchFirstParentCommits({
+    sampleSize: policy.sampleSize,
+    fetchCommit: async (ref) => {
+      const result = await fetchJson(
+        apiUrl(`${repoPath}/commits/${encodeURIComponent(ref)}`),
+        token,
+        `default-branch commit ${ref}`,
+      );
+      return result.data;
+    },
+  });
   const codeqlAnalyses = await fetchAll(
     apiUrl(`${repoPath}/code-scanning/analyses?tool_name=CodeQL&per_page=100`),
     token,
@@ -118,7 +144,7 @@ async function collectLiveEvidence(options, policy, token) {
     fs.readFileSync(options.governanceJson, "utf8"),
   );
   return {
-    recentCommits: commitsResult.data.map((commit) => ({ sha: commit.sha })),
+    recentCommits,
     codeqlAnalyses,
     scorecardAlerts,
     governanceReport,

--- a/scripts/check-scorecard-evidence.test.mjs
+++ b/scripts/check-scorecard-evidence.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { collectDefaultBranchFirstParentCommits } from "./check-scorecard-evidence.mjs";
+
 import {
   buildScorecardEvidenceReport,
   buildUnavailableScorecardEvidenceReport,
@@ -48,6 +50,29 @@ const governanceReport = {
   exitCode: 0,
   ruleset: { status: "current", differences: [] },
 };
+
+test("#532 default-branch sampling follows first parents instead of merged branch commits", async () => {
+  const graph = new Map([
+    ["main", { sha: "merge", parents: [{ sha: "base" }, { sha: "feature" }] }],
+    ["base", { sha: "base", parents: [{ sha: "root" }] }],
+    ["root", { sha: "root", parents: [] }],
+    ["feature", { sha: "feature", parents: [{ sha: "base" }] }],
+  ]);
+  const requested = [];
+  const commits = await collectDefaultBranchFirstParentCommits({
+    sampleSize: 3,
+    fetchCommit: async (ref) => {
+      requested.push(ref);
+      return graph.get(ref);
+    },
+  });
+  assert.deepEqual(commits, [
+    { sha: "merge" },
+    { sha: "base" },
+    { sha: "root" },
+  ]);
+  assert.deepEqual(requested, ["main", "base", "root"]);
+});
 
 test("#532 current residual-risk policy is complete", () => {
   assert.deepEqual(validateScorecardResidualRiskPolicy(policy), []);


### PR DESCRIPTION
## Summary
- sample governance CodeQL evidence from the actual first-parent `main` history
- avoid treating merged feature-branch commits as default-branch CodeQL coverage gaps
- add regression coverage for merge commits with second parents

## Verification
- `pnpm run check:scorecard-evidence`
- `pnpm run check:best-practices`
- `pnpm run check:quality-gates`
- `pnpm run check:branch-protection`
- full pre-push `pnpm run check` passed
- live GitHub reconciliation: 30/30 sampled first-parent commits have both required CodeQL categories; status current

## Context
Fixes the scheduled Governance Evidence failure on main run 33380763691 without weakening the 30-commit SAST evidence requirement.