### PR TITLE
fix(docs): keep BoardReadyOps support evidence aligned

### DIFF
--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -60,7 +60,7 @@ artifacts.
 | Studio CLI / KiCad | stable `10.0.x`; deprecated `9.x`, `8.x`; preview `11.0.x`; no dropped lines | CLI support is capability-probed. If unsupported, install/configure a supported `kicad-cli`. MCP is evaluated separately. |
 | MCP server product | required/recommended `>=3.5.2 <4.0.0`; tested against published `kicad-mcp-pro` `3.33.3` | PyPI is the published-artifact source. Install a server inside the supported range and re-run diagnostics. |
 | MCP protocol | active `2025-11-25`; next `2026-07-28`; activation `blocked` | Protocol activation is independent from server semver and remains gated by ADR 0008 evidence. |
-| BoardReadyOps | required `>=1.2.0 <2.0.0`; tested against npm `1.35.0`; findings schema `1`; evidence bundle schema `2` | npm is the published-artifact source. Upgrade the CLI when the detected version is outside the supported range. |
+| BoardReadyOps | required `>=1.2.0 <2.0.0`; tested against npm `1.37.0`; findings schema `1`; evidence bundle schema `2` | npm is the published-artifact source. Upgrade the CLI when the detected version is outside the supported range. |
 
 This split is deliberate: Studio can continue to offer CLI/viewer workflows for a
 KiCad line even when the installed MCP server is unsupported, and an MCP server

--- a/scripts/check-compatibility-contract.test.mjs
+++ b/scripts/check-compatibility-contract.test.mjs
@@ -89,6 +89,16 @@ test("#621 embedded support axes reject BoardReadyOps contract drift", () => {
   );
 });
 
+test("#623 BoardReadyOps support-matrix evidence matches compatibility metadata", () => {
+  const supportMatrix = fs.readFileSync("docs/support-matrix.md", "utf8");
+  const testedVersion = compatibility.supportAxes.boardReadyOps.testedAgainst.version;
+  const documentedVersion = supportMatrix.match(
+    /\| BoardReadyOps \|[^\n]*tested against npm `([^`]+)`/u,
+  )?.[1];
+
+  assert.equal(documentedVersion, testedVersion);
+});
+
 test("repository compatibility contract validates current state", () => {
   assert.deepEqual(validateCompatibilityContract(), []);
 });


### PR DESCRIPTION
## Summary
- align the BoardReadyOps tested-artifact version in the independent support-axes documentation with canonical `compatibility.yaml`
- add a regression test so the manually maintained support-matrix row cannot silently drift from the compatibility contract again

## Root cause
`docs/support-matrix.md` contains an Independent Support Axes table outside the generated compatibility marker block. `compatibility.yaml` and the embedded extension matrix had advanced BoardReadyOps to `1.37.0`, while that manual row remained at `1.35.0`; existing generation and compatibility checks did not bind the duplicate documentation value back to canonical metadata.

## Verification
- TDD red: new regression failed with `1.35.0 !== 1.37.0`
- focused regression: 24/24 pass
- compatibility contract suite: 42/42 pass
- full repository pre-push quality gate: exit 0
- extension unit suite: 134/134 suites, 1143/1143 tests
- coverage ratchet: 10/10 suites, 133/133 tests
- security: 12/12 tests
- accessibility: 76/76 tests
- full docs site/build/bundle checks pass
- repeatable VSIX check pass

Refs #623
